### PR TITLE
feat: shape annotations + animation presets for AI-authored overlays

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -43,6 +43,17 @@ enum AgentInstructions {
           on screen or quote the words said. Hits are source-second ranges ready to convert \
           into add_clips trims.
 
+        # Annotations & motion graphics
+        - For tutorial-style annotations (circle a button, arrow to a feature, callout \
+          rectangle), use add_shapes — vector overlays that compose with every existing \
+          keyframe track. Bake enter/exit/loop animations into the same call by name: \
+          'fade-in', 'pop-in', 'draw-on' for arrows/circles, 'shake-subtle' for \
+          attention, 'fade-out'/'pop-out' to clear. add_shapes is the right tool any \
+          time the user says "highlight", "circle", "point to", "draw a box around".
+        - For animating an existing clip (any type), call apply_animation with a preset \
+          name. It replaces the keyframe tracks the preset drives — so applying \
+          'fade-in' again overwrites any earlier opacity keyframes on the clip.
+
         # Editing
         - Placements must match track type: video on video tracks, audio on audio tracks.
         - The clip-editing surface mirrors human gestures — one tool per gesture, applied to a \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -14,6 +14,8 @@ enum ToolName: String, CaseIterable, Sendable {
     case rippleDeleteRanges = "ripple_delete_ranges"
     case addTexts = "add_texts"
     case addCaptions = "add_captions"
+    case addShapes = "add_shapes"
+    case applyAnimation = "apply_animation"
     case generateVideo = "generate_video"
     case generateImage = "generate_image"
     case generateAudio = "generate_audio"
@@ -315,6 +317,83 @@ enum ToolDefinitions {
                     "textCase": ["type": "string", "enum": ["auto", "upper", "lower"], "description": "Optional letter case (default auto)."],
                     "censorProfanity": ["type": "boolean", "description": "Optional. Mask profanity (default false)."],
                 ]
+            )
+        ),
+        AgentTool(
+            name: .addShapes,
+            description: "Adds one or more vector shape clips (rect, oval, circle, arrow, line) as overlays on top of the video — the right tool for tutorial annotations like a red circle around a button, an arrow pointing at a feature, or a callout rectangle. Single undoable action. Each shape gets its own clip and reuses every existing keyframe track for animation.\n\nPosition uses 0–1 normalized canvas coords (matches add_texts and set_clip_properties). For rect/oval/circle, pass `transform` with centerX/centerY/width/height — omit for a default 20%×20% box at canvas center. For arrow/line, pass `endpoints` with fromX/fromY/toX/toY (optional controlX/controlY for a curved arrow); the bounding box is derived automatically and `transform` is ignored.\n\nStyle defaults to a red 6pt stroke with no fill — overrideable per entry. Colors are hex '#RRGGBB' or '#RRGGBBAA'.\n\nAnimations: pass enterAnim / exitAnim / loopAnim by NAME and the tool expands them to keyframes on the clip. Enter presets: 'fade-in', 'pop-in', 'draw-on', 'slide-in-up'/'down'/'left'/'right'. Exit: 'fade-out', 'pop-out', 'un-draw', 'slide-out-{dir}'. Loop: 'shake-subtle', 'shake-strong', 'spin'. enterDurationFrames / exitDurationFrames default to 15. 'draw-on' on an arrow is the iconic 'arrow draws itself' tutorial effect.\n\ntrackIndex is optional. Omit it on all entries and the tool auto-creates one new video track at the top. To target an existing track, set trackIndex on every entry (audio tracks rejected). Mixing is rejected — split into two calls.",
+            inputSchema: objectSchema(
+                properties: [
+                    "entries": [
+                        "type": "array",
+                        "description": "Shape clips to add.",
+                        "items": [
+                            "type": "object",
+                            "properties": [
+                                "kind": ["type": "string", "enum": ["rect", "oval", "circle", "arrow", "line"], "description": "Shape primitive."],
+                                "trackIndex": ["type": "integer", "description": "Optional. 0-based track index for an existing non-audio track."],
+                                "startFrame": ["type": "integer", "description": "Frame position to place the clip."],
+                                "durationFrames": ["type": "integer", "description": "Duration in frames (>= 1)."],
+                                "transform": [
+                                    "type": "object",
+                                    "description": "Position/size for rect/oval/circle. Normalized 0–1 canvas coords. Ignored for arrow/line (their box is derived from endpoints).",
+                                    "properties": [
+                                        "centerX": ["type": "number"],
+                                        "centerY": ["type": "number"],
+                                        "width": ["type": "number"],
+                                        "height": ["type": "number"],
+                                    ],
+                                ],
+                                "endpoints": [
+                                    "type": "object",
+                                    "description": "Required for arrow/line. Normalized 0–1 canvas coords.",
+                                    "properties": [
+                                        "fromX": ["type": "number"],
+                                        "fromY": ["type": "number"],
+                                        "toX": ["type": "number"],
+                                        "toY": ["type": "number"],
+                                        "controlX": ["type": "number", "description": "Optional. Quadratic bezier control point for a curved arrow."],
+                                        "controlY": ["type": "number"],
+                                    ],
+                                    "required": ["fromX", "fromY", "toX", "toY"],
+                                ],
+                                "style": [
+                                    "type": "object",
+                                    "description": "Visual style overrides.",
+                                    "properties": [
+                                        "strokeColor": ["type": "string", "description": "Hex '#RRGGBB' or '#RRGGBBAA' (default red)."],
+                                        "strokeWidth": ["type": "number", "description": "Canvas points at 1080p (default 6)."],
+                                        "fillColor": ["type": "string", "description": "Optional fill. Hex. Omit for stroke-only."],
+                                        "cornerRadius": ["type": "number", "description": "Rect only. 0..0.5 of the shorter side."],
+                                        "arrowheadStyle": ["type": "string", "enum": ["triangle", "open", "none"], "description": "Arrow only (default triangle)."],
+                                        "arrowheadSize": ["type": "number", "description": "Arrow only. Canvas points at 1080p (default 24)."],
+                                        "dash": ["type": "array", "items": ["type": "number"], "description": "Optional dash pattern in canvas points (e.g. [12, 6]). Empty/omitted = solid."],
+                                    ],
+                                ],
+                                "enterAnim": ["type": "string", "enum": ["fade-in", "pop-in", "draw-on", "slide-in-up", "slide-in-down", "slide-in-left", "slide-in-right"], "description": "Optional enter animation preset."],
+                                "enterDurationFrames": ["type": "integer", "description": "Default 15."],
+                                "exitAnim": ["type": "string", "enum": ["fade-out", "pop-out", "un-draw", "slide-out-up", "slide-out-down", "slide-out-left", "slide-out-right"], "description": "Optional exit animation preset."],
+                                "exitDurationFrames": ["type": "integer", "description": "Default 15."],
+                                "loopAnim": ["type": "string", "enum": ["shake-subtle", "shake-strong", "spin"], "description": "Optional looping animation that runs while the shape is visible."],
+                            ],
+                            "required": ["kind", "startFrame", "durationFrames"],
+                        ],
+                    ],
+                ],
+                required: ["entries"]
+            )
+        ),
+        AgentTool(
+            name: .applyAnimation,
+            description: "Apply a named animation preset to one existing clip — works on any clip type (shape, text, video, image). Replaces existing keyframes on the properties the preset drives (e.g. fade-in clears opacityTrack and writes a new one). Use this to animate a clip you already placed.\n\nPresets: 'fade-in', 'fade-out', 'pop-in', 'pop-out', 'draw-on' (shape stroke), 'un-draw', 'shake-subtle', 'shake-strong', 'spin', and 'slide-{in,out}-{up,down,left,right}'.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipId": ["type": "string", "description": "The clip to animate."],
+                    "preset": ["type": "string", "description": "Preset name. See tool description for the full list."],
+                    "windowFrames": ["type": "integer", "description": "Optional. Length of the enter/exit window (default 15). Ignored for loop presets."],
+                    "intensity": ["type": "string", "enum": ["subtle", "medium", "strong"], "description": "Optional. Default 'medium'. Used by shake-* and spin."],
+                ],
+                required: ["clipId", "preset"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -28,6 +28,8 @@ extension ToolExecutor {
             throw ToolError("Text generation is not wired through the generate tool.")
         case .lottie:
             throw ToolError("Lottie animations aren't generated through this tool.")
+        case .shape:
+            throw ToolError("Shape clips are created with the add_shapes tool, not generate.")
         }
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Shapes.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Shapes.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+extension ToolExecutor {
+    private static let addShapesEntryKeys: Set<String> = [
+        "kind", "trackIndex", "startFrame", "durationFrames",
+        "transform", "endpoints", "style",
+        "enterAnim", "enterDurationFrames",
+        "exitAnim", "exitDurationFrames",
+        "loopAnim",
+    ]
+    private static let addShapesAllowedKeys: Set<String> = ["entries"]
+    private static let shapeStyleAllowedKeys: Set<String> = [
+        "strokeColor", "strokeWidth", "fillColor",
+        "cornerRadius", "arrowheadStyle", "arrowheadSize", "dash",
+    ]
+    private static let shapeTransformAllowedKeys: Set<String> = ["centerX", "centerY", "width", "height"]
+    private static let shapeEndpointsAllowedKeys: Set<String> = ["fromX", "fromY", "toX", "toY", "controlX", "controlY"]
+
+    private struct ParsedShapeEntry {
+        let trackIndex: Int?
+        let startFrame: Int
+        let durationFrames: Int
+        let style: ShapeStyle
+        let transform: Transform?
+        let enterAnim: AnimationPreset?
+        let enterDurationFrames: Int?
+        let exitAnim: AnimationPreset?
+        let exitDurationFrames: Int?
+        let loopAnim: AnimationPreset?
+    }
+
+    func addShapes(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.addShapesAllowedKeys, path: "add_shapes")
+        guard let rawEntries = args["entries"] as? [Any], !rawEntries.isEmpty else {
+            throw ToolError("Missing or empty 'entries' array")
+        }
+
+        var parsed: [ParsedShapeEntry] = []
+        parsed.reserveCapacity(rawEntries.count)
+        for (idx, raw) in rawEntries.enumerated() {
+            let path = "entries[\(idx)]"
+            guard let entry = raw as? [String: Any] else {
+                throw ToolError("\(path) must be an object")
+            }
+            try validateUnknownKeys(entry, allowed: Self.addShapesEntryKeys, path: path)
+
+            guard let kindStr = entry.string("kind"), let kind = ShapeStyle.Kind(rawValue: kindStr) else {
+                throw ToolError("\(path): 'kind' is required, one of \(ShapeStyle.Kind.allCases.map(\.rawValue).joined(separator: ", "))")
+            }
+            let startFrame = try entry.requireInt("startFrame")
+            let durationFrames = try entry.requireInt("durationFrames")
+            guard startFrame >= 0 else { throw ToolError("\(path): startFrame must be >= 0 (got \(startFrame))") }
+            guard durationFrames >= 1 else { throw ToolError("\(path): durationFrames must be >= 1 (got \(durationFrames))") }
+
+            let trackIndex = entry.int("trackIndex")
+            if let ti = trackIndex {
+                guard editor.timeline.tracks.indices.contains(ti) else {
+                    throw ToolError("\(path): track index \(ti) out of range (0..\(editor.timeline.tracks.count - 1))")
+                }
+                guard ClipType.shape.isCompatible(with: editor.timeline.tracks[ti].type) else {
+                    throw ToolError("\(path): track \(ti) is an audio track; shapes require a visual track")
+                }
+            }
+
+            var style = ShapeStyle()
+            style.kind = kind
+
+            if let styleDict = entry["style"] as? [String: Any] {
+                try validateUnknownKeys(styleDict, allowed: Self.shapeStyleAllowedKeys, path: "\(path).style")
+                if let c = try parseColorHex(styleDict.string("strokeColor"), path: "\(path).style.strokeColor") {
+                    style.stroke.color = c
+                    style.stroke.enabled = true
+                }
+                if let w = styleDict.double("strokeWidth") {
+                    guard w >= 0 else { throw ToolError("\(path).style.strokeWidth must be >= 0") }
+                    style.stroke.width = w
+                    style.stroke.enabled = w > 0
+                }
+                if let f = try parseColorHex(styleDict.string("fillColor"), path: "\(path).style.fillColor") {
+                    style.fill.color = f
+                    style.fill.enabled = true
+                }
+                if let r = styleDict.double("cornerRadius") {
+                    guard r >= 0 && r <= 0.5 else { throw ToolError("\(path).style.cornerRadius must be 0..0.5") }
+                    style.cornerRadius = r
+                }
+                if let ahStr = styleDict.string("arrowheadStyle") {
+                    guard let ah = ShapeStyle.Arrowhead.Style(rawValue: ahStr) else {
+                        throw ToolError("\(path).style.arrowheadStyle: expected 'triangle', 'open', or 'none' (got '\(ahStr)')")
+                    }
+                    style.arrowhead.style = ah
+                }
+                if let s = styleDict.double("arrowheadSize") {
+                    guard s >= 0 else { throw ToolError("\(path).style.arrowheadSize must be >= 0") }
+                    style.arrowhead.size = s
+                }
+                if let dashes = styleDict["dash"] as? [Any] {
+                    var out: [Double] = []
+                    out.reserveCapacity(dashes.count)
+                    for (di, raw) in dashes.enumerated() {
+                        guard let v = (raw as? Double) ?? (raw as? Int).map(Double.init) ?? (raw as? NSNumber)?.doubleValue, v.isFinite, v > 0 else {
+                            throw ToolError("\(path).style.dash[\(di)] must be a positive number")
+                        }
+                        out.append(v)
+                    }
+                    style.stroke.dash = out
+                }
+            }
+
+            if let endpointsDict = entry["endpoints"] as? [String: Any] {
+                try validateUnknownKeys(endpointsDict, allowed: Self.shapeEndpointsAllowedKeys, path: "\(path).endpoints")
+                guard let fx = endpointsDict.double("fromX"), let fy = endpointsDict.double("fromY"),
+                      let tx = endpointsDict.double("toX"), let ty = endpointsDict.double("toY") else {
+                    throw ToolError("\(path).endpoints requires fromX, fromY, toX, toY")
+                }
+                style.endpoints = ShapeStyle.Endpoints(
+                    fromX: fx, fromY: fy, toX: tx, toY: ty,
+                    controlX: endpointsDict.double("controlX"),
+                    controlY: endpointsDict.double("controlY")
+                )
+            }
+            if (kind == .arrow || kind == .line) && style.endpoints == nil {
+                throw ToolError("\(path): kind '\(kindStr)' requires 'endpoints' { fromX, fromY, toX, toY }")
+            }
+
+            var transform: Transform? = nil
+            if let tDict = entry["transform"] as? [String: Any] {
+                try validateUnknownKeys(tDict, allowed: Self.shapeTransformAllowedKeys, path: "\(path).transform")
+                guard let cx = tDict.double("centerX"), let cy = tDict.double("centerY"),
+                      let w = tDict.double("width"), let h = tDict.double("height") else {
+                    throw ToolError("\(path).transform must contain centerX, centerY, width, height")
+                }
+                transform = Transform(center: (cx, cy), width: w, height: h)
+            }
+
+            let enterAnim = try parsePreset(entry.string("enterAnim"), kind: .enter, path: "\(path).enterAnim")
+            let exitAnim = try parsePreset(entry.string("exitAnim"), kind: .exit, path: "\(path).exitAnim")
+            let loopAnim = try parsePreset(entry.string("loopAnim"), kind: .loop, path: "\(path).loopAnim")
+
+            parsed.append(.init(
+                trackIndex: trackIndex,
+                startFrame: startFrame,
+                durationFrames: durationFrames,
+                style: style,
+                transform: transform,
+                enterAnim: enterAnim,
+                enterDurationFrames: entry.int("enterDurationFrames"),
+                exitAnim: exitAnim,
+                exitDurationFrames: entry.int("exitDurationFrames"),
+                loopAnim: loopAnim
+            ))
+        }
+
+        let omittedCount = parsed.filter { $0.trackIndex == nil }.count
+        guard omittedCount == 0 || omittedCount == parsed.count else {
+            throw ToolError("Mixed trackIndex: \(omittedCount) of \(parsed.count) entries omitted trackIndex. Either set it on every entry or omit it on every entry (to auto-create a shared new track).")
+        }
+
+        let actionName = parsed.count == 1 ? "Add Shape (Agent)" : "Add Shapes (Agent)"
+        let (ids, createdTrackInfo, summaries) = try withUndoGroup(editor, actionName: actionName) {
+            () -> ([String], String?, [String]) in
+            var createdTrackInfo: String? = nil
+            var createdTrackId: String? = nil
+            let resolvedTrackId: String?
+            if omittedCount == parsed.count {
+                let newIdx = editor.insertTrack(at: 0, type: .video)
+                createdTrackInfo = "track \(newIdx) ('\(editor.timelineTrackDisplayLabel(at: newIdx))')"
+                createdTrackId = editor.timeline.tracks.indices.contains(newIdx)
+                    ? editor.timeline.tracks[newIdx].id
+                    : nil
+                resolvedTrackId = createdTrackId
+            } else {
+                resolvedTrackId = nil
+            }
+
+            var specs: [EditorViewModel.ShapeClipSpec] = []
+            specs.reserveCapacity(parsed.count)
+            for p in parsed {
+                let trackIdx: Int
+                if let resolvedTrackId,
+                   let i = editor.timeline.tracks.firstIndex(where: { $0.id == resolvedTrackId }) {
+                    trackIdx = i
+                } else if let explicit = p.trackIndex {
+                    trackIdx = explicit
+                } else {
+                    continue
+                }
+                specs.append(.init(
+                    trackIndex: trackIdx,
+                    startFrame: p.startFrame,
+                    durationFrames: p.durationFrames,
+                    style: p.style,
+                    transform: p.transform
+                ))
+            }
+
+            let placedIds = editor.placeShapeClips(specs)
+            guard !placedIds.isEmpty else {
+                if let tid = createdTrackId { editor.removeTrack(id: tid) }
+                throw ToolError("Failed to place any shape clips")
+            }
+
+            // Apply enter / exit / loop animations to each placed clip.
+            var summaries: [String] = []
+            summaries.reserveCapacity(placedIds.count)
+            for (i, clipId) in placedIds.enumerated() {
+                let p = parsed[i]
+                var animNotes: [String] = []
+                applyOptionalAnimation(p.enterAnim, windowFrames: p.enterDurationFrames, clipId: clipId, editor: editor, notes: &animNotes)
+                applyOptionalAnimation(p.exitAnim, windowFrames: p.exitDurationFrames, clipId: clipId, editor: editor, notes: &animNotes)
+                applyOptionalAnimation(p.loopAnim, windowFrames: nil, clipId: clipId, editor: editor, notes: &animNotes)
+
+                let trackIdx = editor.findClip(id: clipId)?.trackIndex ?? -1
+                let extras = animNotes.isEmpty ? "" : " [\(animNotes.joined(separator: ", "))]"
+                summaries.append("\(clipId) (\(p.style.kind.rawValue)) on track \(trackIdx) @ \(p.startFrame) for \(p.durationFrames)\(extras)")
+            }
+
+            editor.undoManager?.registerUndo(withTarget: editor) { vm in
+                vm.removeClips(ids: Set(placedIds))
+            }
+            return (placedIds, createdTrackInfo, summaries)
+        }
+        // Shapes render via the CAShapeLayer overlay, not the AVFoundation composition.
+        // Skip the composition rebuild — same pattern text clips use to dodge an
+        // AVAsset load when only overlay state changed.
+        editor.videoEngine?.syncShapeLayers()
+
+        let prefix = createdTrackInfo.map { "Created \($0). " } ?? ""
+        return .ok("\(prefix)Added \(ids.count) shape clip\(ids.count == 1 ? "" : "s"): \(summaries.joined(separator: "; "))")
+    }
+
+    func applyAnimation(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["clipId", "preset", "windowFrames", "intensity"], path: "apply_animation")
+        let clipId = try args.requireString("clipId")
+        let presetStr = try args.requireString("preset")
+        guard let preset = AnimationPreset(rawValue: presetStr) else {
+            throw ToolError("apply_animation: unknown preset '\(presetStr)'. Available: \(AnimationPreset.allCases.map(\.rawValue).joined(separator: ", "))")
+        }
+        let windowFrames = args.int("windowFrames")
+        if let w = windowFrames, w < 1 {
+            throw ToolError("apply_animation: windowFrames must be >= 1 (got \(w))")
+        }
+        let intensity: AnimationIntensity
+        if let raw = args.string("intensity") {
+            guard let parsed = AnimationIntensity(rawValue: raw) else {
+                throw ToolError("apply_animation: intensity must be 'subtle', 'medium', or 'strong' (got '\(raw)')")
+            }
+            intensity = parsed
+        } else {
+            intensity = .medium
+        }
+
+        guard let loc = editor.findClip(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
+        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+
+        try withUndoGroup(editor, actionName: "Apply Animation (Agent)") {
+            applyPreset(preset, windowFrames: windowFrames, intensity: intensity, clipId: clipId, restingTransform: clip.transform, clipDurationFrames: clip.durationFrames, editor: editor)
+        }
+        // Skip composition rebuild for shape-only animations — same reason as add_shapes.
+        if clip.mediaType == .shape {
+            editor.videoEngine?.syncShapeLayers()
+        } else {
+            editor.notifyTimelineChanged()
+        }
+        return .ok("Applied '\(preset.rawValue)' to \(clipId).")
+    }
+
+    // MARK: - Helpers
+
+    private func parsePreset(_ raw: String?, kind: AnimationPreset.Kind, path: String) throws -> AnimationPreset? {
+        guard let raw else { return nil }
+        guard let p = AnimationPreset(rawValue: raw) else {
+            throw ToolError("\(path): unknown preset '\(raw)'")
+        }
+        guard p.kind == kind else {
+            throw ToolError("\(path): '\(raw)' is a \(p.kind) preset; expected a \(kind) preset")
+        }
+        return p
+    }
+
+    private func applyOptionalAnimation(
+        _ preset: AnimationPreset?,
+        windowFrames: Int?,
+        clipId: String,
+        editor: EditorViewModel,
+        notes: inout [String]
+    ) {
+        guard let preset, let loc = editor.findClip(id: clipId) else { return }
+        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        applyPreset(preset, windowFrames: windowFrames, intensity: .medium, clipId: clipId, restingTransform: clip.transform, clipDurationFrames: clip.durationFrames, editor: editor)
+        notes.append(preset.rawValue)
+    }
+
+    private func applyPreset(
+        _ preset: AnimationPreset,
+        windowFrames: Int?,
+        intensity: AnimationIntensity,
+        clipId: String,
+        restingTransform: Transform,
+        clipDurationFrames: Int,
+        editor: EditorViewModel
+    ) {
+        let application = AnimationPresetEngine.apply(
+            preset: preset,
+            windowFrames: windowFrames,
+            clipDurationFrames: clipDurationFrames,
+            restingTransform: restingTransform,
+            intensity: intensity
+        )
+        editor.commitClipProperty(clipId: clipId) { clip in
+            AnimationPresetEngine.merge(application, into: &clip)
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -293,6 +293,7 @@ extension ToolExecutor {
         case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping)
         case .lottie: return try await readLottie(asset: asset, args: args)
         case .text: throw ToolError("Text clips are not stored as media assets.")
+        case .shape: throw ToolError("Shape clips are not stored as media assets.")
         }
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -40,6 +40,8 @@ final class ToolExecutor {
             case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)
             case .addTexts:      return try addTexts(editor, args)
             case .addCaptions:   return try await addCaptions(editor, args)
+            case .addShapes:     return try addShapes(editor, args)
+            case .applyAnimation: return try applyAnimation(editor, args)
             case .generateVideo: return try generate(editor, args, type: .video)
             case .generateImage: return try generate(editor, args, type: .image)
             case .generateAudio: return try await generateAudio(editor, args)

--- a/Sources/PalmierPro/Editor/Animations/AnimationPresets.swift
+++ b/Sources/PalmierPro/Editor/Animations/AnimationPresets.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// Named preset animations the agent (and later UI) can apply to any clip.
+/// Each preset compiles to a set of keyframe rows that drop into the clip's
+/// existing tracks — so undo, export, and the inspector all just work.
+enum AnimationPreset: String, CaseIterable, Sendable {
+    case fadeIn       = "fade-in"
+    case fadeOut      = "fade-out"
+    case popIn        = "pop-in"
+    case popOut       = "pop-out"
+    case drawOn       = "draw-on"
+    case unDraw       = "un-draw"
+    case shakeSubtle  = "shake-subtle"
+    case shakeStrong  = "shake-strong"
+    case spin         = "spin"
+    case slideInUp    = "slide-in-up"
+    case slideInDown  = "slide-in-down"
+    case slideInLeft  = "slide-in-left"
+    case slideInRight = "slide-in-right"
+    case slideOutUp    = "slide-out-up"
+    case slideOutDown  = "slide-out-down"
+    case slideOutLeft  = "slide-out-left"
+    case slideOutRight = "slide-out-right"
+
+    enum Kind: Sendable { case enter, exit, loop }
+
+    var kind: Kind {
+        switch self {
+        case .fadeIn, .popIn, .drawOn, .slideInUp, .slideInDown, .slideInLeft, .slideInRight:
+            return .enter
+        case .fadeOut, .popOut, .unDraw, .slideOutUp, .slideOutDown, .slideOutLeft, .slideOutRight:
+            return .exit
+        case .shakeSubtle, .shakeStrong, .spin:
+            return .loop
+        }
+    }
+}
+
+enum AnimationIntensity: String, Sendable {
+    case subtle, medium, strong
+}
+
+/// The keyframes a preset produces, ready to merge into a Clip's tracks.
+/// All frames are CLIP-RELATIVE (offset from clip's startFrame).
+struct AnimationApplication: Sendable {
+    var opacityKeyframes: [Keyframe<Double>]?
+    var positionKeyframes: [Keyframe<AnimPair>]?
+    var scaleKeyframes: [Keyframe<AnimPair>]?
+    var rotationKeyframes: [Keyframe<Double>]?
+    var strokeProgressKeyframes: [Keyframe<Double>]?
+}
+
+enum AnimationPresetEngine {
+    static let defaultWindowFrames: Int = 15
+
+    /// Compile a preset into a concrete keyframe application.
+    /// - Parameters:
+    ///   - preset: the named preset.
+    ///   - windowFrames: enter / exit window length. Ignored for loop presets.
+    ///   - clipDurationFrames: full clip length on the timeline.
+    ///   - restingTransform: the clip's static transform (used as the slide-in target / shake origin).
+    ///   - intensity: subtle / medium / strong.
+    static func apply(
+        preset: AnimationPreset,
+        windowFrames: Int? = nil,
+        clipDurationFrames: Int,
+        restingTransform: Transform,
+        intensity: AnimationIntensity = .medium
+    ) -> AnimationApplication {
+        let window = max(1, min(windowFrames ?? defaultWindowFrames, clipDurationFrames))
+        switch preset {
+        case .fadeIn:       return fadeIn(window: window)
+        case .fadeOut:      return fadeOut(window: window, clipDuration: clipDurationFrames)
+        case .popIn:        return popIn(window: window, target: restingTransform)
+        case .popOut:       return popOut(window: window, clipDuration: clipDurationFrames, target: restingTransform)
+        case .drawOn:       return drawOn(window: window)
+        case .unDraw:       return unDraw(window: window, clipDuration: clipDurationFrames)
+        case .shakeSubtle:  return shake(clipDuration: clipDurationFrames, target: restingTransform, intensity: .subtle)
+        case .shakeStrong:  return shake(clipDuration: clipDurationFrames, target: restingTransform, intensity: .strong)
+        case .spin:         return spin(clipDuration: clipDurationFrames, intensity: intensity)
+        case .slideInUp:    return slideIn(window: window, target: restingTransform, dx: 0, dy: -1.5)
+        case .slideInDown:  return slideIn(window: window, target: restingTransform, dx: 0, dy: 1.5)
+        case .slideInLeft:  return slideIn(window: window, target: restingTransform, dx: -1.5, dy: 0)
+        case .slideInRight: return slideIn(window: window, target: restingTransform, dx: 1.5, dy: 0)
+        case .slideOutUp:    return slideOut(window: window, clipDuration: clipDurationFrames, target: restingTransform, dx: 0, dy: -1.5)
+        case .slideOutDown:  return slideOut(window: window, clipDuration: clipDurationFrames, target: restingTransform, dx: 0, dy: 1.5)
+        case .slideOutLeft:  return slideOut(window: window, clipDuration: clipDurationFrames, target: restingTransform, dx: -1.5, dy: 0)
+        case .slideOutRight: return slideOut(window: window, clipDuration: clipDurationFrames, target: restingTransform, dx: 1.5, dy: 0)
+        }
+    }
+
+    /// Merge a new application's keyframes into a clip. Preserves keyframes
+    /// on properties this preset doesn't touch. Replaces (not appends) the
+    /// rows on properties the preset DOES touch — overlapping a fade-in onto
+    /// an existing fade-in is destructive on purpose.
+    static func merge(_ application: AnimationApplication, into clip: inout Clip) {
+        if let kfs = application.opacityKeyframes {
+            clip.opacityTrack = kfs.isEmpty ? nil : KeyframeTrack(keyframes: dedupedSorted(kfs))
+        }
+        if let kfs = application.positionKeyframes {
+            clip.positionTrack = kfs.isEmpty ? nil : KeyframeTrack(keyframes: dedupedSorted(kfs))
+        }
+        if let kfs = application.scaleKeyframes {
+            clip.scaleTrack = kfs.isEmpty ? nil : KeyframeTrack(keyframes: dedupedSorted(kfs))
+        }
+        if let kfs = application.rotationKeyframes {
+            clip.rotationTrack = kfs.isEmpty ? nil : KeyframeTrack(keyframes: dedupedSorted(kfs))
+        }
+        if let kfs = application.strokeProgressKeyframes {
+            clip.strokeProgressTrack = kfs.isEmpty ? nil : KeyframeTrack(keyframes: dedupedSorted(kfs))
+        }
+    }
+
+    // MARK: - Presets
+
+    private static func fadeIn(window: Int) -> AnimationApplication {
+        AnimationApplication(opacityKeyframes: [
+            Keyframe(frame: 0, value: 0.0, interpolationOut: .smooth),
+            Keyframe(frame: window, value: 1.0, interpolationOut: .smooth),
+        ])
+    }
+
+    private static func fadeOut(window: Int, clipDuration: Int) -> AnimationApplication {
+        let start = max(0, clipDuration - window)
+        return AnimationApplication(opacityKeyframes: [
+            Keyframe(frame: start, value: 1.0, interpolationOut: .smooth),
+            Keyframe(frame: clipDuration, value: 0.0, interpolationOut: .smooth),
+        ])
+    }
+
+    private static func popIn(window: Int, target: Transform) -> AnimationApplication {
+        let tw = target.width, th = target.height
+        let peakW = tw * 1.12
+        let peakH = th * 1.12
+        let peakFrame = max(1, Int(Double(window) * 0.7))
+        let topLeft = target.topLeft
+        let peakTL_x = topLeft.x - (peakW - tw) / 2
+        let peakTL_y = topLeft.y - (peakH - th) / 2
+        return AnimationApplication(
+            positionKeyframes: [
+                Keyframe(frame: 0,         value: AnimPair(a: topLeft.x + tw / 2, b: topLeft.y + th / 2), interpolationOut: .smooth),
+                Keyframe(frame: peakFrame, value: AnimPair(a: peakTL_x,           b: peakTL_y),           interpolationOut: .smooth),
+                Keyframe(frame: window,    value: AnimPair(a: topLeft.x,          b: topLeft.y),          interpolationOut: .smooth),
+            ],
+            scaleKeyframes: [
+                Keyframe(frame: 0,         value: AnimPair(a: 0,     b: 0),     interpolationOut: .smooth),
+                Keyframe(frame: peakFrame, value: AnimPair(a: peakW, b: peakH), interpolationOut: .smooth),
+                Keyframe(frame: window,    value: AnimPair(a: tw,    b: th),    interpolationOut: .smooth),
+            ]
+        )
+    }
+
+    private static func popOut(window: Int, clipDuration: Int, target: Transform) -> AnimationApplication {
+        let start = max(0, clipDuration - window)
+        let tw = target.width, th = target.height
+        let peakW = tw * 1.15
+        let peakH = th * 1.15
+        let peakFrame = start + max(1, Int(Double(window) * 0.3))
+        let topLeft = target.topLeft
+        let peakTL_x = topLeft.x - (peakW - tw) / 2
+        let peakTL_y = topLeft.y - (peakH - th) / 2
+        return AnimationApplication(
+            positionKeyframes: [
+                Keyframe(frame: start,        value: AnimPair(a: topLeft.x,           b: topLeft.y),          interpolationOut: .smooth),
+                Keyframe(frame: peakFrame,    value: AnimPair(a: peakTL_x,            b: peakTL_y),           interpolationOut: .smooth),
+                Keyframe(frame: clipDuration, value: AnimPair(a: topLeft.x + tw / 2,  b: topLeft.y + th / 2), interpolationOut: .smooth),
+            ],
+            scaleKeyframes: [
+                Keyframe(frame: start,        value: AnimPair(a: tw,    b: th),    interpolationOut: .smooth),
+                Keyframe(frame: peakFrame,    value: AnimPair(a: peakW, b: peakH), interpolationOut: .smooth),
+                Keyframe(frame: clipDuration, value: AnimPair(a: 0,     b: 0),     interpolationOut: .smooth),
+            ]
+        )
+    }
+
+    private static func drawOn(window: Int) -> AnimationApplication {
+        AnimationApplication(strokeProgressKeyframes: [
+            Keyframe(frame: 0, value: 0.0, interpolationOut: .smooth),
+            Keyframe(frame: window, value: 1.0, interpolationOut: .smooth),
+        ])
+    }
+
+    private static func unDraw(window: Int, clipDuration: Int) -> AnimationApplication {
+        let start = max(0, clipDuration - window)
+        return AnimationApplication(strokeProgressKeyframes: [
+            Keyframe(frame: start, value: 1.0, interpolationOut: .smooth),
+            Keyframe(frame: clipDuration, value: 0.0, interpolationOut: .smooth),
+        ])
+    }
+
+    private static func shake(clipDuration: Int, target: Transform, intensity: AnimationIntensity) -> AnimationApplication {
+        let amplitude: Double = {
+            switch intensity {
+            case .subtle: return 0.005
+            case .medium: return 0.012
+            case .strong: return 0.025
+            }
+        }()
+        let stepFrames = 2
+        let count = max(2, clipDuration / stepFrames)
+        let baseTopLeft = target.topLeft
+        var kfs: [Keyframe<AnimPair>] = []
+        kfs.reserveCapacity(count + 1)
+        // Deterministic pseudo-random walk so playback is stable across redraws.
+        for i in 0...count {
+            let f = min(clipDuration, i * stepFrames)
+            let phase = Double(i) * 1.7
+            let dx = amplitude * sin(phase * 2.1)
+            let dy = amplitude * cos(phase * 2.9)
+            kfs.append(Keyframe(
+                frame: f,
+                value: AnimPair(a: baseTopLeft.x + dx, b: baseTopLeft.y + dy),
+                interpolationOut: .linear
+            ))
+        }
+        return AnimationApplication(positionKeyframes: kfs)
+    }
+
+    private static func spin(clipDuration: Int, intensity: AnimationIntensity) -> AnimationApplication {
+        let rotations: Double = {
+            switch intensity {
+            case .subtle: return 0.5
+            case .medium: return 1.0
+            case .strong: return 2.0
+            }
+        }()
+        return AnimationApplication(rotationKeyframes: [
+            Keyframe(frame: 0, value: 0, interpolationOut: .linear),
+            Keyframe(frame: clipDuration, value: 360.0 * rotations, interpolationOut: .linear),
+        ])
+    }
+
+    private static func slideIn(window: Int, target: Transform, dx: Double, dy: Double) -> AnimationApplication {
+        let topLeft = target.topLeft
+        let startTL_x = topLeft.x + dx
+        let startTL_y = topLeft.y + dy
+        return AnimationApplication(positionKeyframes: [
+            Keyframe(frame: 0,      value: AnimPair(a: startTL_x, b: startTL_y), interpolationOut: .smooth),
+            Keyframe(frame: window, value: AnimPair(a: topLeft.x, b: topLeft.y), interpolationOut: .smooth),
+        ])
+    }
+
+    private static func slideOut(window: Int, clipDuration: Int, target: Transform, dx: Double, dy: Double) -> AnimationApplication {
+        let start = max(0, clipDuration - window)
+        let topLeft = target.topLeft
+        let endTL_x = topLeft.x + dx
+        let endTL_y = topLeft.y + dy
+        return AnimationApplication(positionKeyframes: [
+            Keyframe(frame: start,        value: AnimPair(a: topLeft.x, b: topLeft.y), interpolationOut: .smooth),
+            Keyframe(frame: clipDuration, value: AnimPair(a: endTL_x,   b: endTL_y),   interpolationOut: .smooth),
+        ])
+    }
+
+    private static func dedupedSorted<V: Codable & Sendable & Equatable>(_ kfs: [Keyframe<V>]) -> [Keyframe<V>] {
+        let sorted = kfs.sorted { $0.frame < $1.frame }
+        var out: [Keyframe<V>] = []
+        out.reserveCapacity(sorted.count)
+        for kf in sorted {
+            if out.last?.frame == kf.frame { out[out.count - 1] = kf } else { out.append(kf) }
+        }
+        return out
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -310,9 +310,13 @@ extension EditorViewModel {
         }
         modify(&clip)
         timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = clip
-        // Text renders via CATextLayer overlay — skip the composition path.
+        // Text & shape clips render via direct CALayer overlays — skip the composition path.
         if clip.mediaType == .text {
             videoEngine?.syncTextLayers()
+            return
+        }
+        if clip.mediaType == .shape {
+            videoEngine?.syncShapeLayers()
             return
         }
         if rebuild {
@@ -328,6 +332,8 @@ extension EditorViewModel {
         timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = original
         if original.mediaType == .text {
             videoEngine?.syncTextLayers()
+        } else if original.mediaType == .shape {
+            videoEngine?.syncShapeLayers()
         } else {
             notifyTimelineChanged()
         }
@@ -391,6 +397,8 @@ extension EditorViewModel {
         registerClipPropertySwap(clipId: clipId, undoTarget: before, redoTarget: clip)
         if clip.mediaType == .text {
             videoEngine?.syncTextLayers()
+        } else if clip.mediaType == .shape {
+            videoEngine?.syncShapeLayers()
         } else {
             notifyTimelineChanged()
         }
@@ -405,6 +413,8 @@ extension EditorViewModel {
             vm.registerClipPropertySwap(clipId: clipId, undoTarget: redoTarget, redoTarget: undoTarget)
             if undoTarget.mediaType == .text {
                 vm.videoEngine?.syncTextLayers()
+            } else if undoTarget.mediaType == .shape {
+                vm.videoEngine?.syncShapeLayers()
             } else {
                 vm.notifyTimelineChanged()
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -47,6 +47,9 @@ extension EditorViewModel {
             case .volume:
                 let currentDb = clip.volumeTrack?.sample(at: f - clip.startFrame, fallback: 0) ?? 0
                 clip.upsertKeyframe(in: \.volumeTrack, frame: f, value: currentDb)
+            case .strokeProgress:
+                let current = clip.strokeProgressTrack?.sample(at: f - clip.startFrame, fallback: 1.0) ?? 1.0
+                clip.upsertKeyframe(in: \.strokeProgressTrack, frame: f, value: current)
             }
         }
         undoManager?.setActionName("Add Keyframe")

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -359,7 +359,7 @@ extension EditorViewModel {
             mediaVisualCache.generateWaveform(for: asset)
         case .image:
             mediaVisualCache.generateImageThumbnail(for: asset)
-        case .text, .lottie:
+        case .text, .lottie, .shape:
             break
         }
     }
@@ -425,6 +425,64 @@ extension EditorViewModel {
             sortClips(trackIndex: i)
         }
         videoEngine?.syncTextLayers()
+        return createdIds.compactMap { $0 }
+    }
+
+    struct ShapeClipSpec {
+        let trackIndex: Int
+        let startFrame: Int
+        let durationFrames: Int
+        let style: ShapeStyle
+        /// When nil the shape sits at a sensible default in the center of the canvas.
+        let transform: Transform?
+    }
+
+    /// Batch placement for the agent (and future UI) flows.
+    /// Caller owns undo + track creation.
+    @discardableResult
+    func placeShapeClips(_ specs: [ShapeClipSpec]) -> [String] {
+        guard !specs.isEmpty else { return [] }
+        var createdIds = [String?](repeating: nil, count: specs.count)
+
+        let indicesByTrack = Dictionary(grouping: specs.indices, by: { specs[$0].trackIndex })
+        for (_, indices) in indicesByTrack {
+            let ordered = indices.sorted { specs[$0].startFrame < specs[$1].startFrame }
+            for i in ordered {
+                let spec = specs[i]
+                guard timeline.tracks.indices.contains(spec.trackIndex) else { continue }
+                let start = max(0, spec.startFrame)
+                let duration = max(1, spec.durationFrames)
+                clearRegion(trackIndex: spec.trackIndex, start: start, end: start + duration, prune: false)
+
+                let resolved: Transform
+                if let t = spec.transform {
+                    resolved = t
+                } else if let endpoints = spec.style.endpoints {
+                    let bb = endpoints.boundingBox
+                    resolved = Transform(center: (bb.centerX, bb.centerY), width: bb.width, height: bb.height)
+                } else {
+                    // Default: 20% × 20% box at canvas center.
+                    resolved = Transform(center: (0.5, 0.5), width: 0.2, height: 0.2)
+                }
+
+                var clip = Clip(
+                    mediaRef: "",
+                    mediaType: .shape,
+                    sourceClipType: .shape,
+                    startFrame: start,
+                    durationFrames: duration,
+                    transform: resolved
+                )
+                clip.shapeStyle = spec.style
+                timeline.tracks[spec.trackIndex].clips.append(clip)
+                createdIds[i] = clip.id
+            }
+        }
+
+        for i in Set(specs.map(\.trackIndex)) where timeline.tracks.indices.contains(i) {
+            sortClips(trackIndex: i)
+        }
+        videoEngine?.syncShapeLayers()
         return createdIds.compactMap { $0 }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -37,7 +37,7 @@ extension EditorViewModel {
         let z = zones
         let bounded = max(0, min(requested, z.trackCount))
         switch type {
-        case .video, .image, .text, .lottie:
+        case .video, .image, .text, .lottie, .shape:
             // Visual tracks must come at or before the first audio track.
             return min(bounded, z.firstAudioIndex)
         case .audio:

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -184,12 +184,19 @@ final class ExportService {
         }
         session.audioMix = result.audioMix
 
-        // Bake text clips into the export via AVVideoCompositionCoreAnimationTool
+        // Bake text + shape clips into the export via AVVideoCompositionCoreAnimationTool
         let (parent, videoLayer) = TextLayerController.buildForExport(
             timeline: timeline,
             fps: timeline.fps,
             renderSize: renderSize
         )
+        // Shapes sit between video and text: insert right after videoLayer (index 0).
+        let shapeHost = ShapeLayerController.buildForExport(
+            timeline: timeline,
+            fps: timeline.fps,
+            renderSize: renderSize
+        )
+        parent.insertSublayer(shapeHost, at: 1)
         let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
         mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -17,7 +17,7 @@ enum EditAction {
         case .image: candidates = [.upscale, .edit, .rerun, .createVideo]
         case .video: candidates = [.upscale, .edit, .generateMusic, .generateSFX, .rerun]
         case .audio, .text: candidates = [.upscale, .edit, .rerun]
-        case .lottie: candidates = []
+        case .lottie, .shape: candidates = []
         }
         return candidates.filter {
             $0.availability(for: asset, effectiveDurationOverride: effectiveDurationOverride).isAvailable
@@ -65,6 +65,8 @@ enum EditAction {
                 return .disabled(reason: "Edit doesn't support text")
             case .lottie:
                 return .disabled(reason: "Edit doesn't support Lottie")
+            case .shape:
+                return .disabled(reason: "Edit doesn't support shapes")
             }
             if asset.isGenerating {
                 return .disabled(reason: "Generation in progress")

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
@@ -296,7 +296,7 @@ enum EditSubmitter {
         case .image:
             guard let m = ImageModelConfig.nanoBananaPro else { return nil }
             modelId = m.id
-        case .audio, .text, .lottie:
+        case .audio, .text, .lottie, .shape:
             return nil
         }
         var stored = GenerationInput(prompt: "", model: modelId, duration: 0, aspectRatio: "", resolution: nil)

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -282,6 +282,7 @@ final class GenerationService {
             case .audio: return "audio/mpeg"
             case .text: return "application/octet-stream"
             case .lottie: return "application/json"
+            case .shape: return "application/octet-stream"
             }
         }
     }

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -966,7 +966,7 @@ struct GenerationView: View {
             case .image: assets = refImages
             case .video: assets = refVideos
             case .audio: assets = refAudios
-            case .text, .lottie: assets = []
+            case .text, .lottie, .shape: assets = []
             }
             let noun = tagNoun(for: type)
             return assets.enumerated().map {
@@ -980,7 +980,7 @@ struct GenerationView: View {
         case .image: videoModel.maxReferenceImages
         case .video: videoModel.maxReferenceVideos
         case .audio: videoModel.maxReferenceAudios
-        case .text, .lottie: 0
+        case .text, .lottie, .shape: 0
         }
     }
 
@@ -989,7 +989,7 @@ struct GenerationView: View {
         case .image: refImages.count
         case .video: refVideos.count
         case .audio: refAudios.count
-        case .text, .lottie: 0
+        case .text, .lottie, .shape: 0
         }
     }
 
@@ -1001,6 +1001,7 @@ struct GenerationView: View {
         case .audio: "Audio"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .shape: "Shape"
         }
     }
 
@@ -1016,7 +1017,7 @@ struct GenerationView: View {
         case .image: selection.imageRefs.append(asset)
         case .video: selection.videoRefs.append(asset)
         case .audio: selection.audioRefs.append(asset)
-        case .text, .lottie:
+        case .text, .lottie, .shape:
             let supported = ClipType.allCases.filter { refCap(for: $0) > 0 }.map(\.rawValue).joined(separator: " and ")
             flashDropError("\(videoModel.displayName) only accepts \(supported) references.")
             return
@@ -1029,7 +1030,7 @@ struct GenerationView: View {
         case .image: refImages.append(asset)
         case .video: refVideos.append(asset)
         case .audio: refAudios.append(asset)
-        case .text, .lottie: break
+        case .text, .lottie, .shape: break
         }
     }
 
@@ -1067,7 +1068,7 @@ struct GenerationView: View {
         case .image: refImages.removeAll { $0.id == id }
         case .video: refVideos.removeAll { $0.id == id }
         case .audio: refAudios.removeAll { $0.id == id }
-        case .text, .lottie: break
+        case .text, .lottie, .shape: break
         }
     }
 
@@ -1080,7 +1081,7 @@ struct GenerationView: View {
     private var refCounterLabel: String {
         let total = totalRefCount
         if let cap = videoModel.maxTotalReferences {
-            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot" } }
+            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot"; case .shape: "shp" } }
             let parts = ClipType.allCases
                 .filter { refCap(for: $0) > 0 }
                 .map { "\(refCount(for: $0)) \(shortLabel($0))" }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -601,7 +601,7 @@ struct MediaTab: View {
 
     private func toolbarMenuIcon<Content: View>(
         systemName: String,
-        foregroundStyle: some ShapeStyle = AppTheme.Text.tertiaryColor,
+        foregroundStyle: some SwiftUI.ShapeStyle = AppTheme.Text.tertiaryColor,
         @ViewBuilder content: () -> Content
     ) -> some View {
         Menu(content: content) {

--- a/Sources/PalmierPro/Models/ClipType.swift
+++ b/Sources/PalmierPro/Models/ClipType.swift
@@ -4,6 +4,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
     case image
     case text
     case lottie
+    case shape
 
     var sfSymbolName: String {
         switch self {
@@ -12,6 +13,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "photo"
         case .text: "textformat"
         case .lottie: "sparkles"
+        case .shape: "square.on.circle"
         }
     }
 
@@ -22,13 +24,14 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "Image"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .shape: "Shape"
         }
     }
 
     var trackLabelPrefix: String { String(trackLabel.prefix(1)) }
 
     var isVisual: Bool {
-        self == .video || self == .image || self == .text || self == .lottie
+        self == .video || self == .image || self == .text || self == .lottie || self == .shape
     }
 
     func isCompatible(with other: ClipType) -> Bool {

--- a/Sources/PalmierPro/Models/Keyframe.swift
+++ b/Sources/PalmierPro/Models/Keyframe.swift
@@ -75,16 +75,17 @@ extension Crop: KeyframeInterpolatable {
 
 /// Identifies which clip property an inspector lane / stamp button drives.
 enum AnimatableProperty: String, CaseIterable, Sendable {
-    case opacity, position, scale, rotation, crop, volume
+    case opacity, position, scale, rotation, crop, volume, strokeProgress
 
     var displayName: String {
         switch self {
-        case .opacity:  "Opacity"
-        case .position: "Position"
-        case .scale:    "Scale"
-        case .rotation: "Rotation"
-        case .crop:     "Crop"
-        case .volume:   "Volume"
+        case .opacity:        "Opacity"
+        case .position:       "Position"
+        case .scale:          "Scale"
+        case .rotation:       "Rotation"
+        case .crop:           "Crop"
+        case .volume:         "Volume"
+        case .strokeProgress: "Stroke Draw"
         }
     }
 }
@@ -104,12 +105,13 @@ extension Clip {
     func keyframeFrames(for property: AnimatableProperty) -> [Int] {
         let offsets: [Int]
         switch property {
-        case .opacity:  offsets = opacityTrack?.keyframes.map(\.frame) ?? []
-        case .position: offsets = positionTrack?.keyframes.map(\.frame) ?? []
-        case .scale:    offsets = scaleTrack?.keyframes.map(\.frame) ?? []
-        case .rotation: offsets = rotationTrack?.keyframes.map(\.frame) ?? []
-        case .crop:     offsets = cropTrack?.keyframes.map(\.frame) ?? []
-        case .volume:   offsets = volumeTrack?.keyframes.map(\.frame) ?? []
+        case .opacity:        offsets = opacityTrack?.keyframes.map(\.frame) ?? []
+        case .position:       offsets = positionTrack?.keyframes.map(\.frame) ?? []
+        case .scale:          offsets = scaleTrack?.keyframes.map(\.frame) ?? []
+        case .rotation:       offsets = rotationTrack?.keyframes.map(\.frame) ?? []
+        case .crop:           offsets = cropTrack?.keyframes.map(\.frame) ?? []
+        case .volume:         offsets = volumeTrack?.keyframes.map(\.frame) ?? []
+        case .strokeProgress: offsets = strokeProgressTrack?.keyframes.map(\.frame) ?? []
         }
         return offsets.map(toAbs)
     }
@@ -117,12 +119,13 @@ extension Clip {
     func interpolation(for property: AnimatableProperty, atFrame frame: Int) -> Interpolation? {
         let o = toOffset(frame)
         switch property {
-        case .opacity:  return opacityTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
-        case .position: return positionTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
-        case .scale:    return scaleTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
-        case .rotation: return rotationTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
-        case .crop:     return cropTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
-        case .volume:   return volumeTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .opacity:        return opacityTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .position:       return positionTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .scale:          return scaleTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .rotation:       return rotationTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .crop:           return cropTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .volume:         return volumeTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
+        case .strokeProgress: return strokeProgressTrack?.keyframes.first(where: { $0.frame == o })?.interpolationOut
         }
     }
 
@@ -136,6 +139,7 @@ extension Clip {
         for kf in rotationTrack?.keyframes ?? [] { s.insert(kf.frame + absStart) }
         for kf in cropTrack?.keyframes ?? [] { s.insert(kf.frame + absStart) }
         for kf in volumeTrack?.keyframes ?? [] { s.insert(kf.frame + absStart) }
+        for kf in strokeProgressTrack?.keyframes ?? [] { s.insert(kf.frame + absStart) }
         return s.sorted()
     }
 
@@ -171,17 +175,21 @@ extension Clip {
         case .volume:
             volumeTrack?.remove(at: o)
             if volumeTrack?.keyframes.isEmpty == true { volumeTrack = nil }
+        case .strokeProgress:
+            strokeProgressTrack?.remove(at: o)
+            if strokeProgressTrack?.keyframes.isEmpty == true { strokeProgressTrack = nil }
         }
     }
 
     mutating func clearKeyframes(for property: AnimatableProperty) {
         switch property {
-        case .opacity:  opacityTrack = nil
-        case .position: positionTrack = nil
-        case .scale:    scaleTrack = nil
-        case .rotation: rotationTrack = nil
-        case .crop:     cropTrack = nil
-        case .volume:   volumeTrack = nil
+        case .opacity:        opacityTrack = nil
+        case .position:       positionTrack = nil
+        case .scale:          scaleTrack = nil
+        case .rotation:       rotationTrack = nil
+        case .crop:           cropTrack = nil
+        case .volume:         volumeTrack = nil
+        case .strokeProgress: strokeProgressTrack = nil
         }
     }
 
@@ -212,18 +220,23 @@ extension Clip {
             if let i = volumeTrack?.keyframes.firstIndex(where: { $0.frame == o }) {
                 volumeTrack?.keyframes[i].interpolationOut = interpolation
             }
+        case .strokeProgress:
+            if let i = strokeProgressTrack?.keyframes.firstIndex(where: { $0.frame == o }) {
+                strokeProgressTrack?.keyframes[i].interpolationOut = interpolation
+            }
         }
     }
 
     mutating func moveKeyframe(for property: AnimatableProperty, from: Int, to: Int) {
         let fromO = toOffset(from), toO = toOffset(to)
         switch property {
-        case .opacity:  opacityTrack?.move(from: fromO, to: toO)
-        case .position: positionTrack?.move(from: fromO, to: toO)
-        case .scale:    scaleTrack?.move(from: fromO, to: toO)
-        case .rotation: rotationTrack?.move(from: fromO, to: toO)
-        case .crop:     cropTrack?.move(from: fromO, to: toO)
-        case .volume:   volumeTrack?.move(from: fromO, to: toO)
+        case .opacity:        opacityTrack?.move(from: fromO, to: toO)
+        case .position:       positionTrack?.move(from: fromO, to: toO)
+        case .scale:          scaleTrack?.move(from: fromO, to: toO)
+        case .rotation:       rotationTrack?.move(from: fromO, to: toO)
+        case .crop:           cropTrack?.move(from: fromO, to: toO)
+        case .volume:         volumeTrack?.move(from: fromO, to: toO)
+        case .strokeProgress: strokeProgressTrack?.move(from: fromO, to: toO)
         }
     }
 }

--- a/Sources/PalmierPro/Models/ShapeStyle.swift
+++ b/Sources/PalmierPro/Models/ShapeStyle.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct ShapeStyle: Codable, Sendable, Equatable {
+    enum Kind: String, Codable, Sendable, CaseIterable {
+        case rect
+        case oval
+        case circle
+        case arrow
+        case line
+    }
+
+    var kind: Kind = .rect
+    var stroke: Stroke = Stroke()
+    var fill: Fill = Fill()
+    /// rect only — normalized 0..0.5 of the shorter side
+    var cornerRadius: Double = 0
+    /// arrow only
+    var arrowhead: Arrowhead = Arrowhead()
+    /// arrow / line only — when set, transform is derived from these for hit-testing,
+    /// but the path is drawn directly from the endpoints in canvas coords.
+    var endpoints: Endpoints?
+
+    struct Stroke: Codable, Sendable, Equatable {
+        var enabled: Bool = true
+        var color: TextStyle.RGBA = TextStyle.RGBA(r: 1, g: 0.231, b: 0.188, a: 1)
+        /// Canvas points at the 1080p reference height; scaled at render time.
+        var width: Double = 6
+        /// Empty = solid. Values are pattern lengths (canvas points).
+        var dash: [Double] = []
+    }
+
+    struct Fill: Codable, Sendable, Equatable {
+        var enabled: Bool = false
+        var color: TextStyle.RGBA = TextStyle.RGBA(r: 1, g: 0.231, b: 0.188, a: 0.25)
+    }
+
+    struct Arrowhead: Codable, Sendable, Equatable {
+        enum Style: String, Codable, Sendable, CaseIterable {
+            case triangle
+            case open
+            case none
+        }
+        var style: Style = .triangle
+        /// Canvas points at the 1080p reference height.
+        var size: Double = 24
+    }
+
+    /// Normalized 0..1 canvas coords. (0,0) top-left, (1,1) bottom-right.
+    struct Endpoints: Codable, Sendable, Equatable {
+        var fromX: Double
+        var fromY: Double
+        var toX: Double
+        var toY: Double
+        var controlX: Double?
+        var controlY: Double?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, stroke, fill, cornerRadius, arrowhead, endpoints
+    }
+}
+
+extension ShapeStyle {
+    /// Missing-key-tolerant decode — older projects without shape clips still load.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: (try? c.decode(Kind.self, forKey: .kind)) ?? .rect,
+            stroke: (try? c.decode(Stroke.self, forKey: .stroke)) ?? Stroke(),
+            fill: (try? c.decode(Fill.self, forKey: .fill)) ?? Fill(),
+            cornerRadius: (try? c.decode(Double.self, forKey: .cornerRadius)) ?? 0,
+            arrowhead: (try? c.decode(Arrowhead.self, forKey: .arrowhead)) ?? Arrowhead(),
+            endpoints: try? c.decode(Endpoints.self, forKey: .endpoints)
+        )
+    }
+}
+
+extension ShapeStyle.Endpoints {
+    /// Bounding box of the endpoints (and optional control point) in normalized canvas space.
+    /// Returned with a small minimum size so degenerate horizontal/vertical arrows still have a box.
+    var boundingBox: (centerX: Double, centerY: Double, width: Double, height: Double) {
+        let minX = [fromX, toX, controlX ?? fromX].min() ?? 0
+        let maxX = [fromX, toX, controlX ?? toX].max() ?? 1
+        let minY = [fromY, toY, controlY ?? fromY].min() ?? 0
+        let maxY = [fromY, toY, controlY ?? toY].max() ?? 1
+        let w = max(0.001, maxX - minX)
+        let h = max(0.001, maxY - minY)
+        return (minX + w / 2, minY + h / 2, w, h)
+    }
+}

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -98,6 +98,9 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     var textContent: String?
     var textStyle: TextStyle?
 
+    // Shape clips only.
+    var shapeStyle: ShapeStyle?
+
     // Keyframe tracks for each animatable property. Nil when no animation exists.
     var opacityTrack: KeyframeTrack<Double>?
     var positionTrack: KeyframeTrack<AnimPair>?
@@ -105,14 +108,17 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     var rotationTrack: KeyframeTrack<Double>?
     var cropTrack: KeyframeTrack<Crop>?
     var volumeTrack: KeyframeTrack<Double>?
+    /// Shape clips: 0..1 fraction of the stroke drawn. Drives draw-on / un-draw presets.
+    var strokeProgressTrack: KeyframeTrack<Double>?
 
     private enum CodingKeys: String, CodingKey {
         case id, mediaRef, mediaType, sourceClipType, startFrame, durationFrames
         case trimStartFrame, trimEndFrame, speed, volume
         case fadeInFrames, fadeOutFrames, fadeInInterpolation, fadeOutInterpolation
         case opacity, transform, crop
-        case linkGroupId, captionGroupId, textContent, textStyle
+        case linkGroupId, captionGroupId, textContent, textStyle, shapeStyle
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
+        case strokeProgressTrack
     }
 
     /// Frame where this clip ends on the timeline
@@ -252,6 +258,7 @@ extension Clip {
         rotationTrack = clampedKeyframeTrack(rotationTrack)
         cropTrack = clampedKeyframeTrack(cropTrack)
         volumeTrack = clampedKeyframeTrack(volumeTrack)
+        strokeProgressTrack = clampedKeyframeTrack(strokeProgressTrack)
     }
 
     mutating func rescaleKeyframes(by scale: Double) {
@@ -261,6 +268,7 @@ extension Clip {
         rotationTrack = rescaledKeyframeTrack(rotationTrack, by: scale)
         cropTrack = rescaledKeyframeTrack(cropTrack, by: scale)
         volumeTrack = rescaledKeyframeTrack(volumeTrack, by: scale)
+        strokeProgressTrack = rescaledKeyframeTrack(strokeProgressTrack, by: scale)
     }
 
     private func clampedKeyframeTrack<V: Codable & Sendable & Equatable>(
@@ -351,12 +359,14 @@ extension Clip {
             captionGroupId: try? c.decode(String.self, forKey: .captionGroupId),
             textContent: try? c.decode(String.self, forKey: .textContent),
             textStyle: try? c.decode(TextStyle.self, forKey: .textStyle),
+            shapeStyle: try? c.decode(ShapeStyle.self, forKey: .shapeStyle),
             opacityTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .opacityTrack),
             positionTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .positionTrack),
             scaleTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .scaleTrack),
             rotationTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .rotationTrack),
             cropTrack: try? c.decode(KeyframeTrack<Crop>.self, forKey: .cropTrack),
-            volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack)
+            volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack),
+            strokeProgressTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .strokeProgressTrack)
         )
     }
 }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -51,10 +51,12 @@ enum CompositionBuilder {
         var unprocessableMediaRefs: Set<String> = []
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
-            // Text renders via CATextLayer overlay (preview) + animation tool (export) — never as composition tracks.
+            // Text + shape clips render via CALayer overlays (preview) + animation tool (export) —
+            // never as composition tracks. Skipping them here also dodges an AVAsset.loadTracks
+            // call against the blackBackground fallback for tracks that are pure overlay.
             let sortedClips = track.clips
                 .sorted { $0.startFrame < $1.startFrame }
-                .filter { $0.mediaType != .text }
+                .filter { $0.mediaType != .text && $0.mediaType != .shape }
             guard !sortedClips.isEmpty else { continue }
             let isAudio = track.type == .audio
             let mediaType: AVMediaType = isAudio ? .audio : .video

--- a/Sources/PalmierPro/Preview/PreviewView.swift
+++ b/Sources/PalmierPro/Preview/PreviewView.swift
@@ -9,8 +9,12 @@ struct PreviewView: NSViewRepresentable {
         let engine = VideoEngine(editor: editor)
         view.playerLayer.player = engine.player
         engine.previewView = view
+        view.setShapeRoot(engine.shapeController.shapeRoot)
         view.setTextRoot(engine.textController.textRoot)
-        view.onVideoRectChange = { [weak engine] _ in engine?.syncTextLayers() }
+        view.onVideoRectChange = { [weak engine] _ in
+            engine?.syncTextLayers()
+            engine?.syncShapeLayers()
+        }
         view.onCmdScroll = { [weak editor] deltaY, pointTopDown, viewSize in
             guard let editor = editor else { return }
             let oldZoom = editor.canvasZoom
@@ -59,12 +63,13 @@ struct PreviewView: NSViewRepresentable {
     }
 }
 
-/// Hosts AVPlayerLayer + a direct CALayer tree for text overlays.
+/// Hosts AVPlayerLayer + CALayer trees for shape (under) and text (over) overlays.
 final class PreviewNSView: NSView {
     let playerLayer = AVPlayerLayer()
     private(set) var textRoot: CALayer?
+    private(set) var shapeRoot: CALayer?
 
-    /// Fires when `playerLayer.videoRect` changes so text layers can re-scale.
+    /// Fires when `playerLayer.videoRect` changes so overlay layers can re-scale.
     var onVideoRectChange: ((CGRect) -> Void)?
 
     /// Fires on cmd+scroll. (deltaY, pointInTopDownViewCoords, viewSize)
@@ -83,7 +88,17 @@ final class PreviewNSView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
-    /// Attach the text layer tree above `playerLayer` — persists across item swaps.
+    /// Attach the shape layer tree above `playerLayer` — persists across item swaps.
+    func setShapeRoot(_ new: CALayer?) {
+        shapeRoot?.removeFromSuperlayer()
+        shapeRoot = new
+        if let new, let host = layer {
+            host.addSublayer(new)
+            new.frame = resolvedVideoRect
+        }
+    }
+
+    /// Attach the text layer tree above the shape tree — persists across item swaps.
     func setTextRoot(_ new: CALayer?) {
         textRoot?.removeFromSuperlayer()
         textRoot = new
@@ -99,6 +114,7 @@ final class PreviewNSView: NSView {
         CATransaction.setDisableActions(true)
         playerLayer.frame = bounds
         let videoRect = resolvedVideoRect
+        shapeRoot?.frame = videoRect
         textRoot?.frame = videoRect
         CATransaction.commit()
         if videoRect != lastVideoRect {

--- a/Sources/PalmierPro/Preview/ShapeLayerController.swift
+++ b/Sources/PalmierPro/Preview/ShapeLayerController.swift
@@ -1,0 +1,428 @@
+import AVFoundation
+import AppKit
+import QuartzCore
+
+/// Preview owns a long-lived `CAShapeLayer` tree with imperative properties.
+/// Export hands a one-shot tree to `AVVideoCompositionCoreAnimationTool`.
+@MainActor
+final class ShapeLayerController {
+
+    let shapeRoot: CALayer = {
+        let layer = CALayer()
+        layer.masksToBounds = false
+        layer.isGeometryFlipped = true
+        return layer
+    }()
+
+    private var clips: [Clip] = []
+    private var videoRect: CGRect = .zero
+    private var layersByID: [String: CAShapeLayer] = [:]
+    private var currentFrame = 0
+
+    private static let prerollFrames = 30
+
+    func sync(timeline: Timeline, videoRect: CGRect) {
+        shapeRoot.frame = videoRect
+        self.videoRect = videoRect
+        clips = ShapeLayerController.visibleShapeClips(in: timeline)
+        reconcile(restyle: true)
+    }
+
+    func tick(_ frame: Int) {
+        currentFrame = frame
+        reconcile(restyle: false)
+    }
+
+    private func reconcile(restyle: Bool) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        var needed = Set<String>()
+        for (index, clip) in clips.enumerated() {
+            guard currentFrame >= clip.startFrame - Self.prerollFrames,
+                  currentFrame < clip.endFrame else { continue }
+            needed.insert(clip.id)
+
+            let layer: CAShapeLayer
+            if let existing = layersByID[clip.id] {
+                layer = existing
+                if restyle { Self.applyStyle(to: layer, clip: clip, containerSize: videoRect.size) }
+            } else {
+                layer = Self.makeShapeLayer()
+                Self.applyStyle(to: layer, clip: clip, containerSize: videoRect.size)
+                layersByID[clip.id] = layer
+                shapeRoot.addSublayer(layer)
+            }
+            layer.zPosition = CGFloat(index)
+
+            // Per-frame: position, scale, rotation, opacity, strokeEnd
+            Self.applyDynamicState(to: layer, clip: clip, frame: currentFrame, containerSize: videoRect.size)
+
+            let visible = currentFrame >= clip.startFrame
+            let target: Float = visible ? Float(clip.opacityAt(frame: currentFrame)) : 0
+            if layer.opacity != target { layer.opacity = target }
+        }
+
+        for (id, layer) in layersByID where !needed.contains(id) {
+            layer.removeFromSuperlayer()
+            layersByID[id] = nil
+        }
+
+        CATransaction.commit()
+    }
+
+    // MARK: - Static builders
+
+    static func buildForExport(
+        timeline: Timeline,
+        fps: Int,
+        renderSize: CGSize
+    ) -> CALayer {
+        let host = CALayer()
+        host.frame = CGRect(origin: .zero, size: renderSize)
+        host.isGeometryFlipped = true
+        host.backgroundColor = NSColor.clear.cgColor
+
+        let fpsD = Double(max(1, fps))
+        let totalSeconds = max(0.001, Double(max(1, timeline.totalFrames)) / fpsD)
+        let totalFrames = max(1, Int((totalSeconds * fpsD).rounded()))
+
+        for clip in visibleShapeClips(in: timeline) {
+            let layer = makeShapeLayer()
+            applyStyle(to: layer, clip: clip, containerSize: renderSize)
+            // Initial state at frame 0.
+            applyDynamicState(to: layer, clip: clip, frame: clip.startFrame, containerSize: renderSize)
+
+            attachExportAnimations(
+                to: layer,
+                clip: clip,
+                totalFrames: totalFrames,
+                totalSeconds: totalSeconds,
+                containerSize: renderSize
+            )
+            layer.displayIfNeeded()
+            host.addSublayer(layer)
+        }
+        return host
+    }
+
+    static func buildSnapshot(
+        timeline: Timeline,
+        canvasSize: CGSize,
+        atFrame frame: Int
+    ) -> CALayer {
+        let host = CALayer()
+        host.frame = CGRect(origin: .zero, size: canvasSize)
+        host.isGeometryFlipped = true
+        for clip in visibleShapeClips(in: timeline) {
+            let layer = makeShapeLayer()
+            applyStyle(to: layer, clip: clip, containerSize: canvasSize)
+            applyDynamicState(to: layer, clip: clip, frame: frame, containerSize: canvasSize)
+            let visible = frame >= clip.startFrame && frame < clip.endFrame
+            layer.opacity = visible ? Float(clip.opacityAt(frame: frame)) : 0
+            host.addSublayer(layer)
+        }
+        return host
+    }
+
+    // MARK: - Private
+
+    static func visibleShapeClips(in timeline: Timeline) -> [Clip] {
+        var result: [Clip] = []
+        for track in timeline.tracks where !track.hidden {
+            for clip in track.clips where clip.mediaType == .shape && clip.endFrame > clip.startFrame {
+                result.append(clip)
+            }
+        }
+        return result
+    }
+
+    private static func makeShapeLayer() -> CAShapeLayer {
+        let layer = CAShapeLayer()
+        layer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        layer.fillColor = nil
+        layer.strokeColor = NSColor.systemRed.cgColor
+        layer.lineWidth = 6
+        layer.lineCap = .round
+        layer.lineJoin = .round
+        layer.actions = [
+            "path": NSNull(),
+            "bounds": NSNull(),
+            "position": NSNull(),
+            "opacity": NSNull(),
+            "transform": NSNull(),
+            "strokeEnd": NSNull(),
+            "strokeStart": NSNull(),
+            "fillColor": NSNull(),
+            "strokeColor": NSNull(),
+            "lineWidth": NSNull(),
+            "lineDashPattern": NSNull(),
+        ]
+        return layer
+    }
+
+    private static let referenceCanvasHeight: CGFloat = 1080
+
+    /// Set time-independent style: path, stroke/fill colors, line width, dash.
+    /// Frame box uses the clip's STATIC transform; per-frame keyframes update
+    /// position/bounds in `applyDynamicState`.
+    private static func applyStyle(to layer: CAShapeLayer, clip: Clip, containerSize: CGSize) {
+        let style = clip.shapeStyle ?? ShapeStyle()
+        let scale = containerSize.height / referenceCanvasHeight
+
+        let box = boundingBox(for: style, transform: clip.transform, containerSize: containerSize)
+        layer.frame = box
+        layer.bounds = CGRect(origin: .zero, size: box.size)
+
+        layer.path = makePath(for: style, in: layer.bounds, scale: scale)
+
+        layer.strokeColor = style.stroke.enabled ? style.stroke.color.nsColor.cgColor : NSColor.clear.cgColor
+        layer.lineWidth = CGFloat(style.stroke.width) * scale
+        layer.fillColor = style.fill.enabled ? style.fill.color.nsColor.cgColor : nil
+        layer.lineDashPattern = style.stroke.dash.isEmpty
+            ? nil
+            : style.stroke.dash.map { NSNumber(value: $0 * Double(scale)) }
+    }
+
+    /// Per-frame state. Mirrors Clip.transformAt + opacityTrack + strokeProgressTrack.
+    private static func applyDynamicState(
+        to layer: CAShapeLayer,
+        clip: Clip,
+        frame: Int,
+        containerSize: CGSize
+    ) {
+        // Position + size from keyframe tracks (or static transform fallback).
+        let style = clip.shapeStyle ?? ShapeStyle()
+        let dynamicTransform = clip.transformAt(frame: frame)
+        let box = boundingBox(for: style, transform: dynamicTransform, containerSize: containerSize)
+
+        // Rotation goes via layer.transform around the (default) anchor point.
+        let rotationRadians = CGFloat(clip.rotationAt(frame: frame) * .pi / 180)
+        layer.transform = CATransform3DIdentity
+        layer.frame = box
+        if rotationRadians != 0 {
+            layer.transform = CATransform3DMakeRotation(rotationRadians, 0, 0, 1)
+        }
+
+        // Stroke draw progress.
+        let progress = clip.strokeProgressTrack?.sample(at: frame - clip.startFrame, fallback: 1.0) ?? 1.0
+        layer.strokeEnd = CGFloat(max(0, min(1, progress)))
+        layer.strokeStart = 0
+    }
+
+    /// Bounding box for the shape, given the clip's transform & container size.
+    /// Endpoint-based shapes use the endpoint bbox so rotation pivots about its center.
+    private static func boundingBox(
+        for style: ShapeStyle,
+        transform: Transform,
+        containerSize: CGSize
+    ) -> CGRect {
+        if let endpoints = style.endpoints {
+            let bb = endpoints.boundingBox
+            return CGRect(
+                x: (bb.centerX - bb.width / 2) * containerSize.width,
+                y: (bb.centerY - bb.height / 2) * containerSize.height,
+                width: bb.width * containerSize.width,
+                height: bb.height * containerSize.height
+            )
+        }
+        let tl = transform.topLeft
+        return CGRect(
+            x: tl.x * containerSize.width,
+            y: tl.y * containerSize.height,
+            width: transform.width * containerSize.width,
+            height: transform.height * containerSize.height
+        )
+    }
+
+    /// CGPath for the shape inside the layer's local bounds.
+    private static func makePath(for style: ShapeStyle, in bounds: CGRect, scale: CGFloat) -> CGPath {
+        switch style.kind {
+        case .rect:
+            let r = max(0, min(0.5, style.cornerRadius)) * Double(min(bounds.width, bounds.height))
+            return CGPath(roundedRect: bounds, cornerWidth: CGFloat(r), cornerHeight: CGFloat(r), transform: nil)
+        case .oval:
+            return CGPath(ellipseIn: bounds, transform: nil)
+        case .circle:
+            let side = min(bounds.width, bounds.height)
+            let dx = (bounds.width - side) / 2
+            let dy = (bounds.height - side) / 2
+            return CGPath(ellipseIn: CGRect(x: dx, y: dy, width: side, height: side), transform: nil)
+        case .line, .arrow:
+            return makeLinePath(for: style, in: bounds, scale: scale, includeArrowhead: style.kind == .arrow)
+        }
+    }
+
+    private static func makeLinePath(
+        for style: ShapeStyle,
+        in bounds: CGRect,
+        scale: CGFloat,
+        includeArrowhead: Bool
+    ) -> CGPath {
+        let path = CGMutablePath()
+        guard let endpoints = style.endpoints else {
+            // Fallback: diagonal across bounds.
+            path.move(to: CGPoint(x: 0, y: 0))
+            path.addLine(to: CGPoint(x: bounds.width, y: bounds.height))
+            return path
+        }
+
+        let bb = endpoints.boundingBox
+        let bbW = max(0.0001, bb.width)
+        let bbH = max(0.0001, bb.height)
+        func localPoint(x: Double, y: Double) -> CGPoint {
+            let nx = (x - (bb.centerX - bb.width / 2)) / bbW
+            let ny = (y - (bb.centerY - bb.height / 2)) / bbH
+            return CGPoint(x: CGFloat(nx) * bounds.width, y: CGFloat(ny) * bounds.height)
+        }
+
+        let from = localPoint(x: endpoints.fromX, y: endpoints.fromY)
+        let to = localPoint(x: endpoints.toX, y: endpoints.toY)
+
+        path.move(to: from)
+        if let cx = endpoints.controlX, let cy = endpoints.controlY {
+            let control = localPoint(x: cx, y: cy)
+            path.addQuadCurve(to: to, control: control)
+        } else {
+            path.addLine(to: to)
+        }
+
+        if includeArrowhead && style.arrowhead.style != .none {
+            appendArrowhead(to: path, tip: to, base: from, style: style.arrowhead, scale: scale)
+        }
+        return path
+    }
+
+    private static func appendArrowhead(
+        to path: CGMutablePath,
+        tip: CGPoint,
+        base: CGPoint,
+        style: ShapeStyle.Arrowhead,
+        scale: CGFloat
+    ) {
+        let dx = tip.x - base.x
+        let dy = tip.y - base.y
+        let length = max(0.001, sqrt(dx * dx + dy * dy))
+        let ux = dx / length
+        let uy = dy / length
+        // Perpendicular unit vector.
+        let px = -uy
+        let py = ux
+
+        let size = CGFloat(style.size) * scale
+        let backX = tip.x - ux * size
+        let backY = tip.y - uy * size
+        let halfWidth = size * 0.6
+
+        let left = CGPoint(x: backX + px * halfWidth, y: backY + py * halfWidth)
+        let right = CGPoint(x: backX - px * halfWidth, y: backY - py * halfWidth)
+
+        switch style.style {
+        case .triangle:
+            path.move(to: tip)
+            path.addLine(to: left)
+            path.addLine(to: right)
+            path.closeSubpath()
+        case .open:
+            path.move(to: left)
+            path.addLine(to: tip)
+            path.addLine(to: right)
+        case .none:
+            break
+        }
+    }
+
+    // MARK: - Export animation bake
+
+    private static func attachExportAnimations(
+        to layer: CAShapeLayer,
+        clip: Clip,
+        totalFrames: Int,
+        totalSeconds: Double,
+        containerSize: CGSize
+    ) {
+        guard totalFrames > 0 else { return }
+
+        var opacityValues: [NSNumber] = []
+        var strokeEndValues: [NSNumber] = []
+        var positionValues: [NSValue] = []
+        var boundsValues: [NSValue] = []
+        var transformValues: [NSValue] = []
+        var keyTimes: [NSNumber] = [NSNumber(value: 0)]
+
+        let style = clip.shapeStyle ?? ShapeStyle()
+        for frame in 0..<totalFrames {
+            let visible = frame >= clip.startFrame && frame < clip.endFrame
+            let v = visible ? clip.opacityAt(frame: frame) : 0
+            opacityValues.append(NSNumber(value: Float(v)))
+
+            let progress = clip.strokeProgressTrack?.sample(at: frame - clip.startFrame, fallback: 1.0) ?? 1.0
+            strokeEndValues.append(NSNumber(value: Float(max(0, min(1, progress)))))
+
+            let dynTransform = clip.transformAt(frame: frame)
+            let box = boundingBox(for: style, transform: dynTransform, containerSize: containerSize)
+            // position = center of frame in parent coords; bounds = layer-local size
+            positionValues.append(NSValue(point: NSPoint(x: box.midX, y: box.midY)))
+            boundsValues.append(NSValue(rect: NSRect(origin: .zero, size: box.size)))
+            let rotation = clip.rotationAt(frame: frame) * .pi / 180
+            transformValues.append(NSValue(caTransform3D: CATransform3DMakeRotation(CGFloat(rotation), 0, 0, 1)))
+
+            keyTimes.append(NSNumber(value: Double(frame + 1) / Double(totalFrames)))
+        }
+
+        // Opacity
+        let opacity = CAKeyframeAnimation(keyPath: "opacity")
+        opacity.calculationMode = .discrete
+        opacity.values = opacityValues
+        opacity.keyTimes = keyTimes
+        opacity.beginTime = AVCoreAnimationBeginTimeAtZero
+        opacity.duration = totalSeconds
+        opacity.fillMode = .both
+        opacity.isRemovedOnCompletion = false
+        layer.add(opacity, forKey: "opacity")
+
+        // Stroke draw
+        let stroke = CAKeyframeAnimation(keyPath: "strokeEnd")
+        stroke.calculationMode = .discrete
+        stroke.values = strokeEndValues
+        stroke.keyTimes = keyTimes
+        stroke.beginTime = AVCoreAnimationBeginTimeAtZero
+        stroke.duration = totalSeconds
+        stroke.fillMode = .both
+        stroke.isRemovedOnCompletion = false
+        layer.add(stroke, forKey: "strokeEnd")
+
+        // Position
+        let position = CAKeyframeAnimation(keyPath: "position")
+        position.calculationMode = .discrete
+        position.values = positionValues
+        position.keyTimes = keyTimes
+        position.beginTime = AVCoreAnimationBeginTimeAtZero
+        position.duration = totalSeconds
+        position.fillMode = .both
+        position.isRemovedOnCompletion = false
+        layer.add(position, forKey: "position")
+
+        // Bounds (for scale changes)
+        let boundsAnim = CAKeyframeAnimation(keyPath: "bounds")
+        boundsAnim.calculationMode = .discrete
+        boundsAnim.values = boundsValues
+        boundsAnim.keyTimes = keyTimes
+        boundsAnim.beginTime = AVCoreAnimationBeginTimeAtZero
+        boundsAnim.duration = totalSeconds
+        boundsAnim.fillMode = .both
+        boundsAnim.isRemovedOnCompletion = false
+        layer.add(boundsAnim, forKey: "bounds")
+
+        // Rotation
+        let rotation = CAKeyframeAnimation(keyPath: "transform")
+        rotation.calculationMode = .discrete
+        rotation.values = transformValues
+        rotation.keyTimes = keyTimes
+        rotation.beginTime = AVCoreAnimationBeginTimeAtZero
+        rotation.duration = totalSeconds
+        rotation.fillMode = .both
+        rotation.isRemovedOnCompletion = false
+        layer.add(rotation, forKey: "transform")
+    }
+}

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -43,12 +43,19 @@ enum TimelineRenderer {
             }
         }
 
-        // Bake text clips in via the animation tool, same as ExportService.
+        // Bake text + shape clips in via the animation tool, same as ExportService.
         let (parent, videoLayer) = TextLayerController.buildForExport(
             timeline: timeline,
             fps: timeline.fps,
             renderSize: renderSize
         )
+        // Shapes sit between video and text: insert right after videoLayer (index 0).
+        let shapeHost = ShapeLayerController.buildForExport(
+            timeline: timeline,
+            fps: timeline.fps,
+            renderSize: renderSize
+        )
+        parent.insertSublayer(shapeHost, at: 1)
         let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
         mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -11,6 +11,7 @@ final class VideoEngine {
     private(set) var player = AVPlayer()
 
     let textController = TextLayerController()
+    let shapeController = ShapeLayerController()
 
     weak var previewView: PreviewNSView?
 
@@ -69,6 +70,7 @@ final class VideoEngine {
     func seek(to frame: Int, mode: PreviewSeekMode = .exact) {
         guard let editor else { return }
         textController.tick(frame)
+        shapeController.tick(frame)
 
         let time = CMTime(value: CMTimeValue(frame), timescale: CMTimeScale(editor.timeline.fps))
         let tolerance: CMTime = mode == .interactiveScrub
@@ -113,9 +115,11 @@ final class VideoEngine {
         switch tab {
         case .timeline:
             textController.textRoot.isHidden = false
+            shapeController.shapeRoot.isHidden = false
             rebuild()
         case .mediaAsset(let id, _, let type):
             textController.textRoot.isHidden = true
+            shapeController.shapeRoot.isHidden = true
             guard let asset = editor.mediaAssets.first(where: { $0.id == id }) else { return }
             if type == .image {
                 replacePlayerItem(nil, reason: "imagePreview")
@@ -178,6 +182,7 @@ final class VideoEngine {
             item.videoComposition = result.videoComposition
             replacePlayerItem(item, reason: "rebuild")
             syncTextLayers()
+            syncShapeLayers()
 
             seek(to: editor.currentFrame, mode: .exact)
             if editor.isPlaying { player.play() }
@@ -218,6 +223,22 @@ final class VideoEngine {
         let resolvedRect = videoRect.isEmpty ? previewView.bounds : videoRect
         textController.sync(timeline: editor.timeline, videoRect: resolvedRect)
         textController.tick(editor.currentFrame)
+    }
+
+    // MARK: - Shape Layers
+
+    func syncShapeLayers() {
+        guard let editor, let previewView else { return }
+        guard editor.activePreviewTab == .timeline else {
+            shapeController.shapeRoot.isHidden = true
+            return
+        }
+
+        shapeController.shapeRoot.isHidden = false
+        let videoRect = previewView.playerLayer.videoRect
+        let resolvedRect = videoRect.isEmpty ? previewView.bounds : videoRect
+        shapeController.sync(timeline: editor.timeline, videoRect: resolvedRect)
+        shapeController.tick(editor.currentFrame)
     }
 
     // MARK: - Seek Coordinator
@@ -297,6 +318,7 @@ final class VideoEngine {
                 if editor.activePreviewTab == .timeline {
                     editor.currentFrame = frame
                     self.textController.tick(frame)
+                    self.shapeController.tick(frame)
                 } else {
                     editor.sourcePlayheadFrame = frame
                 }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -136,6 +136,7 @@ enum AppTheme {
         static let image = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
         static let text = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
         static let lottie = NSColor(red: 0xE0/255.0, green: 0xA8/255.0, blue: 0x00/255.0, alpha: 1)
+        static let shape = NSColor(red: 0xE0/255.0, green: 0x3B/255.0, blue: 0x3B/255.0, alpha: 1)
     }
 
     // MARK: - Corner radii
@@ -311,6 +312,7 @@ extension ClipType {
         case .image: AppTheme.TrackColor.image
         case .text: AppTheme.TrackColor.text
         case .lottie: AppTheme.TrackColor.lottie
+        case .shape: AppTheme.TrackColor.shape
         }
     }
 }


### PR DESCRIPTION
Addresses #45.

Opening this as a **draft** per CONTRIBUTING.md — happy to leave it parked until there's room to review, or close it if the direction doesn't fit. The issue lays out the user-problem framing; this PR is the implementation.

## Summary

- New `.shape` clip type (rect, oval, circle, arrow, line) rendered as `CAShapeLayer` overlays — same pattern text clips already use, never composition tracks.
- 17 named animation presets (`pop-in`, `draw-on`, `shake-{subtle,strong}`, `spin`, `fade-{in,out}`, `slide-{in,out}-{up,down,left,right}`, `un-draw`) that compile to keyframe rows on the existing tracks.
- Two MCP tools: `add_shapes` (batch, with enter/exit/loop animations in one call) and `apply_animation` (preset on an existing clip). Each is one undoable action; strict allowed-keys validation matches `add_texts`.
- Reuses every existing keyframe track (`position`, `scale`, `rotation`, `opacity`); adds one new `strokeProgressTrack` to drive draw-on / un-draw.

## File map

| Phase | Files | Purpose |
|---|---|---|
| Data model | `Models/ClipType.swift`, `Models/ShapeStyle.swift` (new), `Models/Timeline.swift`, `Models/Keyframe.swift`, `UI/AppTheme.swift` | `.shape` case, style payload, `Clip.shapeStyle` + `Clip.strokeProgressTrack`, `AnimatableProperty.strokeProgress`, track color |
| Renderer | `Preview/ShapeLayerController.swift` (new), `Preview/PreviewView.swift`, `Preview/VideoEngine.swift`, `Preview/CompositionBuilder.swift`, `Preview/TimelineRenderer.swift`, `Export/ExportService.swift` | CAShapeLayer overlay tree + per-frame state + export bake via `AVVideoCompositionCoreAnimationTool`; `CompositionBuilder` filters out shape clips (same as text) so they never become AVAsset-backed composition tracks |
| VM | `Editor/ViewModel/EditorViewModel+ClipMutations.swift`, `EditorViewModel+Keyframes.swift`, `EditorViewModel+MediaLibrary.swift`, `EditorViewModel+Tracks.swift` | `placeShapeClips` (mirrors `placeTextClips`), shape-aware property mutation routing (`syncShapeLayers` instead of composition rebuild) |
| Presets | `Editor/Animations/AnimationPresets.swift` (new) | 17 named presets — pure functions, deterministic, returns keyframe rows ready to merge into a `Clip` |
| MCP | `Agent/Tools/ToolDefinitions.swift`, `ToolExecutor.swift`, `ToolExecutor+Shapes.swift` (new), `ToolExecutor+Generate.swift`, `ToolExecutor+Timeline.swift`, `AgentInstructions.swift` | `add_shapes`, `apply_animation` tool definitions + executor; `.shape` rejected at generate/timeline-inspect paths; agent guidance for tutorial-annotation patterns |
| Boilerplate switch coverage | `Generation/Edit/*.swift`, `Generation/GenerationService.swift`, `Generation/UI/GenerationView.swift`, `MediaPanel/MediaTab/MediaTab.swift` | Adds `.shape` to existing `ClipType` exhaustive switches; disambiguates SwiftUI's `ShapeStyle` protocol where it collides with the new model type |

27 files, +1402 / -55, 4 new files.

## What the agent call looks like end-to-end

```bash
curl -X POST http://127.0.0.1:19789/mcp \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
    "name":"add_shapes",
    "arguments":{"entries":[{
      "kind":"circle",
      "startFrame":15,"durationFrames":120,
      "transform":{"centerX":0.5,"centerY":0.5,"width":0.22,"height":0.22},
      "style":{"strokeColor":"#FF3B30","strokeWidth":10},
      "enterAnim":"pop-in","exitAnim":"fade-out","loopAnim":"shake-subtle"
    }]}
  }}'

# → "Created track 0 ('V1'). Added 1 shape clip: 64F1FBD3-… (circle)
#    on track 0 @ 15 for 120 [pop-in, fade-out, shake-subtle]"
```

One undoable action; the preview's `CAShapeLayer` tree updates immediately via `syncShapeLayers()`; no composition rebuild required.

## Test plan

- [x] `swift build` clean (no new warnings introduced)
- [x] `swift test` — existing tests pass; no behavioral regressions in keyframe sampling, composition build for non-shape timelines, or text-clip placement
- [x] MCP `tools/list` exposes `add_shapes` + `apply_animation` with their schemas
- [x] `tools/call add_shapes` against a live MCP server returns success + clip IDs
- [ ] Visual confirmation in preview — blocked on a pre-existing AVFoundation continuation issue on my dev machine (macOS 26.4.1 / M1 8GB, `libconvexmobile.a` built for SDK 26.2 vs deployment 26.0). Code paths verified via MCP responses and OSLog. Will fold in a recording on a healthy machine when reviewed.

## Out of scope (intentional)

- Manual draw-on-canvas tool (would land as a PR #2 with `ShapeTab` inspector mirroring `TextTab`)
- Free-form path / pen, gradients, blur/glow, boolean operations between shapes
- Auto-tracking (shape follows a moving subject) — needs the search/index team's tracking work
- Per-keyframe easing curves beyond `linear` / `hold` / `smooth`

## How I'd split this if you'd rather review smaller chunks

1. Data model + renderer (Phases 1–2 above) — ~850 LOC
2. Presets + MCP tools (Phases 3–5) — ~600 LOC

Happy to rebase into that shape on request. Also happy to close this if the direction doesn't fit — no hard feelings either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)