### PR TITLE
rewrite xmeml 4 export

### DIFF
--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 /// Exports a Timeline as XMEML 4 (Final Cut Pro 7 XML)
@@ -55,6 +56,8 @@ enum XMLExporter {
         /// Clip id → position within its media type, used to emit `<link>` cross-references.
         private var clipAddresses: [String: ClipAddress] = [:]
         private var clipsByLinkGroup: [String: [Clip]] = [:]
+        /// Source start timecode (frames) per media ref; nil = no timecode track. Avoids re-reading per file.
+        private var startFrameCache: [String: Int?] = [:]
 
         private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
         private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
@@ -186,8 +189,17 @@ enum XMLExporter {
             emittedFiles.insert(key)
 
             let entry = resolver.entry(for: mediaRef)
-            let pathUrl = resolver.resolveURL(for: mediaRef)?.absoluteString ?? "media/\(mediaRef)"
-            let durationFrames = entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0
+            let url = resolver.resolveURL(for: mediaRef)
+            // Resolve matches media by exact filename + extension.
+            let fileName = url?.lastPathComponent ?? entry?.name ?? mediaRef
+            // Resolve needs Premiere's extra-slash host form; the canonical single-slash one fails.
+            let pathUrl = url
+                .map { $0.absoluteString.replacingOccurrences(of: "file://", with: "file://localhost//") }
+                ?? "media/\(mediaRef)"
+            // A still decodes to exactly 1 frame; Resolve marks it offline if the file declares more than
+            // that, so stills report duration 1 (matching DaVinci's own export) rather than the held length.
+            let isImage = entry?.type == .image
+            let durationFrames = isImage ? 1 : (entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0)
             // NTSC flag follows the source's real fps (29.97 → TRUE), avoiding 0.1% sync drift.
             let (timebase, ntsc) = rateTags(forFPS: entry?.sourceFPS ?? Double(fps))
 
@@ -196,7 +208,7 @@ enum XMLExporter {
                     el("samplecharacteristics", [leaf("samplerate", 48000), leaf("depth", 16)]),
                     leaf("channelcount", 2),
                   ])])
