### PR TITLE
Allow a custom Anthropic API base URL

### DIFF
--- a/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
@@ -34,7 +34,10 @@ struct AnthropicClient: AgentClient {
     let model: AnthropicModel
     var maxTokens: Int = 8192
 
-    private static let endpoint = URL(string: "https://api.anthropic.com/v1/messages")!
+    /// Messages API endpoint. Defaults to the user-configured base URL
+    /// (see ``AnthropicEndpoint``) so requests can be routed through an
+    /// Anthropic-compatible proxy. Re-evaluated each time a client is built.
+    var endpoint: URL = AnthropicEndpoint.resolvedMessagesURL()
 
     func stream(
         system: String,
@@ -62,7 +65,7 @@ struct AnthropicClient: AgentClient {
     ) async throws {
         guard !apiKey.isEmpty else { throw AnthropicClientError.missingAPIKey }
 
-        var request = URLRequest(url: Self.endpoint)
+        var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")

--- a/Sources/PalmierPro/Agent/Clients/AnthropicEndpoint.swift
+++ b/Sources/PalmierPro/Agent/Clients/AnthropicEndpoint.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Resolves the base URL used for Anthropic Messages API requests.
+///
+/// Defaults to the official endpoint but can be pointed at any
+/// Anthropic-compatible proxy or gateway (VibeProxy, LiteLLM, one-api, …)
+/// via the Agent settings field. In DEBUG builds the `ANTHROPIC_BASE_URL`
+/// environment variable takes precedence, mirroring `ANTHROPIC_API_KEY`.
+enum AnthropicEndpoint {
+    static let defaultBaseURL = "https://api.anthropic.com"
+    private static let defaultsKey = "anthropicBaseURL"
+    private static let messagesPath = "/v1/messages"
+
+    /// The user-configured base URL, or `nil` when the default is in effect.
+    static func storedBaseURL() -> String? {
+        guard let raw = UserDefaults.standard.string(forKey: defaultsKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else { return nil }
+        return raw
+    }
+
+    /// Persists a custom base URL, or clears it (restoring the default) when blank.
+    static func save(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            UserDefaults.standard.removeObject(forKey: defaultsKey)
+        } else {
+            UserDefaults.standard.set(trimmed, forKey: defaultsKey)
+        }
+    }
+
+    /// The effective base URL: DEBUG env override, then stored value, then default.
+    static func resolvedBaseURL() -> String {
+        #if DEBUG
+        if let env = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !env.isEmpty {
+            return env
+        }
+        #endif
+        return storedBaseURL() ?? defaultBaseURL
+    }
+
+    /// The full Messages API URL for the effective base URL.
+    static func resolvedMessagesURL() -> URL {
+        messagesURL(base: resolvedBaseURL())
+    }
+
+    /// Builds the Messages API URL for a given base, appending `/v1/messages`.
+    ///
+    /// A blank or malformed base falls back to the official endpoint so a bad
+    /// setting can never produce a nil request URL. Trailing slashes on the
+    /// base are ignored, matching the `ANTHROPIC_BASE_URL` convention.
+    static func messagesURL(base: String) -> URL {
+        let trimmed = base.trimmingCharacters(in: .whitespacesAndNewlines)
+        var root = trimmed.isEmpty ? defaultBaseURL : trimmed
+        while root.hasSuffix("/") { root.removeLast() }
+        return URL(string: root + messagesPath)
+            ?? URL(string: defaultBaseURL + messagesPath)!
+    }
+}

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -6,6 +6,8 @@ struct AgentPane: View {
     @State private var hasKey: Bool = false
     @State private var maskedKey: String = ""
     @State private var draft: String = ""
+    @State private var currentBaseURL: String = ""
+    @State private var baseURLDraft: String = ""
     @FocusState private var isFocused: Bool
 
     private let consoleURL = URL(string: "https://console.anthropic.com/settings/keys")!
@@ -13,6 +15,7 @@ struct AgentPane: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
             apiKeySection
+            baseURLSection
             Divider().overlay(AppTheme.Border.subtleColor)
             mcpSection
         }
@@ -111,6 +114,9 @@ struct AgentPane: View {
         let key = AnthropicKeychain.load() ?? ""
         hasKey = !key.isEmpty
         maskedKey = mask(key)
+        let stored = AnthropicEndpoint.storedBaseURL() ?? ""
+        currentBaseURL = stored
+        baseURLDraft = stored
     }
 
     private func save() {
@@ -131,6 +137,81 @@ struct AgentPane: View {
     private func mask(_ key: String) -> String {
         guard key.count > 4 else { return String(repeating: "\u{2022}", count: 32) }
         return String(repeating: "\u{2022}", count: 36) + key.suffix(4)
+    }
+
+    // MARK: - API base URL
+
+    private var baseURLSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            baseURLHeader
+            baseURLField
+        }
+    }
+
+    private var baseURLHeader: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("API Base URL")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+
+            Text("Route requests through an Anthropic-compatible proxy or gateway like VibeProxy. Leave blank to use \(AnthropicEndpoint.defaultBaseURL).")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var baseURLField: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            TextField(AnthropicEndpoint.defaultBaseURL, text: $baseURLDraft)
+                .textFieldStyle(.plain)
+                .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .onSubmit(saveBaseURL)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.smMd)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+                )
+            baseURLTrailingControl
+        }
+    }
+
+    @ViewBuilder
+    private var baseURLTrailingControl: some View {
+        let trimmed = baseURLDraft.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty, trimmed != currentBaseURL {
+            Button("Save", action: saveBaseURL)
+                .buttonStyle(.capsule(.prominent, size: .regular))
+                .controlSize(.large)
+        } else if !currentBaseURL.isEmpty {
+            Button(action: resetBaseURL) {
+                Image(systemName: "arrow.uturn.backward")
+                    .font(.system(size: AppTheme.FontSize.md))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+            }
+            .buttonStyle(.capsule(.secondary, size: .regular))
+            .controlSize(.large)
+            .help("Reset to default endpoint")
+        }
+    }
+
+    private func saveBaseURL() {
+        let raw = baseURLDraft.trimmingCharacters(in: .whitespaces)
+        guard !raw.isEmpty else { return }
+        AnthropicEndpoint.save(raw)
+        refresh()
+    }
+
+    private func resetBaseURL() {
+        AnthropicEndpoint.save("")
+        refresh()
     }
 
     // MARK: - MCP server

