### PR TITLE
Fix rotated clips rendering black + crop overlay rotation

### DIFF
--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -165,11 +165,11 @@ enum CompositionBuilder {
 
                 if let natSize = try? await source.track.load(.naturalSize),
                    natSize.width > 0, natSize.height > 0 {
-                    // Store display size and transform for layer orientation.
+                    // Store clip display size and transform with origin at (0,0)
                     let pt = (try? await source.track.load(.preferredTransform)) ?? .identity
-                    let display = natSize.applying(pt)
-                    clipNaturalSizes[clip.id] = CGSize(width: abs(display.width), height: abs(display.height))
-                    clipTransforms[clip.id] = pt
+                    let box = CGRect(origin: .zero, size: natSize).applying(pt)
+                    clipNaturalSizes[clip.id] = CGSize(width: abs(box.width), height: abs(box.height))
+                    clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
                 }
 
                 if await insertClip(

--- a/Sources/PalmierPro/Preview/CropOverlayView.swift
+++ b/Sources/PalmierPro/Preview/CropOverlayView.swift
@@ -14,47 +14,54 @@ struct CropOverlayView: View {
 
             if let clip = selectedClip {
                 let frame = editor.activeFrame
-                let clipRect = clipFrame(clip.transformAt(frame: frame), videoRect: videoRect)
+                let transform = clip.transformAt(frame: frame)
+                let clipRect = clipFrame(transform, videoRect: videoRect)
                 let cropRect = cropFrame(clip.cropAt(frame: frame), in: clipRect)
 
-                Canvas { ctx, _ in
-                    let dim = GraphicsContext.Shading.color(dimColor)
-                    ctx.fill(Path(CGRect(x: clipRect.minX, y: clipRect.minY, width: clipRect.width, height: cropRect.minY - clipRect.minY)), with: dim)
-                    ctx.fill(Path(CGRect(x: clipRect.minX, y: cropRect.maxY, width: clipRect.width, height: clipRect.maxY - cropRect.maxY)), with: dim)
-                    ctx.fill(Path(CGRect(x: clipRect.minX, y: cropRect.minY, width: cropRect.minX - clipRect.minX, height: cropRect.height)), with: dim)
-                    ctx.fill(Path(CGRect(x: cropRect.maxX, y: cropRect.minY, width: clipRect.maxX - cropRect.maxX, height: cropRect.height)), with: dim)
+                ZStack {
+                    Canvas { ctx, _ in
+                        let dim = GraphicsContext.Shading.color(dimColor)
+                        ctx.fill(Path(CGRect(x: clipRect.minX, y: clipRect.minY, width: clipRect.width, height: cropRect.minY - clipRect.minY)), with: dim)
+                        ctx.fill(Path(CGRect(x: clipRect.minX, y: cropRect.maxY, width: clipRect.width, height: clipRect.maxY - cropRect.maxY)), with: dim)
+                        ctx.fill(Path(CGRect(x: clipRect.minX, y: cropRect.minY, width: cropRect.minX - clipRect.minX, height: cropRect.height)), with: dim)
+                        ctx.fill(Path(CGRect(x: cropRect.maxX, y: cropRect.minY, width: clipRect.maxX - cropRect.maxX, height: cropRect.height)), with: dim)
 
-                    var thirds = Path()
-                    for i in 1...2 {
-                        let f = CGFloat(i) / 3
-                        thirds.move(to: CGPoint(x: cropRect.minX + cropRect.width * f, y: cropRect.minY))
-                        thirds.addLine(to: CGPoint(x: cropRect.minX + cropRect.width * f, y: cropRect.maxY))
-                        thirds.move(to: CGPoint(x: cropRect.minX, y: cropRect.minY + cropRect.height * f))
-                        thirds.addLine(to: CGPoint(x: cropRect.maxX, y: cropRect.minY + cropRect.height * f))
+                        var thirds = Path()
+                        for i in 1...2 {
+                            let f = CGFloat(i) / 3
+                            thirds.move(to: CGPoint(x: cropRect.minX + cropRect.width * f, y: cropRect.minY))
+                            thirds.addLine(to: CGPoint(x: cropRect.minX + cropRect.width * f, y: cropRect.maxY))
+                            thirds.move(to: CGPoint(x: cropRect.minX, y: cropRect.minY + cropRect.height * f))
+                            thirds.addLine(to: CGPoint(x: cropRect.maxX, y: cropRect.minY + cropRect.height * f))
+                        }
+                        ctx.stroke(thirds, with: .color(guideColor), lineWidth: AppTheme.BorderWidth.thin)
+                        ctx.stroke(Path(cropRect), with: .color(borderColor), lineWidth: AppTheme.BorderWidth.medium)
                     }
-                    ctx.stroke(thirds, with: .color(guideColor), lineWidth: AppTheme.BorderWidth.thin)
-                    ctx.stroke(Path(cropRect), with: .color(borderColor), lineWidth: AppTheme.BorderWidth.medium)
-                }
-                .allowsHitTesting(false)
+                    .allowsHitTesting(false)
 
-                Rectangle()
-                    .fill(Color.clear)
-                    .contentShape(Rectangle())
-                    .frame(width: cropRect.width, height: cropRect.height)
-                    .position(x: cropRect.midX, y: cropRect.midY)
-                    .onHover { hovering in
-                        if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
-                    }
-                    .gesture(panGesture(clip: clip, clipRect: clipRect))
-
-                ForEach(Corner.allCases, id: \.self) { corner in
-                    let pos = cornerPosition(corner, in: cropRect)
                     Rectangle()
-                        .fill(borderColor)
-                        .frame(width: handleSize, height: handleSize)
-                        .position(x: pos.x, y: pos.y)
-                        .gesture(resizeGesture(clip: clip, corner: corner, clipRect: clipRect))
+                        .fill(Color.clear)
+                        .contentShape(Rectangle())
+                        .frame(width: cropRect.width, height: cropRect.height)
+                        .position(x: cropRect.midX, y: cropRect.midY)
+                        .onHover { hovering in
+                            if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
+                        }
+                        .gesture(panGesture(clip: clip, clipRect: clipRect))
+
+                    ForEach(Corner.allCases, id: \.self) { corner in
+                        let pos = cornerPosition(corner, in: cropRect)
+                        Rectangle()
+                            .fill(borderColor)
+                            .frame(width: handleSize, height: handleSize)
+                            .position(x: pos.x, y: pos.y)
+                            .gesture(resizeGesture(clip: clip, corner: corner, clipRect: clipRect))
+                    }
                 }
+                .frame(width: geo.size.width, height: geo.size.height)
+                // Match the clip's rotation about its center; gestures counter-rotate to stay in clip-local axes.
+                .rotationEffect(.degrees(transform.rotation),
+                                anchor: UnitPoint(x: clipRect.midX / geo.size.width, y: clipRect.midY / geo.size.height))
             }
         }
         .allowsHitTesting(selectedClip != nil)
@@ -65,19 +72,30 @@ struct CropOverlayView: View {
     @State private var dragStart: Crop?
 
     private func panGesture(clip: Clip, clipRect: CGRect) -> some Gesture {
-        DragGesture()
+        DragGesture(coordinateSpace: .global)
             .onChanged { value in
                 if dragStart == nil { dragStart = clip.cropAt(frame: editor.activeFrame) }
                 guard let start = dragStart else { return }
-                let updated = pannedCrop(start, by: value.translation, clipRect: clipRect)
+                let updated = pannedCrop(start, by: clipLocal(value.translation, clip: clip), clipRect: clipRect)
                 editor.applyCrop(clipId: clip.id, newCrop: updated)
             }
             .onEnded { value in
                 guard let start = dragStart else { return }
-                let updated = pannedCrop(start, by: value.translation, clipRect: clipRect)
+                let updated = pannedCrop(start, by: clipLocal(value.translation, clip: clip), clipRect: clipRect)
                 dragStart = nil
                 editor.commitCrop(clipId: clip.id, newCrop: updated)
             }
+    }
+
+    /// Rotate a screen-space drag delta into the clip's local (unrotated) axes, so crop math
+    /// stays correct when the clip's rotation tilts the overlay.
+    private func clipLocal(_ translation: CGSize, clip: Clip) -> CGSize {
+        let r = clip.transformAt(frame: editor.activeFrame).rotation * .pi / 180
+        let c = cos(r), s = sin(r)
+        return CGSize(
+            width:  translation.width * c + translation.height * s,
+            height: -translation.width * s + translation.height * c
+        )
     }
 
     private func pannedCrop(_ start: Crop, by translation: CGSize, clipRect: CGRect) -> Crop {
@@ -92,16 +110,16 @@ struct CropOverlayView: View {
     }
 
     private func resizeGesture(clip: Clip, corner: Corner, clipRect: CGRect) -> some Gesture {
-        DragGesture()
+        DragGesture(coordinateSpace: .global)
             .onChanged { value in
                 if dragStart == nil { dragStart = clip.cropAt(frame: editor.activeFrame) }
                 guard let start = dragStart else { return }
-                let updated = resizedCrop(start, corner: corner, by: value.translation, clipRect: clipRect, clip: clip)
+                let updated = resizedCrop(start, corner: corner, by: clipLocal(value.translation, clip: clip), clipRect: clipRect, clip: clip)
                 editor.applyCrop(clipId: clip.id, newCrop: updated)
             }
             .onEnded { value in
                 guard let start = dragStart else { return }
-                let updated = resizedCrop(start, corner: corner, by: value.translation, clipRect: clipRect, clip: clip)
+                let updated = resizedCrop(start, corner: corner, by: clipLocal(value.translation, clip: clip), clipRect: clipRect, clip: clip)
                 dragStart = nil
                 editor.commitCrop(clipId: clip.id, newCrop: updated)
             }


### PR DESCRIPTION
two fixes.

### 1. Rotated source renders black (`286e11d`)
A source whose `preferredTransform` is a **bare rotation** (`tx=ty=0`) placed its rotated content off-canvas, so the opaque black background layer showed straight through: pure black in preview and export, while text/audio survived. 

Fix: recenter the `preferredTransform` into the positive quadrant via its bounding box in `CompositionBuilder`, so content always lands on-canvas. Non-regressive — identity transforms have zero offset.

Verified across every orientation matrix (90° bare/iOS, 180°, 270°, horizontal flip, flip+90°) by rendering frames through the export pipeline and confirming non-black output.

### 2. Crop overlay follows clip rotation (`2122317`)
The crop overlay drew an axis-aligned rectangle while rotated clips tilted their content, so handles and the dim mask no longer matched what actually gets cropped 

## Test plan
- Import a bare-rotation clip → renders content (not black) in preview and export.
- Rotate a clip with crop applied → overlay handles/mask align to the tilted frame; resize/pan track the grabbed edge.
- Regression: normal (non-rotated) clips unchanged.