-                : el("media", [el("video", [el("samplecharacteristics", [
+                : el("media", [el("video", (isImage ? [leaf("duration", 1)] : []) + [el("samplecharacteristics", [
                     leaf("width", entry?.sourceWidth ?? seqWidth),
                     leaf("height", entry?.sourceHeight ?? seqHeight),
                     bool("anamorphic", false),
@@ -205,13 +217,63 @@ enum XMLExporter {
                     rate(timebase, ntsc: ntsc),
                   ])])])
 
+            // timecode is required for Davinci Resolve. Either read from source or emit a dummy 00:00:00:00.
+            let dropFrame = ntsc && timebase % 30 == 0
+            let startFrame = sourceStartFrame(for: mediaRef) ?? 0
+            let timecode = el("timecode", [
+                rate(timebase, ntsc: ntsc),
+                leaf("string", formatTimecode(frame: startFrame, fps: timebase, dropFrame: dropFrame)),
+                leaf("frame", startFrame),
+                leaf("displayformat", dropFrame ? "DF" : "NDF"),
+            ])
             return el("file", attrs: [("id", fileId)], [
-                leaf("name", entry?.name ?? mediaRef),
+                leaf("name", fileName),
                 leaf("pathurl", pathUrl),
                 rate(timebase, ntsc: ntsc),
                 leaf("duration", durationFrames),
+                timecode,
                 media,
             ])
+        }
+
+        /// Source start timecode — one read serves both the video and audio file nodes.
+        private func sourceStartFrame(for mediaRef: String) -> Int? {
+            if let cached = startFrameCache[mediaRef] { return cached }
+            let frame = resolver.resolveURL(for: mediaRef).flatMap(Builder.readStartTimecodeFrame)
+            startFrameCache[mediaRef] = frame
+            return frame
+        }
+
+        /// Start frame from the QuickTime `tmcd` track; skip the leading edit-boundary buffer (no data buffer).
+        private static func readStartTimecodeFrame(url: URL) -> Int? {
+            let asset = AVURLAsset(url: url)
+            guard let track = asset.tracks(withMediaType: .timecode).first,
+                  let reader = try? AVAssetReader(asset: asset) else { return nil }
+            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+            guard reader.canAdd(output) else { return nil }
+            reader.add(output)
+            guard reader.startReading() else { return nil }
+            while let sample = output.copyNextSampleBuffer() {
+                guard let block = CMSampleBufferGetDataBuffer(sample) else { continue }
+                var be: UInt32 = 0
+                guard CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: 4, destination: &be) == kCMBlockBufferNoErr
+                else { return nil }
+                return Int(UInt32(bigEndian: be))
+            }
+            return nil
+        }
+
+        /// Frame count → SMPTE string; drop-frame (29.97/59.94) uses `;` separators and skips dropped frames.
+        private func formatTimecode(frame: Int, fps: Int, dropFrame: Bool) -> String {
+            var f = frame
+            if dropFrame {
+                let drop = Int((Double(fps) * 0.066666).rounded())   // 2 @ 30, 4 @ 60
+                let d = f / (fps * 600), m = f % (fps * 600)
+                f += drop * 9 * d + (m > drop ? drop * ((m - drop) / (fps * 60)) : 0)
+            }
+            let sep = dropFrame ? ";" : ":"
+            let ff = f % fps, ss = (f / fps) % 60, mm = (f / (fps * 60)) % 60, hh = f / (fps * 3600)
+            return String(format: "%02d\(sep)%02d\(sep)%02d\(sep)%02d", hh, mm, ss, ff)
         }
 
         // MARK: - Links

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -196,11 +196,9 @@ enum XMLExporter {
             let pathUrl = url
                 .map { $0.absoluteString.replacingOccurrences(of: "file://", with: "file://localhost//") }
                 ?? "media/\(mediaRef)"
-            // A still decodes to exactly 1 frame; Resolve marks it offline if the file declares more than
-            // that, so stills report duration 1 (matching DaVinci's own export) rather than the held length.
+            // A still decodes to exactly 1 frame
             let isImage = entry?.type == .image
             let durationFrames = isImage ? 1 : (entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0)
-            // NTSC flag follows the source's real fps (29.97 → TRUE), avoiding 0.1% sync drift.
             let (timebase, ntsc) = rateTags(forFPS: entry?.sourceFPS ?? Double(fps))
 
             let media: XMLNode = isAudio

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -1,6 +1,39 @@
 import Foundation
 
-/// Exports a timeline as XMEML 4 (FCP7 XML) — compatible with Premiere Pro, DaVinci Resolve, Final Cut Pro.
+/// Exports a Timeline as XMEML 4 (Final Cut Pro 7 XML)
+///
+/// There are two formats for timeline data: XMEML and FCPXML.
+/// FCPXML is the newer format that supports more features. But Premiere Pro does not support it natively.
+/// If we choose FCPXML, users need to use DaVinci as a bridge or 3rd party software to translate .fcpxml to .xml.
+/// Premiere Pro is the current priority so we went with XMEML, even tho its already deprecated.
+///
+/// How to read this file: the document is built as an `XMLNode` tree (defined at the bottom).
+/// Every `el(...)` / `leaf(...)` call is one XML element; `render` owns all indentation and
+/// escaping, so no emitter hardcodes whitespace. Read `build()` top-down to see the format: the
+/// `<xmeml><sequence><media>` shell, then tracks → clipitems → files / filters / links.
+///
+/// What transports:
+/// - Clip placement & trims → `<clipitem>` `<start>`/`<end>`/`<in>`/`<out>`
+/// - Speed → Time Remap filter
+/// - Volume (static + keyframed) → Audio Levels filter
+/// - Opacity (static + keyframed) → its own Opacity filter
+/// - Transform — scale / rotation / position (static + keyframed) → Basic Motion filter
+/// - Crop (static + keyframed) → Crop filter
+/// - Fade in/out → single-sided transition (Cross Dissolve for video, Cross Fade for audio)
+/// - Linked A/V clips → reciprocal `<link>` blocks
+/// - Source frame rate → per-file NTSC flag (29.97/23.976/59.94 → ntsc TRUE)
+///
+/// What does NOT transport:
+/// - Text overlays. FCPXML supports this, not XMEML.
+/// - Flips (horizontal/vertical)
+/// - Keyframe interpolation curves (linear/hold/smooth): keyframes import with default easing
+///
+/// Coordinates are in timeline frames; FCP7 rotation is counter-clockwise-positive, so we negate our clockwise-positive values.
+/// 
+/// References:
+/// XMEML: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/FinalCutPro_XML/VersionsoftheInterchangeFormat/VersionsoftheInterchangeFormat.html
+/// FCPXML: https://developer.apple.com/documentation/professional-video-applications/fcpxml-reference
+
 enum XMLExporter {
 
     static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) {
@@ -19,22 +52,12 @@ enum XMLExporter {
 
         /// Files already emitted in full; repeat references collapse to `<file id="..."/>`.
         private var emittedFiles: Set<FileKey> = []
-
         /// Clip id → position within its media type, used to emit `<link>` cross-references.
         private var clipAddresses: [String: ClipAddress] = [:]
-
         private var clipsByLinkGroup: [String: [Clip]] = [:]
 
-        private struct FileKey: Hashable {
-            let mediaRef: String
-            let isAudio: Bool
-        }
-
-        private struct ClipAddress {
-            let trackIndex: Int   // 1-based
-            let clipIndex: Int    // 1-based
-            let isAudio: Bool
-        }
+        private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
+        private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
 
         init(timeline: Timeline, resolver: MediaResolver) {
             self.timeline = timeline
@@ -44,94 +67,312 @@ enum XMLExporter {
             self.seqHeight = timeline.height
         }
 
+        // MARK: - Document shell
+
         func build() -> String {
             // FCP XML orders video tracks bottom→top; our model stores them top→bottom.
             let videoTracks = Array(timeline.tracks.filter { $0.type.isVisual }.reversed())
             let audioTracks = timeline.tracks.filter { $0.type == .audio }
+            let sortedVideo = videoTracks.map(sortEmittable)
+            let sortedAudio = audioTracks.map(sortEmittable)
 
-            let sortedVideo = videoTracks.map { sortEmittable($0) }
-            let sortedAudio = audioTracks.map { sortEmittable($0) }
             indexAddresses(sortedVideo, isAudio: false)
             indexAddresses(sortedAudio, isAudio: true)
             indexLinkGroups()
 
-            let videoTracksXml = zip(videoTracks, sortedVideo)
-                .map { buildTrack($0.0, sortedClips: $0.1, isAudio: false) }
-                .joined(separator: "\n")
-            let audioTracksXml = zip(audioTracks, sortedAudio)
-                .map { buildTrack($0.0, sortedClips: $0.1, isAudio: true) }
-                .joined(separator: "\n")
+            let videoTrackNodes = zip(videoTracks, sortedVideo).map { trackNode($0, sortedClips: $1, isAudio: false) }
+            let audioTrackNodes = zip(audioTracks, sortedAudio).map { trackNode($0, sortedClips: $1, isAudio: true) }
 
-            return """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE xmeml>
-            <xmeml version="4">
-              <sequence id="sequence-1">
-                <name>Timeline Export</name>
-                <duration>\(timeline.totalFrames)</duration>
-                <rate>
-                  <timebase>\(fps)</timebase>
-                  <ntsc>FALSE</ntsc>
-                </rate>
-                <timecode>
-                  <rate>
-                    <timebase>\(fps)</timebase>
-                    <ntsc>FALSE</ntsc>
-                  </rate>
-                  <string>00:00:00:00</string>
-                  <frame>0</frame>
-                  <source>source</source>
-                  <displayformat>NDF</displayformat>
-                </timecode>
-                <media>
-                  <video>
-                    <format>
-                      <samplecharacteristics>
-                        <width>\(seqWidth)</width>
-                        <height>\(seqHeight)</height>
-                        <anamorphic>FALSE</anamorphic>
-                        <pixelaspectratio>square</pixelaspectratio>
-                        <fielddominance>none</fielddominance>
-                        <rate>
-                          <timebase>\(fps)</timebase>
-                          <ntsc>FALSE</ntsc>
-                        </rate>
-                      </samplecharacteristics>
-                    </format>
-            \(videoTracksXml)
-                  </video>
-                  <audio>
-                    <numOutputChannels>2</numOutputChannels>
-                    <format>
-                      <samplecharacteristics>
-                        <samplerate>48000</samplerate>
-                        <depth>16</depth>
-                      </samplecharacteristics>
-                    </format>
-                    <outputs>
-                      <group>
-                        <index>1</index>
-                        <numchannels>2</numchannels>
-                        <downmix>0</downmix>
-                        <channel>
-                          <index>1</index>
-                        </channel>
-                        <channel>
-                          <index>2</index>
-                        </channel>
-                      </group>
-                    </outputs>
-            \(audioTracksXml)
-                  </audio>
-                </media>
-              </sequence>
-            </xmeml>
-            """
+            let root = el("xmeml", attrs: [("version", "4")], [
+                el("sequence", attrs: [("id", "sequence-1")], [
+                    leaf("name", "Timeline Export"),
+                    leaf("duration", timeline.totalFrames),
+                    rate(fps),
+                    timecodeNode(),
+                    el("media", [
+                        el("video", [videoFormatNode()] + videoTrackNodes),
+                        el("audio", [leaf("numOutputChannels", 2), audioFormatNode(), audioOutputsNode()] + audioTrackNodes),
+                    ]),
+                ]),
+            ])
+            return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE xmeml>\n" + render(root, indent: 0)
         }
 
-        // MARK: - Indexing
+        private func timecodeNode() -> XMLNode {
+            el("timecode", [
+                rate(fps),
+                leaf("string", "00:00:00:00"),
+                leaf("frame", 0),
+                leaf("source", "source"),
+                leaf("displayformat", "NDF"),
+            ])
+        }
 
-        /// Drops unresolvable clips here so track builders and `<link>` indices agree.
+        private func videoFormatNode() -> XMLNode {
+            el("format", [el("samplecharacteristics", [
+                leaf("width", seqWidth),
+                leaf("height", seqHeight),
+                bool("anamorphic", false),
+                leaf("pixelaspectratio", "square"),
+                leaf("fielddominance", "none"),
+                rate(fps),
+            ])])
+        }
+
+        private func audioFormatNode() -> XMLNode {
+            el("format", [el("samplecharacteristics", [leaf("samplerate", 48000), leaf("depth", 16)])])
+        }
+
+        private func audioOutputsNode() -> XMLNode {
+            el("outputs", [el("group", [
+                leaf("index", 1),
+                leaf("numchannels", 2),
+                leaf("downmix", 0),
+                el("channel", [leaf("index", 1)]),
+                el("channel", [leaf("index", 2)]),
+            ])])
+        }
+
+        // MARK: - Tracks → clipitems
+
+        private func trackNode(_ track: Track, sortedClips: [Clip], isAudio: Bool) -> XMLNode {
+            let enabled = isAudio ? !track.muted : !track.hidden
+            var children: [XMLNode] = [bool("enabled", enabled), bool("locked", false)]
+            for clip in sortedClips {
+                if let fadeIn = fadeTransition(clip, edge: .left, isAudio: isAudio) { children.append(fadeIn) }
+                children.append(clipItemNode(clip, isAudio: isAudio))
+                if let fadeOut = fadeTransition(clip, edge: .right, isAudio: isAudio) { children.append(fadeOut) }
+            }
+            return el("track", children)
+        }
+
+        private func clipItemNode(_ clip: Clip, isAudio: Bool) -> XMLNode {
+            let sourceDuration = sourceDurationFrames(for: clip.mediaRef) ?? clip.sourceDurationFrames
+            // in/out are source-frame offsets, so they span sourceFramesConsumed (Time Remap handles rate).
+            let inPoint = clip.trimStartFrame
+            let outPoint = clip.trimStartFrame + clip.sourceFramesConsumed
+
+            var children: [XMLNode] = [
+                leaf("masterclipid", masterclipId(for: clip, isAudio: isAudio)),
+                leaf("name", resolver.displayName(for: clip.mediaRef)),
+                bool("enabled", true),
+                leaf("duration", sourceDuration),
+                rate(fps),
+                leaf("start", clip.startFrame),
+                leaf("end", clip.endFrame),
+                leaf("in", inPoint),
+                leaf("out", outPoint),
+                fileNode(for: clip.mediaRef, isAudio: isAudio),
+            ]
+            if let remap = timeRemapFilter(speed: clip.speed, isAudio: isAudio) { children.append(remap) }
+            children += isAudio ? volumeFilters(clip) : videoFilters(clip)
+            children += linkNodes(for: clip)
+            return el("clipitem", attrs: [("id", "clipitem-\(clip.id)")], children)
+        }
+
+        private func masterclipId(for clip: Clip, isAudio: Bool) -> String {
+            if let group = clip.linkGroupId { return "masterclip-\(group)" }
+            return "masterclip-\(clip.mediaRef)-\(isAudio ? "audio" : "video")"
+        }
+
+        // MARK: - File elements
+
+        /// Separate ids per media type — Premiere rejects a clipitem pointing at a `<file>` of the
+        /// wrong type. Repeats collapse to a self-closing `<file id="..."/>`.
+        private func fileNode(for mediaRef: String, isAudio: Bool) -> XMLNode {
+            let fileId = "file-\(mediaRef)-\(isAudio ? "audio" : "video")"
+            let key = FileKey(mediaRef: mediaRef, isAudio: isAudio)
+            if emittedFiles.contains(key) { return el("file", attrs: [("id", fileId)]) }
+            emittedFiles.insert(key)
+
+            let entry = resolver.entry(for: mediaRef)
+            let pathUrl = resolver.resolveURL(for: mediaRef)?.absoluteString ?? "media/\(mediaRef)"
+            let durationFrames = entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0
+            // NTSC flag follows the source's real fps (29.97 → TRUE), avoiding 0.1% sync drift.
+            let (timebase, ntsc) = rateTags(forFPS: entry?.sourceFPS ?? Double(fps))
+
+            let media: XMLNode = isAudio
+                ? el("media", [el("audio", [
+                    el("samplecharacteristics", [leaf("samplerate", 48000), leaf("depth", 16)]),
+                    leaf("channelcount", 2),
+                  ])])
+                : el("media", [el("video", [el("samplecharacteristics", [
+                    leaf("width", entry?.sourceWidth ?? seqWidth),
+                    leaf("height", entry?.sourceHeight ?? seqHeight),
+                    bool("anamorphic", false),
+                    leaf("pixelaspectratio", "square"),
+                    leaf("fielddominance", "none"),
+                    rate(timebase, ntsc: ntsc),
+                  ])])])
+
+            return el("file", attrs: [("id", fileId)], [
+                leaf("name", entry?.name ?? mediaRef),
+                leaf("pathurl", pathUrl),
+                rate(timebase, ntsc: ntsc),
+                leaf("duration", durationFrames),
+                media,
+            ])
+        }
+
+        // MARK: - Links
+
+        /// Linked clips emit a `<link>` per partner so Premiere rebuilds the A/V pair.
+        private func linkNodes(for clip: Clip) -> [XMLNode] {
+            guard let group = clip.linkGroupId,
+                  let partners = clipsByLinkGroup[group], partners.count > 1 else { return [] }
+            return partners.compactMap { partner in
+                guard let addr = clipAddresses[partner.id] else { return nil }
+                return el("link", [
+                    leaf("linkclipref", "clipitem-\(partner.id)"),
+                    leaf("mediatype", addr.isAudio ? "audio" : "video"),
+                    leaf("trackindex", addr.trackIndex),
+                    leaf("clipindex", addr.clipIndex),
+                ])
+            }
+        }
+
+        // MARK: - Transitions (fades)
+
+        /// A fade exports as a single-sided dissolve to black/silence (no clip-to-clip model).
+        private func fadeTransition(_ clip: Clip, edge: FadeEdge, isAudio: Bool) -> XMLNode? {
+            let frames = clip.fadeFrames(edge)
+            guard frames > 0 else { return nil }
+
+            let start: Int, end: Int, alignment: String, cutFrames: Int
+            switch edge {
+            case .left:  start = clip.startFrame;          end = clip.startFrame + frames; alignment = "start-black"; cutFrames = 0
+            case .right: start = clip.endFrame - frames;   end = clip.endFrame;            alignment = "end-black";   cutFrames = frames
+            }
+
+            var children: [XMLNode] = [leaf("start", start), leaf("end", end), leaf("alignment", alignment)]
+            if isAudio {
+                children.append(rate(fps))
+                children.append(effect(name: "Cross Fade ( 0dB)", id: "KGAudioTransCrossFade0dB", type: "transition", mediatype: "audio"))
+            } else {
+                // Premiere's private cut-point, in ticks (254016000000/sec): 0 for fade-in, full length for fade-out.
+                let cutPointTicks = Int64(cutFrames) * (Int64(254_016_000_000) / Int64(fps))
+                children.append(leaf("cutPointTicks", String(cutPointTicks)))
+                children.append(rate(fps))
+                children.append(effect(name: "Cross Dissolve", id: "Cross Dissolve", type: "transition", mediatype: "video", category: "Dissolve", body: [
+                    leaf("wipecode", 0),
+                    leaf("wipeaccuracy", 100),
+                    leaf("startratio", 0),
+                    leaf("endratio", 1),
+                    bool("reverse", false),
+                ]))
+            }
+            return el("transitionitem", children)
+        }
+
+        // MARK: - Filters
+
+        /// Premiere needs this to apply speed; it won't infer it from the in/out vs start/end ratio.
+        private func timeRemapFilter(speed: Double, isAudio: Bool) -> XMLNode? {
+            guard speed != 1.0 else { return nil }
+            return filter(effect(name: "Time Remap", id: "timeremap", type: "motion", mediatype: isAudio ? "audio" : "video", body: [
+                parameter(id: "variablespeed", name: "variablespeed", min: "0", max: "1", value: leaf("value", 0)),
+                parameter(id: "speed", name: "speed", min: "-100000", max: "100000", value: leaf("value", String(format: "%.4f", speed * 100))),
+                parameter(id: "reverse", name: "reverse", value: bool("value", false)),
+                parameter(id: "frameblending", name: "frameblending", value: bool("value", false)),
+            ]))
+        }
+
+        /// `level` is linear (1 = 0 dB, clamped to ~3.98). Uses fade-excluded volume since fades
+        /// export separately as a transition.
+        private func volumeFilters(_ clip: Clip) -> [XMLNode] {
+            func clampLevel(_ v: Double) -> Double { max(0, min(v, 3.98)) }
+            let frames = clip.keyframeFrames(for: .volume)
+            let level: XMLNode
+            if frames.isEmpty {
+                guard clip.volume != 1.0 else { return [] }
+                level = scalarParam(id: "level", name: "Level", min: "0", max: "3.98107", base: clampLevel(clip.volume), spec: "%.4f")
+            } else {
+                let kfs = frames.map { (when: $0 - clip.startFrame, value: clampLevel(clip.rawVolumeAt(frame: $0))) }
+                level = scalarParam(id: "level", name: "Level", min: "0", max: "3.98107", base: kfs[0].value, keyframes: kfs, spec: "%.4f")
+            }
+            return [filter(effect(name: "Audio Levels", id: "audiolevels", type: "audio", mediatype: "audio", body: [level]))]
+        }
+
+        private func videoFilters(_ clip: Clip) -> [XMLNode] {
+            [motionFilter(clip), cropFilter(clip), opacityFilter(clip)].compactMap { $0 }
+        }
+
+        /// Basic Motion: scale, rotation, center — keyframed, or static (defaults omitted).
+        private func motionFilter(_ clip: Clip) -> XMLNode? {
+            let sourceWidth = resolver.entry(for: clip.mediaRef)?.sourceWidth ?? 0
+            func scalePct(_ width: Double) -> Double {
+                sourceWidth > 0 ? (Double(seqWidth) / Double(sourceWidth)) * width * 100 : width * 100
+            }
+
+            // FCP7 center uses normalized coordinates (0 = center), not pixels.
+            func center(_ t: Transform) -> (x: Double, y: Double) {
+                (t.centerX - 0.5, t.centerY - 0.5)
+            }
+
+            // Center depends on position + scale, so sample all transform params at the union of frames.
+            let frames = Set(clip.keyframeFrames(for: .position)
+                + clip.keyframeFrames(for: .scale)
+                + clip.keyframeFrames(for: .rotation)).sorted()
+
+            var params: [XMLNode] = []
+            if frames.isEmpty {
+                let t = clip.transform
+                let c = center(t), scaled = scalePct(t.width), rotated = -t.rotation
+                let needsCenter = abs(c.x) > 0.001 || abs(c.y) > 0.001   // normalized, so a small epsilon
+                let needsScale = abs(scaled - 100) > 0.1
+                let needsRotation = abs(rotated) > 0.05
+                guard needsCenter || needsScale || needsRotation else { return nil }
+                if needsScale { params.append(scalarParam(id: "scale", name: "Scale", min: "0", max: "1000", base: scaled)) }
+                if needsRotation { params.append(scalarParam(id: "rotation", name: "Rotation", min: "-100000", max: "100000", base: rotated)) }
+                if needsCenter { params.append(centerParam(base: c)) }
+            } else {
+                let scaleKfs = frames.map { (when: $0 - clip.startFrame, value: scalePct(clip.sizeAt(frame: $0).width)) }
+                let rotationKfs = frames.map { (when: $0 - clip.startFrame, value: -clip.rotationAt(frame: $0)) }
+                let centerKfs = frames.map { f -> (when: Int, x: Double, y: Double) in
+                    let c = center(clip.transformAt(frame: f)); return (f - clip.startFrame, c.x, c.y)
+                }
+                params = [
+                    scalarParam(id: "scale", name: "Scale", min: "0", max: "1000", base: scaleKfs[0].value, keyframes: scaleKfs),
+                    scalarParam(id: "rotation", name: "Rotation", min: "-100000", max: "100000", base: rotationKfs[0].value, keyframes: rotationKfs),
+                    centerParam(base: (centerKfs[0].x, centerKfs[0].y), keyframes: centerKfs),
+                ]
+            }
+            return filter(effect(name: "Basic Motion", id: "basic", type: "motion", mediatype: "video", body: params))
+        }
+
+        /// Crop filter — edge insets as 0–100 percentages (our model stores 0–1 fractions).
+        private func cropFilter(_ clip: Clip) -> XMLNode? {
+            let frames = clip.keyframeFrames(for: .crop)
+            if frames.isEmpty && clip.crop.isIdentity { return nil }
+
+            func edge(_ id: String, _ kp: KeyPath<Crop, Double>) -> XMLNode {
+                if frames.isEmpty {
+                    return scalarParam(id: id, name: id, min: "0", max: "100", base: clip.crop[keyPath: kp] * 100)
+                }
+                let kfs = frames.map { (when: $0 - clip.startFrame, value: clip.cropAt(frame: $0)[keyPath: kp] * 100) }
+                return scalarParam(id: id, name: id, min: "0", max: "100", base: kfs[0].value, keyframes: kfs)
+            }
+            let params = [edge("left", \.left), edge("right", \.right), edge("top", \.top), edge("bottom", \.bottom)]
+            return filter(effect(name: "Crop", id: "crop", type: "motion", mediatype: "video", category: "motion", body: params))
+        }
+
+        /// FCP7 keeps opacity in its own Opacity effect (Basic Motion has no opacity parameter).
+        private func opacityFilter(_ clip: Clip) -> XMLNode? {
+            let frames = clip.keyframeFrames(for: .opacity)
+            let opacity: XMLNode
+            if frames.isEmpty {
+                guard clip.opacity != 1.0 else { return nil }
+                opacity = scalarParam(id: "opacity", name: "Opacity", min: "0", max: "100", base: clip.opacity * 100, spec: "%.1f")
+            } else {
+                let kfs = frames.map { (when: $0 - clip.startFrame, value: clip.rawOpacityAt(frame: $0) * 100) }
+                opacity = scalarParam(id: "opacity", name: "Opacity", min: "0", max: "100", base: kfs[0].value, keyframes: kfs, spec: "%.1f")
+            }
+            return filter(effect(name: "Opacity", id: "opacity", type: "motion", mediatype: "video", body: [opacity]))
+        }
+
+        // MARK: - Indexing helpers
+
+        /// Drops unresolvable clips so track builders and `<link>` indices agree.
         private func sortEmittable(_ track: Track) -> [Clip] {
             track.clips
                 .filter { resolver.resolveURL(for: $0.mediaRef) != nil }
@@ -155,320 +396,102 @@ enum XMLExporter {
             }
         }
 
-        // MARK: - Tracks
-
-        private func buildTrack(_ track: Track, sortedClips: [Clip], isAudio: Bool) -> String {
-            let enabled = isAudio ? !track.muted : !track.hidden
-            let body = sortedClips.map { clip -> String in
-                let mediaFilter = isAudio ? buildVolumeFilter(for: clip) : buildVideoFilters(clip)
-                let inner = buildFileElement(for: clip.mediaRef, isAudio: isAudio)
-                    + buildTimeRemapFilter(speed: clip.speed, isAudio: isAudio)
-                    + mediaFilter
-                    + buildLinks(for: clip)
-                return clipItemXml(clip: clip, isAudio: isAudio, inner: inner)
-            }.joined(separator: "\n")
-
-            return """
-                    <track>
-                      <enabled>\(enabled ? "TRUE" : "FALSE")</enabled>
-                      <locked>FALSE</locked>
-            \(body)
-                    </track>
-            """
-        }
-
-        // MARK: - Clipitem
-
-        private func clipItemXml(clip: Clip, isAudio: Bool, inner: String) -> String {
-            let name = resolver.displayName(for: clip.mediaRef)
-            let sourceDuration = sourceDurationFrames(for: clip.mediaRef) ?? clip.sourceDurationFrames
-            // <in>/<out> are source-frame offsets, so use sourceFramesConsumed (not the
-            // timeline durationFrames). The Time Remap filter handles the rate conversion.
-            let inPt = clip.trimStartFrame
-            let outPt = clip.trimStartFrame + clip.sourceFramesConsumed
-            return """
-                      <clipitem id="clipitem-\(esc(clip.id))">
-                        <masterclipid>\(esc(masterclipId(for: clip, isAudio: isAudio)))</masterclipid>
-                        <name>\(esc(name))</name>
-                        <enabled>TRUE</enabled>
-                        <duration>\(sourceDuration)</duration>
-                        <rate>
-                          <timebase>\(fps)</timebase>
-                          <ntsc>FALSE</ntsc>
-                        </rate>
-                        <start>\(clip.startFrame)</start>
-                        <end>\(clip.endFrame)</end>
-                        <in>\(inPt)</in>
-                        <out>\(outPt)</out>
-            \(inner)
-                      </clipitem>
-            """
-        }
-
-        private func masterclipId(for clip: Clip, isAudio: Bool) -> String {
-            if let group = clip.linkGroupId {
-                return "masterclip-\(group)"
-            }
-            return "masterclip-\(clip.mediaRef)-\(isAudio ? "audio" : "video")"
-        }
-
-        // MARK: - File elements
-
-        /// Separate ids per media type — Premiere rejects an audio clipitem pointing at a
-        /// file whose `<media>` only declares video characteristics, and vice versa.
-        private func buildFileElement(for mediaRef: String, isAudio: Bool) -> String {
-            let fileId = "file-\(mediaRef)-\(isAudio ? "audio" : "video")"
-            let key = FileKey(mediaRef: mediaRef, isAudio: isAudio)
-            if emittedFiles.contains(key) {
-                return """
-
-                        <file id="\(esc(fileId))"/>
-            """
-            }
-            emittedFiles.insert(key)
-
-            let entry = resolver.entry(for: mediaRef)
-            let pathUrl = resolver.resolveURL(for: mediaRef)?.absoluteString ?? "media/\(mediaRef)"
-            let name = entry?.name ?? mediaRef
-            let durationFrames = entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0
-
-            let mediaSec: String
-            if isAudio {
-                mediaSec = """
-                            <audio>
-                              <samplecharacteristics>
-                                <samplerate>48000</samplerate>
-                                <depth>16</depth>
-                              </samplecharacteristics>
-                              <channelcount>2</channelcount>
-                            </audio>
-            """
-            } else {
-                let w = entry?.sourceWidth ?? seqWidth
-                let h = entry?.sourceHeight ?? seqHeight
-                mediaSec = """
-                            <video>
-                              <samplecharacteristics>
-                                <width>\(w)</width>
-                                <height>\(h)</height>
-                                <anamorphic>FALSE</anamorphic>
-                                <pixelaspectratio>square</pixelaspectratio>
-                                <fielddominance>none</fielddominance>
-                                <rate>
-                                  <timebase>\(fps)</timebase>
-                                  <ntsc>FALSE</ntsc>
-                                </rate>
-                              </samplecharacteristics>
-                            </video>
-            """
-            }
-
-            return """
-
-                        <file id="\(esc(fileId))">
-                          <name>\(esc(name))</name>
-                          <pathurl>\(esc(pathUrl))</pathurl>
-                          <rate>
-                            <timebase>\(fps)</timebase>
-                            <ntsc>FALSE</ntsc>
-                          </rate>
-                          <duration>\(durationFrames)</duration>
-                          <media>
-            \(mediaSec)
-                          </media>
-                        </file>
-            """
-        }
-
         private func sourceDurationFrames(for mediaRef: String) -> Int? {
             guard let seconds = resolver.entry(for: mediaRef)?.duration else { return nil }
             return max(0, secondsToFrame(seconds: seconds, fps: fps))
         }
 
-        // MARK: - Links
-
-        /// Partners share a linkGroupId; emitting a `<link>` per partner lets Premiere
-        /// rebuild the A/V pair on import.
-        private func buildLinks(for clip: Clip) -> String {
-            guard let group = clip.linkGroupId,
-                  let partners = clipsByLinkGroup[group],
-                  partners.count > 1 else { return "" }
-
-            return partners.compactMap { partner -> String? in
-                guard let addr = clipAddresses[partner.id] else { return nil }
-                return """
-
-                        <link>
-                          <linkclipref>clipitem-\(esc(partner.id))</linkclipref>
-                          <mediatype>\(addr.isAudio ? "audio" : "video")</mediatype>
-                          <trackindex>\(addr.trackIndex)</trackindex>
-                          <clipindex>\(addr.clipIndex)</clipindex>
-                        </link>
-            """
-            }.joined()
+        /// Real fps → FCP7 (timebase, ntsc). NTSC rates (timebase×1000/1001: 29.97, 23.976, …) set ntsc TRUE.
+        private func rateTags(forFPS rawFps: Double) -> (timebase: Int, ntsc: Bool) {
+            let timebase = max(1, Int(rawFps.rounded()))
+            let ntscRate = Double(timebase) * 1000.0 / 1001.0
+            return (timebase, abs(rawFps - ntscRate) < abs(rawFps - Double(timebase)))
         }
 
-        // MARK: - Filters
+        // MARK: - Effect & parameter builders
 
-        /// Premiere doesn't infer speed from the `<in>`/`<out>` vs `<start>`/`<end>` ratio —
-        /// without this filter, fast clips trim and slow clips black-pad.
-        private func buildTimeRemapFilter(speed: Double, isAudio: Bool) -> String {
-            guard speed != 1.0 else { return "" }
-            let pct = speed * 100
-            return """
-
-                        <filter>
-                          <effect>
-                            <name>Time Remap</name>
-                            <effectid>timeremap</effectid>
-                            <effecttype>motion</effecttype>
-                            <mediatype>\(isAudio ? "audio" : "video")</mediatype>
-                            <parameter>
-                              <parameterid>variablespeed</parameterid>
-                              <name>variablespeed</name>
-                              <valuemin>0</valuemin>
-                              <valuemax>1</valuemax>
-                              <value>0</value>
-                            </parameter>
-                            <parameter>
-                              <parameterid>speed</parameterid>
-                              <name>speed</name>
-                              <valuemin>-100000</valuemin>
-                              <valuemax>100000</valuemax>
-                              <value>\(String(format: "%.4f", pct))</value>
-                            </parameter>
-                            <parameter>
-                              <parameterid>reverse</parameterid>
-                              <name>reverse</name>
-                              <value>FALSE</value>
-                            </parameter>
-                            <parameter>
-                              <parameterid>frameblending</parameterid>
-                              <name>frameblending</name>
-                              <value>FALSE</value>
-                            </parameter>
-                          </effect>
-                        </filter>
-            """
+        private func rate(_ timebase: Int, ntsc: Bool = false) -> XMLNode {
+            el("rate", [leaf("timebase", timebase), bool("ntsc", ntsc)])
         }
 
-        private func buildVolumeFilter(for clip: Clip) -> String {
-            // FCP7 Audio Levels takes one static value, so sample at clip midpoint.
-            let effective = clip.volumeAt(frame: clip.startFrame + clip.durationFrames / 2)
-            guard effective != 1.0 else { return "" }
-            // FCP7 Audio Levels `level` is linear (1 = 0 dB, ~3.98 = +12 dB); out-of-range
-            // values silence the clip in Premiere.
-            let level = max(0, min(effective, 3.98))
-            return """
+        private func filter(_ effect: XMLNode) -> XMLNode { el("filter", [effect]) }
 
-                        <filter>
-                          <effect>
-                            <name>Audio Levels</name>
-                            <effectid>audiolevels</effectid>
-                            <effecttype>audio</effecttype>
-                            <mediatype>audio</mediatype>
-                            <parameter>
-                              <parameterid>level</parameterid>
-                              <name>Level</name>
-                              <valuemin>0</valuemin>
-                              <valuemax>3.98107</valuemax>
-                              <value>\(String(format: "%.4f", level))</value>
-                            </parameter>
-                          </effect>
-                        </filter>
-            """
+        private func effect(name: String, id: String, type: String, mediatype: String,
+                            category: String? = nil, body: [XMLNode] = []) -> XMLNode {
+            var children = [leaf("name", name), leaf("effectid", id)]
+            if let category { children.append(leaf("effectcategory", category)) }
+            children.append(leaf("effecttype", type))
+            children.append(leaf("mediatype", mediatype))
+            children += body
+            return el("effect", children)
         }
 
-        private func buildVideoFilters(_ clip: Clip) -> String {
-            let opacity = clip.opacity
-            let t = clip.transform
-            let cx = (t.centerX - 0.5) * Double(seqWidth)
-            let cy = -(t.centerY - 0.5) * Double(seqHeight)
-
-            let scalePct: Double
-            if let sw = resolver.entry(for: clip.mediaRef)?.sourceWidth, sw > 0 {
-                scalePct = (Double(seqWidth) / Double(sw)) * t.width * 100
-            } else {
-                scalePct = t.width * 100
-            }
-
-            let needsCenter = abs(cx) > 0.1 || abs(cy) > 0.1
-            let needsScale = abs(scalePct - 100) > 0.1
-            // FCP7 Basic Motion rotation is counter-clockwise positive; our model is clockwise positive.
-            let rotationFcp = -t.rotation
-            let needsRotation = abs(rotationFcp) > 0.05
-            guard needsCenter || needsScale || needsRotation || opacity != 1.0 else { return "" }
-
-            var params = ""
-            if needsScale {
-                params += """
-
-                            <parameter>
-                              <parameterid>scale</parameterid>
-                              <name>Scale</name>
-                              <valuemin>0</valuemin>
-                              <valuemax>1000</valuemax>
-                              <value>\(String(format: "%.2f", scalePct))</value>
-                            </parameter>
-                """
-            }
-            if needsRotation {
-                params += """
-
-                            <parameter>
-                              <parameterid>rotation</parameterid>
-                              <name>Rotation</name>
-                              <valuemin>-100000</valuemin>
-                              <valuemax>100000</valuemax>
-                              <value>\(String(format: "%.2f", rotationFcp))</value>
-                            </parameter>
-                """
-            }
-            if needsCenter {
-                params += """
-
-                            <parameter>
-                              <parameterid>center</parameterid>
-                              <name>Center</name>
-                              <value>
-                                <horiz>\(String(format: "%.1f", cx))</horiz>
-                                <vert>\(String(format: "%.1f", cy))</vert>
-                              </value>
-                            </parameter>
-                """
-            }
-            if opacity != 1.0 {
-                params += """
-
-                            <parameter>
-                              <parameterid>opacity</parameterid>
-                              <name>Opacity</name>
-                              <value>\(String(format: "%.1f", opacity * 100))</value>
-                            </parameter>
-                """
-            }
-
-            return """
-
-                        <filter>
-                          <effect>
-                            <name>Basic Motion</name>
-                            <effectid>basic</effectid>
-                            <effecttype>motion</effecttype>
-                            <mediatype>video</mediatype>\(params)
-                          </effect>
-                        </filter>
-            """
+        /// A `<parameter>`; `value` is its `<value>` node, optionally animated by `keyframes`.
+        private func parameter(id: String, name: String, min: String? = nil, max: String? = nil,
+                               value: XMLNode, keyframes: [(when: Int, value: XMLNode)] = []) -> XMLNode {
+            var children = [leaf("parameterid", id), leaf("name", name)]
+            if let min { children.append(leaf("valuemin", min)) }
+            if let max { children.append(leaf("valuemax", max)) }
+            children.append(value)
+            children += keyframes.map { el("keyframe", [leaf("when", $0.when), $0.value]) }
+            return el("parameter", children)
         }
 
-        // MARK: - Escape
+        /// Scalar `<parameter>` whose value (and keyframes) are numbers formatted by `spec`.
+        private func scalarParam(id: String, name: String, min: String, max: String, base: Double,
+                                 keyframes: [(when: Int, value: Double)] = [], spec: String = "%.2f") -> XMLNode {
+            parameter(id: id, name: name, min: min, max: max,
+                      value: leaf("value", String(format: spec, base)),
+                      keyframes: keyframes.map { (when: $0.when, value: leaf("value", String(format: spec, $0.value))) })
+        }
 
-        private func esc(_ str: String) -> String {
-            str.replacingOccurrences(of: "&", with: "&amp;")
-               .replacingOccurrences(of: "<", with: "&lt;")
-               .replacingOccurrences(of: ">", with: "&gt;")
-               .replacingOccurrences(of: "\"", with: "&quot;")
-               .replacingOccurrences(of: "'", with: "&apos;")
+        /// Two-component Center `<parameter>` whose value is a `<horiz>`/`<vert>` pair.
+        private func centerParam(base: (x: Double, y: Double), keyframes: [(when: Int, x: Double, y: Double)] = []) -> XMLNode {
+            func vec(_ x: Double, _ y: Double) -> XMLNode {
+                el("value", [leaf("horiz", String(format: "%.5f", x)), leaf("vert", String(format: "%.5f", y))])
+            }
+            return parameter(id: "center", name: "Center", value: vec(base.x, base.y),
+                             keyframes: keyframes.map { (when: $0.when, value: vec($0.x, $0.y)) })
         }
     }
+}
+
+// MARK: - XML rendering
+
+/// A minimal XML tree. The emitters above describe document *structure*; `render` owns every bit
+/// of whitespace and escaping so no fragment ever hardcodes its own indentation.
+private struct XMLNode {
+    let name: String
+    var attributes: [(String, String)] = []
+    var text: String? = nil        // leaf value → `<name>text</name>`
+    var children: [XMLNode] = []   // empty + no text → self-closing `<name/>`
+}
+
+private func el(_ name: String, _ children: [XMLNode] = []) -> XMLNode {
+    XMLNode(name: name, children: children)
+}
+private func el(_ name: String, attrs: [(String, String)], _ children: [XMLNode] = []) -> XMLNode {
+    XMLNode(name: name, attributes: attrs, children: children)
+}
+private func leaf(_ name: String, _ value: String) -> XMLNode { XMLNode(name: name, text: value) }
+private func leaf(_ name: String, _ value: Int) -> XMLNode { XMLNode(name: name, text: String(value)) }
+private func bool(_ name: String, _ value: Bool) -> XMLNode { XMLNode(name: name, text: value ? "TRUE" : "FALSE") }
+
+private func render(_ node: XMLNode, indent: Int) -> String {
+    let pad = String(repeating: " ", count: indent)
+    let attrs = node.attributes.map { " \($0.0)=\"\(escapeXML($0.1))\"" }.joined()
+    if let text = node.text {
+        return "\(pad)<\(node.name)\(attrs)>\(escapeXML(text))</\(node.name)>"
+    }
+    guard !node.children.isEmpty else { return "\(pad)<\(node.name)\(attrs)/>" }
+    let inner = node.children.map { render($0, indent: indent + 2) }.joined(separator: "\n")
+    return "\(pad)<\(node.name)\(attrs)>\n\(inner)\n\(pad)</\(node.name)>"
+}
+
+private func escapeXML(_ s: String) -> String {
+    s.replacingOccurrences(of: "&", with: "&amp;")
+     .replacingOccurrences(of: "<", with: "&lt;")
+     .replacingOccurrences(of: ">", with: "&gt;")
+     .replacingOccurrences(of: "\"", with: "&quot;")
+     .replacingOccurrences(of: "'", with: "&apos;")
 }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -198,6 +198,16 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         return volume * kfGain * fadeMultiplier(at: frame)
     }
 
+    func rawVolumeAt(frame: Int) -> Double {
+        let kfGain: Double
+        if let track = volumeTrack, track.isActive {
+            kfGain = VolumeScale.linearFromDb(track.sample(at: keyframeOffset(forFrame: frame), fallback: 0))
+        } else {
+            kfGain = 1.0
+        }
+        return volume * kfGain
+    }
+
     /// 0…1 envelope from the fade head/tail ramps.
     func fadeMultiplier(at frame: Int) -> Double {
         let rel = frame - startFrame

--- a/Tests/PalmierProTests/XMLExporterTests.swift
+++ b/Tests/PalmierProTests/XMLExporterTests.swift
@@ -314,7 +314,7 @@ struct XMLExporterTests {
         #expect(!xml.contains("audiolevels"))
     }
 
-    @Test func opacityNotOneEmitsBasicMotionWithOpacity() throws {
+    @Test func opacityNotOneEmitsDedicatedOpacityEffect() throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         var clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 30)
         clip.opacity = 0.5
@@ -324,7 +324,8 @@ struct XMLExporterTests {
         XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
-        #expect(xml.contains("<effectid>basic</effectid>"))
+        // FCP7 keeps opacity in its own Opacity effect, not inside Basic Motion.
+        #expect(xml.contains("<effectid>opacity</effectid>"))
         #expect(xml.contains("<parameterid>opacity</parameterid>"))
         // opacity 0.5 → 50.0%
         #expect(xml.contains("<value>50.0</value>"))
@@ -561,5 +562,221 @@ struct XMLExporterTests {
         if let b = bottomRange, let t = topRange {
             #expect(b.lowerBound < t.lowerBound, "bottom track should appear before top track in FCP XML")
         }
+    }
+
+    // MARK: - Keyframes, crop, transitions, NTSC
+
+    /// Resolver backed by a real temp file so `resolveURL` (which checks `fileExists`) keeps
+    /// the clip; `sourceFPS` drives the file-rate NTSC flag.
+    private func fixture(width: Int = 3840, height: Int = 2160, sourceFPS: Double? = nil) throws -> (MediaResolver, URL) {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kf-\(UUID().uuidString).mov")
+        try Data().write(to: file)
+        var entry = MediaManifestEntry(
+            id: "media-1", name: "Clip", type: .video,
+            source: .external(absolutePath: file.path), duration: 5,
+            sourceWidth: width, sourceHeight: height
+        )
+        entry.sourceFPS = sourceFPS
+        var manifest = MediaManifest()
+        manifest.entries = [entry]
+        return (MediaResolver(manifest: { manifest }, projectURL: { nil }), file)
+    }
+
+    private func export(_ clip: Clip, resolver: MediaResolver) -> String {
+        let track = clip.mediaType == .audio
+            ? Fixtures.audioTrack(clips: [clip])
+            : Fixtures.videoTrack(clips: [clip])
+        let timeline = Fixtures.timeline(tracks: [track])
+        let out = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export-\(UUID().uuidString).xml")
+        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: out)
+        return (try? String(contentsOf: out, encoding: .utf8)) ?? ""
+    }
+
+    @Test func positionKeyframesEmitVaryingCenter() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        // topLeft (0,0) → center (0.5,0.5) → export (0,0); topLeft (0.5,0.5) → center (1,1) → (1920,-1080).
+        var clip = Fixtures.clip(start: 0, duration: 200)
+        clip.positionTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: AnimPair(a: 0.0, b: 0.0)),
+            Keyframe(frame: 100, value: AnimPair(a: 0.5, b: 0.5)),
+        ])
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<parameterid>center</parameterid>"))
+        // Center is normalized (0 = frame center), not pixels, positive toward bottom-right.
+        // topLeft (0.5,0.5) + size 1 → center (1,1) → horiz 0.5, vert 0.5.
+        #expect(xml.contains("<horiz>0.50000</horiz>"))
+        #expect(xml.contains("<vert>0.50000</vert>"))
+    }
+
+    @Test func opacityKeyframesEmittedWithClipRelativeWhen() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        // Clip starts at frame 100; keyframes are stored clip-relative.
+        var clip = Fixtures.clip(start: 100, duration: 200)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 30, value: 1.0),
+            Keyframe(frame: 150, value: 0.5),
+        ])
+        let xml = export(clip, resolver: resolver)
+
+        // Own Opacity effect, not folded into Basic Motion.
+        #expect(xml.contains("<effectid>opacity</effectid>"))
+        // <when> is clip-relative (the stored offset), and values scale to 0–100.
+        #expect(xml.contains("<when>30</when>"))
+        #expect(xml.contains("<value>100.0</value>"))
+        #expect(xml.contains("<when>150</when>"))
+        #expect(xml.contains("<value>50.0</value>"))
+    }
+
+    @Test func volumeKeyframesEmittedOnAudioClip() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(mediaType: .audio, start: 0, duration: 100)
+        clip.volumeTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0),    // 0 dB → linear 1
+            Keyframe(frame: 50, value: -6),  // attenuated
+        ])
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<effectid>audiolevels</effectid>"))
+        #expect(xml.contains("<when>0</when>"))
+        #expect(xml.contains("<when>50</when>"))
+        // A keyframe block lives inside the Level parameter.
+        #expect(xml.contains("<keyframe>"))
+    }
+
+    @Test func fadesEmitSingleSidedCrossDissolveTransitions() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(start: 100, duration: 200)
+        clip.fadeInFrames = 30
+        clip.fadeOutFrames = 20
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<effectid>Cross Dissolve</effectid>"))
+        // Fade-in: start-black spanning [start, start+fadeIn).
+        #expect(xml.contains("<alignment>start-black</alignment>"))
+        #expect(xml.contains("<start>100</start>"))
+        #expect(xml.contains("<end>130</end>"))
+        // Fade-out: end-black spanning [end-fadeOut, end).
+        #expect(xml.contains("<alignment>end-black</alignment>"))
+        #expect(xml.contains("<start>280</start>"))
+        #expect(xml.contains("<end>300</end>"))
+        // The transition precedes its clipitem in document order.
+        let tIdx = try #require(xml.range(of: "start-black"))
+        let cIdx = try #require(xml.range(of: "<clipitem"))
+        #expect(tIdx.lowerBound < cIdx.lowerBound)
+    }
+
+    @Test func audioClipFadesEmitCrossFadeTransitions() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(mediaType: .audio, start: 0, duration: 100)
+        clip.fadeInFrames = 10
+        clip.fadeOutFrames = 15
+        let xml = export(clip, resolver: resolver)
+
+        // Audio uses Cross Fade, not the video Cross Dissolve, and carries no wipe tags.
+        #expect(xml.contains("<effectid>KGAudioTransCrossFade0dB</effectid>"))
+        #expect(xml.contains("<mediatype>audio</mediatype>"))
+        #expect(!xml.contains("Cross Dissolve"))
+        #expect(!xml.contains("<wipecode>"))
+        // Fade-in [0,10) and fade-out [85,100).
+        #expect(xml.contains("<start>0</start>"))
+        #expect(xml.contains("<end>10</end>"))
+        #expect(xml.contains("<start>85</start>"))
+        #expect(xml.contains("<end>100</end>"))
+    }
+
+    @Test func noFadeEmitsNoTransition() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let clip = Fixtures.clip(start: 0, duration: 100)
+        let xml = export(clip, resolver: resolver)
+
+        #expect(!xml.contains("<transitionitem>"))
+    }
+
+    @Test func staticCropEmitsCropFilterAsPercentages() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(start: 0, duration: 100)
+        clip.crop = Crop(left: 0.1, top: 0.25, right: 0.2, bottom: 0.05)
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<effectid>crop</effectid>"))
+        #expect(xml.contains("<parameterid>left</parameterid>"))
+        // 0.1 → 10%, 0.25 → 25%.
+        #expect(xml.contains("<value>10.00</value>"))
+        #expect(xml.contains("<value>25.00</value>"))
+        #expect(!xml.contains("<keyframe>"))
+    }
+
+    @Test func cropKeyframesEmitClipRelativeWhen() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(start: 40, duration: 200)
+        clip.cropTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: Crop()),
+            Keyframe(frame: 60, value: Crop(left: 0.5, top: 0, right: 0, bottom: 0)),
+        ])
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<effectid>crop</effectid>"))
+        #expect(xml.contains("<when>0</when>"))
+        #expect(xml.contains("<when>60</when>"))
+        #expect(xml.contains("<value>50.00</value>"))
+    }
+
+    @Test func identityCropEmitsNoFilter() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let clip = Fixtures.clip(start: 0, duration: 100)
+        let xml = export(clip, resolver: resolver)
+
+        #expect(!xml.contains("<effectid>crop</effectid>"))
+    }
+
+    @Test func ntscSourceMarksFileRateTrue() throws {
+        // 29.97 footage → the <file> rate carries ntsc TRUE, while the sequence stays FALSE.
+        let (resolver, file) = try fixture(sourceFPS: 30000.0 / 1001.0)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let xml = export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
+        #expect(xml.contains("<ntsc>TRUE</ntsc>"))   // the source file
+        #expect(xml.contains("<ntsc>FALSE</ntsc>"))  // the sequence
+    }
+
+    @Test func cleanFpsSourceStaysNtscFalse() throws {
+        let (resolver, file) = try fixture(sourceFPS: 30.0)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let xml = export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
+        #expect(!xml.contains("<ntsc>TRUE</ntsc>"))
+    }
+
+    @Test func noKeyframesStillEmitsStaticValueOnly() throws {
+        let (resolver, file) = try fixture()
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var clip = Fixtures.clip(start: 0, duration: 100)
+        clip.opacity = 0.5
+        let xml = export(clip, resolver: resolver)
+
+        #expect(xml.contains("<effectid>opacity</effectid>"))
+        #expect(!xml.contains("<keyframe>"))
     }
 }


