### PR TITLE
Cache the chat conversation prefix

### DIFF
--- a/Sources/PalmierPro/Agent/AgentMentionContext.swift
+++ b/Sources/PalmierPro/Agent/AgentMentionContext.swift
@@ -18,7 +18,7 @@ enum AgentMentionContext {
         inlined: InlinedMentions = InlinedMentions()
     ) -> String {
         let entries = mentionEntries(mentions, editor: editor, inlined: inlined)
-        let data = (try? JSONSerialization.data(withJSONObject: entries)) ?? Data()
+        let data = (try? JSONSerialization.data(withJSONObject: entries, options: [.sortedKeys])) ?? Data()
         let json = String(data: data, encoding: .utf8) ?? "[]"
         let notes = mentionNotes(mentions, inlined: inlined)
         let suffix = notes.isEmpty ? "" : " " + notes.joined(separator: " ")

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -302,9 +302,19 @@ final class AgentService {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let referencedMentions = AgentMentionContext.referencedMentions(mentions, in: trimmed)
+        // Snapshot the mention/timeline context
+        let contextHint = referencedMentions.isEmpty
+            ? nil
+            : AgentMentionContext.hint(
+                referencedMentions, editor: editor,
+                inlined: inlineImageBlocks(for: referencedMentions)
+            )
 
         resolveOrphanToolUses()
-        messages.append(AgentMessage(role: .user, blocks: [.text(trimmed)], mentions: referencedMentions))
+        messages.append(AgentMessage(
+            role: .user, blocks: [.text(trimmed)],
+            mentions: referencedMentions, contextHint: contextHint
+        ))
         streamError = nil
         kickOffStream()
     }
@@ -506,7 +516,8 @@ final class AgentService {
             var content = msg.blocks.compactMap(Self.contentBlockJSON)
             if msg.role == .user, !msg.mentions.isEmpty {
                 let inlined = inlineImageBlocks(for: msg.mentions)
-                let hint = AgentMentionContext.hint(msg.mentions, editor: editor, inlined: inlined)
+                let hint = msg.contextHint
+                    ?? AgentMentionContext.hint(msg.mentions, editor: editor, inlined: inlined)
                 content.insert(contentsOf: inlined.blocks, at: 0)
                 content.insert(["type": "text", "text": hint], at: 0)
             }
@@ -584,12 +595,14 @@ struct AgentMessage: Identifiable, Codable {
     let role: Role
     var blocks: [AgentContentBlock]
     var mentions: [AgentMention]
+    var contextHint: String?
 
-    init(id: UUID = UUID(), role: Role, blocks: [AgentContentBlock], mentions: [AgentMention] = []) {
+    init(id: UUID = UUID(), role: Role, blocks: [AgentContentBlock], mentions: [AgentMention] = [], contextHint: String? = nil) {
         self.id = id
         self.role = role
         self.blocks = blocks
         self.mentions = mentions
+        self.contextHint = contextHint
     }
 }
 

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -68,6 +68,21 @@ protocol AgentClient: Sendable {
     ) -> AsyncThrowingStream<AnthropicStreamEvent, Error>
 }
 
+// MARK: - Usage logging
+
+enum AgentUsageLog {
+    static func record(_ usage: [String: Any]) {
+        #if DEBUG
+        let input = usage["input_tokens"] as? Int ?? 0
+        let cacheWrite = usage["cache_creation_input_tokens"] as? Int ?? 0
+        let cacheRead = usage["cache_read_input_tokens"] as? Int ?? 0
+        let billed = input + cacheWrite + cacheRead
+        let readPct = billed > 0 ? Int((Double(cacheRead) / Double(billed)) * 100) : 0
+        print("[agent cache] input=\(input) cacheWrite=\(cacheWrite) cacheRead=\(cacheRead) (\(readPct)% read)")
+        #endif
+    }
+}
+
 // MARK: - Shared SSE parser
 
 enum AnthropicSSE {
@@ -84,6 +99,12 @@ enum AnthropicSSE {
                   let type = event["type"] as? String else { continue }
 
             switch type {
+            case "message_start":
+                if let message = event["message"] as? [String: Any],
+                   let usage = message["usage"] as? [String: Any] {
+                    AgentUsageLog.record(usage)
+                }
+
             case "content_block_start":
                 if let index = event["index"] as? Int,
                    let block = event["content_block"] as? [String: Any],
@@ -148,12 +169,24 @@ enum AnthropicRequestBody {
             last["cache_control"] = ["type": "ephemeral"]
             toolBlocks.append(last)
         }
+        // Prompt-cache the conversation prefix
+        var messageBlocks: [[String: Any]] = messages.map {
+            ["role": $0.role.rawValue, "content": $0.content]
+        }
+        if var lastMsg = messageBlocks.popLast(),
+           var content = lastMsg["content"] as? [[String: Any]],
+           var lastBlock = content.popLast() {
+            lastBlock["cache_control"] = ["type": "ephemeral"]
+            content.append(lastBlock)
+            lastMsg["content"] = content
+            messageBlocks.append(lastMsg)
+        }
         var body: [String: Any] = [
             "model": model.rawValue,
             "max_tokens": maxTokens,
             "stream": true,
             "system": [["type": "text", "text": system, "cache_control": ["type": "ephemeral"]]],
-            "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
+            "messages": messageBlocks,
         ]
         if !toolBlocks.isEmpty { body["tools"] = toolBlocks }
         return body

--- a/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
@@ -68,9 +68,12 @@ struct AnthropicClient: AgentClient {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
         request.setValue("text/event-stream", forHTTPHeaderField: "accept")
-        request.httpBody = try JSONSerialization.data(withJSONObject: AnthropicRequestBody.build(
-            model: model, maxTokens: maxTokens, system: system, tools: tools, messages: messages
-        ))
+        request.httpBody = try JSONSerialization.data(
+            withJSONObject: AnthropicRequestBody.build(
+                model: model, maxTokens: maxTokens, system: system, tools: tools, messages: messages
+            ),
+            options: [.sortedKeys]
+        )
 
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {

--- a/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
@@ -46,9 +46,12 @@ struct PalmierClient: AgentClient {
         request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
         request.setValue("text/event-stream", forHTTPHeaderField: "accept")
-        request.httpBody = try JSONSerialization.data(withJSONObject: AnthropicRequestBody.build(
-            model: model, maxTokens: maxTokens, system: system, tools: tools, messages: messages
-        ))
+        request.httpBody = try JSONSerialization.data(
+            withJSONObject: AnthropicRequestBody.build(
+                model: model, maxTokens: maxTokens, system: system, tools: tools, messages: messages
+            ),
+            options: [.sortedKeys]
+        )
 
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {


### PR DESCRIPTION
## Problem

only caching system + tools, not conversation

## Changes

add `cache_control` breakpoint on the last block of the last message. also snapshot the runtime context so it stays the same.

## Test

Measured over a multi-turn chat with tool use:

```
[agent cache] input=3 cacheWrite=0    cacheRead=12396 (99% read)
[agent cache] input=1 cacheWrite=1279 cacheRead=12396 (90% read)
[agent cache] input=3 cacheWrite=290  cacheRead=13675 (97% read)
[agent cache] input=1 cacheWrite=2597 cacheRead=13965 (84% read)
[agent cache] input=3 cacheWrite=211  cacheRead=16562 (98% read)
[agent cache] input=3 cacheWrite=752  cacheRead=16773 (95% read)
```