### PR TITLE
Fix on-device transcription failing with non-default system region

### DIFF
--- a/Sources/PalmierPro/Transcription/Transcription.swift
+++ b/Sources/PalmierPro/Transcription/Transcription.swift
@@ -80,10 +80,15 @@ enum Transcription {
 
     static func matchLocale(candidates: [Locale], supported: [Locale]) -> Locale? {
         for candidate in candidates {
-            guard let lang = candidate.language.languageCode?.identifier else { continue }
+            // Strip Unicode extension tags (e.g. -u-rg-zazzzz from en-US-u-rg-zazzzz) before
+            // matching — the Speech framework doesn't recognise composite BCP 47 tags.
+            let baseId = candidate.identifier(.bcp47).components(separatedBy: "-u-").first
+                ?? candidate.identifier
+            let base = Locale(identifier: baseId)
+            guard let lang = base.language.languageCode?.identifier else { continue }
             let sameLang = supported.filter { $0.language.languageCode?.identifier == lang }
             guard !sameLang.isEmpty else { continue }
-            let region = candidate.region?.identifier
+            let region = base.region?.identifier
             return sameLang.first { $0.region?.identifier == region } ?? sameLang.first
         }
         return nil


### PR DESCRIPTION
## Summary

- `matchLocale` was calling `candidate.region?.identifier` directly on the raw locale, so a locale like `en-US-u-rg-zazzzz` (English US language + South Africa region) produced a garbled region and failed to match any supported Speech locale
- Fix strips the Unicode extension suffix (`-u-*`) from the BCP 47 identifier before matching, leaving a clean tag like `en-US` that the Speech framework recognises

## Repro

System language: English (US), Region: South Africa → locale becomes `en-US-u-rg-zazzzz` → transcription fails with "On-device transcription is not available for en-US-u-rg-zazzzz"

<img width="478" height="612" alt="Language & Region settings showing English US language with South Africa region" src="https://github.com/user-attachments/assets/fa7d9dba-e1fa-47ed-9db7-cff3b344ea66" />

## Test plan

- [ ] Set System Settings → General → Language & Region to any language with a mismatched region (e.g. English US + South Africa)
- [ ] Open a video in the timeline and trigger transcription
- [ ] Confirm transcription completes instead of showing the unsupported locale error