### PR TITLE
OpenRouter provider integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,12 @@ AI-native macOS video editor. Swift 6.2, SwiftUI + AppKit, AVFoundation. macOS 2
 ## Build
 
 ```bash
-swift build
-swift run
+SWIFT_PLUGIN_PATHS="-Xswiftc -plugin-path -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins -Xswiftc -plugin-path -Xswiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins"
+swift build $SWIFT_PLUGIN_PATHS
+swift run $SWIFT_PLUGIN_PATHS
 ```
+
+(CLT toolchain is missing `PreviewsMacros` and `SwiftUIMacros` plugins used by `#Preview` / `@Entry`. The flags above point to the Xcode toolchain's plugin libraries.)
 
 ## Code style
 

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -5,8 +5,10 @@ import Observation
 @MainActor
 final class AgentService {
 
-    private var apiKey: String = ""
+    private var anthropicApiKey: String = AnthropicKeychain.load() ?? ""
+    private var openRouterApiKey: String = OpenRouterKeychain.load() ?? ""
     private var apiKeyObserver: NSObjectProtocol?
+    private var openRouterKeyObserver: NSObjectProtocol?
 
     init() {
         reloadAPIKey()
@@ -16,46 +18,76 @@ final class AgentService {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.reloadAPIKey()
+                self?.anthropicApiKey = AnthropicKeychain.load() ?? ""
+            }
+        }
+        openRouterKeyObserver = NotificationCenter.default.addObserver(
+            forName: .openRouterKeyChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.openRouterApiKey = OpenRouterKeychain.load() ?? ""
             }
         }
     }
 
     private func reloadAPIKey() {
         Task { [weak self] in
-            let key = await Task.detached(priority: .utility) {
+            let anthropic = await Task.detached(priority: .utility) {
                 AnthropicKeychain.load() ?? ""
             }.value
-            self?.apiKey = key
+            let openRouter = await Task.detached(priority: .utility) {
+                OpenRouterKeychain.load() ?? ""
+            }.value
+            self?.anthropicApiKey = anthropic
+            self?.openRouterApiKey = openRouter
         }
     }
 
     isolated deinit {
-        if let token = apiKeyObserver {
-            NotificationCenter.default.removeObserver(token)
+        [apiKeyObserver, openRouterKeyObserver].compactMap { $0 }.forEach {
+            NotificationCenter.default.removeObserver($0)
         }
     }
 
-    var hasApiKey: Bool { !apiKey.isEmpty }
+    var hasAnthropicKey: Bool { !anthropicApiKey.isEmpty }
+    var hasOpenRouterKey: Bool { !openRouterApiKey.isEmpty }
 
     var canStream: Bool {
-        if hasApiKey { return true }
-        let account = AccountService.shared
-        return account.isSignedIn && account.hasCredits
+        switch provider {
+        case .palmier:
+            let account = AccountService.shared
+            return account.isSignedIn && account.hasCredits
+        case .anthropic: return hasAnthropicKey
+        case .openRouter: return hasOpenRouterKey && !openRouterModel.isEmpty
+        }
     }
 
     var availableModels: [AnthropicModel] {
-        if hasApiKey { return AnthropicModel.allCases }
-        return AccountService.shared.isPaid ? [.sonnet46] : [.haiku45]
+        switch provider {
+        case .anthropic:
+            if hasAnthropicKey { return AnthropicModel.allCases }
+            return []
+        case .palmier:
+            return AccountService.shared.isPaid ? [.sonnet46] : [.haiku45]
+        case .openRouter:
+            return []
+        }
     }
 
     private func selectClient() -> (any AgentClient)? {
-        let chosen = effectiveModel
-        if hasApiKey { return AnthropicClient(apiKey: apiKey, model: chosen) }
-        if AccountService.shared.isSignedIn {
-            return PalmierClient(model: chosen)
+        switch provider {
+        case .palmier:
+            guard AccountService.shared.isSignedIn else { return nil }
+            return PalmierClient(model: effectiveModel)
+        case .anthropic:
+            guard hasAnthropicKey else { return nil }
+            return AnthropicClient(apiKey: anthropicApiKey, model: effectiveModel)
+        case .openRouter:
+            guard hasOpenRouterKey, !openRouterModel.isEmpty else { return nil }
+            return OpenRouterClient(apiKey: openRouterApiKey, model: openRouterModel)
         }
-        return nil
     }
 
     var effectiveModel: AnthropicModel {
@@ -74,11 +106,27 @@ final class AgentService {
         didSet { UserDefaults.standard.set(model.rawValue, forKey: "agentModel") }
     }
 
+    var provider: AgentProvider = {
+        if let raw = UserDefaults.standard.string(forKey: "agentProvider"),
+           let p = AgentProvider(rawValue: raw) {
+            return p
+        }
+        return .palmier
+    }() {
+        didSet { UserDefaults.standard.set(provider.rawValue, forKey: "agentProvider") }
+    }
+
+    var openRouterModel: String = {
+        UserDefaults.standard.string(forKey: "openRouterModel") ?? "openai/gpt-4o"
+    }() {
+        didSet { UserDefaults.standard.set(openRouterModel, forKey: "openRouterModel") }
+    }
+
     var sessions: [ChatSession] = []
     var currentSessionId: UUID?
     var messages: [AgentMessage] = []
     var isStreaming: Bool = false
-    var streamError: PalmierClientError?
+    var streamError: Error?
     var onSessionsChanged: (@MainActor () -> Void)?
 
     var draft: String = ""
@@ -296,7 +344,7 @@ final class AgentService {
 
     func send(text: String, mentions: [AgentMention]) {
         guard canStream else {
-            streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
+            streamError = AgentError.upstream("Sign in to a paid plan or add an API key to start.")
             return
         }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -340,7 +388,7 @@ final class AgentService {
 
     private func runLoop() async {
         guard let client = selectClient() else {
-            streamError = .upstream("No backend available.")
+            streamError = AgentError.upstream("No backend available.")
             return
         }
         let tools = ToolDefinitions.all.map {
@@ -383,13 +431,9 @@ final class AgentService {
             } catch is CancellationError {
                 dropEmptyAssistantTurn(id: assistantID)
                 break loop
-            } catch let err as PalmierClientError {
-                dropEmptyAssistantTurn(id: assistantID)
-                streamError = err
-                break loop
             } catch {
                 dropEmptyAssistantTurn(id: assistantID)
-                streamError = .upstream(error.localizedDescription)
+                streamError = error
                 break loop
             }
         }

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -58,6 +58,22 @@ enum AnthropicClientError: LocalizedError {
     }
 }
 
+// MARK: - Provider selection
+
+enum AgentProvider: String, CaseIterable, Sendable {
+    case palmier
+    case anthropic
+    case openRouter
+
+    var displayName: String {
+        switch self {
+        case .palmier: "Palmier Backend"
+        case .anthropic: "Anthropic API Key"
+        case .openRouter: "OpenRouter"
+        }
+    }
+}
+
 // MARK: - Client protocol
 
 protocol AgentClient: Sendable {
@@ -190,5 +206,61 @@ enum AnthropicRequestBody {
         ]
         if !toolBlocks.isEmpty { body["tools"] = toolBlocks }
         return body
+    }
+}
+
+// MARK: - OpenRouter keychain
+
+extension Notification.Name {
+    static let openRouterKeyChanged = Notification.Name("openRouterKeyChanged")
+}
+
+enum OpenRouterKeychain {
+    private static let account = "openrouter-api-key"
+
+    static func save(_ key: String) {
+        KeychainStore.save(key, account: account)
+        NotificationCenter.default.post(name: .openRouterKeyChanged, object: nil)
+    }
+
+    static func load() -> String? {
+        KeychainStore.load(account: account)
+    }
+
+    static func delete() {
+        KeychainStore.delete(account: account)
+        NotificationCenter.default.post(name: .openRouterKeyChanged, object: nil)
+    }
+}
+
+// MARK: - Generic agent error
+
+enum AgentError: LocalizedError {
+    case unauthenticated
+    case insufficientCredits(String)
+    case upstream(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthenticated: "Sign in to your provider to use the AI agent."
+        case .insufficientCredits(let m): m
+        case .upstream(let m): m
+        }
+    }
+}
+
+// MARK: - OpenRouter error
+
+enum OpenRouterClientError: LocalizedError {
+    case missingAPIKey
+    case httpError(status: Int, body: String)
+    case streamError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey: "No OpenRouter API key is set."
+        case .httpError(let status, let body): "OpenRouter API error (\(status)): \(body.prefix(500))"
+        case .streamError(let msg): "Stream error: \(msg)"
+        }
     }
 }

--- a/Sources/PalmierPro/Agent/Clients/OpenRouterClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/OpenRouterClient.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+struct OpenRouterClient: AgentClient {
+    let apiKey: String
+    let model: String
+    var maxTokens: Int = 8192
+
+    private static let baseURL = URL(string: "https://openrouter.ai/api/v1")!
+
+    func stream(
+        system: String,
+        tools: [AnthropicToolSchema],
+        messages: [AnthropicMessage]
+    ) -> AsyncThrowingStream<AnthropicStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await run(system: system, tools: tools, messages: messages, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func run(
+        system: String,
+        tools: [AnthropicToolSchema],
+        messages: [AnthropicMessage],
+        continuation: AsyncThrowingStream<AnthropicStreamEvent, Error>.Continuation
+    ) async throws {
+        guard !apiKey.isEmpty else { throw OpenRouterClientError.missingAPIKey }
+
+        var request = URLRequest(url: Self.baseURL.appendingPathComponent("chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "accept")
+
+        let body = try Self.buildBody(system: system, tools: tools, messages: messages, model: model, maxTokens: maxTokens)
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            var bodyText = ""
+            for try await line in bytes.lines { bodyText += line + "\n" }
+            throw OpenRouterClientError.httpError(status: http.statusCode, body: bodyText)
+        }
+
+        try await OpenAISSE.parse(bytes: bytes, continuation: continuation)
+    }
+
+    // MARK: - OpenAI-format body builder
+
+    private static func buildBody(
+        system: String,
+        tools: [AnthropicToolSchema],
+        messages: [AnthropicMessage],
+        model: String,
+        maxTokens: Int
+    ) throws -> [String: Any] {
+        var body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTokens,
+            "stream": true,
+        ]
+
+        if !system.isEmpty {
+            body["system"] = system
+        }
+
+        if !tools.isEmpty {
+            body["tools"] = tools.map { tool in
+                [
+                    "type": "function",
+                    "function": [
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.inputSchema,
+                    ],
+                ]
+            }
+        }
+
+        body["messages"] = Self.translateMessages(messages)
+        return body
+    }
+
+    // MARK: - Message translation (Anthropic → OpenAI)
+
+    static func translateMessages(_ messages: [AnthropicMessage]) -> [[String: Any]] {
+        var out: [[String: Any]] = []
+        for msg in messages {
+            out.append(contentsOf: translateOne(msg))
+        }
+        return out
+    }
+
+    private static func translateOne(_ msg: AnthropicMessage) -> [[String: Any]] {
+        var textBlocks: [[String: Any]] = []
+        var toolUseBlocks: [(id: String, name: String, inputJSON: String)] = []
+        var toolResultBlocks: [(id: String, content: String, isError: Bool)] = []
+
+        for block in msg.content {
+            guard let type = block["type"] as? String else { continue }
+            switch type {
+            case "text":
+                if let text = block["text"] as? String {
+                    textBlocks.append(["type": "text", "text": text])
+                }
+            case "image":
+                if let source = block["source"] as? [String: Any],
+                   let sourceType = source["type"] as? String,
+                   sourceType == "base64",
+                   let mediaType = source["media_type"] as? String,
+                   let data = source["data"] as? String {
+                    let dataURL = "data:\(mediaType);base64,\(data)"
+                    textBlocks.append(["type": "image_url", "image_url": ["url": dataURL]])
+                }
+            case "tool_use":
+                if let id = block["id"] as? String,
+                   let name = block["name"] as? String,
+                   let input = block["input"] {
+                    let json = (try? JSONSerialization.data(withJSONObject: input)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+                    toolUseBlocks.append((id, name, json))
+                }
+            case "tool_result":
+                if let toolUseId = block["tool_use_id"] as? String,
+                   let contentArr = block["content"] as? [[String: Any]] {
+                    let text = contentArr.compactMap { $0["text"] as? String }.joined(separator: "\n")
+                    let isError = block["is_error"] as? Bool ?? false
+                    toolResultBlocks.append((toolUseId, text, isError))
+                }
+            default:
+                break
+            }
+        }
+
+        var result: [[String: Any]] = []
+
+        if !toolResultBlocks.isEmpty {
+            for tr in toolResultBlocks {
+                var entry: [String: Any] = [
+                    "role": "tool",
+                    "tool_call_id": tr.id,
+                    "content": tr.content,
+                ]
+                if tr.isError {
+                    entry["content"] = "Error: \(tr.content)"
+                }
+                result.append(entry)
+            }
+        } else {
+            let role = msg.role.rawValue
+
+            if !toolUseBlocks.isEmpty {
+                var entry: [String: Any] = ["role": role]
+                if !textBlocks.isEmpty {
+                    entry["content"] = textBlocks
+                } else {
+                    entry["content"] = nil
+                }
+                entry["tool_calls"] = toolUseBlocks.map { tc in
+                    [
+                        "id": tc.id,
+                        "type": "function",
+                        "function": [
+                            "name": tc.name,
+                            "arguments": tc.inputJSON,
+                        ],
+                    ]
+                }
+                result.append(entry)
+            } else {
+                let content: Any
+                if textBlocks.isEmpty {
+                    content = ""
+                } else if textBlocks.count == 1, textBlocks[0]["type"] as? String == "text" {
+                    content = textBlocks[0]["text"] as? String ?? ""
+                } else {
+                    content = textBlocks
+                }
+                result.append(["role": role, "content": content])
+            }
+        }
+
+        return result
+    }
+}
+
+// MARK: - OpenAI SSE stream parser
+
+enum OpenAISSE {
+    static func parse(
+        bytes: URLSession.AsyncBytes,
+        continuation: AsyncThrowingStream<AnthropicStreamEvent, Error>.Continuation
+    ) async throws {
+        var pendingToolCalls: [Int: (id: String, name: String, arguments: String)] = [:]
+        var finishedToolIds: Set<Int> = []
+        var didStop = false
+
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            if line == "data: [DONE]" { break }
+
+            guard line.hasPrefix("data:"),
+                  let data = line.dropFirst("data:".count).trimmingCharacters(in: .whitespaces).data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let choice = choices.first else { continue }
+
+            guard let delta = choice["delta"] as? [String: Any] else { continue }
+
+            if let content = delta["content"] as? String, !content.isEmpty {
+                continuation.yield(.textDelta(content))
+            }
+
+            if let toolCalls = delta["tool_calls"] as? [[String: Any]] {
+                for tc in toolCalls {
+                    guard let index = tc["index"] as? Int else { continue }
+
+                    if let id = tc["id"] as? String, let fn = tc["function"] as? [String: Any],
+                       let name = fn["name"] as? String {
+                        pendingToolCalls[index] = (id, name, "")
+                        finishedToolIds.remove(index)
+                    }
+
+                    if var acc = pendingToolCalls[index],
+                       let fn = tc["function"] as? [String: Any],
+                       let argsDelta = fn["arguments"] as? String {
+                        acc.arguments += argsDelta
+                        pendingToolCalls[index] = acc
+                    }
+                }
+            }
+
+            if let finishReasonText = choice["finish_reason"] as? String, !finishReasonText.isEmpty {
+                didStop = true
+                for (idx, acc) in pendingToolCalls where !finishedToolIds.contains(idx) {
+                    let json = acc.arguments.isEmpty ? "{}" : acc.arguments
+                    continuation.yield(.toolUseComplete(id: acc.id, name: acc.name, inputJSON: json))
+                    finishedToolIds.insert(idx)
+                }
+                let reason = Self.mapStopReason(finishReasonText)
+                continuation.yield(.messageStop(stopReason: reason))
+            }
+        }
+
+        guard !didStop else { return }
+
+        for (idx, acc) in pendingToolCalls where !finishedToolIds.contains(idx) {
+            let json = acc.arguments.isEmpty ? "{}" : acc.arguments
+            continuation.yield(.toolUseComplete(id: acc.id, name: acc.name, inputJSON: json))
+        }
+        continuation.yield(.messageStop(stopReason: .endTurn))
+    }
+
+    static func mapStopReason(_ raw: String) -> AnthropicStopReason {
+        switch raw {
+        case "stop": .endTurn
+        case "length": .maxTokens
+        case "tool_calls": .toolUse
+        case "content_filter": .refusal
+        default: .other
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -141,7 +141,7 @@ private struct ToolRunRow: View {
             ForEach(Array(r.content.enumerated()), id: \.offset) { _, block in
                 switch block {
                 case .text(let s):
-                    Text(s).frame(maxWidth: .infinity, alignment: .leading)
+                    Text(s).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading)
                 case .image(let base64, _):
                     ToolResultImageView(base64: base64)
                 }

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -137,7 +137,7 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var modelPicker: some View {
-        if service.hasApiKey {
+        if !service.availableModels.isEmpty {
             Menu {
                 ForEach(service.availableModels, id: \.self) { m in
                     Button(m.displayName) { service.model = m }
@@ -160,11 +160,16 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var byokIndicator: some View {
-        if service.hasApiKey {
+        if service.hasAnthropicKey {
             Text("using API key")
                 .font(.system(size: AppTheme.FontSize.xs).italic())
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
-                .help("Streaming through your Anthropic API key (BYOK)")
+                .help("Streaming through your Anthropic API key")
+        } else if service.hasOpenRouterKey {
+            Text("via OpenRouter")
+                .font(.system(size: AppTheme.FontSize.xs).italic())
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .help("Streaming through OpenRouter")
         }
     }
 
@@ -260,6 +265,7 @@ struct AgentPanelView: View {
                     .font(.system(size: AppTheme.FontSize.xs))
                     .foregroundStyle(.red)
                     .multilineTextAlignment(.leading)
+                    .textSelection(.enabled)
                 if let cta = errorCTA(for: err) {
                     Button(action: cta.action) {
                         Text(cta.title)
@@ -277,20 +283,37 @@ struct AgentPanelView: View {
         let action: () -> Void
     }
 
-    private func errorCTA(for error: PalmierClientError?) -> ErrorCTA? {
+    private func errorCTA(for error: Error?) -> ErrorCTA? {
         guard let error else { return nil }
-        switch error {
-        case .unauthenticated:
-            return ErrorCTA(title: "Sign in") {
-                SettingsWindowController.shared.show(tab: .account)
+        if error is PalmierClientError {
+            switch error as! PalmierClientError {
+            case .unauthenticated:
+                return ErrorCTA(title: "Sign in") {
+                    SettingsWindowController.shared.show(tab: .account)
+                }
+            case .insufficientCredits:
+                return ErrorCTA(title: "View plans") {
+                    SettingsWindowController.shared.show(tab: .account)
+                }
+            case .upstream:
+                return nil
             }
-        case .insufficientCredits:
-            return ErrorCTA(title: "View plans") {
-                SettingsWindowController.shared.show(tab: .account)
-            }
-        case .upstream:
-            return nil
         }
+        if error is AgentError {
+            switch error as! AgentError {
+            case .unauthenticated:
+                return ErrorCTA(title: "Sign in") {
+                    SettingsWindowController.shared.show(tab: .account)
+                }
+            case .insufficientCredits:
+                return ErrorCTA(title: "View plans") {
+                    SettingsWindowController.shared.show(tab: .account)
+                }
+            case .upstream:
+                return nil
+            }
+        }
+        return nil
     }
 
     @ViewBuilder
@@ -317,6 +340,13 @@ struct AgentPanelView: View {
     @ViewBuilder
     private var missingKeyState: some View {
         let account = AccountService.shared
+        let providerName: String = {
+            switch service.provider {
+            case .palmier: return "Sign in"
+            case .anthropic: return "your own Anthropic key"
+            case .openRouter: return "your own OpenRouter key"
+            }
+        }()
         HStack(alignment: .firstTextBaseline, spacing: 4) {
             Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
                 Text(missingKeyPrimaryAction(account: account))
@@ -325,15 +355,17 @@ struct AgentPanelView: View {
             }
             .buttonStyle(.plain)
 
-            Text("or use")
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
+            if service.provider != .palmier {
+                Text("or use")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
 
-            Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
-                Text("your own Anthropic key")
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
+                Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
+                    Text(providerName)
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
         .font(.system(size: AppTheme.FontSize.md, weight: .medium))
     }

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -3,30 +3,91 @@ import SwiftUI
 
 struct AgentPane: View {
     @Bindable private var appState = AppState.shared
-    @State private var hasKey: Bool = false
-    @State private var maskedKey: String = ""
-    @State private var draft: String = ""
-    @FocusState private var isFocused: Bool
+    @State private var hasAnthropicKey: Bool = false
+    @State private var anthropicMaskedKey: String = ""
+    @State private var anthropicDraft: String = ""
+    @FocusState private var isAnthropicFocused: Bool
+    @State private var hasOpenRouterKey: Bool = false
+    @State private var openRouterMaskedKey: String = ""
+    @State private var openRouterDraft: String = ""
+    @FocusState private var isOpenRouterFocused: Bool
+    @State private var openRouterModelDraft: String = ""
 
-    private let consoleURL = URL(string: "https://console.anthropic.com/settings/keys")!
+    private let anthropicConsoleURL = URL(string: "https://console.anthropic.com/settings/keys")!
+    private let openRouterConsoleURL = URL(string: "https://openrouter.ai/keys")!
+
+    @AppStorage("agentProvider") private var providerRaw: String = AgentProvider.palmier.rawValue
+    @AppStorage("openRouterModel") private var openRouterModel: String = "openai/gpt-4o"
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            apiKeySection
+            providerSection
             Divider().overlay(AppTheme.Border.subtleColor)
             mcpSection
         }
         .onAppear(perform: refresh)
     }
 
-    private var apiKeySection: some View {
+    private var providerSection: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
-            header
-            keyField
+            providerPicker
+            providerFields
         }
     }
 
-    private var header: some View {
+    private var providerPicker: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("AI Provider")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+
+            Picker("Provider", selection: Binding(
+                get: { AgentProvider(rawValue: providerRaw) ?? .palmier },
+                set: { providerRaw = $0.rawValue }
+            )) {
+                ForEach(AgentProvider.allCases, id: \.self) { p in
+                    Text(p.displayName).tag(p)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var currentProvider: AgentProvider {
+        AgentProvider(rawValue: providerRaw) ?? .palmier
+    }
+
+    @ViewBuilder
+    private var providerFields: some View {
+        switch currentProvider {
+        case .palmier:
+            palmierInfo
+        case .anthropic:
+            anthropicSection
+        case .openRouter:
+            openRouterSection
+        }
+    }
+
+    private var palmierInfo: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("Using Palmier's backend for AI chat. Model access depends on your subscription tier.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+        }
+        .padding(.vertical, AppTheme.Spacing.xs)
+    }
+
+    // MARK: - Anthropic section
+
+    private var anthropicSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            anthropicHeader
+            anthropicKeyField
+        }
+    }
+
+    private var anthropicHeader: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
             Text("Anthropic API Key")
                 .font(.system(size: AppTheme.FontSize.md, weight: .medium))
@@ -38,7 +99,7 @@ struct AgentPane: View {
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Button(action: { NSWorkspace.shared.open(consoleURL, configuration: .init(), completionHandler: nil) }) {
+                Button(action: { NSWorkspace.shared.open(anthropicConsoleURL, configuration: .init(), completionHandler: nil) }) {
                     HStack(spacing: 2) {
                         Text("Get Anthropic API key")
                         Image(systemName: "arrow.up.right")
@@ -53,49 +114,46 @@ struct AgentPane: View {
         }
     }
 
-    private var keyField: some View {
+    private var anthropicKeyField: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
-            fieldBox
-            trailingControl
+            SecureField(anthropicPlaceholder, text: $anthropicDraft)
+                .textFieldStyle(.plain)
+                .focused($isAnthropicFocused)
+                .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .onSubmit(saveAnthropic)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.smMd)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .strokeBorder(
+                            isAnthropicFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
+                            lineWidth: AppTheme.BorderWidth.thin
+                        )
+                )
+                .animation(.easeOut(duration: AppTheme.Anim.hover), value: isAnthropicFocused)
+
+            anthropicTrailingControl
         }
     }
 
-    private var fieldBox: some View {
-        SecureField(placeholder, text: $draft)
-            .textFieldStyle(.plain)
-            .focused($isFocused)
-            .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
-            .foregroundStyle(AppTheme.Text.primaryColor)
-            .onSubmit(save)
-            .padding(.horizontal, AppTheme.Spacing.md)
-            .padding(.vertical, AppTheme.Spacing.smMd)
-            .background(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(Color.black.opacity(AppTheme.Opacity.muted))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(
-                        isFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
-                        lineWidth: AppTheme.BorderWidth.thin
-                    )
-            )
-            .animation(.easeOut(duration: AppTheme.Anim.hover), value: isFocused)
-    }
-
-    private var placeholder: String {
-        hasKey ? maskedKey : "sk-ant-..."
+    private var anthropicPlaceholder: String {
+        hasAnthropicKey ? anthropicMaskedKey : "sk-ant-..."
     }
 
     @ViewBuilder
-    private var trailingControl: some View {
-        let trimmed = draft.trimmingCharacters(in: .whitespaces)
+    private var anthropicTrailingControl: some View {
+        let trimmed = anthropicDraft.trimmingCharacters(in: .whitespaces)
         if !trimmed.isEmpty {
-            Button("Save", action: save)
+            Button("Save", action: saveAnthropic)
                 .buttonStyle(.capsule(.prominent, size: .regular))
                 .controlSize(.large)
-        } else if hasKey {
-            Button(action: remove) {
+        } else if hasAnthropicKey {
+            Button(action: removeAnthropic) {
                 Image(systemName: "trash")
                     .font(.system(size: AppTheme.FontSize.md))
                     .foregroundStyle(AppTheme.Text.secondaryColor)
@@ -107,24 +165,180 @@ struct AgentPane: View {
         }
     }
 
-    private func refresh() {
-        let key = AnthropicKeychain.load() ?? ""
-        hasKey = !key.isEmpty
-        maskedKey = mask(key)
+    // MARK: - OpenRouter section
+
+    private var openRouterSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            openRouterHeader
+            openRouterKeyField
+            openRouterModelField
+        }
     }
 
-    private func save() {
-        let key = draft.trimmingCharacters(in: .whitespaces)
+    private var openRouterHeader: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("OpenRouter API Key")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+
+            HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
+                Text("Use any LLM via OpenRouter. Key stored in your macOS Keychain.")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button(action: { NSWorkspace.shared.open(openRouterConsoleURL, configuration: .init(), completionHandler: nil) }) {
+                    HStack(spacing: 2) {
+                        Text("Get OpenRouter API key")
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                    }
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
+                .fixedSize()
+            }
+        }
+    }
+
+    private var openRouterKeyField: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            SecureField(openRouterPlaceholder, text: $openRouterDraft)
+                .textFieldStyle(.plain)
+                .focused($isOpenRouterFocused)
+                .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .onSubmit(saveOpenRouter)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.smMd)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .strokeBorder(
+                            isOpenRouterFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
+                            lineWidth: AppTheme.BorderWidth.thin
+                        )
+                )
+                .animation(.easeOut(duration: AppTheme.Anim.hover), value: isOpenRouterFocused)
+
+            openRouterTrailingControl
+        }
+    }
+
+    private var openRouterPlaceholder: String {
+        hasOpenRouterKey ? openRouterMaskedKey : "sk-or-..."
+    }
+
+    @ViewBuilder
+    private var openRouterTrailingControl: some View {
+        let trimmed = openRouterDraft.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            Button("Save", action: saveOpenRouter)
+                .buttonStyle(.capsule(.prominent, size: .regular))
+                .controlSize(.large)
+        } else if hasOpenRouterKey {
+            Button(action: removeOpenRouter) {
+                Image(systemName: "trash")
+                    .font(.system(size: AppTheme.FontSize.md))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+            }
+            .buttonStyle(.capsule(.secondary, size: .regular))
+            .controlSize(.large)
+            .help("Remove OpenRouter API key")
+        }
+    }
+
+    private var openRouterModelField: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("Model")
+                .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+
+            HStack(spacing: AppTheme.Spacing.sm) {
+                TextField("openai/gpt-4o", text: $openRouterModelDraft)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .onSubmit(saveOpenRouterModel)
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+                    )
+
+                let trimmedModel = openRouterModelDraft.trimmingCharacters(in: .whitespaces)
+                if !trimmedModel.isEmpty, trimmedModel != openRouterModel {
+                    Button("Save", action: saveOpenRouterModel)
+                        .buttonStyle(.capsule(.prominent, size: .regular))
+                        .controlSize(.large)
+                }
+            }
+
+            Text("Use any model slug from OpenRouter (e.g. openai/gpt-4o, google/gemini-2.5-pro, anthropic/claude-sonnet-4-6)")
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func refresh() {
+        let aKey = AnthropicKeychain.load() ?? ""
+        hasAnthropicKey = !aKey.isEmpty
+        anthropicMaskedKey = mask(aKey)
+
+        let oKey = OpenRouterKeychain.load() ?? ""
+        hasOpenRouterKey = !oKey.isEmpty
+        openRouterMaskedKey = mask(oKey)
+
+        openRouterModelDraft = openRouterModel
+    }
+
+    private func saveAnthropic() {
+        let key = anthropicDraft.trimmingCharacters(in: .whitespaces)
         guard !key.isEmpty else { return }
         AnthropicKeychain.save(key)
-        draft = ""
-        isFocused = false
+        anthropicDraft = ""
+        isAnthropicFocused = false
         refresh()
     }
 
-    private func remove() {
+    private func removeAnthropic() {
         AnthropicKeychain.delete()
-        draft = ""
+        anthropicDraft = ""
+        refresh()
+    }
+
+    private func saveOpenRouter() {
+        let key = openRouterDraft.trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else { return }
+        OpenRouterKeychain.save(key)
+        openRouterDraft = ""
+        isOpenRouterFocused = false
+        refresh()
+    }
+
+    private func removeOpenRouter() {
+        OpenRouterKeychain.delete()
+        openRouterDraft = ""
+        refresh()
+    }
+
+    private func saveOpenRouterModel() {
+        let m = openRouterModelDraft.trimmingCharacters(in: .whitespaces)
+        guard !m.isEmpty else { return }
+        openRouterModel = m
         refresh()
     }
 

--- a/Tests/PalmierProTests/Agent/OpenRouterClientTests.swift
+++ b/Tests/PalmierProTests/Agent/OpenRouterClientTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("OpenRouterClient - message translation")
+struct OpenRouterClientTests {
+
+    // MARK: - Message translation
+
+    @Test func translateUserTextMessage() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "text", "text": "Hello"]
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result.count == 1)
+        #expect(result[0]["role"] as? String == "user")
+        #expect(result[0]["content"] as? String == "Hello")
+    }
+
+    @Test func translateUserTextWithMultipleBlocksJoinsIntoContentArray() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "text", "text": "Part one"],
+            ["type": "text", "text": "Part two"],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result.count == 1)
+        let content = result[0]["content"] as? [[String: Any]]
+        #expect(content?.count == 2)
+    }
+
+    @Test func translateImageBlockToDataURL() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "image", "source": [
+                "type": "base64",
+                "media_type": "image/jpeg",
+                "data": "abc123",
+            ]],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        let content = result[0]["content"] as? [[String: Any]]
+        #expect(content?.first?["type"] as? String == "image_url")
+        let imageURL = (content?.first?["image_url"] as? [String: Any])?["url"] as? String
+        #expect(imageURL == "data:image/jpeg;base64,abc123")
+    }
+
+    @Test func translateAssistantToolUse() {
+        let msg = AnthropicMessage(role: .assistant, content: [
+            ["type": "text", "text": "Let me check"],
+            ["type": "tool_use", "id": "tu_1", "name": "get_weather", "input": ["city": "NYC"]],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result.count == 1)
+        #expect(result[0]["role"] as? String == "assistant")
+        let toolCalls = result[0]["tool_calls"] as? [[String: Any]]
+        #expect(toolCalls?.count == 1)
+        #expect(toolCalls?[0]["id"] as? String == "tu_1")
+        let fn = toolCalls?[0]["function"] as? [String: Any]
+        #expect(fn?["name"] as? String == "get_weather")
+        #expect(fn?["arguments"] as? String == #"{"city":"NYC"}"#)
+    }
+
+    @Test func translateToolResult() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "tool_result", "tool_use_id": "tu_1", "content": [["type": "text", "text": "75°F"]], "is_error": false],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result.count == 1)
+        #expect(result[0]["role"] as? String == "tool")
+        #expect(result[0]["tool_call_id"] as? String == "tu_1")
+        #expect(result[0]["content"] as? String == "75°F")
+    }
+
+    @Test func translateToolResultErrorPrefixesContent() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "tool_result", "tool_use_id": "tu_1", "content": [["type": "text", "text": "not found"]], "is_error": true],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect((result[0]["content"] as? String)?.hasPrefix("Error:") == true)
+    }
+
+    @Test func translateEmptyTextBlockBecomesEmptyString() {
+        let msg = AnthropicMessage(role: .user, content: [
+            ["type": "text", "text": ""],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result[0]["content"] as? String == "")
+    }
+
+    @Test func translateEmptyContentArrayBecomesEmptyString() {
+        let msg = AnthropicMessage(role: .user, content: [])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result[0]["content"] as? String == "")
+    }
+
+    @Test func translateAssistantOnlyToolUseNoText() {
+        let msg = AnthropicMessage(role: .assistant, content: [
+            ["type": "tool_use", "id": "tu_1", "name": "search", "input": ["q": "test"]],
+        ])
+        let result = OpenRouterClient.translateMessages([msg])
+        #expect(result[0]["role"] as? String == "assistant")
+        // content should be nil when there's no text blocks
+        #expect(result[0]["content"] as? [String: Any] ?? nil == nil)
+        let toolCalls = result[0]["tool_calls"] as? [[String: Any]]
+        #expect(toolCalls?.count == 1)
+    }
+
+    // MARK: - Stop reason mapping
+
+    @Test func mapStopStopReason() {
+        #expect(OpenAISSE.mapStopReason("stop") == .endTurn)
+    }
+
+    @Test func mapLengthStopReason() {
+        #expect(OpenAISSE.mapStopReason("length") == .maxTokens)
+    }
+
+    @Test func mapToolCallsStopReason() {
+        #expect(OpenAISSE.mapStopReason("tool_calls") == .toolUse)
+    }
+
+    @Test func mapContentFilterStopReason() {
+        #expect(OpenAISSE.mapStopReason("content_filter") == .refusal)
+    }
+
+    @Test func mapUnknownStopReason() {
+        #expect(OpenAISSE.mapStopReason("something_else") == .other)
+    }
+}
+
+


### PR DESCRIPTION
- New OpenRouterClient implementing AgentClient with OpenAI-format streaming
- AgentProvider enum (palmier, anthropic, openRouter) with dual keychain
- Provider picker in Settings with conditional key/model fields
- Model field Save button (visible when draft differs from saved value)
- Copyable error messages and tool result text in agent panel
- 11 unit tests for message translation and stop-reason mapping
- AGENTS.md build flags for CLT toolchain macro plugins