### PR TITLE
Fix Sentry crashers and startup hangs

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -330,8 +330,9 @@ final class AgentService {
         loop: while !Task.isCancelled {
             resolveOrphanToolUses()
             let apiMsgs = apiMessages()
-            messages.append(AgentMessage(role: .assistant, blocks: []))
-            let assistantIndex = messages.count - 1
+            let assistant = AgentMessage(role: .assistant, blocks: [])
+            messages.append(assistant)
+            let assistantID = assistant.id
 
             do {
                 let stream = client.stream(
@@ -346,45 +347,46 @@ final class AgentService {
                     try Task.checkCancellation()
                     switch event {
                     case .textDelta(let chunk):
-                        appendTextDelta(chunk, toAssistantAt: assistantIndex)
+                        appendTextDelta(chunk, toAssistant: assistantID)
                     case .toolUseComplete(let id, let name, let inputJSON):
-                        messages[assistantIndex].blocks.append(
-                            .toolUse(id: id, name: name, inputJSON: inputJSON)
-                        )
+                        appendToolUse(id: id, name: name, inputJSON: inputJSON, toAssistant: assistantID)
                     case .messageStop(let reason):
                         stopReason = reason
                     }
                 }
 
                 if stopReason == .toolUse {
-                    await runPendingToolUses(assistantIndex: assistantIndex)
+                    await runPendingToolUses(assistantID: assistantID)
                     continue loop
                 }
                 break loop
             } catch is CancellationError {
-                dropEmptyAssistantTurn(at: assistantIndex)
+                dropEmptyAssistantTurn(id: assistantID)
                 break loop
             } catch let err as PalmierClientError {
-                dropEmptyAssistantTurn(at: assistantIndex)
+                dropEmptyAssistantTurn(id: assistantID)
                 streamError = err
                 break loop
             } catch {
-                dropEmptyAssistantTurn(at: assistantIndex)
+                dropEmptyAssistantTurn(id: assistantID)
                 streamError = .upstream(error.localizedDescription)
                 break loop
             }
         }
     }
 
-    private func dropEmptyAssistantTurn(at index: Int) {
-        guard messages.indices.contains(index),
-              messages[index].role == .assistant,
+    private func assistantMessageIndex(id: UUID) -> Int? {
+        messages.firstIndex { $0.id == id && $0.role == .assistant }
+    }
+
+    private func dropEmptyAssistantTurn(id: UUID) {
+        guard let index = assistantMessageIndex(id: id),
               messages[index].blocks.isEmpty else { return }
         messages.remove(at: index)
     }
 
-    private func appendTextDelta(_ chunk: String, toAssistantAt index: Int) {
-        guard messages.indices.contains(index) else { return }
+    private func appendTextDelta(_ chunk: String, toAssistant id: UUID) {
+        guard let index = assistantMessageIndex(id: id) else { return }
         if case .text(let existing)? = messages[index].blocks.last {
             messages[index].blocks[messages[index].blocks.count - 1] = .text(existing + chunk)
         } else {
@@ -392,8 +394,13 @@ final class AgentService {
         }
     }
 
-    private func runPendingToolUses(assistantIndex: Int) async {
-        guard messages.indices.contains(assistantIndex) else { return }
+    private func appendToolUse(id toolUseID: String, name: String, inputJSON: String, toAssistant assistantID: UUID) {
+        guard let index = assistantMessageIndex(id: assistantID) else { return }
+        messages[index].blocks.append(.toolUse(id: toolUseID, name: name, inputJSON: inputJSON))
+    }
+
+    private func runPendingToolUses(assistantID: UUID) async {
+        guard let assistantIndex = assistantMessageIndex(id: assistantID) else { return }
         guard let executor = toolExecutor else {
             messages.append(AgentMessage(role: .user, blocks: [.text("Tool executor unavailable.")]))
             return

--- a/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
@@ -36,6 +36,7 @@ struct AgentInputBox<LeadingTools: View>: View {
     @State private var mentionTab: MentionTab = .all
     @State private var mentionScrollTick: Int = 0
     @State private var isDropTargeted = false
+    @State private var textEditorID = UUID()
     @Namespace private var sendStopNamespace
 
     private var showMentionPicker: Bool { mentionQuery != nil }
@@ -86,6 +87,7 @@ struct AgentInputBox<LeadingTools: View>: View {
     private var textField: some View {
         ZStack(alignment: .topLeading) {
             TextEditor(text: $draft)
+                .id(textEditorID)
                 .font(.body)
                 .scrollContentBackground(.hidden)
                 .scrollIndicators(.never)
@@ -94,7 +96,12 @@ struct AgentInputBox<LeadingTools: View>: View {
                 .padding(.bottom, AppTheme.Spacing.xs)
                 .focused($focused)
                 .frame(minHeight: 32, maxHeight: 64)
-                .onChange(of: draft) { _, new in updateMentionQuery(from: new) }
+                .onChange(of: draft) { old, new in
+                    updateMentionQuery(from: new)
+                    if !old.isEmpty && new.isEmpty {
+                        textEditorID = UUID()
+                    }
+                }
                 .onPasteCommand(of: [.fileURL, .image, .png, .jpeg, .tiff], perform: handlePaste)
                 .onKeyPress(phases: [.down, .repeat]) { press in handleKey(press) }
                 // NSTextView eats Tab before the general onKeyPress fires.

--- a/Sources/PalmierPro/Agent/Tools/OverviewRenderer.swift
+++ b/Sources/PalmierPro/Agent/Tools/OverviewRenderer.swift
@@ -26,7 +26,11 @@ enum OverviewRenderer {
     private static let jpegQuality: CGFloat = 0.7
 
     static func make(url: URL, start: Double, end: Double) async throws -> Sheet {
-        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+        let asset = AVURLAsset(url: url)
+        guard (try? await asset.loadTracks(withMediaType: .video).first) != nil else {
+            throw RenderError(message: "No video track available")
+        }
+        let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.maximumSize = CGSize(width: tileWidth * 2, height: tileHeight * 2)
         let span = max(end - start, 0.001)

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -553,6 +553,7 @@ extension AgentTool {
         case let arr as [Any]: return .array(arr.map(valueFromJSON))
         case let dict as [String: Any]:
             var out: [String: Value] = [:]
+            out.reserveCapacity(dict.count)
             for (k, v) in dict { out[k] = valueFromJSON(v) }
             return .object(out)
         default: return .null
@@ -563,6 +564,7 @@ extension AgentTool {
 enum ToolArgsBridge {
     static func argsFromMCP(_ args: [String: Value]) -> [String: Any] {
         var out: [String: Any] = [:]
+        out.reserveCapacity(args.count)
         for (k, v) in args { out[k] = anyFromValue(v) }
         return out
     }
@@ -578,6 +580,7 @@ enum ToolArgsBridge {
         case .array(let arr): return arr.map(anyFromValue)
         case .object(let obj):
             var out: [String: Any] = [:]
+            out.reserveCapacity(obj.count)
             for (k, v) in obj { out[k] = anyFromValue(v) }
             return out
         }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
@@ -45,6 +45,9 @@ extension ToolExecutor {
             renderSize: canvas
         )
 
+        guard (try? await composition.composition.loadTracks(withMediaType: .video).first) != nil else {
+            throw ToolError("No video track available in timeline.")
+        }
         let generator = AVAssetImageGenerator(asset: composition.composition)
         generator.videoComposition = composition.videoComposition
         generator.appliesPreferredTrackTransform = true

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -415,7 +415,11 @@ extension ToolExecutor {
             }
         }
 
-        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+        let asset = AVURLAsset(url: url)
+        guard (try? await asset.loadTracks(withMediaType: .video).first) != nil else {
+            throw ToolError("No video track available in \(name)")
+        }
+        let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.maximumSize = CGSize(
             width: readVideoFrameMaxDimension,

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -9,9 +9,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Start Sparkle updater
         _ = Updater.shared
 
-        // Seed registry from default directory on first launch
-        ProjectRegistry.shared.migrateDefaultDirectoryIfNeeded()
-
         HomeWindowController.shared.showWindow(nil)
 
         AppNotifications.configure()

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -46,18 +46,24 @@ final class AppState {
             HomeWindowController.shared.showWindow(nil)
             return
         }
+        let presentHome = {
+            if let url = project.fileURL {
+                ProjectRegistry.shared.register(url)
+            }
+            project.windowControllers.forEach { $0.window?.orderOut(nil) }
+            if self.activeProject === project {
+                self.activeProject = nil
+            }
+            HomeWindowController.shared.showWindow(nil)
+        }
         if project.isDocumentEdited {
-            project.autosave(withImplicitCancellability: false) { [weak self] _ in
+            project.autosave(withImplicitCancellability: false) { _ in
                 DispatchQueue.main.async {
-                    self?.activeProject?.windowControllers.forEach { $0.window?.orderOut(nil) }
-                    self?.activeProject = nil
-                    HomeWindowController.shared.showWindow(nil)
+                    presentHome()
                 }
             }
         } else {
-            activeProject?.windowControllers.forEach { $0.window?.orderOut(nil) }
-            activeProject = nil
-            HomeWindowController.shared.showWindow(nil)
+            presentHome()
         }
     }
 

--- a/Sources/PalmierPro/Editor/Tour/TourController.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourController.swift
@@ -150,7 +150,7 @@ final class TourController {
             TourStep(kind: .spotlight(.panel(.timeline)), title: "Timeline",
                      instruction: "Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music."),
             TourStep(kind: .spotlight(.element(.timelineRuler)), title: "Select a range",
-                     instruction: "This is the timeline ruler. Cmd-drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range."),
+                     instruction: "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range."),
             TourStep(kind: .spotlight(.panel(.agent)), title: "AI agent",
                      instruction: "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key."),
             TourStep(kind: .outro, title: "You're all set",

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -253,6 +253,10 @@ extension EditorViewModel {
         let videoComposition = isTimelineTab ? currentItem.videoComposition : nil
 
         Task.detached {
+            guard (try? await asset.loadTracks(withMediaType: .video).first) != nil else {
+                Log.project.error("captureCurrentFrameToMedia: no video track")
+                return
+            }
             let generator = AVAssetImageGenerator(asset: asset)
             generator.appliesPreferredTrackTransform = true
             generator.requestedTimeToleranceBefore = .zero

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -302,7 +302,9 @@ struct ExportView: View {
         for track in editor.timeline.tracks where track.type == .video {
             for clip in track.clips {
                 guard let url = editor.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
-                let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+                let asset = AVURLAsset(url: url)
+                guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
+                let generator = AVAssetImageGenerator(asset: asset)
                 generator.maximumSize = CGSize(width: 480, height: 270)
                 generator.appliesPreferredTrackTransform = true
                 let time = CMTime(value: CMTimeValue(clip.trimStartFrame), timescale: CMTimeScale(editor.timeline.fps))

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -72,6 +72,11 @@ final class ModelCatalog {
         var newAudio: [AudioModelConfig] = []
         var newUpscale: [UpscaleModelConfig] = []
         var newById: [String: ModelKind] = [:]
+        newVideo.reserveCapacity(entries.count)
+        newImage.reserveCapacity(entries.count)
+        newAudio.reserveCapacity(entries.count)
+        newUpscale.reserveCapacity(entries.count)
+        newById.reserveCapacity(entries.count)
 
         for entry in entries {
             switch entry.uiCapabilities {

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -128,31 +128,48 @@ struct GenerationView: View {
 
     // MARK: - Computed state
 
-    private var videoModel: VideoModelConfig { VideoModelConfig.allModels[selectedVideoModelIndex] }
-    private var imageModel: ImageModelConfig { ImageModelConfig.allModels[selectedImageModelIndex] }
-    private var audioModel: AudioModelConfig { AudioModelConfig.allModels[selectedAudioModelIndex] }
+    private var videoModels: [VideoModelConfig] { ModelCatalog.shared.video }
+    private var imageModels: [ImageModelConfig] { ModelCatalog.shared.image }
+    private var audioModels: [AudioModelConfig] { ModelCatalog.shared.audio }
+
+    private var videoModel: VideoModelConfig { selectedModel(videoModels, at: selectedVideoModelIndex) }
+    private var imageModel: ImageModelConfig { selectedModel(imageModels, at: selectedImageModelIndex) }
+    private var audioModel: AudioModelConfig { selectedModel(audioModels, at: selectedAudioModelIndex) }
+
+    private func selectedModel<T>(_ models: [T], at index: Int) -> T {
+        let safeIndex = models.indices.contains(index) ? index : models.startIndex
+        return models[safeIndex]
+    }
 
     private var enabledVideoModels: [(index: Int, model: VideoModelConfig)] {
-        VideoModelConfig.allModels.enumerated()
+        videoModels.enumerated()
             .filter { ModelPreferences.shared.isEnabled($0.element.id) }
             .map { (index: $0.offset, model: $0.element) }
     }
     private var enabledImageModels: [(index: Int, model: ImageModelConfig)] {
-        ImageModelConfig.allModels.enumerated()
+        imageModels.enumerated()
             .filter { ModelPreferences.shared.isEnabled($0.element.id) }
             .map { (index: $0.offset, model: $0.element) }
     }
     private var enabledAudioModels: [(index: Int, model: AudioModelConfig)] {
-        AudioModelConfig.allModels.enumerated()
+        audioModels.enumerated()
             .filter { ModelPreferences.shared.isEnabled($0.element.id) }
             .map { (index: $0.offset, model: $0.element) }
+    }
+    private var enabledAudioModelsByCategory: [AudioModelConfig.Category: [(index: Int, model: AudioModelConfig)]] {
+        var grouped: [AudioModelConfig.Category: [(index: Int, model: AudioModelConfig)]] = [:]
+        grouped.reserveCapacity(AudioModelConfig.Category.allCases.count)
+        for item in enabledAudioModels {
+            grouped[item.model.category, default: []].append(item)
+        }
+        return grouped
     }
 
     private func normalizeModelSelection() {
         switch selectedType {
-        case .video: selectedVideoModelIndex = enabledIndex(selectedVideoModelIndex, in: VideoModelConfig.allModels.map(\.id))
-        case .image: selectedImageModelIndex = enabledIndex(selectedImageModelIndex, in: ImageModelConfig.allModels.map(\.id))
-        case .audio: selectedAudioModelIndex = enabledIndex(selectedAudioModelIndex, in: AudioModelConfig.allModels.map(\.id))
+        case .video: selectedVideoModelIndex = enabledIndex(selectedVideoModelIndex, in: videoModels.map(\.id))
+        case .image: selectedImageModelIndex = enabledIndex(selectedImageModelIndex, in: imageModels.map(\.id))
+        case .audio: selectedAudioModelIndex = enabledIndex(selectedAudioModelIndex, in: audioModels.map(\.id))
         }
     }
 
@@ -160,7 +177,7 @@ struct GenerationView: View {
     private func enabledIndex(_ current: Int, in ids: [String]) -> Int {
         let prefs = ModelPreferences.shared
         if ids.indices.contains(current), prefs.isEnabled(ids[current]) { return current }
-        return ids.firstIndex { prefs.isEnabled($0) } ?? current
+        return ids.firstIndex { prefs.isEnabled($0) } ?? (ids.indices.contains(current) ? current : 0)
     }
 
     private var trimmedPrompt: String { prompt.trimmingCharacters(in: .whitespaces) }
@@ -404,9 +421,9 @@ struct GenerationView: View {
     }
 
     private var catalogReady: Bool {
-        !VideoModelConfig.allModels.isEmpty
-            && !ImageModelConfig.allModels.isEmpty
-            && !AudioModelConfig.allModels.isEmpty
+        !videoModels.isEmpty
+            && !imageModels.isEmpty
+            && !audioModels.isEmpty
     }
 
     var body: some View {
@@ -1347,9 +1364,8 @@ struct GenerationView: View {
                     Button(item.model.displayName) { selectedImageModelIndex = item.index }
                 }
             case .audio:
-                let grouped = Dictionary(grouping: enabledAudioModels, by: { $0.model.category })
                 ForEach(AudioModelConfig.Category.allCases, id: \.self) { category in
-                    if let items = grouped[category], !items.isEmpty {
+                    if let items = enabledAudioModelsByCategory[category], !items.isEmpty {
                         Section(category.label) {
                             ForEach(items, id: \.index) { item in
                                 Button(item.model.displayName) { selectedAudioModelIndex = item.index }
@@ -1761,17 +1777,17 @@ struct GenerationView: View {
     private func populatePanel(asset: MediaAsset, stored: GenerationInput) {
         switch ModelRegistry.byId[stored.model] {
         case .video:
-            guard let idx = VideoModelConfig.allModels.firstIndex(where: { $0.id == stored.model }) else { return }
+            guard let idx = videoModels.firstIndex(where: { $0.id == stored.model }) else { return }
             isPopulatingPanel = true
             selectedType = .video
             selectedVideoModelIndex = idx
         case .image:
-            guard let idx = ImageModelConfig.allModels.firstIndex(where: { $0.id == stored.model }) else { return }
+            guard let idx = imageModels.firstIndex(where: { $0.id == stored.model }) else { return }
             isPopulatingPanel = true
             selectedType = .image
             selectedImageModelIndex = idx
         case .audio:
-            guard let idx = AudioModelConfig.allModels.firstIndex(where: { $0.id == stored.model }) else { return }
+            guard let idx = audioModels.firstIndex(where: { $0.id == stored.model }) else { return }
             isPopulatingPanel = true
             selectedType = .audio
             selectedAudioModelIndex = idx

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -923,8 +923,8 @@ struct InspectorView: View {
     private func fileSection(_ asset: MediaAsset) -> some View {
         metadataSection(title: "File") {
             plainMetadataRow(label: "Type", value: asset.type.trackLabel)
-            if asset.type != .audio, let size = imageDimensions(for: asset.url) {
-                plainMetadataRow(label: "Dimensions", value: "\(size.width) × \(size.height)")
+            if asset.type != .audio, let width = asset.sourceWidth, let height = asset.sourceHeight {
+                plainMetadataRow(label: "Dimensions", value: "\(width) × \(height)")
             }
             if asset.duration > 0 && asset.type != .image {
                 plainMetadataRow(label: "Duration", value: formatDuration(asset.duration))
@@ -1044,14 +1044,6 @@ struct InspectorView: View {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
         return formatter.string(fromByteCount: bytes)
-    }
-
-    private func imageDimensions(for url: URL) -> (width: Int, height: Int)? {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
-              let w = props[kCGImagePropertyPixelWidth] as? Int,
-              let h = props[kCGImagePropertyPixelHeight] as? Int else { return nil }
-        return (w, h)
     }
 
     private func formatDuration(_ seconds: Double) -> String {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -249,7 +249,9 @@ private struct MomentThumbnail: View {
     }
 
     private static func thumbnail(url: URL, time: Double) async -> CGImage? {
-        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+        let asset = AVURLAsset(url: url)
+        guard (try? await asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
+        let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.maximumSize = CGSize(width: 240, height: 240)
         let tolerance = CMTime(seconds: 1, preferredTimescale: 600)

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -123,7 +123,9 @@ final class MediaAsset: Identifiable {
         }
         if type == .video {
             var videoDuration: Double?
+            var hasVideoTrack = false
             if let videoTrack = try? await avAsset.loadTracks(withMediaType: .video).first {
+                hasVideoTrack = true
                 if let size = try? await videoTrack.load(.naturalSize),
                    let transform = try? await videoTrack.load(.preferredTransform) {
                     let corrected = size.applying(transform)
@@ -143,13 +145,15 @@ final class MediaAsset: Identifiable {
             if let audioTracks = try? await avAsset.loadTracks(withMediaType: .audio) {
                 hasAudio = !audioTracks.isEmpty
             }
-            let gen = AVAssetImageGenerator(asset: avAsset)
-            gen.maximumSize = CGSize(width: 320, height: 320)   // square budget — portrait gets full res too
-            gen.appliesPreferredTrackTransform = true
-            if let cgImage = try? await gen.image(at: .zero).image {
-                // Use the generated frame's true pixel size — a hardcoded 16:9 size makes
-                // SwiftUI's aspectRatio squeeze non-16:9 (e.g. vertical) thumbnails.
-                thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+            if hasVideoTrack {
+                let gen = AVAssetImageGenerator(asset: avAsset)
+                gen.maximumSize = CGSize(width: 320, height: 320)   // square budget — portrait gets full res too
+                gen.appliesPreferredTrackTransform = true
+                if let cgImage = try? await gen.image(at: .zero).image {
+                    // Use the generated frame's true pixel size — a hardcoded 16:9 size makes
+                    // SwiftUI's aspectRatio squeeze non-16:9 (e.g. vertical) thumbnails.
+                    thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                }
             }
         }
     }

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -96,11 +96,14 @@ final class MediaAsset: Identifiable {
     func loadMetadata() async {
         if type == .image {
             duration = Defaults.imageDurationSeconds
-            thumbnail = NSImage(contentsOf: url)
-            if let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-               let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] {
-                sourceWidth = props[kCGImagePropertyPixelWidth] as? Int
-                sourceHeight = props[kCGImagePropertyPixelHeight] as? Int
+            let imageURL = url
+            let metadata = await Task.detached(priority: .utility) {
+                ImageEncoder.metadata(url: imageURL, thumbnailMaxPixelSize: 1568)
+            }.value
+            if let width = metadata.width { sourceWidth = width }
+            if let height = metadata.height { sourceHeight = height }
+            if let image = metadata.thumbnail {
+                thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
             }
             return
         }

--- a/Sources/PalmierPro/Project/ProjectCard.swift
+++ b/Sources/PalmierPro/Project/ProjectCard.swift
@@ -117,7 +117,7 @@ struct ProjectCard: View {
         } message: {
             Text("The project will be moved to the Trash.")
         }
-        .task { loadThumbnail() }
+        .task(id: entry.lastOpenedDate) { await loadThumbnail(for: entry.url) }
     }
 
     private static let relativeDateFormatter: RelativeDateTimeFormatter = {
@@ -130,11 +130,13 @@ struct ProjectCard: View {
         relativeDateFormatter.localizedString(for: date, relativeTo: Date())
     }
 
-    private func loadThumbnail() {
-        let thumbURL = entry.url.appendingPathComponent(Project.thumbnailFilename)
-        if let data = try? Data(contentsOf: thumbURL),
-           let image = NSImage(data: data) {
-            thumbnail = image
-        }
+    private func loadThumbnail(for projectURL: URL) async {
+        thumbnail = nil
+        let image = await Task.detached(priority: .utility) {
+            let thumbURL = projectURL.appendingPathComponent(Project.thumbnailFilename, isDirectory: false)
+            return ImageEncoder.thumbnail(url: thumbURL, maxPixelSize: 640)
+        }.value
+        guard let image, !Task.isCancelled else { return }
+        thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
     }
 }

--- a/Sources/PalmierPro/Project/ProjectCard.swift
+++ b/Sources/PalmierPro/Project/ProjectCard.swift
@@ -112,7 +112,7 @@ struct ProjectCard: View {
         .alert("Delete \"\(entry.name)\"?", isPresented: $showDeleteConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
-                try? ProjectRegistry.shared.delete(entry.url)
+                ProjectRegistry.shared.delete(entry.url)
             }
         } message: {
             Text("The project will be moved to the Trash.")

--- a/Sources/PalmierPro/Project/ProjectRegistry.swift
+++ b/Sources/PalmierPro/Project/ProjectRegistry.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ProjectEntry: Codable, Identifiable {
+struct ProjectEntry: Codable, Identifiable, Sendable {
     let id: UUID
     var url: URL
     var createdDate: Date
@@ -22,6 +22,9 @@ final class ProjectRegistry {
     }
 
     private let fileURL: URL
+    private let disk = ProjectRegistryDisk()
+    private var isLoading = false
+    private var pendingMutations: [(inout [ProjectEntry]) -> Void] = []
 
     private init() {
         fileURL = Project.storageDirectory.appendingPathComponent(Project.registryFilename)
@@ -30,77 +33,108 @@ final class ProjectRegistry {
 
     init(fileURL: URL) {
         self.fileURL = fileURL
-        load()
+        entries = Self.loadEntries(from: fileURL)
     }
 
     // MARK: - Mutations
 
     func register(_ url: URL) {
         let resolved = url.standardizedFileURL
-        if let index = entries.firstIndex(where: { $0.url.standardizedFileURL == resolved }) {
-            entries[index].lastOpenedDate = Date()
-        } else {
-            entries.append(ProjectEntry(id: UUID(), url: resolved, createdDate: Date(), lastOpenedDate: Date()))
+        mutate { entries in
+            if let index = entries.firstIndex(where: { $0.url.standardizedFileURL == resolved }) {
+                entries[index].lastOpenedDate = Date()
+            } else {
+                entries.append(ProjectEntry(id: UUID(), url: resolved, createdDate: Date(), lastOpenedDate: Date()))
+            }
         }
-        save()
     }
 
     func remove(_ url: URL) {
         let resolved = url.standardizedFileURL
-        entries.removeAll { $0.url.standardizedFileURL == resolved }
-        save()
+        mutate { entries in
+            entries.removeAll { $0.url.standardizedFileURL == resolved }
+        }
     }
 
-    /// Moves the project file to Trash and removes it from the registry.
-    /// If the file is already gone, just removes the registry entry.
-    func delete(_ url: URL) throws {
-        if FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+    func delete(_ url: URL) {
+        Task { [weak self] in
+            guard let self, await self.disk.trashIfPresent(url) else { return }
+            self.remove(url)
         }
-        remove(url)
     }
 
     func updateURL(from oldURL: URL, to newURL: URL) {
         let resolvedOld = oldURL.standardizedFileURL
-        if let index = entries.firstIndex(where: { $0.url.standardizedFileURL == resolvedOld }) {
-            entries[index].url = newURL.standardizedFileURL
-            entries[index].lastOpenedDate = Date()
-            save()
+        let resolvedNew = newURL.standardizedFileURL
+        mutate { entries in
+            if let index = entries.firstIndex(where: { $0.url.standardizedFileURL == resolvedOld }) {
+                entries[index].url = resolvedNew
+                entries[index].lastOpenedDate = Date()
+            }
         }
-    }
-
-    // MARK: - Migration
-
-    func migrateDefaultDirectoryIfNeeded() {
-        let key = "ProjectRegistryMigrated"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        defer { UserDefaults.standard.set(true, forKey: key) }
-
-        guard let contents = try? FileManager.default.contentsOfDirectory(
-            at: Project.storageDirectory,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        for fileURL in contents where fileURL.pathExtension == Project.fileExtension {
-            let resolved = fileURL.standardizedFileURL
-            guard !entries.contains(where: { $0.url.standardizedFileURL == resolved }) else { continue }
-            let modDate = (try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date()
-            entries.append(ProjectEntry(id: UUID(), url: resolved, createdDate: modDate, lastOpenedDate: modDate))
-        }
-        save()
     }
 
     // MARK: - Persistence
 
     private func load() {
-        guard let data = try? Data(contentsOf: fileURL),
-              let decoded = try? JSONDecoder().decode([ProjectEntry].self, from: data) else { return }
-        entries = decoded
+        isLoading = true
+        Task { [weak self] in
+            guard let self else { return }
+            let loaded = await self.disk.load(from: self.fileURL)
+            self.finishLoading(loaded)
+        }
     }
 
     private func save() {
+        Self.saveEntries(entries, to: fileURL)
+    }
+
+    private func mutate(_ apply: @escaping (inout [ProjectEntry]) -> Void) {
+        guard !isLoading else {
+            pendingMutations.append(apply)
+            return
+        }
+        apply(&entries)
+        save()
+    }
+
+    private func finishLoading(_ loaded: [ProjectEntry]) {
+        entries = loaded
+        isLoading = false
+        guard !pendingMutations.isEmpty else { return }
+
+        let mutations = pendingMutations
+        pendingMutations.removeAll()
+        for mutation in mutations {
+            mutation(&entries)
+        }
+        save()
+    }
+
+    fileprivate nonisolated static func loadEntries(from fileURL: URL) -> [ProjectEntry] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([ProjectEntry].self, from: data) else { return [] }
+        return decoded
+    }
+
+    fileprivate nonisolated static func saveEntries(_ entries: [ProjectEntry], to fileURL: URL) {
         guard let data = try? JSONEncoder().encode(entries) else { return }
         try? data.write(to: fileURL, options: .atomic)
+    }
+}
+
+private actor ProjectRegistryDisk {
+    func load(from fileURL: URL) -> [ProjectEntry] {
+        ProjectRegistry.loadEntries(from: fileURL)
+    }
+
+    func trashIfPresent(_ url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return true }
+        do {
+            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+            return true
+        } catch {
+            return false
+        }
     }
 }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -236,7 +236,9 @@ final class VideoProject: NSDocument {
         for track in editorViewModel.timeline.tracks where track.type == .video {
             for clip in track.clips {
                 guard let url = editorViewModel.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
-                let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+                let asset = AVURLAsset(url: url)
+                guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
+                let generator = AVAssetImageGenerator(asset: asset)
                 generator.maximumSize = CGSize(width: 320, height: 180)
                 generator.appliesPreferredTrackTransform = true
                 let time = CMTime(value: CMTimeValue(clip.trimStartFrame), timescale: CMTimeScale(editorViewModel.timeline.fps))

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -236,6 +236,14 @@ final class VideoProject: NSDocument {
         for track in editorViewModel.timeline.tracks where track.type == .video {
             for clip in track.clips {
                 guard let url = editorViewModel.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
+                if clip.mediaType == .image,
+                   let image = ImageEncoder.thumbnail(url: url, maxPixelSize: 640),
+                   let data = ImageEncoder.encodeJPEG(image, quality: 0.7) {
+                    cachedThumbnail = data
+                    return data
+                }
+                guard clip.mediaType == .video else { continue }
+
                 let asset = AVURLAsset(url: url)
                 guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
                 let generator = AVAssetImageGenerator(asset: asset)
@@ -248,7 +256,10 @@ final class VideoProject: NSDocument {
                     result = image
                     semaphore.signal()
                 }
-                semaphore.wait()
+                guard semaphore.wait(timeout: .now() + .seconds(5)) == .success else {
+                    generator.cancelAllCGImageGeneration()
+                    continue
+                }
                 if let cgImage = result {
                     let rep = NSBitmapImageRep(cgImage: cgImage)
                     cachedThumbnail = rep.representation(using: .jpeg, properties: [.compressionFactor: 0.7])

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -16,12 +16,13 @@ final class VideoProject: NSDocument {
 
     private nonisolated(unsafe) var packageWrapper = FileWrapper(directoryWithFileWrappers: [:])
 
-    /// Captured on main thread in save(to:) before fileWrapper runs (possibly off-main).
+    /// Captured on main thread before fileWrapper runs (possibly off-main).
     private nonisolated(unsafe) var snapshotTimeline: Data?
     private nonisolated(unsafe) var snapshotManifest: Data?
     private nonisolated(unsafe) var snapshotGenerationLog: Data?
     private nonisolated(unsafe) var snapshotThumbnail: Data?
     private nonisolated(unsafe) var snapshotChatSessionFiles: [(name: String, data: Data)] = []
+    private nonisolated(unsafe) var snapshotPreparedForFileWrapper = false
 
     // MARK: - Persistence
 
@@ -58,19 +59,19 @@ final class VideoProject: NSDocument {
             fileModificationDate = date
         }
 
-        snapshotTimeline = try? JSONEncoder().encode(editorViewModel.timeline)
-        snapshotManifest = try? JSONEncoder().encode(editorViewModel.mediaManifest)
-        snapshotGenerationLog = try? JSONEncoder().encode(editorViewModel.generationLog)
-        snapshotThumbnail = captureThumbnail()
-        snapshotChatSessionFiles = editorViewModel.agentService.sessions
-            .filter { !$0.messages.isEmpty }
-            .compactMap { session in
-                ChatSessionStore.encodeSession(session).map { (name: "\(session.id.uuidString).json", data: $0) }
-            }
+        captureSaveSnapshot()
         super.save(to: url, ofType: typeName, for: saveOperation, completionHandler: completionHandler)
     }
 
     override func fileWrapper(ofType typeName: String) throws -> FileWrapper {
+        if !snapshotPreparedForFileWrapper {
+            guard Thread.isMainThread else {
+                Log.project.error("save: snapshot not prepared for off-main fileWrapper()")
+                throw CocoaError(.fileWriteUnknown)
+            }
+            captureSaveSnapshot()
+        }
+        defer { snapshotPreparedForFileWrapper = false }
         guard let data = snapshotTimeline else {
             Log.project.error("save: snapshotTimeline missing at fileWrapper()")
             throw CocoaError(.fileWriteUnknown)
@@ -84,6 +85,19 @@ final class VideoProject: NSDocument {
         if let mediaDir = mediaDirWrapper() { replaceChild(Project.mediaDirectoryName, with: mediaDir) }
 
         return packageWrapper
+    }
+
+    private func captureSaveSnapshot() {
+        snapshotTimeline = try? JSONEncoder().encode(editorViewModel.timeline)
+        snapshotManifest = try? JSONEncoder().encode(editorViewModel.mediaManifest)
+        snapshotGenerationLog = try? JSONEncoder().encode(editorViewModel.generationLog)
+        snapshotThumbnail = captureThumbnail()
+        snapshotChatSessionFiles = editorViewModel.agentService.sessions
+            .filter { !$0.messages.isEmpty }
+            .compactMap { session in
+                ChatSessionStore.encodeSession(session).map { (name: "\(session.id.uuidString).json", data: $0) }
+            }
+        snapshotPreparedForFileWrapper = true
     }
 
     private func mediaDirWrapper() -> FileWrapper? {

--- a/Sources/PalmierPro/Search/Indexing/FrameSampler.swift
+++ b/Sources/PalmierPro/Search/Indexing/FrameSampler.swift
@@ -45,8 +45,8 @@ enum FrameSampler {
     ) async throws {
         let asset = AVURLAsset(url: url)
         var interval = options.candidateInterval
-        if let track = try? await asset.loadTracks(withMediaType: .video).first,
-           let size = try? await track.load(.naturalSize),
+        guard let track = try? await asset.loadTracks(withMediaType: .video).first else { return }
+        if let size = try? await track.load(.naturalSize),
            max(abs(size.width), abs(size.height)) >= options.highResEdge {
             interval *= 2
         }

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -114,30 +114,32 @@ final class MediaVisualCache {
 
             if results.isEmpty {
                 let avAsset = AVURLAsset(url: url)
-                let duration = (try? await avAsset.load(.duration).seconds) ?? 0
-                let times = Self.videoThumbnailTimes(duration: duration)
+                if (try? await avAsset.loadTracks(withMediaType: .video).first) != nil {
+                    let duration = (try? await avAsset.load(.duration).seconds) ?? 0
+                    let times = Self.videoThumbnailTimes(duration: duration)
 
-                if !times.isEmpty {
-                    let generator = AVAssetImageGenerator(asset: avAsset)
-                    generator.maximumSize = CGSize(width: 120, height: 68)
-                    generator.appliesPreferredTrackTransform = true
-                    generator.requestedTimeToleranceBefore = CMTime(seconds: 1.0, preferredTimescale: 600)
-                    generator.requestedTimeToleranceAfter = CMTime(seconds: 1.0, preferredTimescale: 600)
+                    if !times.isEmpty {
+                        let generator = AVAssetImageGenerator(asset: avAsset)
+                        generator.maximumSize = CGSize(width: 120, height: 68)
+                        generator.appliesPreferredTrackTransform = true
+                        generator.requestedTimeToleranceBefore = CMTime(seconds: 1.0, preferredTimescale: 600)
+                        generator.requestedTimeToleranceAfter = CMTime(seconds: 1.0, preferredTimescale: 600)
 
-                    for await result in generator.images(for: times) {
-                        if case .success(requestedTime: let requestedTime, image: let image, actualTime: _) = result {
-                            results.append((time: requestedTime.seconds, image: image))
-                            // Publish progressively so long videos fill in instead of appearing at the end.
-                            if results.count % 50 == 0, let self {
-                                let partial = results
-                                await MainActor.run { [self] in
-                                    self.videoThumbnails[key] = partial
-                                    self.timelineView?.needsDisplay = true
+                        for await result in generator.images(for: times) {
+                            if case .success(requestedTime: let requestedTime, image: let image, actualTime: _) = result {
+                                results.append((time: requestedTime.seconds, image: image))
+                                // Publish progressively so long videos fill in instead of appearing at the end.
+                                if results.count % 50 == 0, let self {
+                                    let partial = results
+                                    await MainActor.run { [self] in
+                                        self.videoThumbnails[key] = partial
+                                        self.timelineView?.needsDisplay = true
+                                    }
                                 }
                             }
                         }
+                        results.sort { $0.time < $1.time }
                     }
-                    results.sort { $0.time < $1.time }
                 }
 
                 if !results.isEmpty, let cacheKey {

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -47,34 +47,20 @@ final class MediaVisualCache {
     // MARK: - Async generation
 
     func generateWaveform(for asset: MediaAsset) {
+        guard asset.type == .audio || (asset.type == .video && asset.hasAudio) else { return }
         let key = asset.id
         guard waveformSamples[key] == nil, !waveformInFlight.contains(key) else { return }
         waveformInFlight.insert(key)
 
         let url = asset.url
         Task.detached(priority: .utility) { [weak self] in
-            let cacheKey = Self.diskCacheKey(for: url)
-            var result = cacheKey.flatMap(Self.loadWaveform(key:))
-            if result == nil {
-                // Gate only the analysis; cached reads shouldn't queue behind extractions.
-                await Self.waveformGate.wait()
-                defer { Task { await Self.waveformGate.signal() } }
-                let analyzer = WaveformAnalyzer()
-                let duration = (try? await AVURLAsset(url: url).load(.duration).seconds) ?? 0
-                let count = Self.waveformSampleCount(duration: duration)
-                result = try? await analyzer.samples(fromAudioAt: url, count: count)
-                if let result, let cacheKey {
-                    Self.saveWaveform(result, key: cacheKey)
-                }
-            }
+            let result = await Self.loadOrGenerateWaveform(url: url)
             guard let self else { return }
             await MainActor.run { [self] in
                 self.waveformInFlight.remove(key)
                 if let result {
                     self.waveformSamples[key] = result
                     self.timelineView?.needsDisplay = true
-                } else {
-                    Log.preview.error("waveform gen FAILED key=\(key.prefix(8)) url=\(url.lastPathComponent)")
                 }
             }
         }
@@ -87,7 +73,12 @@ final class MediaVisualCache {
 
         let url = asset.url
         Task.detached(priority: .utility) { [weak self] in
-            await Self.imageThumbnailGate.wait()
+            do {
+                try await Self.imageThumbnailGate.wait()
+            } catch {
+                await MainActor.run { [weak self] in _ = self?.imageThumbnailInFlight.remove(key) }
+                return
+            }
             defer { Task { await Self.imageThumbnailGate.signal() } }
 
             let thumbnail = Self.makeImageThumbnail(url: url)
@@ -169,6 +160,27 @@ final class MediaVisualCache {
         ]
         guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions) else { return nil }
         return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary)
+    }
+
+    private nonisolated static func loadOrGenerateWaveform(url: URL) async -> [Float]? {
+        let cacheKey = diskCacheKey(for: url)
+        if let cacheKey, let cached = loadWaveform(key: cacheKey) { return cached }
+
+        do {
+            try await waveformGate.wait()
+        } catch {
+            return nil
+        }
+        defer { Task { await waveformGate.signal() } }
+
+        let asset = AVURLAsset(url: url)
+        guard (try? await asset.loadTracks(withMediaType: .audio).first) != nil else { return nil }
+
+        let duration = (try? await asset.load(.duration).seconds) ?? 0
+        let count = waveformSampleCount(duration: duration)
+        guard let samples = try? await WaveformAnalyzer().samples(fromAudioAt: url, count: count) else { return nil }
+        if let cacheKey { saveWaveform(samples, key: cacheKey) }
+        return samples
     }
 
     private nonisolated static func waveformSampleCount(duration: Double) -> Int {

--- a/Sources/PalmierPro/Utilities/AsyncSemaphore.swift
+++ b/Sources/PalmierPro/Utilities/AsyncSemaphore.swift
@@ -2,24 +2,46 @@
 /// share a finite system resource (e.g. CoreMedia's audio decoders).
 actor AsyncSemaphore {
     private var permits: Int
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var nextWaiterID = 0
+    private var waiters: [(id: Int, continuation: CheckedContinuation<Void, Error>)] = []
 
     init(value: Int) { self.permits = max(0, value) }
 
-    func wait() async {
+    func wait() async throws {
         if permits > 0 {
             permits -= 1
             return
         }
-        await withCheckedContinuation { waiters.append($0) }
+
+        try Task.checkCancellation()
+        let id = nextWaiterID
+        nextWaiterID += 1
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waiters.append((id, continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: id) }
+        }
     }
 
     func signal() {
         if let next = waiters.first {
             waiters.removeFirst()
-            next.resume()
+            next.continuation.resume()
         } else {
             permits += 1
         }
+    }
+
+    private func cancelWaiter(id: Int) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
     }
 }

--- a/Sources/PalmierPro/Utilities/ImageEncoder.swift
+++ b/Sources/PalmierPro/Utilities/ImageEncoder.swift
@@ -16,6 +16,12 @@ enum ImageEncoder {
         let mime: String
     }
 
+    struct ImageMetadata: Sendable {
+        let width: Int?
+        let height: Int?
+        let thumbnail: CGImage?
+    }
+
     static func encode(url: URL) -> Output? {
         let stamp = fileStamp(url: url)
         if let stamp, let hit = cache[stamp] { return hit }
@@ -35,27 +41,45 @@ enum ImageEncoder {
         return CGImageDestinationFinalize(dest) ? buffer as Data : nil
     }
 
+    nonisolated static func metadata(url: URL, thumbnailMaxPixelSize: Int? = nil) -> ImageMetadata {
+        guard let source = imageSource(url: url) else {
+            return ImageMetadata(width: nil, height: nil, thumbnail: nil)
+        }
+        let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+        let thumbnailImage: CGImage?
+        if let thumbnailMaxPixelSize {
+            thumbnailImage = makeThumbnail(source: source, maxPixelSize: thumbnailMaxPixelSize)
+        } else {
+            thumbnailImage = nil
+        }
+        return ImageMetadata(
+            width: props?[kCGImagePropertyPixelWidth] as? Int,
+            height: props?[kCGImagePropertyPixelHeight] as? Int,
+            thumbnail: thumbnailImage
+        )
+    }
+
+    nonisolated static func thumbnail(url: URL, maxPixelSize: Int) -> CGImage? {
+        guard let source = imageSource(url: url) else { return nil }
+        return makeThumbnail(source: source, maxPixelSize: maxPixelSize)
+    }
+
     // MARK: - Paths
 
     private static func passthrough(url: URL, stamp: FileStamp?) -> Output? {
+        let imageMetadata = metadata(url: url)
         guard let mime = passthroughMime(url.pathExtension.lowercased()),
               let size = stamp?.size, size <= maxBytes,
-              let (w, h) = dimensions(url: url), max(w, h) <= maxLongestEdge,
+              let width = imageMetadata.width,
+              let height = imageMetadata.height,
+              max(width, height) <= maxLongestEdge,
               let data = try? Data(contentsOf: url, options: [.mappedIfSafe])
         else { return nil }
         return Output(data: data, mime: mime)
     }
 
     private static func downscaled(url: URL) -> Output? {
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxLongestEdge,
-            kCGImageSourceShouldCache: false,
-        ]
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
-        else { return nil }
+        guard let image = thumbnail(url: url, maxPixelSize: maxLongestEdge) else { return nil }
         for quality in [0.85, 0.7, 0.55, 0.4] as [CGFloat] {
             if let data = encodeJPEG(image, quality: quality), data.count <= maxBytes {
                 return Output(data: data, mime: "image/jpeg")
@@ -96,12 +120,17 @@ enum ImageEncoder {
         }
     }
 
-    private static func dimensions(url: URL) -> (Int, Int)? {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
-              let w = props[kCGImagePropertyPixelWidth] as? Int,
-              let h = props[kCGImagePropertyPixelHeight] as? Int
-        else { return nil }
-        return (w, h)
+    private nonisolated static func imageSource(url: URL) -> CGImageSource? {
+        CGImageSourceCreateWithURL(url as CFURL, [kCGImageSourceShouldCache: false] as CFDictionary)
+    }
+
+    private nonisolated static func makeThumbnail(source: CGImageSource, maxPixelSize: Int) -> CGImage? {
+        let options = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ] as CFDictionary
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, options)
     }
 }


### PR DESCRIPTION
each commit is a sentry fix  

1. Video frame generation crash
      - Issue: PALMIER-PRO-1A / PALMIER-PRO-1G could crash or leak continuations when frame
        generation ran on assets without usable video tracks.

      - Solution: Guard video frame generation call sites so non-video or unreadable assets are
        skipped before hitting AVFoundation.

      - Files touched: OverviewRenderer.swift, ToolExecutor+InspectTimeline.swift,
        ToolExecutor+Timeline.swift, EditorViewModel+MediaLibrary.swift, ExportView.swift,
        MediaTab+Search.swift, MediaAsset.swift, VideoProject.swift, FrameSampler.swift,
        MediaVisualCache.swift

  2. Agent stream array crash
      - Issue: PALMIER-PRO-1H crashed from mutating an array index while streamed assistant messages
        changed.

      - Solution: Track the streamed assistant message by stable message id instead of relying on a
        stale array index.

      - Files touched: AgentService.swift

  3. Agent input clear crash
      - Issue: PALMIER-PRO-J crashed in AppKit text storage after clearing/sending agent input.
      - Solution: Reset the TextEditor identity after clear/send so AppKit does not reuse stale
        undo/range state.

      - Files touched: AgentInputBox.swift

  4. Waveform generation crash
      - Issue: PALMIER-PRO-19 / PALMIER-PRO-11 could crash or leak continuations when waveform
        generation ran on media without audio.

      - Solution: Skip waveform generation for assets without audio, treat waveform failures as
        cache misses, and make the async semaphore cancellation-safe.

      - Files touched: MediaVisualCache.swift, AsyncSemaphore.swift

  5. Project registry app hang
      - Issue: PALMIER-PRO-16, PALMIER-PRO-1N, and PALMIER-PRO-1J showed app hangs from registry
        load/save/migration and project delete work on the main thread.

      - Solution: Remove the obsolete migration, load the project registry off the main actor, queue
        early registry mutations during startup load, and move project trash work off the main
        actor.

      - Files touched: AppDelegate.swift, ProjectRegistry.swift, ProjectCard.swift
      
   6. Issue: Project save can fail when AppKit calls fileWrapper() directly, leaving snapshotTimeline
     missing.
     Solution: Prepare the project snapshot before direct fileWrapper() saves, and keep the existing
     save(to:) path explicit.
     Files touched: Sources/PalmierPro/Project/VideoProject.swift

  7. Issue: App hangs while model/tool dictionaries are rebuilt or resized on hot paths.
     Solution: Preallocate model catalog and tool schema dictionaries before filling them.
     Files touched: Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift, Sources/PalmierPro/
     Agent/Tools/ToolDefinitions.swift

  8. Issue: Project cards do not show thumbnails for image-only timelines.
     Solution: Generate project snapshots from still-image timeline content instead of only video
     content.
     Files touched: Sources/PalmierPro/Project/ProjectCard.swift / snapshot-related project
     thumbnail code

  9. Issue: Generation panel can hang while reading model arrays and grouping audio models during
     SwiftUI body updates.
     Solution: Read model lists through ModelCatalog, clamp stale selected indexes, and pregroup
     audio models outside the picker body.
     Files touched: Sources/PalmierPro/Generation/UI/GenerationView.swift