### PR TITLE
Snapshot full generation metadata in generation-log entries

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Cost.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Cost.swift
@@ -2,8 +2,18 @@ import Foundation
 
 /// Append-only record of every AI generation in the project. Persisted as `generation-log.json`
 struct GenerationLog: Codable, Sendable, Equatable {
-    var version: Int = 1
+    var version: Int = 2
     var entries: [GenerationLogEntry] = []
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        entries = try c.decodeIfPresent([GenerationLogEntry].self, forKey: .entries) ?? []
+    }
+
+    init() {}
+
+    private enum CodingKeys: String, CodingKey { case version, entries }
 }
 
 /// One row in the Project Activity log.
@@ -12,6 +22,33 @@ struct GenerationLogEntry: Codable, Sendable, Equatable, Identifiable {
     let model: String
     let cost: Double?
     let createdAt: Date?
+    var assetId: String?
+    var assetName: String?
+    var assetType: ClipType?
+    var folderId: String?
+    var generationInput: GenerationInput?
+
+    init(
+        id: String = UUID().uuidString,
+        model: String,
+        cost: Double?,
+        createdAt: Date?,
+        assetId: String? = nil,
+        assetName: String? = nil,
+        assetType: ClipType? = nil,
+        folderId: String? = nil,
+        generationInput: GenerationInput? = nil
+    ) {
+        self.id = id
+        self.model = model
+        self.cost = cost
+        self.createdAt = createdAt
+        self.assetId = assetId
+        self.assetName = assetName
+        self.assetType = assetType
+        self.folderId = folderId
+        self.generationInput = generationInput
+    }
 }
 
 @MainActor
@@ -28,6 +65,20 @@ extension GenerationLogEntry {
         case .upscale?: "arrow.up.right.square.fill"
         case nil:       "sparkles"
         }
+    }
+
+    init(asset: MediaAsset) {
+        let gen = asset.generationInput!
+        self.init(
+            model: gen.model,
+            cost: gen.estimatedCost ?? CostEstimator.cost(for: gen),
+            createdAt: gen.createdAt,
+            assetId: asset.id,
+            assetName: asset.name,
+            assetType: asset.type,
+            folderId: asset.folderId,
+            generationInput: gen
+        )
     }
 }
 
@@ -49,24 +100,18 @@ extension EditorViewModel {
     }
 
     func appendGenerationLog(for asset: MediaAsset) {
-        guard let gen = asset.generationInput else { return }
-        generationLog.entries.append(GenerationLogEntry(
-            model: gen.model,
-            cost: gen.estimatedCost ?? CostEstimator.cost(for: gen),
-            createdAt: gen.createdAt
-        ))
+        guard asset.generationInput != nil else { return }
+        generationLog.version = 2
+        generationLog.entries.append(GenerationLogEntry(asset: asset))
     }
 
     /// For old projects saved before the persistent log existed:
     func seedGenerationLogFromAssets() {
         guard generationLog.entries.isEmpty else { return }
+        generationLog.version = 2
         generationLog.entries = mediaAssets.compactMap { asset in
-            guard let gen = asset.generationInput else { return nil }
-            return GenerationLogEntry(
-                model: gen.model,
-                cost: gen.estimatedCost ?? CostEstimator.cost(for: gen),
-                createdAt: gen.createdAt
-            )
+            guard asset.generationInput != nil else { return nil }
+            return GenerationLogEntry(asset: asset)
         }
     }
 }


### PR DESCRIPTION
Persist prompts, asset identity, and reference IDs at log time so deleted assets remain auditable for cost and prompt analysis.

---

📊 This PR enhances the generation log system to capture comprehensive metadata about AI generations, including prompts, asset identity, and reference IDs, ensuring that cost and prompt analysis remains possible even after assets are deleted.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Schema Evolution**: Upgraded `GenerationLog` version from 1 to 2 with backward-compatible deserialization
- **Enhanced Metadata**: Added `assetId`, `assetName`, `assetType`, `folderId`, and `generationInput` fields to `GenerationLogEntry`
- **Improved Constructors**: Added convenience initializer for creating log entries directly from `MediaAsset` objects
- **Refactored Logging**: Simplified generation log appending logic by leveraging the new asset-based constructor

### Technical Implementation
```mermaid
sequenceDiagram
    participant VM as EditorViewModel
    participant Asset as MediaAsset
    participant Log as GenerationLog
    participant Entry as GenerationLogEntry
    
    VM->>Asset: appendGenerationLog(for: asset)
    Asset->>Entry: GenerationLogEntry(asset: asset)
    Entry->>Entry: Extract metadata (id, name, type, folder, input)
    Entry->>Log: Append to entries
    Log->>Log: Set version = 2
```

### Impact
- **Data Persistence**: Generation metadata is now fully preserved even when source assets are deleted, enabling comprehensive audit trails
- **Cost Analysis**: Enhanced ability to analyze generation costs and patterns across the project lifecycle
- **Backward Compatibility**: Graceful handling of older log formats through custom decoder implementation
- **Code Maintainability**: Cleaner, more maintainable code through consolidated constructor logic and reduced duplication

</details>

_Created with [Palmier](https://www.palmier.io)_