### PR TITLE
Show reference thumbnails in AI generation details

### DIFF
--- a/Sources/PalmierPro/Inspector/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/AIEditTab.swift
@@ -316,9 +316,13 @@ struct AIEditTab: View {
             if let r = gen.resolution {
                 rerunRow("rectangle.split.3x3", label: "Resolution", value: r)
             }
-            let refCount = gen.imageURLs?.count ?? 0
-            if refCount > 0 {
-                rerunRow("photo.on.rectangle", label: "References", value: "\(refCount)")
+            if GenerationReferencesStrip.hasResolvableReferences(gen, in: editor.mediaAssets) {
+                GenerationReferencesStrip(generationInput: gen)
+            } else {
+                let refCount = gen.imageURLs?.count ?? 0
+                if refCount > 0 {
+                    rerunRow("photo.on.rectangle", label: "References", value: "\(refCount)")
+                }
             }
             if !gen.prompt.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {

--- a/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
+++ b/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct GenerationReferencesStrip: View {
+    let generationInput: GenerationInput
+    @Environment(EditorViewModel.self) private var editor
+
+    var body: some View {
+        let slots = Self.slots(for: generationInput, in: editor.mediaAssets)
+        if !slots.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: AppTheme.Spacing.sm) {
+                    ForEach(Array(slots.enumerated()), id: \.offset) { _, slot in
+                        thumbnail(label: slot.0, asset: slot.1)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns true if any reference asset can be resolved against `assets`.
+    static func hasResolvableReferences(_ gen: GenerationInput, in assets: [MediaAsset]) -> Bool {
+        !slots(for: gen, in: assets).isEmpty
+    }
+
+    private static func slots(for gen: GenerationInput, in assets: [MediaAsset]) -> [(String, MediaAsset)] {
+        let lookup: (String) -> MediaAsset? = { id in assets.first(where: { $0.id == id }) }
+        let primaryLabels = primaryLabels(for: gen)
+        let groups: [([String]?, (Int, Int) -> String)] = [
+            (gen.imageURLAssetIds,       { i, _ in primaryLabels[safe: i] ?? "Reference" }),
+            (gen.referenceImageAssetIds, numbered("Image Ref")),
+            (gen.referenceVideoAssetIds, numbered("Video Ref")),
+            (gen.referenceAudioAssetIds, numbered("Audio Ref")),
+        ]
+        return groups.flatMap { ids, label in
+            let ids = ids ?? []
+            return ids.enumerated().compactMap { i, id in
+                lookup(id).map { (label(i, ids.count), $0) }
+            }
+        }
+    }
+
+    private static func primaryLabels(for gen: GenerationInput) -> [String] {
+        guard case .video(let m) = ModelRegistry.byId[gen.model] else { return [] }
+        if m.requiresSourceVideo { return m.supportsReferences ? ["Source", "Reference"] : ["Source"] }
+        if m.supportsFirstFrame  { return m.supportsLastFrame  ? ["First Frame", "Last Frame"] : ["First Frame"] }
+        return []
+    }
+
+    private static func numbered(_ base: String) -> (Int, Int) -> String {
+        { i, total in total > 1 ? "\(base) \(i + 1)" : base }
+    }
+
+    private func thumbnail(label: String, asset: MediaAsset) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ZStack {
+                Rectangle().fill(Color.black)
+                if let thumb = asset.thumbnail {
+                    Image(nsImage: thumb).resizable().aspectRatio(contentMode: .fit)
+                } else {
+                    Image(systemName: asset.type.sfSymbolName)
+                        .font(.system(size: 14))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                }
+            }
+            .frame(width: 72, height: 41)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
+            .overlay(RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5))
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(AppTheme.Text.mutedColor)
+                .lineLimit(1)
+        }
+        .help("\(label) · \(asset.name)")
+        .onTapGesture {
+            editor.selectedClipIds.removeAll()
+            editor.selectedFolderIds.removeAll()
+            editor.selectedMediaAssetIds = [asset.id]
+            editor.openPreviewTab(for: asset)
+            editor.mediaPanelRevealAssetId = asset.id
+        }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
+++ b/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
@@ -9,32 +9,33 @@ struct GenerationReferencesStrip: View {
         if !slots.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top, spacing: AppTheme.Spacing.sm) {
-                    ForEach(Array(slots.enumerated()), id: \.offset) { _, slot in
-                        thumbnail(label: slot.0, asset: slot.1)
+                    ForEach(slots.indices, id: \.self) { i in
+                        thumbnail(label: slots[i].0, asset: slots[i].1)
                     }
                 }
             }
         }
     }
 
-    /// Returns true if any reference asset can be resolved against `assets`.
     static func hasResolvableReferences(_ gen: GenerationInput, in assets: [MediaAsset]) -> Bool {
         !slots(for: gen, in: assets).isEmpty
     }
 
-    private static func slots(for gen: GenerationInput, in assets: [MediaAsset]) -> [(String, MediaAsset)] {
-        let lookup: (String) -> MediaAsset? = { id in assets.first(where: { $0.id == id }) }
-        let primaryLabels = primaryLabels(for: gen)
-        let groups: [([String]?, (Int, Int) -> String)] = [
-            (gen.imageURLAssetIds,       { i, _ in primaryLabels[safe: i] ?? "Reference" }),
-            (gen.referenceImageAssetIds, numbered("Image Ref")),
-            (gen.referenceVideoAssetIds, numbered("Video Ref")),
-            (gen.referenceAudioAssetIds, numbered("Audio Ref")),
+    static func slots(for gen: GenerationInput, in assets: [MediaAsset]) -> [(String, MediaAsset)] {
+        let byId = Dictionary(uniqueKeysWithValues: assets.map { ($0.id, $0) })
+        let primary = primaryLabels(for: gen)
+        let groups: [(ids: [String]?, base: String, primary: [String])] = [
+            (gen.imageURLAssetIds,       "Reference", primary),
+            (gen.referenceImageAssetIds, "Image Ref", []),
+            (gen.referenceVideoAssetIds, "Video Ref", []),
+            (gen.referenceAudioAssetIds, "Audio Ref", []),
         ]
-        return groups.flatMap { ids, label in
+        return groups.flatMap { ids, base, primary -> [(String, MediaAsset)] in
             let ids = ids ?? []
             return ids.enumerated().compactMap { i, id in
-                lookup(id).map { (label(i, ids.count), $0) }
+                guard let asset = byId[id] else { return nil }
+                if i < primary.count { return (primary[i], asset) }
+                return (ids.count > 1 ? "\(base) \(i + 1)" : base, asset)
             }
         }
     }
@@ -44,10 +45,6 @@ struct GenerationReferencesStrip: View {
         if m.requiresSourceVideo { return m.supportsReferences ? ["Source", "Reference"] : ["Source"] }
         if m.supportsFirstFrame  { return m.supportsLastFrame  ? ["First Frame", "Last Frame"] : ["First Frame"] }
         return []
-    }
-
-    private static func numbered(_ base: String) -> (Int, Int) -> String {
-        { i, total in total > 1 ? "\(base) \(i + 1)" : base }
     }
 
     private func thumbnail(label: String, asset: MediaAsset) -> some View {
@@ -79,11 +76,5 @@ struct GenerationReferencesStrip: View {
             editor.openPreviewTab(for: asset)
             editor.mediaPanelRevealAssetId = asset.id
         }
-    }
-}
-
-private extension Array {
-    subscript(safe index: Int) -> Element? {
-        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -742,6 +742,8 @@ struct InspectorView: View {
                                 metadataRow("clock", label: "Duration", value: "\(gen.duration)s")
                             }
 
+                            GenerationReferencesStrip(generationInput: gen)
+
                             if !gen.prompt.isEmpty {
                                 VStack(alignment: .leading, spacing: 2) {
                                     HStack(spacing: AppTheme.Spacing.xs) {


### PR DESCRIPTION
Adds a labeled thumbnail strip for first/last frame, source video, and image/video/audio references in the Inspector's AI Generated card and the AI tab's Rerun details. Tapping a thumbnail selects the asset, opens its preview, and reveals it in the media panel.

---

🖼️ This PR enhances the AI generation details UI by replacing simple reference counts with interactive thumbnail strips that display labeled previews of source videos, first/last frames, and reference assets. Users can now click thumbnails to select, preview, and locate the referenced media assets directly from the generation details.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Component**: Created `GenerationReferencesStrip.swift` - a reusable SwiftUI component that renders horizontal scrollable thumbnail strips for AI generation references
- **Inspector Integration**: Updated both `AIEditTab.swift` and `InspectorView.swift` to conditionally show the new thumbnail strip when resolvable references exist
- **Smart Labeling**: Implements intelligent labeling logic that differentiates between source videos, first/last frames, and numbered reference assets based on model capabilities
- **Interactive Thumbnails**: Each thumbnail is clickable and triggers asset selection, preview opening, and media panel navigation

### Technical Implementation
```mermaid
flowchart TD
    A[GenerationInput] --> B[hasResolvableReferences check]
    B -->|Yes| C[GenerationReferencesStrip]
    B -->|No| D[Fallback reference count]
    C --> E[slots function]
    E --> F[Asset lookup by ID]
    F --> G[Thumbnail rendering]
    G --> H[Click handler]
    H --> I[Select asset + Open preview + Reveal in panel]
```

### Impact
- **Enhanced UX**: Users can visually identify and quickly access reference assets instead of seeing just a count
- **Improved Navigation**: Direct thumbnail clicks provide seamless navigation to referenced media assets
- **Better Context**: Smart labeling (Source, First Frame, Last Frame, etc.) provides clear context about each reference's role
- **Backward Compatibility**: Gracefully falls back to the original count display when assets cannot be resolved

</details>

_Created with [Palmier](https://www.palmier.io)_