### PR TITLE
improve logging and better feedback for unprocessable media

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -137,7 +137,14 @@ extension EditorViewModel {
 
     /// missing on disk or present-but-unloadable (no permission, ejected volume)
     func isMediaOffline(_ mediaRef: String) -> Bool {
-        offlineMediaRefs.contains(mediaRef) || mediaResolver.isMissing(for: mediaRef)
+        offlineMediaRefs.contains(mediaRef)
+            || unprocessableMediaRefs.contains(mediaRef)
+            || mediaResolver.isMissing(for: mediaRef)
+    }
+
+    /// Present-but-unpreparable (e.g. failed to encode)
+    func isMediaUnprocessable(_ mediaRef: String) -> Bool {
+        unprocessableMediaRefs.contains(mediaRef) && !mediaResolver.isMissing(for: mediaRef)
     }
 
     func isClipMediaOffline(_ clip: Clip) -> Bool {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -109,6 +109,7 @@ final class EditorViewModel {
 
     var mediaAssets: [MediaAsset] = []
     var offlineMediaRefs: Set<String> = []
+    var unprocessableMediaRefs: Set<String> = []
     let mediaVisualCache = MediaVisualCache()
     let searchIndex = SearchIndexCoordinator()
     var projectURL: URL? {

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -116,15 +116,15 @@ final class ExportService {
                     self.error = "Export was cancelled"
                     Log.export.notice("export cancelled")
                 } else {
-                    self.error = Self.detailedMessage(for: error)
-                    Log.export.error("export failed: \(Self.detailedMessage(for: error))")
+                    self.error = Log.detail(error)
+                    Log.export.error("export failed: \(Log.detail(error))")
                 }
             }
 
             progressTask.cancel()
         } catch {
-            self.error = Self.detailedMessage(for: error)
-            Log.export.error("export setup failed: \(Self.detailedMessage(for: error))")
+            self.error = Log.detail(error)
+            Log.export.error("export setup failed: \(Log.detail(error))")
         }
 
         isExporting = false
@@ -157,8 +157,8 @@ final class ExportService {
             Log.export.notice("palmier export ok collected=\(report.collected.count) missing=\(report.missing.count)")
             return report
         } catch {
-            self.error = Self.detailedMessage(for: error)
-            Log.export.error("palmier export failed: \(Self.detailedMessage(for: error))")
+            self.error = Log.detail(error)
+            Log.export.error("palmier export failed: \(Log.detail(error))")
             return nil
         }
     }
@@ -197,21 +197,6 @@ final class ExportService {
         )
         session.videoComposition = mutableVC
         return session
-    }
-
-    private static func detailedMessage(for error: Error) -> String {
-        let ns = error as NSError
-        var message = ns.localizedDescription
-        if let reason = ns.localizedFailureReason, !message.contains(reason) {
-            message += " — \(reason)"
-        }
-        var codes: [String] = []
-        var current: NSError? = ns
-        while let e = current {
-            codes.append("\(e.domain) \(e.code)")
-            current = e.userInfo[NSUnderlyingErrorKey] as? NSError
-        }
-        return "\(message) (\(codes.joined(separator: " → ")))"
     }
 
     // MARK: - Export preset mapping

