### PR TITLE
Add Codex CLI agent provider

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -38,10 +38,17 @@ final class AgentService {
 
     var hasApiKey: Bool { !apiKey.isEmpty }
 
+    var hasCodexCLI: Bool { CodexCLIClient.isAvailable }
+
     var canStream: Bool {
-        if hasApiKey { return true }
-        let account = AccountService.shared
-        return account.isSignedIn && account.hasCredits
+        switch backend {
+        case .anthropic:
+            if hasApiKey { return true }
+            let account = AccountService.shared
+            return account.isSignedIn && account.hasCredits
+        case .codexCLI:
+            return hasCodexCLI
+        }
     }
 
     var availableModels: [AnthropicModel] {
@@ -50,12 +57,17 @@ final class AgentService {
     }
 
     private func selectClient() -> (any AgentClient)? {
-        let chosen = effectiveModel
-        if hasApiKey { return AnthropicClient(apiKey: apiKey, model: chosen) }
-        if AccountService.shared.isSignedIn {
-            return PalmierClient(model: chosen)
+        switch backend {
+        case .anthropic:
+            let chosen = effectiveModel
+            if hasApiKey { return AnthropicClient(apiKey: apiKey, model: chosen) }
+            if AccountService.shared.isSignedIn {
+                return PalmierClient(model: chosen)
+            }
+            return nil
+        case .codexCLI:
+            return hasCodexCLI ? CodexCLIClient() : nil
         }
-        return nil
     }
 
     var effectiveModel: AnthropicModel {
@@ -72,6 +84,16 @@ final class AgentService {
         return .sonnet46
     }() {
         didSet { UserDefaults.standard.set(model.rawValue, forKey: "agentModel") }
+    }
+
+    var backend: AgentBackend = {
+        if let raw = UserDefaults.standard.string(forKey: "agentBackend"),
+           let backend = AgentBackend(rawValue: raw) {
+            return backend
+        }
+        return .anthropic
+    }() {
+        didSet { UserDefaults.standard.set(backend.rawValue, forKey: "agentBackend") }
     }
 
     var sessions: [ChatSession] = []
@@ -296,7 +318,9 @@ final class AgentService {
 
     func send(text: String, mentions: [AgentMention]) {
         guard canStream else {
-            streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
+            streamError = .upstream(backend == .codexCLI
+                ? "Codex CLI not found. Install Codex or open Codex.app."
+                : "Sign in to a paid plan or add an Anthropic API key to start.")
             return
         }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -16,6 +16,18 @@ enum AnthropicModel: String, CaseIterable, Sendable {
     }
 }
 
+enum AgentBackend: String, CaseIterable, Sendable {
+    case anthropic
+    case codexCLI
+
+    var displayName: String {
+        switch self {
+        case .anthropic: "Anthropic"
+        case .codexCLI: "Codex CLI"
+        }
+    }
+}
+
 enum AnthropicStopReason: String, Sendable {
     case endTurn = "end_turn"
     case toolUse = "tool_use"

--- a/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+struct CodexCLIClient: AgentClient {
+    static var isAvailable: Bool { executableURL != nil }
+
+    static var executableURL: URL? {
+        executableURL(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func executableURL(environment: [String: String]) -> URL? {
+        let fm = FileManager.default
+        for path in candidatePaths(environment: environment) where fm.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
+    }
+
+    static func candidatePaths(environment: [String: String]) -> [String] {
+        let home = environment["HOME"] ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let homePaths = [
+            "\(home)/.npm-global/bin/codex",
+            "\(home)/.local/bin/codex"
+        ]
+        let defaults = [
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex"
+        ]
+        let pathEntries = environment["PATH", default: ""]
+            .split(separator: ":")
+            .map { String($0) + "/codex" }
+        return pathEntries + homePaths + defaults
+    }
+
+    func stream(
+        system: String,
+        tools: [AnthropicToolSchema],
+        messages: [AnthropicMessage]
+    ) -> AsyncThrowingStream<AnthropicStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let process = Process()
+            let task = Task {
+                do {
+                    let response = try Self.run(
+                        process: process,
+                        prompt: Self.prompt(system: system, tools: tools, messages: messages)
+                    )
+                    for event in Self.events(from: response) {
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                process.terminate()
+                task.cancel()
+            }
+        }
+    }
+
+    private static func run(process: Process, prompt: String) throws -> CodexResponse {
+        guard let executableURL else {
+            throw PalmierClientError.upstream("Codex CLI not found. Install Codex or open Codex.app.")
+        }
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let lastMessage = dir.appendingPathComponent("last.txt")
+        let stdoutURL = dir.appendingPathComponent("stdout.jsonl")
+        let stderrURL = dir.appendingPathComponent("stderr.log")
+        let schemaURL = dir.appendingPathComponent("schema.json")
+        FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+        FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+        try Data(Self.outputSchema.utf8).write(to: schemaURL)
+
+        let stdout = try FileHandle(forWritingTo: stdoutURL)
+        let stderr = try FileHandle(forWritingTo: stderrURL)
+        defer {
+            try? stdout.close()
+            try? stderr.close()
+        }
+
+        let stdin = Pipe()
+        process.executableURL = executableURL
+        process.arguments = Self.codexArguments(schemaURL: schemaURL, lastMessageURL: lastMessage)
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        stdin.fileHandleForWriting.write(Data(prompt.utf8))
+        try stdin.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let err = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? ""
+            throw PalmierClientError.upstream("Codex CLI failed: \(err.prefix(500))")
+        }
+
+        let data = try Data(contentsOf: lastMessage)
+        return try JSONDecoder().decode(CodexResponse.self, from: data)
+    }
+
+    static func events(from data: Data) throws -> [AnthropicStreamEvent] {
+        try events(from: JSONDecoder().decode(CodexResponse.self, from: data))
+    }
+
+    private static func events(from response: CodexResponse) -> [AnthropicStreamEvent] {
+        var events: [AnthropicStreamEvent] = []
+        if !response.text.isEmpty { events.append(.textDelta(response.text)) }
+        events += response.toolCalls.map {
+            .toolUseComplete(id: $0.id, name: $0.name, inputJSON: $0.inputJSON)
+        }
+        events.append(.messageStop(stopReason: response.stopReason))
+        return events
+    }
+
+    static func codexArguments(schemaURL: URL, lastMessageURL: URL) -> [String] {
+        [
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--ignore-rules",
+            "--skip-git-repo-check",
+            "--sandbox", "read-only",
+            "-c", "approval_policy=\"never\"",
+            "--output-schema", schemaURL.path,
+            "--output-last-message", lastMessageURL.path,
+            "-"
+        ]
+    }
+
+    static func prompt(
+        system: String,
+        tools: [AnthropicToolSchema] = [],
+        messages: [AnthropicMessage]
+    ) -> String {
+        """
+        \(system)
+
+        You are running inside Palmier Pro through Codex CLI.
+        Reply as JSON matching the provided schema. To act on the timeline, choose tool calls from Available tools.
+        Set stop_reason to tool_use when tool_calls is non-empty, otherwise end_turn.
+        input_json must be a valid JSON object string.
+
+        Available tools:
+        \(toolsJSON(tools))
+
+        Conversation:
+        \(messages.map(render).joined(separator: "\n\n"))
+        """
+    }
+
+    private static func render(_ message: AnthropicMessage) -> String {
+        let body = message.content.compactMap(renderBlock).joined(separator: "\n")
+        return "\(message.role.rawValue.uppercased()): \(body)"
+    }
+
+    private static func renderBlock(_ block: [String: Any]) -> String? {
+        switch block["type"] as? String {
+        case "text":
+            return block["text"] as? String
+        case "tool_result":
+            return "Tool result: \(block["content"] ?? "")"
+        case "tool_use":
+            return "Tool request: \(block["name"] ?? "") \(block["input"] ?? "")"
+        case "image":
+            return "[Image omitted by Codex CLI chat bridge. Use Palmier inspect/search tools if needed.]"
+        default:
+            return nil
+        }
+    }
+
+    private static func toolsJSON(_ tools: [AnthropicToolSchema]) -> String {
+        let value = tools.map {
+            [
+                "name": $0.name,
+                "description": $0.description,
+                "input_schema": $0.inputSchema
+            ] as [String: Any]
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return text
+    }
+
+    private static let outputSchema = """
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "type": "string" },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "input_json": { "type": "string" }
+            },
+            "required": ["id", "name", "input_json"]
+          }
+        },
+        "stop_reason": { "type": "string", "enum": ["end_turn", "tool_use"] }
+      },
+      "required": ["text", "tool_calls", "stop_reason"]
+    }
+    """
+}
+
+private struct CodexResponse: Decodable {
+    let text: String
+    let toolCalls: [ToolCall]
+    let stopReason: AnthropicStopReason
+
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case toolCalls = "tool_calls"
+        case stopReason = "stop_reason"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        text = try c.decode(String.self, forKey: .text)
+        toolCalls = try c.decode([ToolCall].self, forKey: .toolCalls)
+        let raw = try c.decode(String.self, forKey: .stopReason)
+        stopReason = AnthropicStopReason(rawValue: raw) ?? .other
+    }
+
+    struct ToolCall: Decodable {
+        let id: String
+        let name: String
+        let inputJSON: String
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case inputJSON = "input_json"
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -137,30 +137,49 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var modelPicker: some View {
-        if service.hasApiKey {
-            Menu {
-                ForEach(service.availableModels, id: \.self) { m in
-                    Button(m.displayName) { service.model = m }
-                }
-            } label: {
-                HStack(spacing: AppTheme.Spacing.xs) {
-                    Text(service.effectiveModel.displayName)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: AppTheme.FontSize.micro, weight: .semibold))
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+        Menu {
+            Section("Provider") {
+                ForEach(AgentBackend.allCases, id: \.self) { backend in
+                    Button(backend.displayName) { service.backend = backend }
                 }
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
+
+            if service.backend == .anthropic {
+                Section("Model") {
+                    ForEach(service.availableModels, id: \.self) { m in
+                        Button(m.displayName) { service.model = m }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Text(modelPickerTitle)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: AppTheme.FontSize.micro, weight: .semibold))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+            }
         }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private var modelPickerTitle: String {
+        service.backend == .codexCLI
+            ? AgentBackend.codexCLI.displayName
+            : service.effectiveModel.displayName
     }
 
     @ViewBuilder
     private var byokIndicator: some View {
-        if service.hasApiKey {
+        if service.backend == .codexCLI {
+            Text("using Codex CLI")
+                .font(.system(size: AppTheme.FontSize.xs).italic())
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .help("Streaming through local Codex CLI")
+        } else if service.hasApiKey {
             Text("using API key")
                 .font(.system(size: AppTheme.FontSize.xs).italic())
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
@@ -316,26 +335,32 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var missingKeyState: some View {
-        let account = AccountService.shared
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
-                Text(missingKeyPrimaryAction(account: account))
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
-            }
-            .buttonStyle(.plain)
-
-            Text("or use")
+        if service.backend == .codexCLI {
+            Text("Install Codex CLI or open Codex.app to use this provider.")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
+        } else {
+            let account = AccountService.shared
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
+                    Text(missingKeyPrimaryAction(account: account))
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
 
-            Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
-                Text("your own Anthropic key")
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
+                Text("or use")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+
+                Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
+                    Text("your own Anthropic key")
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+            .font(.system(size: AppTheme.FontSize.md, weight: .medium))
         }
-        .font(.system(size: AppTheme.FontSize.md, weight: .medium))
     }
 
     private func missingKeyPrimaryAction(account: AccountService) -> String {

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -33,7 +33,7 @@ struct AgentPane: View {
                 .foregroundStyle(AppTheme.Text.primaryColor)
 
             HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
-                Text("Used your own API key for the AI chat. Stored in your macOS Keychain.")
+                Text("Use your own API key for Anthropic chat. Codex CLI works from the chat model picker.")
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
+++ b/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("CodexCLIClient")
+struct CodexCLIClientTests {
+    @Test func promptRendersConversationForCodexExec() {
+        let prompt = CodexCLIClient.prompt(
+            system: "System instructions",
+            messages: [
+                AnthropicMessage(role: .user, content: [["type": "text", "text": "Trim first clip"]]),
+                AnthropicMessage(role: .assistant, content: [["type": "text", "text": "Done"]])
+            ]
+        )
+
+        #expect(prompt.contains("System instructions"))
+        #expect(prompt.contains("Reply as JSON matching the provided schema"))
+        #expect(prompt.contains("USER: Trim first clip"))
+        #expect(prompt.contains("ASSISTANT: Done"))
+    }
+
+    @Test func codexArgumentsUseSchemaFileAndIgnoreProjectRules() {
+        let schemaURL = URL(fileURLWithPath: "/tmp/schema.json")
+        let lastURL = URL(fileURLWithPath: "/tmp/last.json")
+
+        let args = CodexCLIClient.codexArguments(schemaURL: schemaURL, lastMessageURL: lastURL)
+
+        #expect(args.contains("--ignore-rules"))
+        #expect(args.contains("approval_policy=\"never\""))
+        #expect(args.pair(after: "--sandbox") == "read-only")
+        #expect(args.pair(after: "--output-schema") == schemaURL.path)
+        #expect(args.pair(after: "--output-last-message") == lastURL.path)
+    }
+
+    @Test func executableLookupUsesPathEnvironment() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let codex = dir.appendingPathComponent("codex")
+        try Data().write(to: codex)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codex.path)
+
+        #expect(CodexCLIClient.executableURL(environment: ["PATH": dir.path]) == codex)
+    }
+
+    @Test func candidatePathsIncludeUserLocalInstallLocations() {
+        let paths = CodexCLIClient.candidatePaths(environment: ["HOME": "/tmp/palmier-home"])
+
+        #expect(paths.contains("/tmp/palmier-home/.npm-global/bin/codex"))
+        #expect(paths.contains("/tmp/palmier-home/.local/bin/codex"))
+    }
+
+    @Test func responseJSONMapsToAgentStreamEvents() throws {
+        let data = Data("""
+        {
+          "text": "Done",
+          "tool_calls": [
+            { "id": "call_1", "name": "move_clips", "input_json": "{\\"clipIds\\":[\\"c1\\"]}" }
+          ],
+          "stop_reason": "tool_use"
+        }
+        """.utf8)
+
+        let events = try CodexCLIClient.events(from: data)
+
+        #expect(events.count == 3)
+        if case .textDelta("Done") = events[0] {} else {
+            Issue.record("Expected text delta")
+        }
+        if case let .toolUseComplete(id, name, inputJSON) = events[1] {
+            #expect(id == "call_1")
+            #expect(name == "move_clips")
+            #expect(inputJSON == "{\"clipIds\":[\"c1\"]}")
+        } else {
+            Issue.record("Expected tool use")
+        }
+        if case .messageStop(.toolUse) = events[2] {} else {
+            Issue.record("Expected tool_use stop")
+        }
+    }
+}
+
+private extension Array where Element == String {
+    func pair(after flag: String) -> String? {
+        guard let index = firstIndex(of: flag), indices.contains(index + 1) else { return nil }
+        return self[index + 1]
+    }
+}

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -36,6 +36,7 @@ fi
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application: Palmier, Inc. (MMFLRC7562)}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-palmier-notary}"
 SENTRY_DSN="${SENTRY_DSN:-}"
+# Set PALMIER_BUNDLE_ID for isolated local builds, e.g. io.palmier.pro.dev.
 RESOURCES="$ROOT/Sources/PalmierPro/Resources"
 APP="$ROOT/.build/PalmierPro.app"
 ZIP="$ROOT/.build/PalmierPro.zip"
@@ -74,6 +75,10 @@ echo "==> Injecting backend config into Info.plist"
 inject_plist PalmierClerkPublishableKey "${CLERK_PUBLISHABLE_KEY:-}"
 inject_plist PalmierConvexDeploymentURL "${CONVEX_DEPLOYMENT_URL:-}"
 inject_plist PalmierConvexHttpURL "${CONVEX_HTTP_URL:-}"
+if [ -n "${PALMIER_BUNDLE_ID:-}" ]; then
+    echo "==> Using bundle id $PALMIER_BUNDLE_ID"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $PALMIER_BUNDLE_ID" "$APP/Contents/Info.plist"
+fi
 cp "$RESOURCES/AppIcon.icns" "$APP/Contents/Resources/AppIcon.icns"
 cp -R "$SPARKLE_FW" "$APP/Contents/Frameworks/Sparkle.framework"
 


### PR DESCRIPTION
## Summary
- add Codex CLI as an agent backend in the chat model picker
- preserve existing Anthropic/Palmier provider path as default
- bridge Codex CLI structured JSON output into existing agent stream/tool execution
- allow isolated local debug bundles via PALMIER_BUNDLE_ID for stable keychain testing

## Testing
- swift test
- Codex CLI structured-output smoke test
- debug bundle build with PALMIER_BUNDLE_ID=io.palmier.pro.dev and Apple Development signing
- launched local dev bundle without the production keychain prompt