### PR TITLE
Media Offline detection + Relink for unloadable clips

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -135,8 +135,13 @@ extension EditorViewModel {
         return mediaResolver.displayName(for: clip.mediaRef)
     }
 
-    func isClipMediaMissing(_ clip: Clip) -> Bool {
-        clip.mediaType != .text && mediaResolver.isMissing(for: clip.mediaRef)
+    /// missing on disk or present-but-unloadable (no permission, ejected volume)
+    func isMediaOffline(_ mediaRef: String) -> Bool {
+        offlineMediaRefs.contains(mediaRef) || mediaResolver.isMissing(for: mediaRef)
+    }
+
+    func isClipMediaOffline(_ clip: Clip) -> Bool {
+        clip.mediaType != .text && isMediaOffline(clip.mediaRef)
     }
 
     func isClipMediaGenerating(_ clip: Clip) -> Bool {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Relink.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Relink.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// Reconnect offline media by repointing assets at a relocated source file or folder.
+extension EditorViewModel {
+
+    /// Repoint a single asset at a new source file, re-validate, and rebuild.
+    func relinkAsset(id: String, to newURL: URL) {
+        guard let asset = mediaAssets.first(where: { $0.id == id }) else { return }
+        if let newType = ClipType(fileExtension: newURL.pathExtension.lowercased()), newType != asset.type {
+            mediaPanelToast = "Can't relink — \"\(newURL.lastPathComponent)\" is \(newType.trackLabel.lowercased()), not \(asset.type.trackLabel.lowercased())."
+            return
+        }
+        applyRelink(id: id, to: newURL)
+        notifyTimelineChanged()
+    }
+
+    /// Match every offline asset to a same-named file under `folder` (recursive) and relink it.
+    @discardableResult
+    func relinkOfflineAssets(fromFolder folder: URL) -> (relinked: Int, total: Int) {
+        let offline = mediaAssets.filter { isMediaOffline($0.id) }
+        guard !offline.isEmpty else { return (0, 0) }
+        let index = fileIndex(in: folder)
+        var relinked = 0
+        for asset in offline {
+            guard let match = index[asset.url.lastPathComponent.lowercased()] else { continue }
+            applyRelink(id: asset.id, to: match)
+            relinked += 1
+        }
+        if relinked > 0 { notifyTimelineChanged() }
+        return (relinked, offline.count)
+    }
+
+    private func applyRelink(id: String, to newURL: URL) {
+        guard let i = mediaAssets.firstIndex(where: { $0.id == id }) else { return }
+        mediaAssets[i].url = newURL
+        if let j = mediaManifest.entries.firstIndex(where: { $0.id == id }) {
+            mediaManifest.entries[j].source = mediaAssets[i].toManifestEntry(projectURL: projectURL).source
+        }
+        let asset = mediaAssets[i]
+        Task { await finalizeImportedAsset(asset) }
+    }
+
+    /// Lowercased filename → URL for regular files under `folder`, first match wins.
+    private func fileIndex(in folder: URL) -> [String: URL] {
+        var map: [String: URL] = [:]
+        let keys: Set<URLResourceKey> = [.isRegularFileKey]
+        guard let walker = FileManager.default.enumerator(at: folder, includingPropertiesForKeys: Array(keys)) else {
+            return map
+        }
+        for case let url as URL in walker {
+            guard (try? url.resourceValues(forKeys: keys))?.isRegularFile == true else { continue }
+            let key = url.lastPathComponent.lowercased()
+            if map[key] == nil { map[key] = url }
+        }
+        return map
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -108,6 +108,7 @@ final class EditorViewModel {
     // MARK: - Media library (in-memory, rebuilt on project open)
 
     var mediaAssets: [MediaAsset] = []
+    var offlineMediaRefs: Set<String> = []
     let mediaVisualCache = MediaVisualCache()
     let searchIndex = SearchIndexCoordinator()
     var projectURL: URL? {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -242,11 +242,11 @@ struct AssetThumbnailView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: AppTheme.FontSize.mdLg))
                 .foregroundStyle(AppTheme.Status.errorColor)
-            Text("Media Missing")
+            Text("Media Offline")
                 .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
                 .foregroundStyle(AppTheme.Text.secondaryColor)
         }
-        .help("The source file for this media could not be found.")
+        .help("Palmier couldn't load this source file. It may be missing, on an ejected drive, or unreadable.")
     }
 
     private func formatDuration(_ seconds: Double) -> String {
@@ -277,9 +277,9 @@ struct AssetThumbnailView: View {
     }
 
     private var isMissing: Bool {
-        // Generating/downloading/failed assets have their own states — not "missing".
+        // Generating/downloading/failed assets have their own states — not "offline".
         guard case .none = asset.generationStatus else { return false }
-        return editor.mediaResolver.isMissing(for: asset.id)
+        return editor.isMediaOffline(asset.id)
     }
 
     private var borderColor: Color {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -81,6 +81,10 @@ struct AssetThumbnailView: View {
             Divider()
         }
         if ids.count == 1, ids.first == asset.id {
+            if isMissing {
+                Button("Relink…") { relinkFile() }
+                Divider()
+            }
             Button("Rename") { beginRename() }
             AIEditMenu(asset: asset)
             Divider()
@@ -98,6 +102,18 @@ struct AssetThumbnailView: View {
                 .map(\.id)
         }
         return [asset.id]
+    }
+
+    private func relinkFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose the source file for \"\(asset.name)\""
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            editor.relinkAsset(id: asset.id, to: url)
+        }
     }
 
     private func revealInFinder(ids: [String]) {

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -19,6 +19,7 @@ struct CompositionResult {
     let trackMappings: [TrackMapping]
     let clipNaturalSizes: [String: CGSize]
     let clipTransforms: [String: CGAffineTransform]
+    let offlineMediaRefs: Set<String>
 }
 
 /// Builds an AVFoundation composition from a Timeline.
@@ -45,6 +46,7 @@ enum CompositionBuilder {
         var trackMappings: [TrackMapping] = []
         var clipNaturalSizes: [String: CGSize] = [:]
         var clipTransforms: [String: CGAffineTransform] = [:]
+        var offlineMediaRefs: Set<String> = []
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
             // Text renders via CATextLayer overlay (preview) + animation tool (export) — never as composition tracks.
@@ -68,6 +70,7 @@ enum CompositionBuilder {
                         resolveSourceSize: resolveSourceSize,
                         renderSize: renderSize
                     ) else {
+                        offlineMediaRefs.insert(clip.mediaRef)
                         continue
                     }
 
@@ -150,6 +153,7 @@ enum CompositionBuilder {
                     resolveSourceSize: resolveSourceSize,
                     renderSize: renderSize
                 ) else {
+                    offlineMediaRefs.insert(clip.mediaRef)
                     continue
                 }
 
@@ -220,7 +224,8 @@ enum CompositionBuilder {
             videoComposition: videoComposition,
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
-            clipTransforms: clipTransforms
+            clipTransforms: clipTransforms,
+            offlineMediaRefs: offlineMediaRefs
         )
     }
 

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -30,8 +30,8 @@ struct PreviewContainerView: View {
                     if let asset = activeMediaAsset, asset.isGenerating {
                         generatingPreview(label: asset.generatingLabel)
                     }
-                    if activeMediaMissing {
-                        missingPreview
+                    if let overlay = offlineOverlay {
+                        offlinePreview(path: overlay.path)
                     }
                     if editor.cropEditingActive {
                         CropOverlayView()
@@ -324,7 +324,36 @@ struct PreviewContainerView: View {
 
     private var activeMediaMissing: Bool {
         guard let asset = activeMediaAsset, case .none = asset.generationStatus else { return false }
-        return editor.mediaResolver.isMissing(for: asset.id)
+        return editor.isMediaOffline(asset.id)
+    }
+
+    /// The offline clip blacking out the current timeline frame, or nil when an online clip covers it.
+    private var timelineOfflineClip: Clip? {
+        guard isTimeline else { return nil }
+        let frame = editor.currentFrame
+        var offline: Clip?
+        for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
+            for clip in track.clips where clip.mediaType != .text {
+                guard clip.contains(timelineFrame: frame) else { continue }
+                if editor.isMediaOffline(clip.mediaRef) {
+                    offline = offline ?? clip
+                } else {
+                    return nil
+                }
+            }
+        }
+        return offline
+    }
+
+    private struct OfflineOverlay { let path: String? }
+
+    /// Resolved once per render so the timeline scan runs at most once.
+    private var offlineOverlay: OfflineOverlay? {
+        if activeMediaMissing { return OfflineOverlay(path: activeMediaAsset?.url.path) }
+        if let clip = timelineOfflineClip {
+            return OfflineOverlay(path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path)
+        }
+        return nil
     }
 
     private func generatingPreview(label: String) -> some View {
@@ -354,18 +383,24 @@ struct PreviewContainerView: View {
         return nil
     }
 
-    private var missingPreview: some View {
+    private func offlinePreview(path: String?) -> some View {
         ZStack {
             Color.black.opacity(AppTheme.Opacity.strong)
             VStack(spacing: AppTheme.Spacing.md) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: AppTheme.FontSize.display))
                     .foregroundStyle(AppTheme.Status.errorColor)
-                Text("Media Missing")
+                Text("Media Offline")
                     .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
                     .foregroundStyle(AppTheme.Text.primaryColor)
-                if let asset = activeMediaAsset {
-                    Text(asset.url.path)
+                Text("Palmier couldn't load this clip's source file. It may be missing, on an ejected drive, or unreadable.")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, AppTheme.Spacing.lg)
+                if let path {
+                    Text(path)
                         .font(.system(size: AppTheme.FontSize.sm))
                         .foregroundStyle(AppTheme.Text.secondaryColor)
                         .multilineTextAlignment(.center)

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct PreviewContainerView: View {
@@ -31,7 +32,7 @@ struct PreviewContainerView: View {
                         generatingPreview(label: asset.generatingLabel)
                     }
                     if let overlay = offlineOverlay {
-                        offlinePreview(path: overlay.path)
+                        offlinePreview(assetId: overlay.assetId, path: overlay.path)
                     }
                     if editor.cropEditingActive {
                         CropOverlayView()
@@ -345,15 +346,42 @@ struct PreviewContainerView: View {
         return offline
     }
 
-    private struct OfflineOverlay { let path: String? }
+    private struct OfflineOverlay { let assetId: String?; let path: String? }
 
     /// Resolved once per render so the timeline scan runs at most once.
     private var offlineOverlay: OfflineOverlay? {
-        if activeMediaMissing { return OfflineOverlay(path: activeMediaAsset?.url.path) }
+        if activeMediaMissing {
+            return OfflineOverlay(assetId: activeMediaAsset?.id, path: activeMediaAsset?.url.path)
+        }
         if let clip = timelineOfflineClip {
-            return OfflineOverlay(path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path)
+            return OfflineOverlay(assetId: clip.mediaRef, path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path)
         }
         return nil
+    }
+
+    private func relinkFile(assetId: String) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose the source file for this clip"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            editor.relinkAsset(id: assetId, to: url)
+        }
+    }
+
+    private func relinkFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose the folder that holds your media"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            let result = editor.relinkOfflineAssets(fromFolder: url)
+            editor.mediaPanelToast = "Relinked \(result.relinked) of \(result.total) offline clips."
+        }
     }
 
     private func generatingPreview(label: String) -> some View {
@@ -383,7 +411,7 @@ struct PreviewContainerView: View {
         return nil
     }
 
-    private func offlinePreview(path: String?) -> some View {
+    private func offlinePreview(assetId: String?, path: String?) -> some View {
         ZStack {
             Color.black.opacity(AppTheme.Opacity.strong)
             VStack(spacing: AppTheme.Spacing.md) {
@@ -409,6 +437,15 @@ struct PreviewContainerView: View {
                         .truncationMode(.middle)
                         .padding(.horizontal, AppTheme.Spacing.lg)
                 }
+                HStack(spacing: AppTheme.Spacing.sm) {
+                    if let assetId {
+                        Button("Relink…") { relinkFile(assetId: assetId) }
+                            .buttonStyle(.capsule(.prominent, size: .regular))
+                    }
+                    Button("Relink Folder…") { relinkFolder() }
+                        .buttonStyle(.capsule(.secondary, size: .regular))
+                }
+                .padding(.top, AppTheme.Spacing.xs)
             }
             .padding(AppTheme.Spacing.xl)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -170,6 +170,7 @@ final class VideoEngine {
             clipNaturalSizes = result.clipNaturalSizes
             clipTransforms = result.clipTransforms
             compositionDuration = result.composition.duration
+            editor.offlineMediaRefs = result.offlineMediaRefs
 
             let item = AVPlayerItem(asset: result.composition)
             item.audioMix = result.audioMix

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -301,7 +301,7 @@ final class TimelineView: NSView {
         for (ti, track) in editor.timeline.tracks.enumerated() {
             for clip in track.clips {
                 let isSelected = editor.selectedClipIds.contains(clip.id)
-                let clipMissing = editor.isClipMediaMissing(clip)
+                let clipMissing = editor.isClipMediaOffline(clip)
                 let clipGenerating = editor.isClipMediaGenerating(clip)
 
                 if let drag = moveDrag, allDraggedIds.contains(clip.id) {
@@ -533,7 +533,7 @@ final class TimelineView: NSView {
                               isSelected: true, opacity: 0.5, context: ctx,
                               cache: editor.mediaVisualCache,
                               fps: editor.timeline.fps,
-                              isMissing: editor.isClipMediaMissing(ghost.clip),
+                              isMissing: editor.isClipMediaOffline(ghost.clip),
                               isGenerating: editor.isClipMediaGenerating(ghost.clip))
         }
     }


### PR DESCRIPTION
### Problem

Timeline scrubbing all black with no explanation when a clip's source file can't be loaded: gone, moved, on an ejected drive, or TCC permission lost (camera footage on removable volumes). The composition silently skipped the clip, so the black background showed through. Detection relied on a fileExists check that missed permission-denied files entirely, and there was no way to recover the media in-app.

### Solution
1. Detect + show offline state — CompositionBuilder now reports which clips actually failed to load (any cause), and the media panel, timeline clips, and preview show a clear "Media Offline" card instead of black.
2. Relink to recover — "Relink…" (pick the file) and "Relink Folder…" (batch-match all offline clips by filename) reconnect the media; the open panel also re-grants macOS file access, and the offline state clears on the next rebuild.
