### PR TITLE
Add Codex CLI agent provider

### DIFF
--- a/Sources/PalmierPro/Account/AccountPopoverCard.swift
+++ b/Sources/PalmierPro/Account/AccountPopoverCard.swift
@@ -17,13 +17,13 @@ struct AccountPopoverCard: View {
             }
 
             Divider().overlay(AppTheme.Border.subtleColor)
-            footerRow
+        footerRow
 
-            if let error = account.lastError {
-                Text(error)
-                    .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(.red)
-            }
+        if let error = account.lastError {
+            Text(UserFacingError.message(error))
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(.red)
+        }
         }
         .padding(AppTheme.Spacing.md)
         .frame(width: Self.cardWidth)

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -10,6 +10,7 @@ final class AgentService {
 
     init() {
         reloadAPIKey()
+        refreshCodexModels()
         apiKeyObserver = NotificationCenter.default.addObserver(
             forName: .anthropicAPIKeyChanged,
             object: nil,
@@ -38,10 +39,17 @@ final class AgentService {
 
     var hasApiKey: Bool { !apiKey.isEmpty }
 
+    var hasCodexCLI: Bool { CodexCLIClient.isAvailable }
+
     var canStream: Bool {
-        if hasApiKey { return true }
-        let account = AccountService.shared
-        return account.isSignedIn && account.hasCredits
+        switch backend {
+        case .anthropic:
+            if hasApiKey { return true }
+            let account = AccountService.shared
+            return account.isSignedIn && account.hasCredits
+        case .codexCLI:
+            return hasCodexCLI
+        }
     }
 
     var availableModels: [AnthropicModel] {
@@ -50,12 +58,20 @@ final class AgentService {
     }
 
     private func selectClient() -> (any AgentClient)? {
-        let chosen = effectiveModel
-        if hasApiKey { return AnthropicClient(apiKey: apiKey, model: chosen) }
-        if AccountService.shared.isSignedIn {
-            return PalmierClient(model: chosen)
+        switch backend {
+        case .anthropic:
+            let chosen = effectiveModel
+            if hasApiKey { return AnthropicClient(apiKey: apiKey, model: chosen) }
+            if AccountService.shared.isSignedIn {
+                return PalmierClient(model: chosen)
+            }
+            return nil
+        case .codexCLI:
+            return hasCodexCLI ? CodexCLIClient(
+                modelSlug: selectedCodexModel?.slug ?? (codexModelSlug.isEmpty ? nil : codexModelSlug),
+                reasoningEffort: selectedCodexReasoningLevel?.effort ?? (codexReasoningEffort.isEmpty ? nil : codexReasoningEffort)
+            ) : nil
         }
-        return nil
     }
 
     var effectiveModel: AnthropicModel {
@@ -72,6 +88,108 @@ final class AgentService {
         return .sonnet46
     }() {
         didSet { UserDefaults.standard.set(model.rawValue, forKey: "agentModel") }
+    }
+
+    var codexModels: [CodexModel] = []
+    var codexCatalogError: String?
+
+    var codexModelSlug: String = {
+        let raw = UserDefaults.standard.string(forKey: "agentCodexModel") ?? ""
+        return raw == "configured-default" ? "" : raw
+    }() {
+        didSet { UserDefaults.standard.set(codexModelSlug, forKey: "agentCodexModel") }
+    }
+
+    var codexReasoningEffort: String = {
+        UserDefaults.standard.string(forKey: "agentCodexReasoningEffort") ?? ""
+    }() {
+        didSet { UserDefaults.standard.set(codexReasoningEffort, forKey: "agentCodexReasoningEffort") }
+    }
+
+    var selectedCodexModel: CodexModel? {
+        codexModels.first { $0.slug == codexModelSlug } ?? codexModels.first
+    }
+
+    var availableCodexReasoningLevels: [CodexReasoningLevel] {
+        selectedCodexModel?.supportedReasoningLevels ?? []
+    }
+
+    var selectedCodexReasoningLevel: CodexReasoningLevel? {
+        let levels = availableCodexReasoningLevels
+        if let match = levels.first(where: { $0.effort == codexReasoningEffort }) {
+            return match
+        }
+        if let defaultLevel = selectedCodexModel?.defaultReasoningLevel,
+           let match = levels.first(where: { $0.effort == defaultLevel }) {
+            return match
+        }
+        return levels.first
+    }
+
+    var codexPickerTitle: String {
+        guard let model = selectedCodexModel else {
+            return codexModelSlug.isEmpty ? "Codex CLI" : codexModelSlug
+        }
+        if let reasoning = selectedCodexReasoningLevel {
+            return "\(model.displayName) \(reasoning.displayName)"
+        }
+        return model.displayName
+    }
+
+    func selectCodexModel(_ model: CodexModel) {
+        codexModelSlug = model.slug
+        normalizeCodexReasoning(for: model)
+    }
+
+    func selectCodexReasoning(_ level: CodexReasoningLevel) {
+        codexReasoningEffort = level.effort
+    }
+
+    private func refreshCodexModels() {
+        guard hasCodexCLI else { return }
+        Task { [weak self] in
+            do {
+                let models = try await Task.detached(priority: .utility) {
+                    try CodexCLIClient.loadModelCatalog()
+                }.value
+                self?.codexCatalogError = nil
+                self?.codexModels = models
+                self?.normalizeCodexSelection()
+            } catch {
+                self?.codexCatalogError = UserFacingError.message(error.localizedDescription)
+            }
+        }
+    }
+
+    private func normalizeCodexSelection() {
+        guard let model = selectedCodexModel else { return }
+        if codexModelSlug.isEmpty || !codexModels.contains(where: { $0.slug == codexModelSlug }) {
+            codexModelSlug = model.slug
+        }
+        normalizeCodexReasoning(for: model)
+    }
+
+    private func normalizeCodexReasoning(for model: CodexModel) {
+        guard !model.supportedReasoningLevels.isEmpty else {
+            codexReasoningEffort = ""
+            return
+        }
+        if model.supportedReasoningLevels.contains(where: { $0.effort == codexReasoningEffort }) {
+            return
+        }
+        codexReasoningEffort = model.defaultReasoningLevel
+            ?? model.supportedReasoningLevels.first?.effort
+            ?? ""
+    }
+
+    var backend: AgentBackend = {
+        if let raw = UserDefaults.standard.string(forKey: "agentBackend"),
+           let backend = AgentBackend(rawValue: raw) {
+            return backend
+        }
+        return .anthropic
+    }() {
+        didSet { UserDefaults.standard.set(backend.rawValue, forKey: "agentBackend") }
     }
 
     var sessions: [ChatSession] = []
@@ -296,7 +414,9 @@ final class AgentService {
 
     func send(text: String, mentions: [AgentMention]) {
         guard canStream else {
-            streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
+            streamError = .upstream(backend == .codexCLI
+                ? "Codex CLI not found. Install Codex or open Codex.app."
+                : "Sign in to a paid plan or add an Anthropic API key to start.")
             return
         }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -16,6 +16,57 @@ enum AnthropicModel: String, CaseIterable, Sendable {
     }
 }
 
+enum AgentBackend: String, CaseIterable, Sendable {
+    case anthropic
+    case codexCLI
+
+    var displayName: String {
+        switch self {
+        case .anthropic: "Anthropic"
+        case .codexCLI: "Codex CLI"
+        }
+    }
+}
+
+struct CodexModelCatalog: Decodable, Sendable {
+    let models: [CodexModel]
+}
+
+struct CodexModel: Decodable, Hashable, Identifiable, Sendable {
+    let slug: String
+    let displayName: String
+    let defaultReasoningLevel: String?
+    let supportedReasoningLevels: [CodexReasoningLevel]
+    let visibility: String?
+
+    var id: String { slug }
+
+    enum CodingKeys: String, CodingKey {
+        case slug
+        case displayName = "display_name"
+        case defaultReasoningLevel = "default_reasoning_level"
+        case supportedReasoningLevels = "supported_reasoning_levels"
+        case visibility
+    }
+}
+
+struct CodexReasoningLevel: Decodable, Hashable, Identifiable, Sendable {
+    let effort: String
+    let description: String?
+
+    var id: String { effort }
+
+    var displayName: String {
+        switch effort {
+        case "low": "Low"
+        case "medium": "Medium"
+        case "high": "High"
+        case "xhigh": "Extra High"
+        default: effort.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+}
+
 enum AnthropicStopReason: String, Sendable {
     case endTurn = "end_turn"
     case toolUse = "tool_use"

--- a/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
@@ -185,12 +185,19 @@ struct CodexCLIClient: AgentClient {
     }
 
     static func events(from data: Data) throws -> [AnthropicStreamEvent] {
-        try events(from: JSONDecoder().decode(CodexResponse.self, from: data))
+        let response = try JSONDecoder().decode(CodexResponse.self, from: data)
+        if response.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           response.toolCalls.isEmpty {
+            throw PalmierClientError.upstream("Codex CLI returned an empty response.")
+        }
+        return events(from: response)
     }
 
     private static func events(from response: CodexResponse) -> [AnthropicStreamEvent] {
         var events: [AnthropicStreamEvent] = []
-        if !response.text.isEmpty { events.append(.textDelta(response.text)) }
+        if !response.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            events.append(.textDelta(response.text))
+        }
         events += response.toolCalls.map {
             .toolUseComplete(id: $0.id, name: $0.name, inputJSON: $0.inputJSON)
         }
@@ -235,6 +242,7 @@ struct CodexCLIClient: AgentClient {
 
         You are running inside Palmier Pro through Codex CLI.
         Reply as JSON matching the provided schema. To act on the timeline, choose tool calls from Available tools.
+        If you do not choose tool calls, text must be a non-empty user-visible response.
         Set stop_reason to tool_use when tool_calls is non-empty, otherwise end_turn.
         input_json must be a valid JSON object string.
 

--- a/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/CodexCLIClient.swift
@@ -1,0 +1,344 @@
+import Foundation
+
+struct CodexCLIClient: AgentClient {
+    let modelSlug: String?
+    let reasoningEffort: String?
+
+    init(modelSlug: String? = nil, reasoningEffort: String? = nil) {
+        self.modelSlug = modelSlug
+        self.reasoningEffort = reasoningEffort
+    }
+
+    static var isAvailable: Bool { executableURL != nil }
+
+    static var executableURL: URL? {
+        executableURL(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func executableURL(environment: [String: String]) -> URL? {
+        let fm = FileManager.default
+        for path in candidatePaths(environment: environment) where fm.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
+    }
+
+    static func candidatePaths(environment: [String: String]) -> [String] {
+        let home = environment["HOME"] ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let homePaths = [
+            "\(home)/.npm-global/bin/codex",
+            "\(home)/.local/bin/codex"
+        ]
+        let defaults = [
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex"
+        ]
+        let pathEntries = environment["PATH", default: ""]
+            .split(separator: ":")
+            .map { String($0) + "/codex" }
+        return pathEntries + homePaths + defaults
+    }
+
+    static func loadModelCatalog() throws -> [CodexModel] {
+        guard let executableURL else {
+            throw PalmierClientError.upstream("Codex CLI not found. Install Codex or open Codex.app.")
+        }
+
+        let fm = FileManager.default
+        let outputURL = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let errorURL = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        _ = fm.createFile(atPath: outputURL.path, contents: nil)
+        _ = fm.createFile(atPath: errorURL.path, contents: nil)
+        defer {
+            try? fm.removeItem(at: outputURL)
+            try? fm.removeItem(at: errorURL)
+        }
+
+        let process = Process()
+        let stdout = try FileHandle(forWritingTo: outputURL)
+        let stderr = try FileHandle(forWritingTo: errorURL)
+        defer {
+            try? stdout.close()
+            try? stderr.close()
+        }
+        process.executableURL = executableURL
+        process.arguments = ["debug", "models"]
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        try? stdout.close()
+        try? stderr.close()
+        let output = try Data(contentsOf: outputURL)
+        if process.terminationStatus == 0 {
+            return try visibleModels(from: output)
+        }
+
+        let stderrText = String(data: (try? Data(contentsOf: errorURL)) ?? Data(), encoding: .utf8) ?? ""
+        throw PalmierClientError.upstream(Self.failureMessage(status: process.terminationStatus, stderr: stderrText))
+    }
+
+    static func visibleModels(from data: Data) throws -> [CodexModel] {
+        try JSONDecoder().decode(CodexModelCatalog.self, from: data)
+            .models
+            .filter { $0.visibility != "hide" }
+    }
+
+    func stream(
+        system: String,
+        tools: [AnthropicToolSchema],
+        messages: [AnthropicMessage]
+    ) -> AsyncThrowingStream<AnthropicStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let process = Process()
+            let task = Task {
+                do {
+                    let response = try Self.run(
+                        process: process,
+                        modelSlug: modelSlug,
+                        reasoningEffort: reasoningEffort,
+                        prompt: Self.prompt(system: system, tools: tools, messages: messages)
+                    )
+                    for event in Self.events(from: response) {
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                process.terminate()
+                task.cancel()
+            }
+        }
+    }
+
+    private static func run(
+        process: Process,
+        modelSlug: String?,
+        reasoningEffort: String?,
+        prompt: String
+    ) throws -> CodexResponse {
+        guard let executableURL else {
+            throw PalmierClientError.upstream("Codex CLI not found. Install Codex or open Codex.app.")
+        }
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let lastMessage = dir.appendingPathComponent("last.txt")
+        let stdoutURL = dir.appendingPathComponent("stdout.jsonl")
+        let stderrURL = dir.appendingPathComponent("stderr.log")
+        let schemaURL = dir.appendingPathComponent("schema.json")
+        FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+        FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+        try Data(Self.outputSchema.utf8).write(to: schemaURL)
+
+        let stdout = try FileHandle(forWritingTo: stdoutURL)
+        let stderr = try FileHandle(forWritingTo: stderrURL)
+        defer {
+            try? stdout.close()
+            try? stderr.close()
+        }
+
+        let stdin = Pipe()
+        process.executableURL = executableURL
+        process.arguments = Self.codexArguments(
+            modelSlug: modelSlug,
+            reasoningEffort: reasoningEffort,
+            schemaURL: schemaURL,
+            lastMessageURL: lastMessage
+        )
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        stdin.fileHandleForWriting.write(Data(prompt.utf8))
+        try stdin.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        let stderrText = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? ""
+        if let data = try? Data(contentsOf: lastMessage), !data.isEmpty,
+           let response = try? JSONDecoder().decode(CodexResponse.self, from: data) {
+            return response
+        }
+
+        guard process.terminationStatus == 0 else {
+            throw PalmierClientError.upstream(Self.failureMessage(
+                status: process.terminationStatus,
+                stderr: stderrText
+            ))
+        }
+
+        throw PalmierClientError.upstream("Codex CLI returned no response.")
+    }
+
+    static func failureMessage(status: Int32, stderr: String) -> String {
+        let message = UserFacingError.message(String(stderr.prefix(500)))
+        return "Codex CLI failed (\(status)): \(message)"
+    }
+
+    static func events(from data: Data) throws -> [AnthropicStreamEvent] {
+        try events(from: JSONDecoder().decode(CodexResponse.self, from: data))
+    }
+
+    private static func events(from response: CodexResponse) -> [AnthropicStreamEvent] {
+        var events: [AnthropicStreamEvent] = []
+        if !response.text.isEmpty { events.append(.textDelta(response.text)) }
+        events += response.toolCalls.map {
+            .toolUseComplete(id: $0.id, name: $0.name, inputJSON: $0.inputJSON)
+        }
+        events.append(.messageStop(stopReason: response.stopReason))
+        return events
+    }
+
+    static func codexArguments(
+        modelSlug: String? = nil,
+        reasoningEffort: String? = nil,
+        schemaURL: URL,
+        lastMessageURL: URL
+    ) -> [String] {
+        var args = [
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--ignore-rules",
+            "--skip-git-repo-check",
+            "--sandbox", "read-only",
+            "-c", "approval_policy=\"never\"",
+            "--output-schema", schemaURL.path,
+            "--output-last-message", lastMessageURL.path,
+            "-"
+        ]
+        if let value = modelSlug?.nilIfEmpty {
+            args.insert(contentsOf: ["-m", value], at: 1)
+        }
+        if let effort = reasoningEffort?.nilIfEmpty {
+            args.insert(contentsOf: ["-c", "model_reasoning_effort=\"\(effort)\""], at: 1)
+        }
+        return args
+    }
+
+    static func prompt(
+        system: String,
+        tools: [AnthropicToolSchema] = [],
+        messages: [AnthropicMessage]
+    ) -> String {
+        """
+        \(system)
+
+        You are running inside Palmier Pro through Codex CLI.
+        Reply as JSON matching the provided schema. To act on the timeline, choose tool calls from Available tools.
+        Set stop_reason to tool_use when tool_calls is non-empty, otherwise end_turn.
+        input_json must be a valid JSON object string.
+
+        Available tools:
+        \(toolsJSON(tools))
+
+        Conversation:
+        \(messages.map(render).joined(separator: "\n\n"))
+        """
+    }
+
+    private static func render(_ message: AnthropicMessage) -> String {
+        let body = message.content.compactMap(renderBlock).joined(separator: "\n")
+        return "\(message.role.rawValue.uppercased()): \(body)"
+    }
+
+    private static func renderBlock(_ block: [String: Any]) -> String? {
+        switch block["type"] as? String {
+        case "text":
+            return block["text"] as? String
+        case "tool_result":
+            return "Tool result: \(block["content"] ?? "")"
+        case "tool_use":
+            return "Tool request: \(block["name"] ?? "") \(block["input"] ?? "")"
+        case "image":
+            return "[Image omitted by Codex CLI chat bridge. Use Palmier inspect/search tools if needed.]"
+        default:
+            return nil
+        }
+    }
+
+    private static func toolsJSON(_ tools: [AnthropicToolSchema]) -> String {
+        let value = tools.map {
+            [
+                "name": $0.name,
+                "description": $0.description,
+                "input_schema": $0.inputSchema
+            ] as [String: Any]
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return text
+    }
+
+    private static let outputSchema = """
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "type": "string" },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "input_json": { "type": "string" }
+            },
+            "required": ["id", "name", "input_json"]
+          }
+        },
+        "stop_reason": { "type": "string", "enum": ["end_turn", "tool_use"] }
+      },
+      "required": ["text", "tool_calls", "stop_reason"]
+    }
+    """
+}
+
+private struct CodexResponse: Decodable {
+    let text: String
+    let toolCalls: [ToolCall]
+    let stopReason: AnthropicStopReason
+
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case toolCalls = "tool_calls"
+        case stopReason = "stop_reason"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        text = try c.decode(String.self, forKey: .text)
+        toolCalls = try c.decode([ToolCall].self, forKey: .toolCalls)
+        let raw = try c.decode(String.self, forKey: .stopReason)
+        stopReason = AnthropicStopReason(rawValue: raw) ?? .other
+    }
+
+    struct ToolCall: Decodable {
+        let id: String
+        let name: String
+        let inputJSON: String
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case inputJSON = "input_json"
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -137,30 +137,68 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var modelPicker: some View {
-        if service.hasApiKey {
-            Menu {
-                ForEach(service.availableModels, id: \.self) { m in
-                    Button(m.displayName) { service.model = m }
-                }
-            } label: {
-                HStack(spacing: AppTheme.Spacing.xs) {
-                    Text(service.effectiveModel.displayName)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: AppTheme.FontSize.micro, weight: .semibold))
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+        Menu {
+            Section("Provider") {
+                ForEach(AgentBackend.allCases, id: \.self) { backend in
+                    Button(backend.displayName) { service.backend = backend }
                 }
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
+
+            if service.backend == .anthropic {
+                Section("Model") {
+                    ForEach(service.availableModels, id: \.self) { m in
+                        Button(m.displayName) { service.model = m }
+                    }
+                }
+        } else {
+            Section("Reasoning") {
+                if service.availableCodexReasoningLevels.isEmpty {
+                    Text(service.codexCatalogError ?? "Loading models...")
+                } else {
+                    ForEach(service.availableCodexReasoningLevels) { level in
+                        Button(level.displayName) { service.selectCodexReasoning(level) }
+                    }
+                }
+            }
+            Section("Model") {
+                if service.codexModels.isEmpty {
+                    Text(service.codexCatalogError ?? "Loading models...")
+                } else {
+                    ForEach(service.codexModels) { m in
+                        Button(m.displayName) { service.selectCodexModel(m) }
+                    }
+                }
+            }
         }
+        } label: {
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Text(modelPickerTitle)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: AppTheme.FontSize.micro, weight: .semibold))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private var modelPickerTitle: String {
+        service.backend == .codexCLI
+            ? service.codexPickerTitle
+            : service.effectiveModel.displayName
     }
 
     @ViewBuilder
     private var byokIndicator: some View {
-        if service.hasApiKey {
+        if service.backend == .codexCLI {
+            Text("using Codex CLI")
+                .font(.system(size: AppTheme.FontSize.xs).italic())
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .help("Streaming through local Codex CLI")
+        } else if service.hasApiKey {
             Text("using API key")
                 .font(.system(size: AppTheme.FontSize.xs).italic())
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
@@ -316,26 +354,32 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var missingKeyState: some View {
-        let account = AccountService.shared
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
-                Text(missingKeyPrimaryAction(account: account))
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
-            }
-            .buttonStyle(.plain)
-
-            Text("or use")
+        if service.backend == .codexCLI {
+            Text("Install Codex CLI or open Codex.app to use this provider.")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
+        } else {
+            let account = AccountService.shared
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
+                    Text(missingKeyPrimaryAction(account: account))
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
 
-            Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
-                Text("your own Anthropic key")
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
+                Text("or use")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+
+                Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
+                    Text("your own Anthropic key")
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+            .font(.system(size: AppTheme.FontSize.md, weight: .medium))
         }
-        .font(.system(size: AppTheme.FontSize.md, weight: .medium))
     }
 
     private func missingKeyPrimaryAction(account: AccountService) -> String {

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -40,6 +40,7 @@ final class ModelCatalog {
     private(set) var lastError: String?
 
     @ObservationIgnored private var subscription: AnyCancellable?
+    @ObservationIgnored private var timeoutTask: Task<Void, Never>?
     @ObservationIgnored private var didConfigure = false
 
     private init() {}
@@ -48,7 +49,19 @@ final class ModelCatalog {
         guard !didConfigure else { return }
         didConfigure = true
 
-        guard let client = AccountService.shared.convex else { return }
+        guard let client = AccountService.shared.convex else {
+            markUnavailable("Model catalog is unavailable. Check backend configuration.")
+            return
+        }
+
+        timeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await MainActor.run {
+                guard let self, !self.isLoaded else { return }
+                Log.generation.error("ModelCatalog subscription timed out")
+                self.markUnavailable("Palmier backend unavailable. Check backend configuration or try again.")
+            }
+        }
 
         subscription = client
             .subscribe(to: "models:list", yielding: [CatalogEntry].self)
@@ -57,7 +70,7 @@ final class ModelCatalog {
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let err) = completion {
                         Log.generation.error("ModelCatalog subscription failed: \(err.localizedDescription)")
-                        self?.lastError = err.localizedDescription
+                        self?.markUnavailable(err.localizedDescription)
                     }
                 },
                 receiveValue: { [weak self] entries in
@@ -66,7 +79,21 @@ final class ModelCatalog {
             )
     }
 
+    private func markUnavailable(_ message: String) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        self.video = []
+        self.image = []
+        self.audio = []
+        self.upscale = []
+        self.byId = [:]
+        self.isLoaded = true
+        self.lastError = UserFacingError.message(message)
+    }
+
     private func apply(_ entries: [CatalogEntry]) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
         var newVideo: [VideoModelConfig] = []
         var newImage: [ImageModelConfig] = []
         var newAudio: [AudioModelConfig] = []

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -422,8 +422,12 @@ struct GenerationView: View {
 
     private var catalogReady: Bool {
         !videoModels.isEmpty
-            && !imageModels.isEmpty
-            && !audioModels.isEmpty
+        && !imageModels.isEmpty
+        && !audioModels.isEmpty
+    }
+
+    private var catalogError: String? {
+        ModelCatalog.shared.lastError
     }
 
     var body: some View {
@@ -440,10 +444,14 @@ struct GenerationView: View {
 
     private var catalogLoadingView: some View {
         VStack(spacing: AppTheme.Spacing.md) {
-            ProgressView()
-            Text("Loading models…")
+            if catalogError == nil {
+                ProgressView()
+            }
+            Text(catalogError ?? "Loading models…")
                 .font(.system(size: AppTheme.FontSize.sm))
                 .foregroundStyle(AppTheme.Text.secondaryColor)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, AppTheme.Spacing.lg)
         }
         .frame(maxWidth: .infinity)
         .frame(height: AppTheme.GenerationPanel.loadingHeight)

--- a/Sources/PalmierPro/Settings/AccountPane.swift
+++ b/Sources/PalmierPro/Settings/AccountPane.swift
@@ -14,13 +14,13 @@ struct AccountPane: View {
                 signedInBody
             } else {
                 signedOutBody
-            }
+        }
 
-            if let error = account.lastError {
-                Text(error)
-                    .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(.red)
-            }
+        if let error = account.lastError {
+            Text(UserFacingError.message(error))
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(.red)
+        }
         }
     }
 

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -3,107 +3,170 @@ import SwiftUI
 
 struct AgentPane: View {
     @Bindable private var appState = AppState.shared
-    @State private var hasKey: Bool = false
-    @State private var maskedKey: String = ""
-    @State private var draft: String = ""
+    @State private var hasKey = false
+    @State private var maskedKey = ""
+    @State private var draft = ""
+    @State private var showKeyField = false
     @FocusState private var isFocused: Bool
 
-    private let consoleURL = URL(string: "https://console.anthropic.com/settings/keys")!
+    private let codexURL = URL(string: "https://developers.openai.com/codex/")!
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            apiKeySection
+            providerSection
             Divider().overlay(AppTheme.Border.subtleColor)
             mcpSection
         }
         .onAppear(perform: refresh)
     }
 
-    private var apiKeySection: some View {
+    private var providerSection: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
-            header
-            keyField
-        }
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
-            Text("Anthropic API Key")
+            Text("Agent Providers")
                 .font(.system(size: AppTheme.FontSize.md, weight: .medium))
                 .foregroundStyle(AppTheme.Text.primaryColor)
 
-            HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
-                Text("Used your own API key for the AI chat. Stored in your macOS Keychain.")
-                    .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .fixedSize(horizontal: false, vertical: true)
+            Text("Choose Anthropic API or local Codex CLI from agent chat model picker.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
 
-                Button(action: { NSWorkspace.shared.open(consoleURL, configuration: .init(), completionHandler: nil) }) {
-                    HStack(spacing: 2) {
-                        Text("Get Anthropic API key")
-                        Image(systemName: "arrow.up.right")
-                            .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
-                    }
-                    .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(AppTheme.Accent.primary)
+            anthropicStatusRow
+
+            providerStatusRow(
+                title: "Codex CLI",
+                detail: CodexCLIClient.isAvailable ? "Connected local Codex CLI" : "Not connected. Install or open Codex app.",
+                isConnected: CodexCLIClient.isAvailable,
+                actionTitle: CodexCLIClient.isAvailable ? nil : "Connect Codex",
+                action: { NSWorkspace.shared.open(codexURL, configuration: .init(), completionHandler: nil) }
+            )
+        }
+    }
+
+    private var anthropicStatusRow: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                statusDot(hasKey)
+
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                    Text("Anthropic API")
+                        .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                        .foregroundStyle(AppTheme.Text.primaryColor)
+                    Text(hasKey ? "Connected with saved API key" : "Not connected. Add API key below.")
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
                 }
-                .buttonStyle(.plain)
-                .fixedSize()
+
+                Spacer()
+
+                if hasKey {
+                    Button(action: remove) {
+                        Image(systemName: "trash")
+                            .font(.system(size: AppTheme.FontSize.md))
+                            .foregroundStyle(AppTheme.Text.secondaryColor)
+                            .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+                    }
+                    .buttonStyle(.capsule(.secondary, size: .regular))
+                    .controlSize(.large)
+                    .help("Remove API key")
+                } else if !showKeyField {
+                    Button("Add key") {
+                        showKeyField = true
+                        DispatchQueue.main.async { isFocused = true }
+                    }
+                    .buttonStyle(.capsule(.secondary))
+                    .controlSize(.small)
+                }
+            }
+
+            if showKeyField && !hasKey {
+                keyField
             }
         }
+        .padding(.horizontal, AppTheme.Spacing.md)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(Color.black.opacity(AppTheme.Opacity.muted))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+        )
+    }
+
+    private func providerStatusRow(
+        title: String,
+        detail: String,
+        isConnected: Bool,
+        actionTitle: String?,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            statusDot(isConnected)
+
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text(title)
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                Text(detail)
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+            }
+
+            Spacer()
+
+            if let actionTitle {
+                Button(actionTitle, action: action)
+                    .buttonStyle(.capsule(.secondary))
+                    .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.md)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(Color.black.opacity(AppTheme.Opacity.muted))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+        )
+    }
+
+    private func statusDot(_ isConnected: Bool) -> some View {
+        Circle()
+            .fill(isConnected ? Color.green : AppTheme.Text.mutedColor)
+            .frame(width: 8, height: 8)
     }
 
     private var keyField: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
-            fieldBox
-            trailingControl
-        }
-    }
+            SecureField(hasKey ? maskedKey : "sk-ant-...", text: $draft)
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .onSubmit(save)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.smMd)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .strokeBorder(
+                            isFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
+                            lineWidth: AppTheme.BorderWidth.thin
+                        )
+                )
 
-    private var fieldBox: some View {
-        SecureField(placeholder, text: $draft)
-            .textFieldStyle(.plain)
-            .focused($isFocused)
-            .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
-            .foregroundStyle(AppTheme.Text.primaryColor)
-            .onSubmit(save)
-            .padding(.horizontal, AppTheme.Spacing.md)
-            .padding(.vertical, AppTheme.Spacing.smMd)
-            .background(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(Color.black.opacity(AppTheme.Opacity.muted))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(
-                        isFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
-                        lineWidth: AppTheme.BorderWidth.thin
-                    )
-            )
-            .animation(.easeOut(duration: AppTheme.Anim.hover), value: isFocused)
-    }
-
-    private var placeholder: String {
-        hasKey ? maskedKey : "sk-ant-..."
-    }
-
-    @ViewBuilder
-    private var trailingControl: some View {
-        let trimmed = draft.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            Button("Save", action: save)
-                .buttonStyle(.capsule(.prominent, size: .regular))
-                .controlSize(.large)
-        } else if hasKey {
-            Button(action: remove) {
-                Image(systemName: "trash")
-                    .font(.system(size: AppTheme.FontSize.md))
-                    .foregroundStyle(AppTheme.Text.secondaryColor)
-                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+            if !draft.trimmingCharacters(in: .whitespaces).isEmpty {
+                Button("Save", action: save)
+                    .buttonStyle(.capsule(.prominent, size: .regular))
+                    .controlSize(.large)
             }
-            .buttonStyle(.capsule(.secondary, size: .regular))
-            .controlSize(.large)
-            .help("Remove API key")
         }
     }
 
@@ -111,6 +174,9 @@ struct AgentPane: View {
         let key = AnthropicKeychain.load() ?? ""
         hasKey = !key.isEmpty
         maskedKey = mask(key)
+        if hasKey {
+            showKeyField = false
+        }
     }
 
     private func save() {
@@ -118,6 +184,7 @@ struct AgentPane: View {
         guard !key.isEmpty else { return }
         AnthropicKeychain.save(key)
         draft = ""
+        showKeyField = false
         isFocused = false
         refresh()
     }
@@ -125,6 +192,7 @@ struct AgentPane: View {
     private func remove() {
         AnthropicKeychain.delete()
         draft = ""
+        showKeyField = false
         refresh()
     }
 
@@ -132,8 +200,6 @@ struct AgentPane: View {
         guard key.count > 4 else { return String(repeating: "\u{2022}", count: 32) }
         return String(repeating: "\u{2022}", count: 36) + key.suffix(4)
     }
-
-    // MARK: - MCP server
 
     private var mcpSection: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
@@ -171,39 +237,34 @@ struct AgentPane: View {
 
     private var mcpStatusRow: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
-            HStack(spacing: AppTheme.Spacing.sm) {
-                Circle()
-                    .fill((appState.mcpService?.isRunning ?? false) ? Color.green : AppTheme.Text.mutedColor)
-                    .frame(width: 8, height: 8)
+            statusDot(appState.mcpService?.isRunning ?? false)
 
-                if appState.mcpService?.isRunning ?? false {
-                    HStack(alignment: .firstTextBaseline, spacing: 0) {
-                        Text("Running on ")
-                            .foregroundStyle(AppTheme.Text.secondaryColor)
-                        Text("127.0.0.1:\(String(MCPService.port))")
-                            .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
-                            .foregroundStyle(AppTheme.Text.primaryColor)
-                    }
-                } else {
-                    Text("Stopped")
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+            if appState.mcpService?.isRunning ?? false {
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text("Running on ")
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                    Text("127.0.0.1:\(String(MCPService.port))")
+                        .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                        .foregroundStyle(AppTheme.Text.primaryColor)
                 }
+            } else {
+                Text("Stopped")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
             }
-            .font(.system(size: AppTheme.FontSize.sm))
 
             Spacer()
 
             Toggle(
                 "",
                 isOn: Binding(
-                    get: { (appState.mcpService?.isRunning ?? false) },
+                    get: { appState.mcpService?.isRunning ?? false },
                     set: { appState.setMCPEnabled($0) }
                 )
             )
             .labelsHidden()
             .toggleStyle(.switch)
-            .controlSize(.small)
         }
+        .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
         .padding(.horizontal, AppTheme.Spacing.md)
         .padding(.vertical, AppTheme.Spacing.smMd)
         .background(

--- a/Sources/PalmierPro/Settings/ModelsPane.swift
+++ b/Sources/PalmierPro/Settings/ModelsPane.swift
@@ -37,7 +37,7 @@ struct ModelsPane: View {
             searchBar
 
             if sections.isEmpty {
-                Text(catalog.isLoaded ? "No models match \"\(query)\"." : "Loading models…")
+                Text(emptyStateText)
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .padding(.top, AppTheme.Spacing.lg)
@@ -47,6 +47,13 @@ struct ModelsPane: View {
                 }
             }
         }
+    }
+
+    private var emptyStateText: String {
+        if let error = catalog.lastError {
+            return error
+        }
+        return catalog.isLoaded ? "No models match \"\(query)\"." : "Loading models…"
     }
 
     private var searchBar: some View {

--- a/Sources/PalmierPro/Utilities/UserFacingError.swift
+++ b/Sources/PalmierPro/Utilities/UserFacingError.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum UserFacingError {
+    static func message(_ raw: String) -> String {
+        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty {
+            return "Something went wrong. Try again."
+        }
+        if text.contains("UniFFI.ClientError.InternalError")
+            || text.localizedCaseInsensitiveContains("channel closed") {
+            return "Palmier backend is unavailable. Check backend configuration or try again."
+        }
+        if text.contains("codex_features")
+            || text.contains("codex_rollout")
+            || text.localizedCaseInsensitiveContains("ghost_commit") {
+            return "Codex CLI returned local warnings. Try again, or run Codex once outside Palmier."
+        }
+        return text
+    }
+}

--- a/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
+++ b/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
@@ -15,6 +15,7 @@ struct CodexCLIClientTests {
 
         #expect(prompt.contains("System instructions"))
         #expect(prompt.contains("Reply as JSON matching the provided schema"))
+        #expect(prompt.contains("text must be a non-empty user-visible response"))
         #expect(prompt.contains("USER: Trim first clip"))
         #expect(prompt.contains("ASSISTANT: Done"))
     }
@@ -129,6 +130,22 @@ struct CodexCLIClientTests {
         }
         if case .messageStop(.toolUse) = events[2] {} else {
             Issue.record("Expected tool_use stop")
+        }
+    }
+
+    @Test func emptyTextWithoutToolCallsThrows() {
+        let data = Data("""
+
+        {
+          "text": "   ",
+          "tool_calls": [],
+          "stop_reason": "end_turn"
+        }
+
+        """.utf8)
+
+        #expect(throws: PalmierClientError.self) {
+            try CodexCLIClient.events(from: data)
         }
     }
 

--- a/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
+++ b/Tests/PalmierProTests/Agent/CodexCLIClientTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("CodexCLIClient")
+struct CodexCLIClientTests {
+    @Test func promptRendersConversationForCodexExec() {
+        let prompt = CodexCLIClient.prompt(
+            system: "System instructions",
+            messages: [
+                AnthropicMessage(role: .user, content: [["type": "text", "text": "Trim first clip"]]),
+                AnthropicMessage(role: .assistant, content: [["type": "text", "text": "Done"]])
+            ]
+        )
+
+        #expect(prompt.contains("System instructions"))
+        #expect(prompt.contains("Reply as JSON matching the provided schema"))
+        #expect(prompt.contains("USER: Trim first clip"))
+        #expect(prompt.contains("ASSISTANT: Done"))
+    }
+
+    @Test func codexArgumentsUseSchemaFileAndIgnoreProjectRules() {
+        let schemaURL = URL(fileURLWithPath: "/tmp/schema.json")
+        let lastURL = URL(fileURLWithPath: "/tmp/last.json")
+
+        let args = CodexCLIClient.codexArguments(schemaURL: schemaURL, lastMessageURL: lastURL)
+
+        #expect(args.contains("--ignore-rules"))
+        #expect(args.pair(after: "-m") == nil)
+        #expect(args.contains("approval_policy=\"never\""))
+        #expect(args.pair(after: "--sandbox") == "read-only")
+        #expect(args.pair(after: "--output-schema") == schemaURL.path)
+        #expect(args.pair(after: "--output-last-message") == lastURL.path)
+    }
+
+    @Test func codexArgumentsPassSelectedModel() {
+        let schemaURL = URL(fileURLWithPath: "/tmp/schema.json")
+        let lastURL = URL(fileURLWithPath: "/tmp/last.json")
+        let args = CodexCLIClient.codexArguments(
+            modelSlug: "gpt-5.5",
+            schemaURL: schemaURL,
+            lastMessageURL: lastURL
+        )
+        #expect(args.pair(after: "-m") == "gpt-5.5")
+    }
+
+    @Test func codexArgumentsPassSelectedReasoning() {
+        let schemaURL = URL(fileURLWithPath: "/tmp/schema.json")
+        let lastURL = URL(fileURLWithPath: "/tmp/last.json")
+        let args = CodexCLIClient.codexArguments(
+            reasoningEffort: "xhigh",
+            schemaURL: schemaURL,
+            lastMessageURL: lastURL
+        )
+        #expect(args.contains("model_reasoning_effort=\"xhigh\""))
+    }
+
+    @Test func codexModelCatalogDecodesDynamicModelsAndReasoning() throws {
+        let data = Data("""
+        {
+          "models": [
+            {
+              "slug": "gpt-5.5",
+              "display_name": "GPT-5.5",
+              "visibility": "list",
+              "default_reasoning_level": "medium",
+              "supported_reasoning_levels": [
+                { "effort": "low", "description": "Fast" },
+                { "effort": "xhigh", "description": "Deep" }
+              ]
+            },
+            {
+              "slug": "codex-auto-review",
+              "display_name": "Codex Auto Review",
+              "visibility": "hide",
+              "default_reasoning_level": "medium",
+              "supported_reasoning_levels": []
+            }
+          ]
+        }
+        """.utf8)
+        let models = try CodexCLIClient.visibleModels(from: data)
+        #expect(models.map(\.slug) == ["gpt-5.5"])
+        #expect(models.first?.supportedReasoningLevels.last?.displayName == "Extra High")
+    }
+
+    @Test func executableLookupUsesPathEnvironment() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let codex = dir.appendingPathComponent("codex")
+        try Data().write(to: codex)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codex.path)
+
+        #expect(CodexCLIClient.executableURL(environment: ["PATH": dir.path]) == codex)
+    }
+
+    @Test func candidatePathsIncludeUserLocalInstallLocations() {
+        let paths = CodexCLIClient.candidatePaths(environment: ["HOME": "/tmp/palmier-home"])
+
+        #expect(paths.contains("/tmp/palmier-home/.npm-global/bin/codex"))
+        #expect(paths.contains("/tmp/palmier-home/.local/bin/codex"))
+    }
+
+    @Test func responseJSONMapsToAgentStreamEvents() throws {
+        let data = Data("""
+        {
+          "text": "Done",
+          "tool_calls": [
+            { "id": "call_1", "name": "move_clips", "input_json": "{\\"clipIds\\":[\\"c1\\"]}" }
+          ],
+          "stop_reason": "tool_use"
+        }
+        """.utf8)
+
+        let events = try CodexCLIClient.events(from: data)
+
+        #expect(events.count == 3)
+        if case .textDelta("Done") = events[0] {} else {
+            Issue.record("Expected text delta")
+        }
+        if case let .toolUseComplete(id, name, inputJSON) = events[1] {
+            #expect(id == "call_1")
+            #expect(name == "move_clips")
+            #expect(inputJSON == "{\"clipIds\":[\"c1\"]}")
+        } else {
+            Issue.record("Expected tool use")
+        }
+        if case .messageStop(.toolUse) = events[2] {} else {
+            Issue.record("Expected tool_use stop")
+        }
+    }
+
+    @Test func failureMessageHidesCodexWarningNoise() {
+        let stderr = """
+        2026-06-18T22:36:21.838174Z WARN codex_features: unknown feature key in config: ghost_commit
+        2026-06-18T22:36:22.082977Z WARN codex_rollout::list: state db discrepancy
+        """
+
+        let message = CodexCLIClient.failureMessage(status: 1, stderr: stderr)
+
+        #expect(message.contains("Codex CLI failed (1)"))
+        #expect(message.contains("Codex CLI returned local warnings"))
+        #expect(!message.contains("ghost_commit"))
+    }
+}
+
+private extension Array where Element == String {
+    func pair(after flag: String) -> String? {
+        guard let index = firstIndex(of: flag), indices.contains(index + 1) else { return nil }
+        return self[index + 1]
+    }
+}

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -36,6 +36,7 @@ fi
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application: Palmier, Inc. (MMFLRC7562)}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-palmier-notary}"
 SENTRY_DSN="${SENTRY_DSN:-}"
+# Set PALMIER_BUNDLE_ID for isolated local builds, e.g. io.palmier.pro.dev.
 RESOURCES="$ROOT/Sources/PalmierPro/Resources"
 APP="$ROOT/.build/PalmierPro.app"
 ZIP="$ROOT/.build/PalmierPro.zip"
@@ -74,6 +75,10 @@ echo "==> Injecting backend config into Info.plist"
 inject_plist PalmierClerkPublishableKey "${CLERK_PUBLISHABLE_KEY:-}"
 inject_plist PalmierConvexDeploymentURL "${CONVEX_DEPLOYMENT_URL:-}"
 inject_plist PalmierConvexHttpURL "${CONVEX_HTTP_URL:-}"
+if [ -n "${PALMIER_BUNDLE_ID:-}" ]; then
+    echo "==> Using bundle id $PALMIER_BUNDLE_ID"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $PALMIER_BUNDLE_ID" "$APP/Contents/Info.plist"
+fi
 cp "$RESOURCES/AppIcon.icns" "$APP/Contents/Resources/AppIcon.icns"
 cp -R "$SPARKLE_FW" "$APP/Contents/Frameworks/Sparkle.framework"
 


### PR DESCRIPTION
## Summary

Adds local Codex CLI as an agent backend alongside the existing Anthropic API path.

- Adds Codex CLI client bridge using `codex exec` with structured JSON output and tool-call mapping.
- Loads Codex models dynamically from `codex debug models`, including reasoning levels, so new visible Codex models appear without app changes.
- Wires Agent settings and chat model picker for Anthropic API vs Codex CLI, model selection, and reasoning selection.
- Keeps Anthropic API route intact and adds empty-response handling so Codex cannot leave a blank assistant turn.

## Validation

- `swift test` passed: 616 tests.
- Local dev app launched from `.build/PalmierPro.app` signed with Apple Development identity.
- Computer Use smoke test selected `GPT-5.4-Mini Medium`, showed `using Codex CLI`, sent `Reply only: Codex CLI smoke passed`, and rendered `Codex CLI smoke passed`.

## Notes

Draft PR for local/user testing before ready-for-review.