### PR TITLE
Support WebP images end to end

### DIFF
--- a/Sources/PalmierPro/Models/ClipType.swift
+++ b/Sources/PalmierPro/Models/ClipType.swift
@@ -39,7 +39,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         switch ext {
         case "mov", "mp4", "m4v": self = .video
         case "mp3", "wav", "aac", "m4a": self = .audio
-        case "png", "jpg", "jpeg", "tiff", "heic": self = .image
+        case "png", "jpg", "jpeg", "tiff", "heic", "webp": self = .image
         case "json", "lottie": self = .lottie
         default: return nil
         }

--- a/Sources/PalmierPro/Utilities/ImageEncoder.swift
+++ b/Sources/PalmierPro/Utilities/ImageEncoder.swift
@@ -68,7 +68,7 @@ enum ImageEncoder {
 
     private static func passthrough(url: URL, stamp: FileStamp?) -> Output? {
         let imageMetadata = metadata(url: url)
-        guard let mime = passthroughMime(url.pathExtension.lowercased()),
+        guard let mime = sniffedMime(url: url),
               let size = stamp?.size, size <= maxBytes,
               let width = imageMetadata.width,
               let height = imageMetadata.height,
@@ -110,13 +110,17 @@ enum ImageEncoder {
 
     // MARK: - Misc
 
-    private static func passthroughMime(_ ext: String) -> String? {
-        switch ext {
-        case "png": "image/png"
-        case "jpg", "jpeg": "image/jpeg"
-        case "gif": "image/gif"
-        case "webp": "image/webp"
-        default: nil
+    /// MIME from the file's real container type (UTI)
+    private static func sniffedMime(url: URL) -> String? {
+        guard let source = imageSource(url: url),
+              let uti = CGImageSourceGetType(source) as String?
+        else { return nil }
+        switch uti {
+        case UTType.png.identifier: return "image/png"
+        case UTType.jpeg.identifier: return "image/jpeg"
+        case UTType.gif.identifier: return "image/gif"
+        case UTType.webP.identifier: return "image/webp"
+        default: return nil
         }
     }
 

--- a/Tests/PalmierProTests/Media/LottieImportTests.swift
+++ b/Tests/PalmierProTests/Media/LottieImportTests.swift
@@ -8,6 +8,7 @@ struct LottieImportTests {
     @Test func classifiesExtensions() {
         #expect(ClipType(fileExtension: "json") == .lottie)
         #expect(ClipType(fileExtension: "lottie") == .lottie)
+        #expect(ClipType(fileExtension: "webp") == .image)
         #expect(ClipType.lottie.isVisual)
         #expect(ClipType.lottie.isCompatible(with: .video))
         #expect(ClipType.lottie.isCompatible(with: .image))


### PR DESCRIPTION
## Problem

Two WebP gaps, both caused by trusting the file **extension** instead of the actual bytes:

1. **Chat (the reported 400):** a WebP file with a `.png` name was sent to the Anthropic API tagged `image/png`. Anthropic sniffs the real bytes and rejects the mismatch:
   > Anthropic API error (400): The image was specified using the image/png media type, but the image appears to be a image/webp image.
2. **Import:** a genuinely-named `.webp` file was rejected at import as "unsupported file type."

## Fix

- `ImageEncoder` now derives the MIME from the decoded container type via `CGImageSourceGetType` (mapped to png/jpeg/gif/webp), so the `media_type` always matches the bytes. Mislabeled or unrecognized files fall through to the existing JPEG re-encode path.
- `ClipType(fileExtension:)` accepts `webp` so real `.webp` files import as images. (The file picker already allowed them — WebP conforms to `public.image` — only the post-selection classifier rejected them.)

## Tests

- Added a `ClipType(fileExtension: "webp") == .image` assertion in `LottieImportTests`.