--- a/Sources/PalmierPro/Help/FeedbackView.swift
+++ b/Sources/PalmierPro/Help/FeedbackView.swift
@@ -15,6 +15,11 @@ struct FeedbackView: View {
 
     let screenshot: Data?
 
+    init(screenshot: Data?, prefill: String = "") {
+        self.screenshot = screenshot
+        _message = State(initialValue: prefill)
+    }
+
     private static let maxMessageLen = 10_000
 
     private var trimmedMessage: String {
@@ -314,11 +319,11 @@ final class FeedbackWindowController: NSWindowController {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
-    func show() {
+    func show(prefill: String = "") {
         // Capture BEFORE the feedback window becomes key so it isn't in the shot.
         let screenshot = FeedbackScreenshot.captureMainWindow()
         hosting?.rootView = AnyView(
-            FeedbackView(screenshot: screenshot)
+            FeedbackView(screenshot: screenshot, prefill: prefill)
                 .id(UUID())
                 .tint(AppTheme.Accent.primary)
         )

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -20,6 +20,7 @@ struct CompositionResult {
     let clipNaturalSizes: [String: CGSize]
     let clipTransforms: [String: CGAffineTransform]
     let offlineMediaRefs: Set<String>
+    let unprocessableMediaRefs: Set<String>
 }
 
 /// Builds an AVFoundation composition from a Timeline.
@@ -47,6 +48,7 @@ enum CompositionBuilder {
         var clipNaturalSizes: [String: CGSize] = [:]
         var clipTransforms: [String: CGAffineTransform] = [:]
         var offlineMediaRefs: Set<String> = []
+        var unprocessableMediaRefs: Set<String> = []
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
             // Text renders via CATextLayer overlay (preview) + animation tool (export) — never as composition tracks.
@@ -63,15 +65,17 @@ enum CompositionBuilder {
                 var normalCursor = CMTime.zero
 
                 for clip in sortedClips {
-                    guard let source = try await loadSource(
+                    let source: (asset: AVURLAsset, track: AVAssetTrack)
+                    switch try await loadSource(
                         clip: clip,
                         mediaType: mediaType,
                         resolveURL: resolveURL,
                         resolveSourceSize: resolveSourceSize,
                         renderSize: renderSize
-                    ) else {
-                        offlineMediaRefs.insert(clip.mediaRef)
-                        continue
+                    ) {
+                    case .loaded(let asset, let track): source = (asset, track)
+                    case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
+                    case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
                     }
 
                     if clip.speed != 1.0 {
@@ -146,15 +150,17 @@ enum CompositionBuilder {
             var previousEndFrame = Int.min
             for clip in sortedClips {
                 guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
-                guard let source = try await loadSource(
+                let source: (asset: AVURLAsset, track: AVAssetTrack)
+                switch try await loadSource(
                     clip: clip,
                     mediaType: mediaType,
                     resolveURL: resolveURL,
                     resolveSourceSize: resolveSourceSize,
                     renderSize: renderSize
-                ) else {
-                    offlineMediaRefs.insert(clip.mediaRef)
-                    continue
+                ) {
+                case .loaded(let asset, let track): source = (asset, track)
+                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
+                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
                 }
 
                 if let natSize = try? await source.track.load(.naturalSize),
@@ -225,8 +231,15 @@ enum CompositionBuilder {
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
-            offlineMediaRefs: offlineMediaRefs
+            offlineMediaRefs: offlineMediaRefs,
+            unprocessableMediaRefs: unprocessableMediaRefs
         )
+    }
+
+    private enum LoadOutcome {
+        case loaded(asset: AVURLAsset, track: AVAssetTrack)
+        case offline
+        case unprocessable
     }
 
     private static func loadSource(
@@ -235,9 +248,11 @@ enum CompositionBuilder {
         resolveURL: @Sendable (String) -> URL?,
         resolveSourceSize: @Sendable (String) -> CGSize?,
         renderSize: CGSize
-    ) async throws -> (asset: AVURLAsset, track: AVAssetTrack)? {
+    ) async throws -> LoadOutcome {
         let mediaURL: URL
-        guard let resolved = resolveURL(clip.mediaRef) else { return nil }
+        guard let resolved = resolveURL(clip.mediaRef) else { return .offline }
+        // A failed generation on a present file is unprocessable; on a missing file it's offline.
+        let sourceExists = FileManager.default.fileExists(atPath: resolved.path)
         if clip.mediaType == .image {
             let imageSize = resolveSourceSize(clip.mediaRef)
                 ?? ImageVideoGenerator.imageNativeSize(url: resolved)
@@ -250,7 +265,7 @@ enum CompositionBuilder {
                 )
             } catch {
                 Log.preview.error("stillVideo failed mediaRef=\(clip.mediaRef) size=\(Int(imageSize.width))x\(Int(imageSize.height)): \(Log.detail(error))")
-                return nil
+                return sourceExists ? .unprocessable : .offline
             }
         } else if clip.mediaType == .lottie {
             let lottieSize = resolveSourceSize(clip.mediaRef) ?? renderSize
@@ -261,8 +276,8 @@ enum CompositionBuilder {
                     size: lottieSize
                 )
             } catch {
-                Log.preview.error("lottieVideo failed mediaRef=\(clip.mediaRef) size=\(Int(lottieSize.width))x\(Int(lottieSize.height)): \(error.localizedDescription)")
-                return nil
+                Log.preview.error("lottieVideo failed mediaRef=\(clip.mediaRef) size=\(Int(lottieSize.width))x\(Int(lottieSize.height)): \(Log.detail(error))")
+                return sourceExists ? .unprocessable : .offline
             }
         } else if mediaType == .video {
             mediaURL = (try? await AlphaVideoNormalizer.premultipliedVideo(for: resolved, mediaRef: clip.mediaRef)) ?? resolved
@@ -274,12 +289,12 @@ enum CompositionBuilder {
         let sourceAsset = AVURLAsset(url: mediaURL)
         do {
             guard let sourceTrack = try await sourceAsset.loadTracks(withMediaType: mediaType).first else {
-                return nil
+                return .offline
             }
-            return (sourceAsset, sourceTrack)
+            return .loaded(asset: sourceAsset, track: sourceTrack)
         } catch {
             Log.preview.error("loadTracks failed — skipping clip. clipId=\(clip.id) mediaRef=\(clip.mediaRef): \(error.localizedDescription)")
-            return nil
+            return .offline
         }
     }
 

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -249,7 +249,7 @@ enum CompositionBuilder {
                     size: imageSize
                 )
             } catch {
-                Log.preview.error("stillVideo failed mediaRef=\(clip.mediaRef) size=\(Int(imageSize.width))x\(Int(imageSize.height)): \(error.localizedDescription)")
+                Log.preview.error("stillVideo failed mediaRef=\(clip.mediaRef) size=\(Int(imageSize.width))x\(Int(imageSize.height)): \(Log.detail(error))")
                 return nil
             }
         } else if clip.mediaType == .lottie {

--- a/Sources/PalmierPro/Preview/ImageVideoGenerator.swift
+++ b/Sources/PalmierPro/Preview/ImageVideoGenerator.swift
@@ -41,7 +41,7 @@ enum ImageVideoGenerator {
             )
             return outputURL
         } catch {
-            Log.preview.error("stillVideo failed file=\(imageURL.lastPathComponent) size=\(Int(size.width))x\(Int(size.height)): \(error.localizedDescription)")
+            Log.preview.error("stillVideo failed file=\(imageURL.lastPathComponent) size=\(Int(size.width))x\(Int(size.height)) alpha=\(hasAlpha): \(Log.detail(error))")
             throw error
         }
     }

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -32,7 +32,7 @@ struct PreviewContainerView: View {
                         generatingPreview(label: asset.generatingLabel)
                     }
                     if let overlay = offlineOverlay {
-                        offlinePreview(assetId: overlay.assetId, path: overlay.path)
+                        offlinePreview(assetId: overlay.assetId, path: overlay.path, isUnprocessable: overlay.isUnprocessable)
                     }
                     if editor.cropEditingActive {
                         CropOverlayView()
@@ -331,7 +331,8 @@ struct PreviewContainerView: View {
     /// The offline clip blacking out the current timeline frame, or nil when an online clip covers it.
     private var timelineOfflineClip: Clip? {
         guard isTimeline else { return nil }
-        let frame = editor.currentFrame
+        guard !editor.offlineMediaRefs.isEmpty || !editor.unprocessableMediaRefs.isEmpty else { return nil }
+        let frame = editor.playheadState.timelineFrame
         var offline: Clip?
         for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
             for clip in track.clips where clip.mediaType != .text {
@@ -346,15 +347,19 @@ struct PreviewContainerView: View {
         return offline
     }
 
-    private struct OfflineOverlay { let assetId: String?; let path: String? }
+    private struct OfflineOverlay { let assetId: String?; let path: String?; let isUnprocessable: Bool }
 
     /// Resolved once per render so the timeline scan runs at most once.
     private var offlineOverlay: OfflineOverlay? {
-        if activeMediaMissing {
-            return OfflineOverlay(assetId: activeMediaAsset?.id, path: activeMediaAsset?.url.path)
+        if activeMediaMissing, let id = activeMediaAsset?.id {
+            return OfflineOverlay(assetId: id, path: activeMediaAsset?.url.path, isUnprocessable: editor.isMediaUnprocessable(id))
         }
         if let clip = timelineOfflineClip {
-            return OfflineOverlay(assetId: clip.mediaRef, path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path)
+            return OfflineOverlay(
+                assetId: clip.mediaRef,
+                path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path,
+                isUnprocessable: editor.isMediaUnprocessable(clip.mediaRef)
+            )
         }
         return nil
     }
@@ -411,17 +416,30 @@ struct PreviewContainerView: View {
         return nil
     }
 
-    private func offlinePreview(assetId: String?, path: String?) -> some View {
+    private static func unprocessablePrefill(path: String?) -> String {
+        let file = path.map { ($0 as NSString).lastPathComponent } ?? "(unknown)"
+        return """
+        A clip's media couldn't be prepared for playback.
+
+        File: \(file)
+
+        What were you doing when this happened?
+        """
+    }
+
+    private func offlinePreview(assetId: String?, path: String?, isUnprocessable: Bool) -> some View {
         ZStack {
             Color.black.opacity(AppTheme.Opacity.strong)
             VStack(spacing: AppTheme.Spacing.md) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: AppTheme.FontSize.display))
                     .foregroundStyle(AppTheme.Status.errorColor)
-                Text("Media Offline")
+                Text(isUnprocessable ? "Couldn't Prepare Media" : "Media Offline")
                     .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
                     .foregroundStyle(AppTheme.Text.primaryColor)
-                Text("Palmier couldn't load this clip's source file. It may be missing, on an ejected drive, or unreadable.")
+                Text(isUnprocessable
+                    ? "Palmier loaded this clip's source file but couldn't prepare it for playback. The file may be corrupt or in an unsupported format."
+                    : "Palmier couldn't load this clip's source file. It may be missing, on an ejected drive, or unreadable.")
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.secondaryColor)
                     .multilineTextAlignment(.center)
@@ -437,15 +455,23 @@ struct PreviewContainerView: View {
                         .truncationMode(.middle)
                         .padding(.horizontal, AppTheme.Spacing.lg)
                 }
-                HStack(spacing: AppTheme.Spacing.sm) {
-                    if let assetId {
-                        Button("Relink…") { relinkFile(assetId: assetId) }
-                            .buttonStyle(.capsule(.prominent, size: .regular))
+                if isUnprocessable {
+                    Button("Report a Problem") {
+                        FeedbackWindowController.shared.show(prefill: Self.unprocessablePrefill(path: path))
                     }
-                    Button("Relink Folder…") { relinkFolder() }
-                        .buttonStyle(.capsule(.secondary, size: .regular))
+                    .buttonStyle(.capsule(.prominent, size: .regular))
+                    .padding(.top, AppTheme.Spacing.xs)
+                } else {
+                    HStack(spacing: AppTheme.Spacing.sm) {
+                        if let assetId {
+                            Button("Relink…") { relinkFile(assetId: assetId) }
+                                .buttonStyle(.capsule(.prominent, size: .regular))
+                        }
+                        Button("Relink Folder…") { relinkFolder() }
+                            .buttonStyle(.capsule(.secondary, size: .regular))
+                    }
+                    .padding(.top, AppTheme.Spacing.xs)
                 }
-                .padding(.top, AppTheme.Spacing.xs)
             }
             .padding(AppTheme.Spacing.xl)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -171,6 +171,7 @@ final class VideoEngine {
             clipTransforms = result.clipTransforms
             compositionDuration = result.composition.duration
             editor.offlineMediaRefs = result.offlineMediaRefs
+            editor.unprocessableMediaRefs = result.unprocessableMediaRefs
 
             let item = AVPlayerItem(asset: result.composition)
             item.audioMix = result.audioMix

--- a/Sources/PalmierPro/Utilities/Log.swift
+++ b/Sources/PalmierPro/Utilities/Log.swift
@@ -21,6 +21,22 @@ enum Log {
     static let crashLogURL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/Logs/PalmierPro/crash.log")
 
+    /// Full NSError chain
+    static func detail(_ error: Error) -> String {
+        let ns = error as NSError
+        var message = ns.localizedDescription
+        if let reason = ns.localizedFailureReason, !message.contains(reason) {
+            message += " — \(reason)"
+        }
+        var codes: [String] = []
+        var current: NSError? = ns
+        while let e = current {
+            codes.append("\(e.domain) \(e.code)")
+            current = e.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return "\(message) (\(codes.joined(separator: " → ")))"
+    }
+
     /// Call once at launch, before `NSApplication.run()`.
     static func bootstrap() {
         CrashHandler.install()


### PR DESCRIPTION
from sentry and user feedback.

### Problem

1. stillvideo/export log only `error.localizedDescription`. so its hard for us to pin down why it failed
2. user only sees black frames if a clip is unprocessable.
 
### Solution

1. add `Log.detail(_:)` so we see the full `NSError` chain
2. surface unprocessable error to preview, with a feedback button