### PR TITLE
Fix NSRangeException crash in text content field

### DIFF
--- a/Sources/PalmierPro/Inspector/Components/TextContentField.swift
+++ b/Sources/PalmierPro/Inspector/Components/TextContentField.swift
@@ -1,14 +1,6 @@
 import AppKit
 import SwiftUI
 
-private final class IsolatedUndoTextView: NSTextView {
-    private let localUndoManager = UndoManager()
-
-    override var undoManager: UndoManager? {
-        localUndoManager
-    }
-}
-
 /// NSTextView-backed — SwiftUI `TextEditor`'s binding drops keystrokes when the parent re-renders per-apply.
 struct TextContentField: NSViewRepresentable {
     @Binding var text: String
@@ -22,12 +14,12 @@ struct TextContentField: NSViewRepresentable {
         scrollView.borderType = .noBorder
         scrollView.autohidesScrollers = true
 
-        let textView = IsolatedUndoTextView()
+        let textView = NSTextView()
         textView.isEditable = true
         textView.isSelectable = true
         textView.isRichText = false
         textView.importsGraphics = false
-        textView.allowsUndo = true
+        textView.allowsUndo = false
         textView.font = .systemFont(ofSize: AppTheme.FontSize.md)
         textView.textColor = AppTheme.Text.primary
         textView.insertionPointColor = AppTheme.Text.primary
@@ -40,7 +32,6 @@ struct TextContentField: NSViewRepresentable {
         textView.isAutomaticSpellingCorrectionEnabled = false
         textView.delegate = context.coordinator
         textView.string = text
-        textView.undoManager?.removeAllActions()
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
@@ -54,7 +45,6 @@ struct TextContentField: NSViewRepresentable {
         guard textView.window?.firstResponder !== textView else { return }
         if textView.string != text {
             textView.string = text
-            textView.undoManager?.removeAllActions()
         }
     }
 


### PR DESCRIPTION
This is a sentry error fix.

Fixes an NSRangeException in the text content field by disabling NSTextView undo registration for this representable.