### PR DESCRIPTION
### what is it:

exporting the timeline to the old XMEML 4 format. There are two format:

1. [FCPXML](https://developer.apple.com/documentation/professional-video-applications/fcpxml-reference) - the newer one with more features, currently supported by FCP and Davinci. Not Premiere, so we are not supporting it.
2. [XMEML](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/FinalCutPro_XML/VersionsoftheInterchangeFormat/VersionsoftheInterchangeFormat.html) - the deprecated one. less features, not maintained. but premiere only works with this one. since we only actively test with premiere, we had to go with this one. it still works with davinci and premiere, just less things supported.

### What is tested and supported:
/// - Clip placement & trims → `<clipitem>` `<start>`/`<end>`/`<in>`/`<out>`
/// - Speed → Time Remap filter
/// - Volume (static + keyframed) → Audio Levels filter
/// - Opacity (static + keyframed) → its own Opacity filter
/// - Transform — scale / rotation / position (static + keyframed) → Basic Motion filter
/// - Crop (static + keyframed) → Crop filter
/// - Fade in/out → single-sided transition (Cross Dissolve for video, Cross Fade for audio)
/// - Linked A/V clips → reciprocal `<link>` blocks
/// - Source frame rate → per-file NTSC flag (29.97/23.976/59.94 → ntsc TRUE)

### What is not supported:
/// - Text overlays. FCPXML supports this, not XMEML.
/// - Flips (horizontal/vertical)
/// - Keyframe interpolation curves (linear/hold/smooth): keyframes import with default easing

---

🎬 This PR significantly expands the XMEML 4 export functionality by adding comprehensive support for keyframes, transitions, crop effects, and NTSC handling to improve compatibility with Premiere Pro and DaVinci Resolve.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Keyframe Support**: Added comprehensive keyframe export for opacity, scale, rotation, position, and volume with clip-relative timing
- **Transition Effects**: Implemented fade in/out as single-sided Cross Dissolve (video) and Cross Fade (audio) transitions
- **Crop Filter**: Added static and keyframed crop effect export with percentage-based values
- **NTSC Detection**: Implemented automatic NTSC flag setting based on source frame rates (29.97/23.976/59.94)
- **Position Fixes**: Corrected center coordinate system to use normalized frame coordinates instead of pixels
- **Audio Volume**: Added `rawVolumeAt()` method to separate keyframed volume from fade envelope calculations

### Technical Implementation
```mermaid
flowchart TD
    A[Timeline Export] --> B[Process Clips]
    B --> C{Has Keyframes?}
    C -->|Yes| D[Export Keyframe Effects]
    C -->|No| E[Export Static Values]
    D --> F[Opacity Effect]
    D --> G[Basic Motion Effect]
    D --> H[Audio Levels Effect]
    D --> I[Crop Effect]
    B --> J{Has Fades?}
    J -->|Yes| K[Generate Transitions]
    K --> L[Cross Dissolve - Video]
    K --> M[Cross Fade - Audio]
    B --> N[Check Source FPS]
    N --> O{NTSC Rate?}
    O -->|Yes| P[Set NTSC=TRUE]
    O -->|No| Q[Set NTSC=FALSE]
```

### Impact
- **Enhanced Compatibility**: Significantly improves timeline export compatibility with Premiere Pro and DaVinci Resolve
- **Professional Workflow**: Enables complex animations and effects to transfer between applications with proper keyframe timing
- **Accurate Positioning**: Fixes coordinate system issues that previously caused clips to appear off-screen or inverted
- **Audio Fidelity**: Proper separation of volume keyframes from fade envelopes ensures accurate audio level export
- **Format Compliance**: Better adherence to XMEML 4 specification with proper NTSC flagging and effect structure

</details>

_Created with [Palmier](https://www.palmier.io)_