### PR TITLE
ci: build and test on push and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test
+    # PalmierPro targets macOS 26 (Tahoe), arm64 only. Requires a macOS 26 runner image.
+    runs-on: macos-26
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,4 @@ For a bundled debug build that launches the `.app` and streams OSLog:
 swift test
 ```
 
-CI runs `swift build` and `swift test` on every pull request. The workflow runs on a
-macOS 26 (Tahoe) / arm64 runner, matching the app's deployment target — keep these green
-before requesting review.
-
 By contributing, you agree your contributions are licensed under [GPLv3](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,14 @@ For a bundled debug build that launches the `.app` and streams OSLog:
 ./scripts/dev.sh
 ```
 
+## Test
+
+```bash
+swift test
+```
+
+CI runs `swift build` and `swift test` on every pull request. The workflow runs on a
+macOS 26 (Tahoe) / arm64 runner, matching the app's deployment target — keep these green
+before requesting review.
+
 By contributing, you agree your contributions are licensed under [GPLv3](LICENSE).


### PR DESCRIPTION
## Summary

Adds the repo's first CI workflow. There's currently no `.github/` directory, so contributions land without any automated check that the project still builds or that the test suite passes.

The workflow runs on push to `main` and on every pull request:

- `swift build`
- `swift test`

It runs on a `macos-26` / arm64 runner to match the app's deployment target (`platforms: [.macOS(.v26)]`), and caches the SwiftPM `.build` directory keyed on `Package.resolved`.

Also documents `swift test` and the CI requirement in `CONTRIBUTING.md`.

## Verification

Verified end-to-end on a real GitHub Actions run (in a fork before opening here):

- `actionlint` — clean
- **Build** step — green
- **Test** step — green (606 tests / 100 suites)
- Confirmed the `macos-26` runner provisions and picks up the job
- Trigger scoping behaves as intended: pushing a feature branch fires nothing (push is pinned to `main`); the `pull_request` event drives PR checks

## Notes

- Requires a `macos-26` runner image to be available to the repository. If that image isn't available on this repo's plan, the job won't start , in that case `runs-on: macos-latest` or a build-only job is an easy fallback.

Fixes : #9 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Introduces the repo's first **GitHub Actions** workflow (`.github/workflows/ci.yml`) so `main` pushes and all pull requests automatically run **`swift build`** and **`swift test`**.
> 
> The job uses **`macos-26`** to align with the app's macOS 26 target, sets a 40-minute timeout, enables **concurrency** with cancel-in-progress, and **caches** SwiftPM's `.build` directory keyed on `Package.resolved`.
> 
> **`CONTRIBUTING.md`** gains a **Test** section documenting `swift test` for local runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3945daa42d0de4311bcee0c92c80c50e59bcb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->