--- a/Tests/PalmierProTests/Agent/AnthropicEndpointTests.swift
+++ b/Tests/PalmierProTests/Agent/AnthropicEndpointTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Anthropic endpoint resolution")
+struct AnthropicEndpointTests {
+
+    // MARK: - messagesURL(base:)
+
+    @Test func defaultBaseAppendsMessagesPath() {
+        let url = AnthropicEndpoint.messagesURL(base: AnthropicEndpoint.defaultBaseURL)
+        #expect(url.absoluteString == "https://api.anthropic.com/v1/messages")
+    }
+
+    @Test func blankBaseFallsBackToDefault() {
+        #expect(AnthropicEndpoint.messagesURL(base: "").absoluteString
+            == "https://api.anthropic.com/v1/messages")
+        #expect(AnthropicEndpoint.messagesURL(base: "   ").absoluteString
+            == "https://api.anthropic.com/v1/messages")
+    }
+
+    @Test func customProxyHostIsHonored() {
+        // The VibeProxy example from the issue.
+        let url = AnthropicEndpoint.messagesURL(base: "http://127.0.0.1:8318")
+        #expect(url.absoluteString == "http://127.0.0.1:8318/v1/messages")
+    }
+
+    @Test func trailingSlashesAreStripped() {
+        #expect(AnthropicEndpoint.messagesURL(base: "http://127.0.0.1:8318/").absoluteString
+            == "http://127.0.0.1:8318/v1/messages")
+        #expect(AnthropicEndpoint.messagesURL(base: "http://127.0.0.1:8318///").absoluteString
+            == "http://127.0.0.1:8318/v1/messages")
+    }
+
+    @Test func surroundingWhitespaceIsTrimmed() {
+        let url = AnthropicEndpoint.messagesURL(base: "  https://proxy.example.com  ")
+        #expect(url.absoluteString == "https://proxy.example.com/v1/messages")
+    }
+
+    @Test func proxyPathPrefixIsPreserved() {
+        // Gateways that mount the API under a sub-path keep it.
+        let url = AnthropicEndpoint.messagesURL(base: "https://gw.example.com/anthropic")
+        #expect(url.absoluteString == "https://gw.example.com/anthropic/v1/messages")
+    }
+
+    // MARK: - persistence round-trip
+
+    @Test func saveAndClearRoundTrip() {
+        let previous = AnthropicEndpoint.storedBaseURL()
+        defer { AnthropicEndpoint.save(previous ?? "") }
+
+        AnthropicEndpoint.save("  http://127.0.0.1:8318  ")
+        #expect(AnthropicEndpoint.storedBaseURL() == "http://127.0.0.1:8318")
+
+        // Saving a blank value clears the override and restores the default.
+        AnthropicEndpoint.save("")
+        #expect(AnthropicEndpoint.storedBaseURL() == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #17.

The Agent settings only expose an **Anthropic API Key**; all requests go to the hardcoded `https://api.anthropic.com/v1/messages` endpoint, so there's no way to route traffic through an Anthropic-compatible proxy or gateway (VibeProxy, LiteLLM, one-api, cli-proxy-api, …). Those tools are commonly used for billing, logging, caching, or reusing an existing Claude subscription. This adds a configurable base URL.

## Changes

- **`AnthropicEndpoint`** (new) — resolves the effective base URL and builds the Messages API URL:
  - precedence: DEBUG `ANTHROPIC_BASE_URL` env override → stored value → default `https://api.anthropic.com`. The DEBUG-only env gating mirrors the existing `ANTHROPIC_API_KEY` handling in `AnthropicKeychain` (happy to relax it to release builds if you'd prefer it always honored).
  - appends `/v1/messages`, strips trailing slashes, trims whitespace, and falls back to the official endpoint on malformed input so a bad setting can never produce a nil request URL.
  - stored in `UserDefaults` (non-secret, same as the `agentModel` setting), not the Keychain.
- **`AnthropicClient`** — endpoint is now an instance property defaulting to `AnthropicEndpoint.resolvedMessagesURL()`. Since `AgentService.selectClient()` builds a fresh client per request, a settings change takes effect on the next message with no restart. The call site is unchanged.
- **`AgentPane`** — adds an "API Base URL" field with Save/Reset, styled to match the existing API-key field. Blank = default.

## Example (VibeProxy, from the issue)

- Base URL: `http://127.0.0.1:8318`
- API Key: any non-empty value (the local proxy handles auth)

## Tests

`swift test --filter AnthropicEndpoint` — 7 tests covering default, blank, custom proxy host, trailing slashes, whitespace, sub-path prefix, and a self-cleaning persistence round-trip. `swift build` passes.

## Notes

- Kept scope to the existing Anthropic client per CONTRIBUTING's preference for small PRs. This is orthogonal to #32 (OpenRouter provider); the only file overlap is a different section of `AgentPane.swift`.
- The DEBUG env override and `/v1/messages` append match the `ANTHROPIC_BASE_URL` convention used by the official Anthropic SDK/CLI.