### PR TITLE
Add export_video and import_image_sequence MCP tools

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -18,6 +18,8 @@ enum ToolName: String, CaseIterable, Sendable {
     case generateAudio = "generate_audio"
     case upscaleMedia = "upscale_media"
     case importMedia = "import_media"
+    case importImageSequence = "import_image_sequence"
+    case exportVideo = "export_video"
     case listModels = "list_models"
     case inspectMedia = "inspect_media"
     case inspectTimeline = "inspect_timeline"
@@ -381,6 +383,36 @@ enum ToolDefinitions {
                     "folderId": ["type": "string", "description": "Optional. Folder id (from list_folders or create_folder) to place the result in. Omit for the project root."],
                 ],
                 required: ["source"]
+            )
+        ),
+        AgentTool(
+            name: .importImageSequence,
+            description: "Assemble an ordered set of still images into a single video clip and add it to the media library — the bridge for image sequences (rendered frames, storyboard panels, slideshows) that import_media can't take (it accepts one file at a time and has no frames-to-video step). Provide exactly one of 'directory' (every supported image in it, ordered by natural filename sort so frame_2 comes before frame_10) or 'paths' (an explicit ordered list). Each image is held for framesPerImage frames at fps; images are aspect-fit and letterboxed onto the project canvas (the timeline's width×height). The result is one H.264 video asset registered in get_media — place it on the timeline with add_clips using the returned durationFrames. Encoding runs locally and the call returns once the asset is ready (long sequences take a while). Costs nothing. Supported image types: png, jpg, jpeg, tiff, heic. Requires an open project.",
+            inputSchema: objectSchema(
+                properties: [
+                    "directory": ["type": "string", "description": "Absolute path to a folder; every supported image inside is used, ordered by natural filename sort. Mutually exclusive with 'paths'."],
+                    "paths": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description": "Explicit, ordered list of absolute image file paths. Mutually exclusive with 'directory'. Order is preserved as given.",
+                    ],
+                    "framesPerImage": ["type": "integer", "description": "How many frames each image is held (>= 1). Default: the project fps (≈ 1 second per image)."],
+                    "fps": ["type": "integer", "description": "Frame rate of the assembled video. Default: the project's timeline fps (recommended, so it places cleanly)."],
+                    "name": ["type": "string", "description": "Display name for the asset in the media library. Defaults to the generated filename."],
+                    "folderId": ["type": "string", "description": "Optional. Folder id (from list_folders or create_folder) to place the result in. Omit for the project root."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .exportVideo,
+            description: "Render the current timeline to a video file on disk — the same composite the editor's File ▸ Export dialog produces, exposed to the agent so a render can finish end-to-end without a human. Writes the timeline with every layer baked in (video/image clips, transforms, crops, keyframes, text and caption overlays, and the full audio mix) to 'path'. Runs locally, costs nothing, and the call returns only once the file is fully written (long timelines take a while). format: 'h264' (default, .mp4), 'h265' (.mp4), 'prores' (.mov), or 'xml' (FCPXML-style timeline interchange for Premiere/DaVinci/Final Cut — the edit only, media is NOT rendered). resolution: '720p', '1080p' (default), or '4k', scaled from the timeline canvas with aspect preserved. The output file extension is normalized to match the format. Call get_timeline first to confirm the timeline has content.",
+            inputSchema: objectSchema(
+                properties: [
+                    "path": ["type": "string", "description": "Absolute output file path. Parent directories are created if missing; the extension is normalized to the chosen format (.mp4/.mov/.xml). An existing file at this path is overwritten."],
+                    "format": ["type": "string", "enum": ["h264", "h265", "prores", "xml"], "description": "Output format. Default 'h264' (H.264 .mp4). 'xml' writes a timeline-interchange file, not a rendered video."],
+                    "resolution": ["type": "string", "enum": ["720p", "1080p", "4k"], "description": "Render resolution, scaled from the timeline canvas (aspect preserved). Default '1080p'. Ignored for 'xml'."],
+                ],
+                required: ["path"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -387,7 +387,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .importImageSequence,
-            description: "Assemble an ordered set of still images into a single video clip and add it to the media library — the bridge for image sequences (rendered frames, storyboard panels, slideshows) that import_media can't take (it accepts one file at a time and has no frames-to-video step). Provide exactly one of 'directory' (every supported image in it, ordered by natural filename sort so frame_2 comes before frame_10) or 'paths' (an explicit ordered list). Each image is held for framesPerImage frames at fps; images are aspect-fit and letterboxed onto the project canvas (the timeline's width×height). The result is one H.264 video asset registered in get_media — place it on the timeline with add_clips using the returned durationFrames. Encoding runs locally and the call returns once the asset is ready (long sequences take a while). Costs nothing. Supported image types: png, jpg, jpeg, tiff, heic. Requires an open project.",
+            description: "Assemble an ordered set of still images into a single video clip and add it to the media library — the bridge for image sequences (rendered frames, storyboard panels, slideshows) that import_media can't take (it accepts one file at a time and has no frames-to-video step). Provide exactly one of 'directory' (every supported image in it, ordered by natural filename sort so frame_2 comes before frame_10) or 'paths' (an explicit ordered list). Each image is held for framesPerImage frames at fps; images are aspect-fit and letterboxed onto the project canvas (the timeline's width×height). The result is one H.264 video asset registered in get_media. By default it just lands in the library (place it later with add_clips using the returned durationFrames); set addToTimeline true to drop it straight onto the timeline in the same call. Encoding runs locally and the call returns once the asset is ready (long sequences take a while). Costs nothing. Supported image types: png, jpg, jpeg, tiff, heic. Requires an open project.",
             inputSchema: objectSchema(
                 properties: [
                     "directory": ["type": "string", "description": "Absolute path to a folder; every supported image inside is used, ordered by natural filename sort. Mutually exclusive with 'paths'."],
@@ -400,6 +400,9 @@ enum ToolDefinitions {
                     "fps": ["type": "integer", "description": "Frame rate of the assembled video. Default: the project's timeline fps (recommended, so it places cleanly)."],
                     "name": ["type": "string", "description": "Display name for the asset in the media library. Defaults to the generated filename."],
                     "folderId": ["type": "string", "description": "Optional. Folder id (from list_folders or create_folder) to place the result in. Omit for the project root."],
+                    "addToTimeline": ["type": "boolean", "description": "Optional (default false). When true, the assembled clip is also placed on the timeline via the same path as add_clips (track auto-creation + overlap handling apply)."],
+                    "startFrame": ["type": "integer", "description": "Only used when addToTimeline is true. Timeline frame to place the clip at (default 0)."],
+                    "trackIndex": ["type": "integer", "description": "Only used when addToTimeline is true. Target track index (0-based); omit to auto-create a new track."],
                 ]
             )
         ),

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -53,15 +53,12 @@ extension ToolExecutor {
 
         let bytes = (try? outputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
         let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
-        let seconds = Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps))
+        let seconds = String(format: "%.2f", Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)))
 
         if format == .xml {
             return .ok("Wrote timeline interchange XML to \(outputURL.path) (\(sizeStr)). This is the edit only — media is not rendered; open it in Premiere/DaVinci/Final Cut.")
         }
-        return .ok(String(
-            format: "Exported timeline to %@ (%@, %@, %@, ≈%.2fs).",
-            outputURL.path, Self.formatLabel(format), resolution.rawValue, sizeStr, seconds
-        ))
+        return .ok("Exported timeline to \(outputURL.path) (\(Self.formatLabel(format)), \(resolution.rawValue), \(sizeStr), ≈\(seconds)s).")
     }
 
     private static func exportFormat(from raw: String?) throws -> ExportFormat {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+extension ToolExecutor {
+    private static let exportVideoAllowedKeys: Set<String> = ["path", "format", "resolution"]
+
+    /// Renders the current timeline to a file on disk — the agent-facing equivalent of the
+    /// File ▸ Export dialog (`ExportView.startExport`). Awaits completion and reports the path,
+    /// matching how the GUI awaits `ExportService.export` and surfaces `service.error`.
+    func exportVideo(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.exportVideoAllowedKeys, path: "export_video")
+
+        let rawPath = try args.requireString("path")
+        let format = try Self.exportFormat(from: args.string("format"))
+        let resolution = try Self.exportResolution(from: args.string("resolution"))
+
+        guard (rawPath as NSString).isAbsolutePath else {
+            throw ToolError("path must be an absolute file path (got '\(rawPath)')")
+        }
+        guard editor.timeline.totalFrames > 0 else {
+            throw ToolError("Timeline is empty — add clips before exporting.")
+        }
+
+        // Normalize the output extension to the chosen format so we never write,
+        // e.g., a ProRes .mov under a .mp4 name.
+        var outputURL = URL(fileURLWithPath: (rawPath as NSString).expandingTildeInPath)
+        if outputURL.pathExtension.lowercased() != format.fileExtension {
+            outputURL.deletePathExtension()
+            outputURL.appendPathExtension(format.fileExtension)
+        }
+
+        let parentDir = outputURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+        } catch {
+            throw ToolError("Could not create output directory \(parentDir.path): \(error.localizedDescription)")
+        }
+
+        let service = ExportService()
+        await service.export(
+            timeline: editor.timeline,
+            resolver: editor.mediaResolver,
+            format: format,
+            resolution: resolution,
+            outputURL: outputURL
+        )
+
+        if let err = service.error {
+            throw ToolError("Export failed: \(err)")
+        }
+        guard FileManager.default.fileExists(atPath: outputURL.path) else {
+            throw ToolError("Export reported success but no file was written at \(outputURL.path)")
+        }
+
+        let bytes = (try? outputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+        let seconds = Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps))
+
+        if format == .xml {
+            return .ok("Wrote timeline interchange XML to \(outputURL.path) (\(sizeStr)). This is the edit only — media is not rendered; open it in Premiere/DaVinci/Final Cut.")
+        }
+        return .ok(String(
+            format: "Exported timeline to %@ (%@, %@, %@, ≈%.2fs).",
+            outputURL.path, Self.formatLabel(format), resolution.rawValue, sizeStr, seconds
+        ))
+    }
+
+    private static func exportFormat(from raw: String?) throws -> ExportFormat {
+        switch (raw ?? "h264").lowercased() {
+        case "h264", "mp4", "avc": return .h264
+        case "h265", "hevc": return .h265
+        case "prores", "mov": return .prores
+        case "xml", "fcpxml": return .xml
+        default:
+            throw ToolError("Invalid format '\(raw ?? "")'. Expected 'h264', 'h265', 'prores', or 'xml'.")
+        }
+    }
+
+    private static func exportResolution(from raw: String?) throws -> ExportResolution {
+        switch (raw ?? "1080p").lowercased() {
+        case "720p", "720": return .r720p
+        case "1080p", "1080", "fhd": return .r1080p
+        case "4k", "2160p", "2160", "uhd": return .r4k
+        default:
+            throw ToolError("Invalid resolution '\(raw ?? "")'. Expected '720p', '1080p', or '4k'.")
+        }
+    }
+
+    private static func formatLabel(_ format: ExportFormat) -> String {
+        switch format {
+        case .h264: return "H.264"
+        case .h265: return "H.265"
+        case .prores: return "ProRes"
+        case .xml: return "XML"
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
@@ -80,11 +80,10 @@ extension ToolExecutor {
             editor.moveAssetsToFolder(assetIds: [asset.id], folderId: folderId)
         }
 
-        let seconds = Double(totalFrames) / Double(fps)
-        let base = String(
-            format: "Assembled %d image(s) into video '%@' (id: %@, %d×%d, %d fps, %d frame(s)/image, %d frames ≈ %.2fs).",
-            imageURLs.count, asset.name, asset.id, width, height, fps, framesPerImage, totalFrames, seconds
-        )
+        let seconds = String(format: "%.2f", Double(totalFrames) / Double(fps))
+        let base = "Assembled \(imageURLs.count) image(s) into video '\(asset.name)' "
+            + "(id: \(asset.id), \(width)×\(height), \(fps) fps, \(framesPerImage) frame(s)/image, "
+            + "\(totalFrames) frames ≈ \(seconds)s)."
 
         // Optionally drop the assembled clip straight onto the timeline, reusing add_clips so
         // track auto-creation and overlap handling stay identical to a normal placement.

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
@@ -5,7 +5,8 @@ import ImageIO
 
 extension ToolExecutor {
     private static let importImageSequenceAllowedKeys: Set<String> =
-        ["directory", "paths", "framesPerImage", "fps", "name", "folderId"]
+        ["directory", "paths", "framesPerImage", "fps", "name", "folderId",
+         "addToTimeline", "startFrame", "trackIndex"]
     private static let imageSequenceExtensions: Set<String> = ["png", "jpg", "jpeg", "tiff", "heic"]
     static let imageSequenceMaxImages = 5000
     static let imageSequenceMaxTotalFrames = 216_000   // 1 hour at 60 fps — runaway guard
@@ -80,10 +81,29 @@ extension ToolExecutor {
         }
 
         let seconds = Double(totalFrames) / Double(fps)
-        return .ok(String(
-            format: "Assembled %d image(s) into video '%@' (id: %@, %d×%d, %d fps, %d frame(s)/image, %d frames ≈ %.2fs). Place it with add_clips using durationFrames: %d.",
-            imageURLs.count, asset.name, asset.id, width, height, fps, framesPerImage, totalFrames, seconds, totalFrames
-        ))
+        let base = String(
+            format: "Assembled %d image(s) into video '%@' (id: %@, %d×%d, %d fps, %d frame(s)/image, %d frames ≈ %.2fs).",
+            imageURLs.count, asset.name, asset.id, width, height, fps, framesPerImage, totalFrames, seconds
+        )
+
+        // Optionally drop the assembled clip straight onto the timeline, reusing add_clips so
+        // track auto-creation and overlap handling stay identical to a normal placement.
+        guard args.bool("addToTimeline") == true else {
+            return .ok(base + " It's in the media library — place it with add_clips using durationFrames: \(totalFrames).")
+        }
+
+        let startFrame = max(0, args.int("startFrame") ?? 0)
+        let trackIndex = args.int("trackIndex")
+        var entry: [String: Any] = [
+            "mediaRef": asset.id,
+            "startFrame": startFrame,
+            "durationFrames": totalFrames,
+        ]
+        if let trackIndex { entry["trackIndex"] = trackIndex }
+        _ = try addClips(editor, ["entries": [entry]])
+
+        let trackNote = trackIndex.map { " on track \($0)" } ?? " on a new track"
+        return .ok(base + " Placed at frame \(startFrame)\(trackNote) for \(totalFrames) frames.")
     }
 
     private static func resolveImageURLs(directory: String?, paths: [String]) throws -> [URL] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift
@@ -1,0 +1,254 @@
+import AVFoundation
+import CoreGraphics
+import Foundation
+import ImageIO
+
+extension ToolExecutor {
+    private static let importImageSequenceAllowedKeys: Set<String> =
+        ["directory", "paths", "framesPerImage", "fps", "name", "folderId"]
+    private static let imageSequenceExtensions: Set<String> = ["png", "jpg", "jpeg", "tiff", "heic"]
+    static let imageSequenceMaxImages = 5000
+    static let imageSequenceMaxTotalFrames = 216_000   // 1 hour at 60 fps — runaway guard
+
+    /// Assembles an ordered set of stills into a single H.264 video and registers it as a media
+    /// asset. Fills the gap left by `import_media` (one file at a time, no frames-to-video step).
+    func importImageSequence(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.importImageSequenceAllowedKeys, path: "import_image_sequence")
+
+        let directory = args.string("directory")
+        let paths = args.stringArray("paths")
+        guard (directory != nil) != !paths.isEmpty else {
+            throw ToolError("Provide exactly one of 'directory' or 'paths'.")
+        }
+
+        let imageURLs = try Self.resolveImageURLs(directory: directory, paths: paths)
+        guard !imageURLs.isEmpty else {
+            throw ToolError("No supported image files found (png, jpg, jpeg, tiff, heic).")
+        }
+        guard imageURLs.count <= Self.imageSequenceMaxImages else {
+            throw ToolError("Too many images (\(imageURLs.count); max \(Self.imageSequenceMaxImages)).")
+        }
+
+        let fps = max(1, args.int("fps") ?? editor.timeline.fps)
+        let framesPerImage = max(1, args.int("framesPerImage") ?? editor.timeline.fps)
+        let totalFrames = imageURLs.count * framesPerImage
+        guard totalFrames <= Self.imageSequenceMaxTotalFrames else {
+            throw ToolError("Resulting video is too long: \(imageURLs.count) images × \(framesPerImage) frames = \(totalFrames) frames (max \(Self.imageSequenceMaxTotalFrames)). Lower framesPerImage or split the sequence.")
+        }
+
+        let width = editor.timeline.width
+        let height = editor.timeline.height
+
+        guard let projectURL = editor.projectURL else {
+            throw ToolError("No project is open; cannot create an image sequence.")
+        }
+        let mediaDir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: mediaDir, withIntermediateDirectories: true)
+        } catch {
+            throw ToolError("Failed to prepare media directory: \(error.localizedDescription)")
+        }
+        let destURL = mediaDir.appendingPathComponent("imgseq-\(UUID().uuidString.prefix(8)).mp4")
+
+        // Encode off the main actor — only the model mutation below needs @MainActor.
+        do {
+            try await Task.detached(priority: .userInitiated) {
+                try ImageSequenceEncoder.encode(
+                    images: imageURLs, width: width, height: height,
+                    fps: fps, framesPerImage: framesPerImage, to: destURL
+                )
+            }.value
+        } catch {
+            try? FileManager.default.removeItem(at: destURL)
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            throw ToolError("Failed to encode image sequence: \(message)")
+        }
+
+        guard let asset = editor.addMediaAsset(from: destURL) else {
+            try? FileManager.default.removeItem(at: destURL)
+            throw ToolError("Encoded the sequence but failed to register it as a media asset.")
+        }
+
+        if let name = args.string("name") {
+            asset.name = name
+            if let idx = editor.mediaManifest.entries.firstIndex(where: { $0.id == asset.id }) {
+                editor.mediaManifest.entries[idx].name = name
+            }
+        }
+        if let folderId = try resolveFolderId(args, editor: editor) {
+            editor.moveAssetsToFolder(assetIds: [asset.id], folderId: folderId)
+        }
+
+        let seconds = Double(totalFrames) / Double(fps)
+        return .ok(String(
+            format: "Assembled %d image(s) into video '%@' (id: %@, %d×%d, %d fps, %d frame(s)/image, %d frames ≈ %.2fs). Place it with add_clips using durationFrames: %d.",
+            imageURLs.count, asset.name, asset.id, width, height, fps, framesPerImage, totalFrames, seconds, totalFrames
+        ))
+    }
+
+    private static func resolveImageURLs(directory: String?, paths: [String]) throws -> [URL] {
+        if let directory {
+            let dirURL = URL(fileURLWithPath: (directory as NSString).expandingTildeInPath)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: dirURL.path, isDirectory: &isDir), isDir.boolValue else {
+                throw ToolError("directory not found or not a directory: \(directory)")
+            }
+            let entries = try FileManager.default.contentsOfDirectory(
+                at: dirURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+            )
+            return entries
+                .filter { imageSequenceExtensions.contains($0.pathExtension.lowercased()) }
+                .sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
+        }
+
+        var urls: [URL] = []
+        for p in paths {
+            let url = URL(fileURLWithPath: (p as NSString).expandingTildeInPath)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ToolError("Image file not found: \(p)")
+            }
+            guard imageSequenceExtensions.contains(url.pathExtension.lowercased()) else {
+                throw ToolError("Unsupported image type '.\(url.pathExtension)' for \(url.lastPathComponent). Supported: png, jpg, jpeg, tiff, heic.")
+            }
+            urls.append(url)
+        }
+        return urls
+    }
+}
+
+/// Offline image-sequence → H.264 encoder. Each image is drawn once into a canvas-sized pixel
+/// buffer (aspect-fit, letterboxed) and appended once per held frame, so the output duration is
+/// exactly `images.count × framesPerImage / fps`. Runs synchronously on a background thread
+/// (called from a detached task), so the `isReadyForMoreMediaData` wait loop is acceptable.
+enum ImageSequenceEncoder {
+    static func encode(
+        images: [URL], width: Int, height: Int, fps: Int, framesPerImage: Int, to outputURL: URL
+    ) throws {
+        try? FileManager.default.removeItem(at: outputURL)
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        input.expectsMediaDataInRealTime = false
+
+        let bufferAttrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+            kCVPixelBufferWidthKey as String: width,
+            kCVPixelBufferHeightKey as String: height,
+        ]
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input, sourcePixelBufferAttributes: bufferAttrs
+        )
+
+        guard writer.canAdd(input) else { throw ImageSequenceError.writerSetup }
+        writer.add(input)
+        guard writer.startWriting() else { throw ImageSequenceError.writerStart(writer.error) }
+        writer.startSession(atSourceTime: .zero)
+
+        let timescale = Int32(fps)
+        var pts: Int64 = 0
+        for url in images {
+            let buffer = try makePixelBuffer(for: url, width: width, height: height, pool: adaptor.pixelBufferPool)
+            for _ in 0..<framesPerImage {
+                while !input.isReadyForMoreMediaData {
+                    Thread.sleep(forTimeInterval: 0.005)
+                }
+                if !adaptor.append(buffer, withPresentationTime: CMTime(value: pts, timescale: timescale)) {
+                    throw ImageSequenceError.appendFailed(writer.error)
+                }
+                pts += 1
+            }
+        }
+
+        input.markAsFinished()
+        writer.endSession(atSourceTime: CMTime(value: pts, timescale: timescale))
+
+        let done = DispatchSemaphore(value: 0)
+        writer.finishWriting { done.signal() }
+        done.wait()
+
+        guard writer.status == .completed else {
+            throw ImageSequenceError.finish(writer.error)
+        }
+    }
+
+    private static func makePixelBuffer(
+        for url: URL, width: Int, height: Int, pool: CVPixelBufferPool?
+    ) throws -> CVPixelBuffer {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ImageSequenceError.imageLoad(url)
+        }
+
+        var pixelBuffer: CVPixelBuffer?
+        if let pool {
+            CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer)
+        }
+        if pixelBuffer == nil {
+            let attrs: [String: Any] = [
+                kCVPixelBufferCGImageCompatibilityKey as String: true,
+                kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+            ]
+            CVPixelBufferCreate(
+                kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, attrs as CFDictionary, &pixelBuffer
+            )
+        }
+        guard let buffer = pixelBuffer else { throw ImageSequenceError.bufferAlloc }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+        guard let base = CVPixelBufferGetBaseAddress(buffer) else { throw ImageSequenceError.bufferAlloc }
+        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        guard let ctx = CGContext(
+            data: base,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ) else {
+            throw ImageSequenceError.context
+        }
+
+        // Letterbox onto a black canvas, aspect preserved.
+        ctx.setFillColor(red: 0, green: 0, blue: 0, alpha: 1)
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        let iw = CGFloat(cgImage.width), ih = CGFloat(cgImage.height)
+        let cw = CGFloat(width), ch = CGFloat(height)
+        guard iw > 0, ih > 0 else { throw ImageSequenceError.imageLoad(url) }
+        let scale = min(cw / iw, ch / ih)
+        let dw = iw * scale, dh = ih * scale
+        ctx.draw(cgImage, in: CGRect(x: (cw - dw) / 2, y: (ch - dh) / 2, width: dw, height: dh))
+
+        return buffer
+    }
+}
+
+enum ImageSequenceError: LocalizedError {
+    case writerSetup
+    case writerStart(Error?)
+    case appendFailed(Error?)
+    case finish(Error?)
+    case imageLoad(URL)
+    case bufferAlloc
+    case context
+
+    var errorDescription: String? {
+        switch self {
+        case .writerSetup: return "could not configure the video writer"
+        case .writerStart(let e): return "video writer failed to start (\(e?.localizedDescription ?? "unknown"))"
+        case .appendFailed(let e): return "failed to append a frame (\(e?.localizedDescription ?? "unknown"))"
+        case .finish(let e): return "video writer failed to finalize (\(e?.localizedDescription ?? "unknown"))"
+        case .imageLoad(let url): return "could not read image \(url.lastPathComponent)"
+        case .bufferAlloc: return "could not allocate a pixel buffer"
+        case .context: return "could not create a drawing context"
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -43,6 +43,8 @@ final class ToolExecutor {
             case .generateAudio: return try await generateAudio(editor, args)
             case .upscaleMedia:  return try upscaleMedia(editor, args)
             case .importMedia:   return try importMedia(editor, args)
+            case .importImageSequence: return try await importImageSequence(editor, args)
+            case .exportVideo:   return try await exportVideo(editor, args)
             case .listModels:    return listModels(args)
             case .listFolders:   return listFolders(editor)
             case .createFolder:  return try createFolder(editor, args)


### PR DESCRIPTION
# Add `export_video` and `import_image_sequence` MCP tools

## Why

Two gaps make Palmier Pro hard to drive end-to-end from an MCP client (Claude
Code/Desktop, Codex, Cursor) without a human at the keyboard:

1. **No export over MCP.** An agent can build the whole timeline, but the only
   way to produce a rendered file is the GUI `File ▸ Export` dialog. The render
   pipeline can't finish headlessly.
2. **No image-sequence import.** `import_media` takes one file per call and has
   no frames-to-video step, so a folder of rendered frames / storyboard panels
   can't become a single clip.

This PR adds two tools that close both gaps. No new dependencies (AVFoundation /
CoreGraphics / ImageIO only); both tools are exposed to the MCP server and the
in-app agent automatically via `ToolDefinitions.all` + the `ToolExecutor`
dispatch.

## `export_video`

Renders the current timeline to disk — the same composite the Export dialog
produces, exposed to the agent. Thin wrapper over the existing
`ExportService.export(timeline:resolver:format:resolution:outputURL:)` that was
previously reachable only from `ExportView.startExport`. Awaits completion and
returns the output path.

- `path` (required, absolute) — parent dirs created, extension normalized to the format.
- `format` — `h264` (default, `.mp4`), `h265` (`.mp4`), `prores` (`.mov`), `xml` (FCPXML interchange).
- `resolution` — `720p` / `1080p` (default) / `4k`, scaled from the canvas, aspect preserved.

## `import_image_sequence`

Assembles an ordered set of stills into a single H.264 asset and registers it in
the library.

- `directory` **xor** `paths` — folder (natural filename sort) or explicit ordered list.
- `framesPerImage` (default = project fps), `fps` (default = timeline fps).
- `name`, `folderId` — optional library placement.
- `addToTimeline` (default false) + `startFrame` / `trackIndex` — optionally drop
  the assembled clip straight onto the timeline, reusing the `add_clips` path so
  track auto-creation and overlap handling are identical to a normal placement.

Each image is drawn once into a canvas-sized pixel buffer (aspect-fit,
letterboxed onto black) and appended once per held frame, so the output duration
is exactly `images.count × framesPerImage / fps`. Encoding runs off the main
actor in a detached task (mirrors `ExportService.exportPalmierProject`). Guards:
≤ 5000 images, ≤ 216 000 total frames, requires an open project.

## Files

- `Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift` — 2 `ToolName` cases + 2 schemas
- `Sources/PalmierPro/Agent/Tools/ToolExecutor.swift` — 2 dispatch arms
- `Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift` — new
- `Sources/PalmierPro/Agent/Tools/ToolExecutor+ImageSequence.swift` — new

## Testing notes

- `export_video` wraps the already-tested `ExportService` path.
- `import_image_sequence`'s pixel-buffer encoder uses the standard
  BGRA / premultipliedFirst recipe; worth a visual check on color/orientation
  with a real sequence on first run.
