### PR TITLE
Open external URLs without blocking the main thread

### DIFF
--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -364,7 +364,7 @@ final class AccountService {
             lastError = "Refused to open untrusted URL."
             return
         }
-        NSWorkspace.shared.open(url)
+        NSWorkspace.shared.open(url, configuration: .init(), completionHandler: nil)
     }
 }
 

--- a/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
@@ -157,7 +157,7 @@ struct TourOverlay: View {
             VStack(spacing: 0) {
                 linkRow("MCP Setup", "puzzlepiece.extension.fill") { HelpWindowController.shared.show(tab: .mcp) }
                 linkRow("Keyboard Shortcuts", "keyboard") { HelpWindowController.shared.show(tab: .shortcuts) }
-                linkRow("Documentation", "book.fill") { NSWorkspace.shared.open(Self.docsURL) }
+                linkRow("Documentation", "book.fill") { NSWorkspace.shared.open(Self.docsURL, configuration: .init(), completionHandler: nil) }
                 linkRow("Settings", "gearshape.fill") { SettingsWindowController.shared.show() }
             }
             HStack {

--- a/Sources/PalmierPro/Help/MCPInstructionsPane.swift
+++ b/Sources/PalmierPro/Help/MCPInstructionsPane.swift
@@ -117,7 +117,7 @@ struct MCPInstructionsPane: View {
             sectionHeading("Connect from Cursor", prominent: true)
             installButton(label: "Install in Cursor", systemImage: "arrow.down.circle") {
                 if let url = cursorDeepLink {
-                    NSWorkspace.shared.open(url)
+                    NSWorkspace.shared.open(url, configuration: .init(), completionHandler: nil)
                 }
             }
             manualFallback(
@@ -144,7 +144,7 @@ struct MCPInstructionsPane: View {
         guard let resourceURL = Bundle.main.resourceURL else { return }
         let url = resourceURL.appendingPathComponent("palmier-pro.mcpb")
         guard FileManager.default.fileExists(atPath: url.path) else { return }
-        NSWorkspace.shared.open(url)
+        NSWorkspace.shared.open(url, configuration: .init(), completionHandler: nil)
     }
 
     private var claudeCodeSection: some View {

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -38,7 +38,7 @@ struct AgentPane: View {
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Button(action: { NSWorkspace.shared.open(consoleURL) }) {
+                Button(action: { NSWorkspace.shared.open(consoleURL, configuration: .init(), completionHandler: nil) }) {
                     HStack(spacing: 2) {
                         Text("Get Anthropic API key")
                         Image(systemName: "arrow.up.right")


### PR DESCRIPTION
This is a sentry issue fix. 
Uses the non-blocking NSWorkspace open API for external links so LaunchServices resolution does not hang the UI.