### PR TITLE
Fix three fatal crashes from Sentry triage

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -25,7 +25,7 @@ extension EditorViewModel {
                 n += 1
             }
         } else {
-            for i in trackIndex..<zones.firstAudioIndex where timeline.tracks[i].type == type {
+            for i in trackIndex..<max(trackIndex + 1, zones.firstAudioIndex) where timeline.tracks[i].type == type {
                 n += 1
             }
         }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -119,15 +119,17 @@ struct CaptionTab: View {
                 Text("No Tracks")
             } else {
                 ForEach(captionTrackIndices, id: \.self) { index in
-                    let track = editor.timeline.tracks[index]
-                    let count = editor.captionTargets(trackIds: [track.id]).count
-                    Button {
-                        selectedTrackId = track.id
-                    } label: {
-                        Label(
-                            "\(trackTitle(index)) · \(count) \(count == 1 ? "clip" : "clips")",
-                            systemImage: selectedTrackId == track.id ? "checkmark" : ""
-                        )
+                    if editor.timeline.tracks.indices.contains(index) {
+                        let track = editor.timeline.tracks[index]
+                        let count = editor.captionTargets(trackIds: [track.id]).count
+                        Button {
+                            selectedTrackId = track.id
+                        } label: {
+                            Label(
+                                "\(trackTitle(index)) · \(count) \(count == 1 ? "clip" : "clips")",
+                                systemImage: selectedTrackId == track.id ? "checkmark" : ""
+                            )
+                        }
                     }
                 }
             }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -755,7 +755,9 @@ enum CompositionBuilder {
             ? normalizedKeyframes(clip.opacityTrack?.keyframes ?? [], duration: clip.durationFrames)
             : []
 
-        emitOpacitySet(config: &config, value: Float(clip.opacityAt(frame: clip.startFrame)), at: start)
+        if clip.durationFrames <= 0 {
+            emitOpacitySet(config: &config, value: Float(clip.opacityAt(frame: clip.startFrame)), at: start)
+        }
         emitEnvelopeRamps(
             clip: clip,
             kfs: kfs,

--- a/Tests/PalmierProTests/Timeline/TrackDisplayLabelTests.swift
+++ b/Tests/PalmierProTests/Timeline/TrackDisplayLabelTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private func makeEditor(_ tracks: [Track]) -> EditorViewModel {
+    let editor = EditorViewModel()
+    editor.timeline = Fixtures.timeline(tracks: tracks)
+    return editor
+}
+
+@Suite("EditorViewModel — track display label")
+@MainActor
+struct TrackDisplayLabelTests {
+
+    @Test func labelsVisualTracksTopToBottomThenAudio() {
+        let editor = makeEditor([
+            Fixtures.videoTrack(),
+            Fixtures.videoTrack(),
+            Fixtures.audioTrack(),
+        ])
+        #expect(editor.timelineTrackDisplayLabel(at: 0) == "V2")
+        #expect(editor.timelineTrackDisplayLabel(at: 1) == "V1")
+        #expect(editor.timelineTrackDisplayLabel(at: 2) == "A1")
+    }
+
+    @Test func outOfRangeIndexReturnsEmpty() {
+        let editor = makeEditor([Fixtures.videoTrack()])
+        #expect(editor.timelineTrackDisplayLabel(at: 5) == "")
+    }
+
+    @Test func visualTrackAfterAudioDoesNotTrap() {
+        // Invariant-violating order (visual below audio) — must not crash on the empty range.
+        var text = Fixtures.videoTrack()
+        text.type = .text
+        let editor = makeEditor([
+            Fixtures.videoTrack(),
+            Fixtures.audioTrack(),
+            text,
+        ])
+        #expect(editor.timelineTrackDisplayLabel(at: 2) == "T1")
+    }
+}


### PR DESCRIPTION
- PALMIER-PRO-2Z: timelineTrackDisplayLabel built an invalid Range (trackIndex..<firstAudioIndex) when a visual track sits at/after the first audio track; clamp the upper bound. Adds regression tests.
- PALMIER-PRO-48: CaptionTab source menu subscripted timeline.tracks with a stale index after a track was removed; bounds-guard the ForEach body.
- PALMIER-PRO-97: emitOpacity seeded a setOpacity at the clip start that overlapped the envelope's first ramp (also at start) → AVFoundation threw. Drop the redundant seed when durationFrames > 0.