### PR TITLE
feat(color): project color grading — looks, LUTs, primaries, curves, scopes

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -33,6 +33,11 @@ enum ToolName: String, CaseIterable, Sendable {
     case renameFolder = "rename_folder"
     case deleteMedia = "delete_media"
     case deleteFolder = "delete_folder"
+    case applyColorGrade = "apply_color_grade"
+    case clearColorGrade = "clear_color_grade"
+    case listColorGrades = "list_color_grades"
+    case adjustColor = "adjust_color"
+    case setColorCurve = "set_color_curve"
 }
 
 struct AgentTool: @unchecked Sendable {
@@ -43,6 +48,55 @@ struct AgentTool: @unchecked Sendable {
 
 enum ToolDefinitions {
     static let all: [AgentTool] = [
+        AgentTool(
+            name: .listColorGrades,
+            description: "List the built-in color looks available to apply_color_grade. Returns each look's id, name, and a one-line summary of when to use it (e.g. 'moody-forest' for hikes/jungle, 'teal-orange' for travel/adventure). Call this before apply_color_grade when picking a look automatically, so you choose one that matches the footage. Built-in looks need no asset import.",
+            inputSchema: objectSchema()
+        ),
+        AgentTool(
+            name: .applyColorGrade,
+            description: "Apply a project-wide color grade (one look over the whole timeline), realized as a final color pass at export. Use a built-in look by id (see list_color_grades) — the zero-setup path for 'color grade this' / 'make it cinematic' — or a custom .cube LUT by file path via lutPath (the .cube is parsed and embedded in the project). Pick the look to match the footage (e.g. 'moody-forest' for jungle/hike, 'vibrant-travel' for bright social vlogs). intensity (0–1, default 1) blends the grade with the original; 0.6–0.8 reads as a tasteful default. Calling again replaces the current look/LUT. Shows live on the canvas and bakes into export. For primary corrections and curves, use adjust_color and set_color_curve.",
+            inputSchema: objectSchema(
+                properties: [
+                    "look": ["type": "string", "description": "Built-in look id from list_color_grades (e.g. 'warm-cinematic', 'teal-orange', 'moody-forest', 'vibrant-travel', 'vintage-film', 'clean-neutral'). Provide either look or lutPath."],
+                    "lutPath": ["type": "string", "description": "Filesystem path to a .cube LUT file (Adobe/Resolve 3D LUT). Parsed and embedded into the project. Use instead of look for a custom film LUT."],
+                    "intensity": ["type": "number", "description": "Grade strength 0–1 (default 1.0). Lower values blend toward the ungraded original."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .clearColorGrade,
+            description: "Remove the project-wide color grade set by apply_color_grade. The next export is ungraded. No-op if none is set.",
+            inputSchema: objectSchema()
+        ),
+        AgentTool(
+            name: .adjustColor,
+            description: "Adjust the project-wide primary color correction (shown live on the canvas and baked into export). Each control is −100…100, 0 = no change. Partial updates: only the fields you pass change; the rest keep their current value. Use to balance a shot — e.g. warm it with temperature, recover a hazy sky with contrast + highlights. Pass reset=true to zero all eight controls (curves are kept). Composes with apply_color_grade (looks/LUTs) and set_color_curve.",
+            inputSchema: objectSchema(
+                properties: [
+                    "temperature": ["type": "number", "description": "−100 (cooler) … 100 (warmer)."],
+                    "tint": ["type": "number", "description": "−100 (green) … 100 (magenta)."],
+                    "exposure": ["type": "number", "description": "−100 … 100 (maps to ±2 EV)."],
+                    "contrast": ["type": "number", "description": "−100 … 100."],
+                    "saturation": ["type": "number", "description": "−100 (grayscale) … 100."],
+                    "vibrance": ["type": "number", "description": "−100 … 100 (saturates muted colors more gently)."],
+                    "highlights": ["type": "number", "description": "−100 (recover/darken) … 100 (brighten)."],
+                    "shadows": ["type": "number", "description": "−100 (crush) … 100 (lift)."],
+                    "reset": ["type": "boolean", "description": "Zero all eight primary controls (keeps curves). Ignores other fields."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .setColorCurve,
+            description: "Set one tone curve of the project grade (shown live + baked into export). Curves map input→output brightness; the master curve affects all channels, red/green/blue shift individual channels (e.g. lift blue shadows for a cool look). Points are [x, y] pairs in 0…1, x = input, y = output, must include endpoints near x=0 and x=1. Pass an empty points array to reset that channel to linear. A gentle S-curve like [[0,0],[0.25,0.2],[0.75,0.8],[1,1]] adds contrast.",
+            inputSchema: objectSchema(
+                properties: [
+                    "channel": ["type": "string", "enum": ["master", "red", "green", "blue"], "description": "Which curve to set."],
+                    "points": ["type": "array", "items": ["type": "array", "items": ["type": "number"]], "description": "[x, y] pairs in 0…1, e.g. [[0,0],[0.5,0.62],[1,1]]. Empty array resets the channel to linear."],
+                ],
+                required: ["channel", "points"]
+            )
+        ),
         AgentTool(
             name: .getTimeline,
             description: "Always call at the start of a session. Returns project settings (fps, resolution, totalFrames), track list with types and order, all clips with their frames and properties, and canGenerate (if false, generation/upscale tools will fail — tell the user to sign in to Palmier and subscribe before attempting them). The clipId/trackId values here are what every other tool accepts.\n\nClip and track fields equal to their defaults are omitted: mediaType 'video', sourceClipType = mediaType, speed 1, volume 1, opacity 1, trims/fades 0, identity transform/crop, default textStyle, track muted/hidden false. Text clips never report trims (no source media).\n\nCaption clips (sharing a captionGroupId) come back per track as captionGroups instead of clips entries: properties common to the group are hoisted into 'shared' and each clip is a [clipId, startFrame, durationFrames, text] row (caption box width/height are auto-fit per text and omitted). Rows are capped at 200 per group — when clipCount exceeds the rows shown, page with startFrame/endFrame. Caption clips whose properties deviate from the group appear individually in clips.",

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+extension ToolExecutor {
+    func listColorGrades() -> ToolResult {
+        .ok(Self.jsonString(["looks": ColorGradeCatalog.catalogJSON]) ?? "{}")
+    }
+
+    func applyColorGrade(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let look = (args["look"] as? String)?.trimmingCharacters(in: .whitespaces)
+        let lutPath = (args["lutPath"] as? String)?.trimmingCharacters(in: .whitespaces)
+        let intensityRaw = (args["intensity"] as? NSNumber)?.doubleValue ?? 1.0
+        let intensity = min(1.0, max(0.0, intensityRaw))
+
+        let ref: LUTRef
+        switch (look?.isEmpty == false ? look : nil, lutPath?.isEmpty == false ? lutPath : nil) {
+        case let (lookID?, nil):
+            guard ColorGradeCatalog.look(id: lookID) != nil else {
+                let ids = ColorGradeCatalog.all.map(\.id).joined(separator: ", ")
+                throw ToolError("Unknown look '\(lookID)'. Available: \(ids). Call list_color_grades.")
+            }
+            ref = .look(lookID, intensity: intensity)
+        case let (nil, path?):
+            let url = URL(fileURLWithPath: path)
+            guard url.pathExtension.lowercased() == "cube" else {
+                throw ToolError("lutPath must point at a .cube file (got '\(url.lastPathComponent)').")
+            }
+            guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+                throw ToolError("Could not read .cube file at \(path)")
+            }
+            let cube: CubeLUT
+            do { cube = try CubeLUTParser.parse(text) }
+            catch { throw ToolError("Invalid .cube: \(error.localizedDescription)") }
+            ref = .cube(cube, name: url.deletingPathExtension().lastPathComponent, intensity: intensity)
+        default:
+            throw ToolError("Provide exactly one of 'look' or 'lutPath'.")
+        }
+
+        editor.setColorGrade(ref)
+        var out = ref.summary
+        out["appliesAt"] = "export"
+        return .ok(Self.jsonString(out) ?? "{}")
+    }
+
+    func clearColorGrade(_ editor: EditorViewModel) throws -> ToolResult {
+        editor.setColorGrade(nil)
+        return .ok(Self.jsonString(["cleared": true]) ?? "{}")
+    }
+
+    func adjustColor(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        var p = editor.timeline.primaries ?? PrimaryGrade()
+        let reset = (args["reset"] as? Bool) == true || (args["reset"] as? NSNumber)?.boolValue == true
+        if reset {
+            let curve = p.curve
+            p = PrimaryGrade()
+            p.curve = curve
+        } else {
+            func clamp(_ v: Double) -> Double { min(100, max(-100, v)) }
+            func num(_ key: String) -> Double? { (args[key] as? NSNumber)?.doubleValue }
+            if let v = num("temperature") { p.temperature = clamp(v) }
+            if let v = num("tint") { p.tint = clamp(v) }
+            if let v = num("exposure") { p.exposure = clamp(v) }
+            if let v = num("contrast") { p.contrast = clamp(v) }
+            if let v = num("saturation") { p.saturation = clamp(v) }
+            if let v = num("vibrance") { p.vibrance = clamp(v) }
+            if let v = num("highlights") { p.highlights = clamp(v) }
+            if let v = num("shadows") { p.shadows = clamp(v) }
+        }
+        editor.setColorPrimaries(p)
+        let out: [String: Any] = [
+            "temperature": p.temperature, "tint": p.tint, "exposure": p.exposure,
+            "contrast": p.contrast, "saturation": p.saturation, "vibrance": p.vibrance,
+            "highlights": p.highlights, "shadows": p.shadows,
+        ]
+        return .ok(Self.jsonString(out) ?? "{}")
+    }
+
+    func setColorCurve(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        guard let channel = args["channel"] as? String else { throw ToolError("Missing 'channel'") }
+        guard ["master", "red", "green", "blue"].contains(channel) else {
+            throw ToolError("channel must be master, red, green, or blue")
+        }
+        guard let rawPoints = args["points"] as? [Any] else { throw ToolError("Missing 'points' array") }
+
+        var points: [CurvePoint] = []
+        for entry in rawPoints {
+            guard let pair = entry as? [Any], pair.count == 2,
+                  let x = (pair[0] as? NSNumber)?.doubleValue,
+                  let y = (pair[1] as? NSNumber)?.doubleValue else {
+                throw ToolError("Each point must be an [x, y] pair of numbers in 0…1")
+            }
+            points.append(CurvePoint(x: min(1, max(0, x)), y: min(1, max(0, y))))
+        }
+        points.sort { $0.x < $1.x }
+
+        var p = editor.timeline.primaries ?? PrimaryGrade()
+        var curve = p.curve ?? GradeCurve()
+        let value = (points == GradeCurve.identityPoints) ? [] : points
+        switch channel {
+        case "master": curve.master = value
+        case "red": curve.red = value
+        case "green": curve.green = value
+        default: curve.blue = value
+        }
+        p.curve = curve.isIdentity ? nil : curve
+        editor.setColorPrimaries(p)
+        return .ok(Self.jsonString(["channel": channel, "points": points.map { [$0.x, $0.y] }]) ?? "{}")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -37,6 +37,13 @@ extension ToolExecutor {
             }
             dict["tracks"] = tracks
         }
+        // Replace the full LUT encoding (which embeds a base64 cube blob) with a
+        // compact summary so the blob never reaches agent context.
+        if let lut = editor.timeline.lut {
+            dict["lut"] = lut.summary
+        } else {
+            dict.removeValue(forKey: "lut")
+        }
         dict["totalFrames"] = editor.timeline.totalFrames
         if let window {
             dict["window"] = [window.lowerBound, min(window.upperBound, editor.timeline.totalFrames)]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -102,6 +102,11 @@ final class ToolExecutor {
         case .renameFolder:  return try renameFolder(editor, args)
         case .deleteMedia:   return try deleteMedia(editor, args)
         case .deleteFolder:  return try deleteFolder(editor, args)
+        case .applyColorGrade: return try applyColorGrade(editor, args)
+        case .clearColorGrade: return try clearColorGrade(editor)
+        case .listColorGrades: return listColorGrades()
+        case .adjustColor:     return try adjustColor(editor, args)
+        case .setColorCurve:   return try setColorCurve(editor, args)
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension EditorViewModel {
+    func setColorGrade(_ lut: LUTRef?) {
+        let prev = timeline.lut
+        guard prev != lut else { return }
+        timeline.lut = lut
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.setColorGrade(prev)
+        }
+        undoManager?.setActionName(lut == nil ? "Clear Color Grade (Agent)" : "Apply Color Grade (Agent)")
+        // Grade renders via CALayer.filters, not the composition; rebuilding would only cause a black flash.
+        videoEngine?.refreshGrade()
+    }
+
+    func setColorPrimaries(_ primaries: PrimaryGrade?) {
+        let next = (primaries?.isIdentity ?? true) ? nil : primaries
+        let prev = timeline.primaries
+        guard prev != next else { return }
+        timeline.primaries = next
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.setColorPrimaries(prev)
+        }
+        undoManager?.setActionName("Adjust Color")
+        videoEngine?.refreshGrade()
+    }
+}

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -126,6 +126,10 @@ final class ExportService {
 
             do {
                 try await session.export(to: outputURL, as: fileType)
+                try await applyLUTPassIfNeeded(
+                    timeline: timeline, format: format,
+                    resolution: resolution, fileType: fileType, outputURL: outputURL
+                )
                 progress = 1.0
                 Log.export.notice(
                     "export ok",
@@ -210,6 +214,31 @@ final class ExportService {
                 data: ["error": Log.detail(error)]
             )
             return nil
+        }
+    }
+
+    /// Grade the just-exported file in place when the timeline carries any grade.
+    private func applyLUTPassIfNeeded(
+        timeline: Timeline,
+        format: ExportFormat,
+        resolution: ExportResolution,
+        fileType: AVFileType,
+        outputURL: URL
+    ) async throws {
+        let filters = GradePipeline.filters(primaries: timeline.primaries, lut: timeline.lut)
+        guard !filters.isEmpty else { return }
+        do {
+            let gradedURL = try await LUTExportPass.apply(
+                processor: FilterChainProcessor(filters: filters),
+                to: outputURL, fileType: fileType,
+                preset: exportPresetName(format: format, resolution: resolution)
+            )
+            // Swap the graded file over the original export.
+            try? FileManager.default.removeItem(at: outputURL)
+            try FileManager.default.moveItem(at: gradedURL, to: outputURL)
+        } catch {
+            // Don't fail the whole export over a bad grade — keep the ungraded file.
+            Log.export.error("grade-pass skipped: \(Log.detail(error))")
         }
     }
 

--- a/Sources/PalmierPro/Export/LUTExportPass.swift
+++ b/Sources/PalmierPro/Export/LUTExportPass.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import CoreImage
+
+/// Grades the flattened export via `applyingCIFiltersWithHandler` (the compositor has no color hook).
+/// The filter chain already bakes in LUT intensity, so this is a straight apply.
+enum LUTExportPass {
+    static func apply(
+        processor: ColorGradeProcessor,
+        to inputURL: URL,
+        fileType: AVFileType,
+        preset: String
+    ) async throws -> URL {
+        let colorSpace = GradePipeline.workingColorSpace
+        let asset = AVURLAsset(url: inputURL)
+
+        let videoComposition = try await AVVideoComposition.videoComposition(
+            with: asset
+        ) { request in
+            let graded = processor.process(request.sourceImage.clampedToExtent(), colorSpace: colorSpace)
+            request.finish(with: graded.cropped(to: request.sourceImage.extent), context: nil)
+        }
+
+        guard let session = AVAssetExportSession(asset: asset, presetName: preset) else {
+            throw LUTPassError.unsupportedPreset
+        }
+        session.videoComposition = videoComposition
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("grade-pass-\(UUID().uuidString).\(inputURL.pathExtension)")
+        try? FileManager.default.removeItem(at: outputURL)
+
+        Log.export.notice("grade-pass start")
+        try await session.export(to: outputURL, as: fileType)
+        Log.export.notice("grade-pass ok url=\(outputURL.lastPathComponent)")
+        return outputURL
+    }
+
+    enum LUTPassError: LocalizedError {
+        case unsupportedPreset
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedPreset: "Export preset unsupported for the color pass"
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/Inspector/ColorGradeInspector.swift
+++ b/Sources/PalmierPro/Inspector/ColorGradeInspector.swift
@@ -1,0 +1,207 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ColorGradeInspector: View {
+    @Environment(EditorViewModel.self) var editor
+    @State private var lutLibrary = LUTLibrary.shared
+
+    private var grade: LUTRef? { editor.timeline.lut }
+
+    private let sliderWidth: CGFloat = 90
+    private let valueWidth: CGFloat = 32
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
+            InspectorRow(icon: "camera.filters", label: "Look") {
+                Picker("", selection: lookBinding) {
+                    Text("None").tag("none")
+                    ForEach(ColorGradeCatalog.all, id: \.id) { look in
+                        Text(look.name).tag(look.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+                .tint(AppTheme.Text.secondaryColor)
+            }
+
+            if grade != nil {
+                InspectorRow(icon: "slider.horizontal.3", label: "Intensity") {
+                    HStack(spacing: AppTheme.Spacing.sm) {
+                        Slider(value: intensityBinding, in: 0...1)
+                            .controlSize(.mini)
+                            .tint(AppTheme.Accent.primary)
+                            .frame(width: sliderWidth)
+                        Text("\(Int((grade?.clampedIntensity ?? 1) * 100))%")
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                            .monospacedDigit()
+                            .frame(width: valueWidth, alignment: .trailing)
+                    }
+                }
+            }
+
+            InspectorRow(icon: "square.stack.3d.forward.dottedline", label: "Custom LUT") {
+                HStack(spacing: AppTheme.Spacing.xs) {
+                    Button(action: loadLUT) {
+                        Text(cubeLabel)
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(AppTheme.Accent.primary)
+                    if grade?.kind == .cube {
+                        Button { editor.setColorGrade(nil) } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: AppTheme.FontSize.xs))
+                                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Remove LUT")
+                    }
+                }
+            }
+
+            InspectorRow(icon: "swatchpalette", label: "LUT Library") {
+                if lutLibrary.isConfigured {
+                    Menu(lutLibrary.folderName) {
+                        ForEach(lutLibrary.groups, id: \.category) { group in
+                            Menu(group.category) {
+                                ForEach(group.luts) { lut in
+                                    Button(lut.name) { applyCube(at: lut.url) }
+                                }
+                            }
+                        }
+                        Divider()
+                        Button("Change Folder…") { chooseLUTFolder() }
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                } else {
+                    Button("Choose Folder…") { chooseLUTFolder() }
+                        .buttonStyle(.plain)
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+            }
+
+            if grade != nil {
+                Button { editor.setColorGrade(nil) } label: {
+                    Text("Clear grade")
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider().opacity(AppTheme.Opacity.faint)
+
+            sliderRow("Temperature", "thermometer.medium", \.temperature)
+            sliderRow("Tint", "drop", \.tint)
+            sliderRow("Exposure", "sun.max", \.exposure)
+            sliderRow("Contrast", "circle.lefthalf.filled", \.contrast)
+            sliderRow("Saturation", "paintpalette", \.saturation)
+            sliderRow("Vibrance", "sparkles", \.vibrance)
+            sliderRow("Highlights", "sun.max.fill", \.highlights)
+            sliderRow("Shadows", "moon.fill", \.shadows)
+
+            Divider().opacity(AppTheme.Opacity.faint)
+            CurveEditorView()
+
+            if editor.timeline.primaries != nil {
+                Button { editor.setColorPrimaries(nil) } label: {
+                    Text("Reset adjustments")
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func sliderRow(_ label: String, _ icon: String, _ kp: WritableKeyPath<PrimaryGrade, Double>) -> some View {
+        InspectorRow(icon: icon, label: label) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Slider(value: primaryBinding(kp), in: -100...100)
+                    .controlSize(.mini)
+                    .tint(AppTheme.Accent.primary)
+                    .frame(width: sliderWidth)
+                Text("\(Int(editor.timeline.primaries?[keyPath: kp] ?? 0))")
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .monospacedDigit()
+                    .frame(width: valueWidth, alignment: .trailing)
+            }
+        }
+    }
+
+    private func primaryBinding(_ kp: WritableKeyPath<PrimaryGrade, Double>) -> Binding<Double> {
+        Binding(
+            get: { editor.timeline.primaries?[keyPath: kp] ?? 0 },
+            set: { value in
+                var p = editor.timeline.primaries ?? PrimaryGrade()
+                p[keyPath: kp] = value
+                editor.setColorPrimaries(p)
+            }
+        )
+    }
+
+    private var cubeLabel: String {
+        if grade?.kind == .cube, let name = grade?.cubeName { return name }
+        return "Load .cube…"
+    }
+
+    private var lookBinding: Binding<String> {
+        Binding(
+            get: { grade?.kind == .look ? (grade?.lookID ?? "none") : "none" },
+            set: { id in
+                if id == "none" {
+                    editor.setColorGrade(nil)
+                } else {
+                    editor.setColorGrade(.look(id, intensity: grade?.clampedIntensity ?? 1.0))
+                }
+            }
+        )
+    }
+
+    private var intensityBinding: Binding<Double> {
+        Binding(
+            get: { grade?.clampedIntensity ?? 1.0 },
+            set: { value in
+                guard var updated = editor.timeline.lut else { return }
+                updated.intensity = value
+                editor.setColorGrade(updated)
+            }
+        )
+    }
+
+    private func loadLUT() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "cube") ?? .data]
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Load LUT"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        applyCube(at: url)
+    }
+
+    private func applyCube(at url: URL) {
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let cube = try? CubeLUTParser.parse(text) else { return }
+        let name = url.deletingPathExtension().lastPathComponent
+        editor.setColorGrade(.cube(cube, name: name, intensity: grade?.clampedIntensity ?? 1.0))
+    }
+
+    private func chooseLUTFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use Folder"
+        panel.message = "Choose a folder of .cube LUTs (e.g. your DaVinci Resolve LUT folder)."
+        if let suggested = LUTLibrary.suggestedFolder { panel.directoryURL = suggested }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        lutLibrary.setFolder(url)
+    }
+}

--- a/Sources/PalmierPro/Inspector/CurveEditorView.swift
+++ b/Sources/PalmierPro/Inspector/CurveEditorView.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+private let curveHeight: CGFloat = 150
+private let pointDiameter: CGFloat = 9
+private let histogramRed = Color(red: 1, green: 0.22, blue: 0.22)
+private let histogramGreen = Color(red: 0.25, green: 0.9, blue: 0.35)
+private let histogramBlue = Color(red: 0.3, green: 0.5, blue: 1)
+
+struct CurveEditorView: View {
+    @Environment(EditorViewModel.self) var editor
+    @State private var channel: Channel = .master
+    @State private var lastTap: (index: Int, time: Date)?
+    @State private var histR: [Float] = []
+    @State private var histG: [Float] = []
+    @State private var histB: [Float] = []
+
+    enum Channel: String, CaseIterable, Identifiable {
+        case master = "M", red = "R", green = "G", blue = "B"
+        var id: String { rawValue }
+        var tint: Color {
+            switch self {
+            case .master: AppTheme.Text.secondaryColor
+            case .red: .red
+            case .green: .green
+            case .blue: .blue
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
+            Picker("", selection: $channel) {
+                ForEach(Channel.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            GeometryReader { geo in
+                let size = CGSize(width: geo.size.width, height: curveHeight)
+                ZStack {
+                    Canvas { ctx, _ in
+                        // Additive blend so overlapping channels read as combined color.
+                        if histR.count > 1 {
+                            ctx.blendMode = .plusLighter
+                            ctx.fill(histogramPath(histR, size), with: .color(histogramRed.opacity(AppTheme.Opacity.strong)))
+                            ctx.fill(histogramPath(histG, size), with: .color(histogramGreen.opacity(AppTheme.Opacity.strong)))
+                            ctx.fill(histogramPath(histB, size), with: .color(histogramBlue.opacity(AppTheme.Opacity.strong)))
+                            ctx.blendMode = .normal
+                        }
+                        let border = Path(CGRect(origin: .zero, size: size))
+                        ctx.stroke(border, with: .color(AppTheme.Border.subtleColor), lineWidth: AppTheme.BorderWidth.hairline)
+                        var diag = Path()
+                        diag.move(to: point(CurvePoint(x: 0, y: 0), size))
+                        diag.addLine(to: point(CurvePoint(x: 1, y: 1), size))
+                        ctx.stroke(diag, with: .color(AppTheme.Border.subtleColor), style: .init(lineWidth: AppTheme.BorderWidth.hairline, dash: [3, 3]))
+                        var curve = Path()
+                        let pts = sortedPoints
+                        for i in stride(from: 0.0, through: 1.0, by: 0.02) {
+                            let p = point(CurvePoint(x: i, y: GradeCurve.eval(pts, i)), size)
+                            if i == 0 { curve.move(to: p) } else { curve.addLine(to: p) }
+                        }
+                        ctx.stroke(curve, with: .color(channel.tint), lineWidth: AppTheme.BorderWidth.medium)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture { location in addPoint(at: location, size: size) }
+
+                    ForEach(Array(sortedPoints.enumerated()), id: \.offset) { index, pt in
+                        Circle()
+                            .fill(channel.tint)
+                            .frame(width: pointDiameter, height: pointDiameter)
+                            .position(point(pt, size))
+                            .gesture(
+                                DragGesture(minimumDistance: 0)
+                                    .onChanged { value in
+                                        if abs(value.translation.width) > 2 || abs(value.translation.height) > 2 {
+                                            drag(index: index, to: value.location, size: size)
+                                        }
+                                    }
+                                    .onEnded { value in
+                                        let moved = abs(value.translation.width) > 2 || abs(value.translation.height) > 2
+                                        if !moved { handleTap(index: index) }
+                                    }
+                            )
+                    }
+                }
+            }
+            .frame(height: curveHeight)
+
+            Text("Click to add a point · drag to shape · double-click to remove")
+                .font(.system(size: AppTheme.FontSize.xxs))
+                .foregroundStyle(AppTheme.Text.mutedColor)
+        }
+        .onAppear { refreshHistogram() }
+        .onChange(of: editor.currentFrame) { _, _ in refreshHistogram() }
+        .onChange(of: editor.isPlaying) { _, playing in if !playing { refreshHistogram() } }
+    }
+
+    private func histogramPath(_ bins: [Float], _ size: CGSize) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: 0, y: size.height))
+        for (i, v) in bins.enumerated() {
+            let x = CGFloat(i) / CGFloat(bins.count - 1) * size.width
+            path.addLine(to: CGPoint(x: x, y: size.height - CGFloat(v) * size.height))
+        }
+        path.addLine(to: CGPoint(x: size.width, y: size.height))
+        path.closeSubpath()
+        return path
+    }
+
+    private func refreshHistogram() {
+        guard let engine = editor.videoEngine, !editor.isPlaying else { return }
+        Task { @MainActor in
+            if let h = await engine.histogramRGB() {
+                histR = h.r; histG = h.g; histB = h.b
+            }
+        }
+    }
+
+    private func handleTap(index: Int) {
+        let now = Date()
+        if let last = lastTap, last.index == index, now.timeIntervalSince(last.time) < 0.4 {
+            removePoint(at: index)
+            lastTap = nil
+        } else {
+            lastTap = (index, now)
+        }
+    }
+
+    // MARK: - Points
+
+    private var sortedPoints: [CurvePoint] {
+        let raw = channelPoints
+        return (raw.isEmpty ? GradeCurve.identityPoints : raw).sorted { $0.x < $1.x }
+    }
+
+    private var channelPoints: [CurvePoint] {
+        let c = editor.timeline.primaries?.curve ?? GradeCurve()
+        switch channel {
+        case .master: return c.master
+        case .red: return c.red
+        case .green: return c.green
+        case .blue: return c.blue
+        }
+    }
+
+    private func point(_ p: CurvePoint, _ size: CGSize) -> CGPoint {
+        CGPoint(x: p.x * size.width, y: (1 - p.y) * size.height)
+    }
+
+    private func value(at location: CGPoint, _ size: CGSize) -> CurvePoint {
+        CurvePoint(
+            x: min(1, max(0, location.x / size.width)),
+            y: min(1, max(0, 1 - location.y / size.height))
+        )
+    }
+
+    private func drag(index: Int, to location: CGPoint, size: CGSize) {
+        var pts = sortedPoints
+        let v = value(at: location, size)
+        let isEndpoint = index == 0 || index == pts.count - 1
+        pts[index].y = v.y
+        if !isEndpoint {
+            let lo = pts[index - 1].x + 0.001
+            let hi = pts[index + 1].x - 0.001
+            pts[index].x = min(hi, max(lo, v.x))
+        }
+        commit(pts)
+    }
+
+    private func addPoint(at location: CGPoint, size: CGSize) {
+        var pts = sortedPoints
+        pts.append(value(at: location, size))
+        commit(pts.sorted { $0.x < $1.x })
+    }
+
+    private func removePoint(at index: Int) {
+        var pts = sortedPoints
+        guard pts.count > 2, index > 0, index < pts.count - 1 else { return }
+        pts.remove(at: index)
+        commit(pts)
+    }
+
+    private func commit(_ pts: [CurvePoint]) {
+        var p = editor.timeline.primaries ?? PrimaryGrade()
+        var c = p.curve ?? GradeCurve()
+        let value = (pts == GradeCurve.identityPoints) ? [] : pts
+        switch channel {
+        case .master: c.master = value
+        case .red: c.red = value
+        case .green: c.green = value
+        case .blue: c.blue = value
+        }
+        p.curve = c.isIdentity ? nil : c
+        editor.setColorPrimaries(p)
+    }
+}

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -115,6 +115,10 @@ struct InspectorView: View {
                     plainMetadataRow(label: "Aspect Ratio", value: formatAspectRatio(width: editor.timeline.width, height: editor.timeline.height))
                     plainMetadataRow(label: "Duration", value: formatDuration(Double(editor.timeline.totalFrames) / Double(editor.timeline.fps)))
                 }
+
+                metadataSection(title: "Color Grade") {
+                    ColorGradeInspector()
+                }
             }
             .padding(.horizontal, AppTheme.Spacing.lg)
             .padding(.vertical, AppTheme.Spacing.md)

--- a/Sources/PalmierPro/Inspector/LUTLibrary.swift
+++ b/Sources/PalmierPro/Inspector/LUTLibrary.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Observation
+
+struct LUTEntry: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let category: String
+    let url: URL
+}
+
+/// A user-chosen folder of `.cube` LUTs, scanned in place and remembered across launches.
+@MainActor
+@Observable
+final class LUTLibrary {
+    static let shared = LUTLibrary()
+    private let defaultsKey = "lutLibraryFolderPath"
+
+    private(set) var folderURL: URL?
+    private(set) var groups: [(category: String, luts: [LUTEntry])] = []
+
+    var isConfigured: Bool { folderURL != nil && !groups.isEmpty }
+    var folderName: String { folderURL?.lastPathComponent ?? "Browse…" }
+
+    init() {
+        if let path = UserDefaults.standard.string(forKey: defaultsKey) {
+            folderURL = URL(fileURLWithPath: path)
+            rescan()
+        }
+    }
+
+    func setFolder(_ url: URL) {
+        folderURL = url
+        UserDefaults.standard.set(url.path, forKey: defaultsKey)
+        rescan()
+    }
+
+    func clear() {
+        folderURL = nil
+        UserDefaults.standard.removeObject(forKey: defaultsKey)
+        groups = []
+    }
+
+    /// Picker default — offered only if it exists on disk.
+    static var suggestedFolder: URL? {
+        let candidates = [
+            URL(fileURLWithPath: "/Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT"),
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support/Blackmagic Design/DaVinci Resolve/LUT"),
+        ]
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private func rescan() {
+        guard let root = folderURL else { groups = []; return }
+        var byCategory: [String: [LUTEntry]] = [:]
+        let fm = FileManager.default
+        if let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: nil) {
+            for case let url as URL in enumerator where url.pathExtension.lowercased() == "cube" {
+                let rel = url.path.replacingOccurrences(of: root.path + "/", with: "")
+                let category = rel.contains("/") ? String(rel.prefix(while: { $0 != "/" })) : root.lastPathComponent
+                byCategory[category, default: []].append(
+                    LUTEntry(id: url.path, name: url.deletingPathExtension().lastPathComponent,
+                             category: category, url: url)
+                )
+            }
+        }
+        groups = byCategory
+            .map { ($0.key, $0.value.sorted { $0.name < $1.name }) }
+            .sorted { $0.0 < $1.0 }
+    }
+}

--- a/Sources/PalmierPro/Models/ColorGrade.swift
+++ b/Sources/PalmierPro/Models/ColorGrade.swift
@@ -1,0 +1,149 @@
+import CoreImage
+import Foundation
+
+struct CurvePoint: Codable, Sendable, Equatable {
+    var x: Double
+    var y: Double
+}
+
+/// Master + per-channel tone curves, compiled to a CubeLUT (identity when diagonal).
+struct GradeCurve: Codable, Sendable, Equatable {
+    var master: [CurvePoint] = []
+    var red: [CurvePoint] = []
+    var green: [CurvePoint] = []
+    var blue: [CurvePoint] = []
+
+    static let identityPoints = [CurvePoint(x: 0, y: 0), CurvePoint(x: 1, y: 1)]
+
+    var isIdentity: Bool {
+        [master, red, green, blue].allSatisfy { $0.isEmpty || $0 == Self.identityPoints }
+    }
+
+    static func eval(_ pts: [CurvePoint], _ x: Double) -> Double {
+        let p = (pts.isEmpty ? identityPoints : pts).sorted { $0.x < $1.x }
+        if x <= p[0].x { return p[0].y }
+        if x >= p[p.count - 1].x { return p[p.count - 1].y }
+        for i in 1..<p.count where x <= p[i].x {
+            let a = p[i - 1], b = p[i]
+            let t = (b.x - a.x) == 0 ? 0 : (x - a.x) / (b.x - a.x)
+            return a.y + (b.y - a.y) * t
+        }
+        return x
+    }
+
+    func cube(dimension n: Int = 17) -> CubeLUT {
+        func clamp(_ v: Double) -> Float { Float(min(1, max(0, v))) }
+        var table = [Float]()
+        table.reserveCapacity(n * n * n * 4)
+        for b in 0..<n {
+            for g in 0..<n {
+                for r in 0..<n {
+                    let rf = Double(r) / Double(n - 1)
+                    let gf = Double(g) / Double(n - 1)
+                    let bf = Double(b) / Double(n - 1)
+                    table.append(clamp(Self.eval(red, Self.eval(master, rf))))
+                    table.append(clamp(Self.eval(green, Self.eval(master, gf))))
+                    table.append(clamp(Self.eval(blue, Self.eval(master, bf))))
+                    table.append(1)
+                }
+            }
+        }
+        return CubeLUT(dimension: n, rgbaTable: table, domainMin: SIMD3(0, 0, 0), domainMax: SIMD3(1, 1, 1))
+    }
+}
+
+/// Project-wide primary color correction. All controls are −100…100 with 0 = identity.
+struct PrimaryGrade: Codable, Sendable, Equatable {
+    var temperature = 0.0
+    var tint = 0.0
+    var exposure = 0.0
+    var contrast = 0.0
+    var saturation = 0.0
+    var vibrance = 0.0
+    var highlights = 0.0
+    var shadows = 0.0
+    var curve: GradeCurve?
+
+    var isIdentity: Bool {
+        temperature == 0 && tint == 0 && exposure == 0 && contrast == 0
+            && saturation == 0 && vibrance == 0 && highlights == 0 && shadows == 0
+            && (curve?.isIdentity ?? true)
+    }
+
+    /// Filters in correction order: WB → exposure → contrast/sat → vibrance → highlights/shadows → curves.
+    func ciFilters() -> [CIFilter] {
+        var out: [CIFilter] = []
+
+        if temperature != 0 || tint != 0, let f = CIFilter(name: "CITemperatureAndTint") {
+            f.setValue(CIVector(x: 6500, y: 0), forKey: "inputNeutral")
+            f.setValue(CIVector(x: 6500 - temperature * 15, y: tint * 15), forKey: "inputTargetNeutral")
+            out.append(f)
+        }
+        if exposure != 0, let f = CIFilter(name: "CIExposureAdjust") {
+            f.setValue(exposure / 50.0, forKey: "inputEV")   // ±100 → ±2 EV
+            out.append(f)
+        }
+        if contrast != 0 || saturation != 0, let f = CIFilter(name: "CIColorControls") {
+            f.setValue(1 + contrast / 100.0, forKey: "inputContrast")
+            f.setValue(1 + saturation / 100.0, forKey: "inputSaturation")
+            out.append(f)
+        }
+        if vibrance != 0, let f = CIFilter(name: "CIVibrance") {
+            f.setValue(vibrance / 100.0, forKey: "inputAmount")
+            out.append(f)
+        }
+        if (highlights != 0 || shadows != 0), let f = CIFilter(name: "CIToneCurve") {
+            let s = shadows / 500.0       // ±100 → ±0.2
+            let h = highlights / 500.0
+            f.setValue(CIVector(x: 0, y: 0), forKey: "inputPoint0")
+            f.setValue(CIVector(x: 0.25, y: max(0, 0.25 + s)), forKey: "inputPoint1")
+            f.setValue(CIVector(x: 0.5, y: 0.5), forKey: "inputPoint2")
+            f.setValue(CIVector(x: 0.75, y: min(1, 0.75 + h)), forKey: "inputPoint3")
+            f.setValue(CIVector(x: 1, y: 1), forKey: "inputPoint4")
+            out.append(f)
+        }
+        if let curve, !curve.isIdentity,
+           let f = curve.cube().makeFilter(colorSpace: GradePipeline.workingColorSpace) {
+            out.append(f)
+        }
+        return out
+    }
+}
+
+/// Applies a prebuilt CIFilter chain — the shared processor for preview and export.
+/// `@unchecked Sendable`: the chain is used single-threaded (one export pass / main-thread preview).
+struct FilterChainProcessor: ColorGradeProcessor, @unchecked Sendable {
+    let filters: [CIFilter]
+    func process(_ image: CIImage, colorSpace: CGColorSpace) -> CIImage {
+        var result = image
+        for f in filters {
+            f.setValue(result, forKey: kCIInputImageKey)
+            if let out = f.outputImage { result = out }
+        }
+        return result
+    }
+}
+
+/// Full grade filter chain (primaries → LUT/look) shared by live preview and export.
+enum GradePipeline {
+    static let workingColorSpace = CGColorSpace(name: CGColorSpace.itur_709) ?? CGColorSpaceCreateDeviceRGB()
+
+    static func filters(primaries: PrimaryGrade?, lut: LUTRef?) -> [CIFilter] {
+        var out: [CIFilter] = []
+        if let primaries, !primaries.isIdentity { out += primaries.ciFilters() }
+        if let lut, lut.clampedIntensity > 0 { out += lutFilters(lut) }
+        return out
+    }
+
+    static func lutFilters(_ lut: LUTRef) -> [CIFilter] {
+        let t = lut.clampedIntensity
+        switch lut.kind {
+        case .look:
+            return lut.lookID.flatMap(ColorGradeCatalog.look(id:))?.ciFilters(intensity: t) ?? []
+        case .cube:
+            guard let dim = lut.cubeDimension, let b64 = lut.cubeBase64,
+                  let cube = CubeLUT(base64: b64, dimension: dim) else { return [] }
+            return cube.intensityBlended(t).makeFilter(colorSpace: workingColorSpace).map { [$0] } ?? []
+        }
+    }
+}

--- a/Sources/PalmierPro/Models/LUT.swift
+++ b/Sources/PalmierPro/Models/LUT.swift
@@ -1,0 +1,53 @@
+import CoreImage
+import Foundation
+
+protocol ColorGradeProcessor: Sendable {
+    func process(_ image: CIImage, colorSpace: CGColorSpace) -> CIImage
+}
+
+/// Project color grade: a built-in look or an inline-embedded `.cube` (RGBA float32
+/// base64). Embedded so the grade is portable with the project; `get_timeline` drops
+/// `cubeBase64` so the blob never reaches agent context.
+struct LUTRef: Codable, Sendable, Equatable {
+    enum Kind: String, Codable, Sendable { case look, cube }
+
+    var kind: Kind
+    var lookID: String?
+    var cubeName: String?
+    var cubeDimension: Int?
+    var cubeBase64: String?
+    var intensity: Double = 1.0
+
+    var clampedIntensity: Double { min(1.0, max(0.0, intensity)) }
+
+    static func look(_ id: String, intensity: Double = 1.0) -> LUTRef {
+        LUTRef(kind: .look, lookID: id, intensity: intensity)
+    }
+
+    static func cube(_ lut: CubeLUT, name: String, intensity: Double = 1.0) -> LUTRef {
+        LUTRef(kind: .cube, cubeName: name, cubeDimension: lut.dimension,
+               cubeBase64: lut.base64, intensity: intensity)
+    }
+
+    func makeProcessor() -> ColorGradeProcessor? {
+        switch kind {
+        case .look:
+            return lookID.flatMap { ColorGradeCatalog.look(id: $0) }
+        case .cube:
+            guard let dim = cubeDimension, let b64 = cubeBase64 else { return nil }
+            return CubeLUT(base64: b64, dimension: dim)
+        }
+    }
+
+    /// Compact form for `get_timeline` — never includes the cube blob.
+    var summary: [String: Any] {
+        var out: [String: Any] = ["kind": kind.rawValue, "intensity": clampedIntensity]
+        switch kind {
+        case .look: if let lookID { out["look"] = lookID }
+        case .cube:
+            if let cubeName { out["cube"] = cubeName }
+            if let cubeDimension { out["dimension"] = cubeDimension }
+        }
+        return out
+    }
+}

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -12,6 +12,11 @@ struct Timeline: Codable, Sendable, Equatable {
     var height: Int = 1080
     var settingsConfigured: Bool = false
     var tracks: [Track] = []
+    /// Optional project-wide color LUT (Phase 1: applied as a final pass at export).
+    /// Optional so existing projects decode unchanged.
+    var lut: LUTRef?
+    /// Optional project-wide primary color correction.
+    var primaries: PrimaryGrade?
 
     var totalFrames: Int {
         var maxFrame = 0

--- a/Sources/PalmierPro/Preview/PreviewView.swift
+++ b/Sources/PalmierPro/Preview/PreviewView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import CoreImage
 
 struct PreviewView: NSViewRepresentable {
     @Environment(EditorViewModel.self) var editor
@@ -35,11 +36,13 @@ struct PreviewView: NSViewRepresentable {
         context.coordinator.engine = engine
         editor.videoEngine = engine
         engine.activateTab(editor.activePreviewTab)
+        view.applyGrade(primaries: editor.timeline.primaries, lut: editor.timeline.lut)
         return view
     }
 
     func updateNSView(_ nsView: PreviewNSView, context: Context) {
         guard let engine = context.coordinator.engine else { return }
+        nsView.applyGrade(primaries: editor.timeline.primaries, lut: editor.timeline.lut)
         if editor.isPlaying && engine.player.timeControlStatus == .paused {
             engine.play()
         } else if !editor.isPlaying && engine.player.timeControlStatus != .paused {
@@ -71,6 +74,20 @@ final class PreviewNSView: NSView {
     var onCmdScroll: ((CGFloat, CGPoint, CGSize) -> Void)?
 
     private var lastVideoRect: CGRect = .zero
+    private var appliedPrimaries: PrimaryGrade?
+    private var appliedLUT: LUTRef?
+
+    /// Live color grade via macOS `CALayer.filters` on the video layer (text stays ungraded).
+    func applyGrade(primaries: PrimaryGrade?, lut: LUTRef?) {
+        guard primaries != appliedPrimaries || lut != appliedLUT else { return }
+        appliedPrimaries = primaries
+        appliedLUT = lut
+        let filters = GradePipeline.filters(primaries: primaries, lut: lut)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        playerLayer.filters = filters.isEmpty ? nil : filters
+        CATransaction.commit()
+    }
 
     override init(frame: NSRect) {
         super.init(frame: frame)

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import AppKit
+import CoreImage
 
 enum PreviewSeekMode: String {
     case exact
@@ -27,6 +28,8 @@ final class VideoEngine {
     private var pendingInteractiveSeek: (time: CMTime, tolerance: CMTime)?
     private var interactiveThrottleTask: Task<Void, Never>?
     private var lastInteractiveDispatchTime: TimeInterval = 0
+
+    private let ciContext = CIContext(options: [.workingColorSpace: NSNull()])
 
     init(editor: EditorViewModel) {
         self.editor = editor
@@ -132,6 +135,43 @@ final class VideoEngine {
         Log.preview.debug("seek state invalidated reason=\(reason)")
     }
 
+    /// Normalized R/G/B histograms of the composited frame at the playhead (source,
+    /// pre-grade), scaled by a shared max. Nil if no frame can be generated.
+    func histogramRGB(count: Int = 256) async -> (r: [Float], g: [Float], b: [Float])? {
+        guard let item = player.currentItem else { return nil }
+        let generator = AVAssetImageGenerator(asset: item.asset)
+        generator.videoComposition = item.videoComposition
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+        generator.maximumSize = CGSize(width: 320, height: 180)
+        guard let cg = try? await generator.image(at: player.currentTime()).image else { return nil }
+
+        let image = CIImage(cgImage: cg)
+        let extent = image.extent
+        guard extent.width > 0, extent.height > 0 else { return nil }
+
+        let hist = image.applyingFilter("CIAreaHistogram", parameters: [
+            kCIInputExtentKey: CIVector(cgRect: extent),
+            "inputScale": 1.0,
+            "inputCount": count,
+        ])
+        var raw = [Float](repeating: 0, count: count * 4)
+        ciContext.render(hist, toBitmap: &raw, rowBytes: count * 4 * MemoryLayout<Float>.size,
+                         bounds: CGRect(x: 0, y: 0, width: count, height: 1), format: .RGBAf, colorSpace: nil)
+
+        var r = [Float](repeating: 0, count: count)
+        var g = r, b = r
+        var maxV: Float = 0
+        for i in 0..<count {
+            r[i] = raw[i * 4]; g[i] = raw[i * 4 + 1]; b[i] = raw[i * 4 + 2]
+            maxV = max(maxV, max(r[i], max(g[i], b[i])))
+        }
+        if maxV > 0 {
+            for i in 0..<count { r[i] /= maxV; g[i] /= maxV; b[i] /= maxV }
+        }
+        return (r, g, b)
+    }
+
     // MARK: - Composition
 
     func rebuild() {
@@ -182,6 +222,12 @@ final class VideoEngine {
             seek(to: editor.currentFrame, mode: .exact)
             if editor.isPlaying { player.play() }
         }
+    }
+
+    /// Update the live color grade only — no composition rebuild, no item swap, no flash.
+    func refreshGrade() {
+        guard let editor, let previewView else { return }
+        previewView.applyGrade(primaries: editor.timeline.primaries, lut: editor.timeline.lut)
     }
 
     func refreshVisuals() {

--- a/Sources/PalmierPro/Utilities/ColorGradeCatalog.swift
+++ b/Sources/PalmierPro/Utilities/ColorGradeCatalog.swift
@@ -1,0 +1,153 @@
+import CoreImage
+import Foundation
+
+/// Built-in color looks the agent applies by name. Each is a small Core Image
+/// primary chain, so it composes with the same export pass as imported `.cube` LUTs.
+enum ColorGradeCatalog {
+
+    struct Look: Sendable, Equatable {
+        let id: String
+        let name: String
+        let summary: String
+        let steps: [Step]
+
+        struct Step: Sendable, Equatable {
+            let filter: String
+            let params: [String: Double]
+            let curve: [CGPoint]?
+            init(_ filter: String, _ params: [String: Double] = [:], curve: [CGPoint]? = nil) {
+                self.filter = filter
+                self.params = params
+                self.curve = curve
+            }
+        }
+    }
+
+    /// Maps input `floor` to black and steepens mids — dehazes hazy footage.
+    private static func dehazeCurve(floor: Double, shoulder: Double = 0.97) -> [CGPoint] {
+        [
+            .init(x: floor, y: 0.0),
+            .init(x: floor + (0.5 - floor) * 0.5, y: 0.24),
+            .init(x: 0.5, y: 0.5),
+            .init(x: 0.5 + (shoulder - 0.5) * 0.5, y: 0.78),
+            .init(x: shoulder, y: 1.0),
+        ]
+    }
+
+    static let all: [Look] = [
+        Look(
+            id: "warm-cinematic",
+            name: "Warm Cinematic",
+            summary: "Warm highlights, real contrast, dehazed blacks. A filmic default for daylight/outdoor footage.",
+            steps: [
+                .init("CITemperatureAndTint", ["neutralX": 7200, "neutralY": 0, "targetX": 6500, "targetY": 0]),
+                .init("CIToneCurve", curve: dehazeCurve(floor: 0.08)),
+                .init("CIColorControls", ["saturation": 1.12, "contrast": 1.12]),
+                .init("CIVibrance", ["amount": 0.2]),
+            ]
+        ),
+        Look(
+            id: "teal-orange",
+            name: "Teal & Orange",
+            summary: "Warm mids against cooler shadows — the classic travel/adventure blockbuster look.",
+            steps: [
+                .init("CITemperatureAndTint", ["neutralX": 6500, "neutralY": 0, "targetX": 6050, "targetY": 16]),
+                .init("CIToneCurve", curve: dehazeCurve(floor: 0.1)),
+                .init("CIColorControls", ["saturation": 1.22, "contrast": 1.14]),
+                .init("CIVibrance", ["amount": 0.35]),
+            ]
+        ),
+        Look(
+            id: "moody-forest",
+            name: "Moody Forest",
+            summary: "Deeper greens, cooler shadows, dehazed and contrasty. Suits hikes, jungle, overcast nature.",
+            steps: [
+                .init("CITemperatureAndTint", ["neutralX": 6200, "neutralY": 0, "targetX": 7000, "targetY": -10]),
+                .init("CIToneCurve", curve: dehazeCurve(floor: 0.12)),
+                .init("CIColorControls", ["saturation": 1.0, "contrast": 1.18, "brightness": -0.02]),
+            ]
+        ),
+        Look(
+            id: "vibrant-travel",
+            name: "Vibrant Travel",
+            summary: "Punchy, bright, saturated, dehazed — pops skies and landscapes for social/vlog delivery.",
+            steps: [
+                .init("CIToneCurve", curve: dehazeCurve(floor: 0.1)),
+                .init("CIColorControls", ["saturation": 1.32, "contrast": 1.16, "brightness": 0.01]),
+                .init("CIVibrance", ["amount": 0.5]),
+            ]
+        ),
+        Look(
+            id: "vintage-film",
+            name: "Vintage Film",
+            summary: "Faded, lifted blacks and softened highlights with a warm cast — a nostalgic Super-8 feel.",
+            steps: [
+                .init("CITemperatureAndTint", ["neutralX": 6500, "neutralY": 0, "targetX": 6000, "targetY": 8]),
+                .init("CIColorControls", ["saturation": 0.88, "contrast": 0.96]),
+                .init("CIToneCurve", curve: [.init(x: 0, y: 0.1), .init(x: 0.25, y: 0.28),
+                                             .init(x: 0.5, y: 0.5), .init(x: 0.75, y: 0.72), .init(x: 1, y: 0.9)]),
+            ]
+        ),
+        Look(
+            id: "clean-neutral",
+            name: "Clean Neutral",
+            summary: "A light, true-to-life polish — modest dehaze, contrast and vibrance. Use when footage is already good.",
+            steps: [
+                .init("CIToneCurve", curve: dehazeCurve(floor: 0.05)),
+                .init("CIColorControls", ["saturation": 1.08, "contrast": 1.06]),
+                .init("CIVibrance", ["amount": 0.18]),
+            ]
+        ),
+    ]
+
+    static func look(id: String) -> Look? { all.first { $0.id == id } }
+
+    static var catalogJSON: [[String: Any]] {
+        all.map { ["id": $0.id, "name": $0.name, "summary": $0.summary] }
+    }
+}
+
+extension ColorGradeCatalog.Look: ColorGradeProcessor {
+    func process(_ image: CIImage, colorSpace: CGColorSpace) -> CIImage {
+        var result = image
+        for filter in ciFilters(intensity: 1.0) {
+            filter.setValue(result, forKey: kCIInputImageKey)
+            if let out = filter.outputImage { result = out }
+        }
+        return result
+    }
+
+    /// Configured filters (no input image) with each step interpolated toward
+    /// identity by `intensity` — used for the live `CALayer.filters` preview.
+    func ciFilters(intensity t: Double) -> [CIFilter] {
+        steps.compactMap { makeFilter($0, intensity: t) }
+    }
+
+    private func makeFilter(_ step: Step, intensity t: Double) -> CIFilter? {
+        guard let f = CIFilter(name: step.filter) else { return nil }
+        switch step.filter {
+        case "CITemperatureAndTint":
+            let nx = step.params["neutralX"] ?? 6500, ny = step.params["neutralY"] ?? 0
+            let tx = step.params["targetX"] ?? nx, ty = step.params["targetY"] ?? ny
+            f.setValue(CIVector(x: nx, y: ny), forKey: "inputNeutral")
+            f.setValue(CIVector(x: nx + (tx - nx) * t, y: ny + (ty - ny) * t), forKey: "inputTargetNeutral")
+        case "CIColorControls":
+            if let s = step.params["saturation"] { f.setValue(1 + (s - 1) * t, forKey: "inputSaturation") }
+            if let c = step.params["contrast"] { f.setValue(1 + (c - 1) * t, forKey: "inputContrast") }
+            if let b = step.params["brightness"] { f.setValue(b * t, forKey: "inputBrightness") }
+        case "CIVibrance":
+            if let a = step.params["amount"] { f.setValue(a * t, forKey: "inputAmount") }
+        default:
+            for (key, value) in step.params {
+                f.setValue(value, forKey: "input" + key.prefix(1).uppercased() + key.dropFirst())
+            }
+        }
+        if let curve = step.curve, curve.count == 5 {
+            for (i, pt) in curve.enumerated() {
+                let y = pt.x + (pt.y - pt.x) * CGFloat(t)   // lerp toward identity (y = x)
+                f.setValue(CIVector(x: pt.x, y: y), forKey: "inputPoint\(i)")
+            }
+        }
+        return f
+    }
+}

--- a/Sources/PalmierPro/Utilities/CubeLUTParser.swift
+++ b/Sources/PalmierPro/Utilities/CubeLUTParser.swift
@@ -1,0 +1,148 @@
+import CoreImage
+import Foundation
+
+/// Parsed 3D `.cube` LUT. `rgbaTable` is `dimension³` RGBA entries in file order
+/// (red fastest, alpha 1) — the exact layout `CIColorCubeWithColorSpace` wants.
+struct CubeLUT: Equatable, Sendable {
+    let dimension: Int
+    let rgbaTable: [Float]
+    // Non-default domains are parsed but not yet remapped.
+    let domainMin: SIMD3<Float>
+    let domainMax: SIMD3<Float>
+
+    var cubeData: Data {
+        rgbaTable.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    var base64: String { cubeData.base64EncodedString() }
+
+    init?(base64: String, dimension: Int) {
+        guard dimension >= 2, let data = Data(base64Encoded: base64) else { return nil }
+        let expected = dimension * dimension * dimension * 4
+        guard data.count == expected * MemoryLayout<Float>.size else { return nil }
+        let floats = data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+        self.init(dimension: dimension, rgbaTable: floats,
+                  domainMin: SIMD3(0, 0, 0), domainMax: SIMD3(1, 1, 1))
+    }
+
+    init(dimension: Int, rgbaTable: [Float], domainMin: SIMD3<Float>, domainMax: SIMD3<Float>) {
+        self.dimension = dimension
+        self.rgbaTable = rgbaTable
+        self.domainMin = domainMin
+        self.domainMax = domainMax
+    }
+
+    var hasNonDefaultDomain: Bool {
+        domainMin != SIMD3(0, 0, 0) || domainMax != SIMD3(1, 1, 1)
+    }
+
+    /// Lerp the table toward the identity cube by `t` (1 = full LUT, 0 = no-op).
+    func intensityBlended(_ t: Double) -> CubeLUT {
+        guard t < 1 else { return self }
+        let n = dimension, f = Float(t)
+        var out = rgbaTable
+        var idx = 0
+        for b in 0..<n {
+            for g in 0..<n {
+                for r in 0..<n {
+                    let ir = Float(r) / Float(n - 1)
+                    let ig = Float(g) / Float(n - 1)
+                    let ib = Float(b) / Float(n - 1)
+                    out[idx]     = ir + (rgbaTable[idx]     - ir) * f
+                    out[idx + 1] = ig + (rgbaTable[idx + 1] - ig) * f
+                    out[idx + 2] = ib + (rgbaTable[idx + 2] - ib) * f
+                    out[idx + 3] = 1
+                    idx += 4
+                }
+            }
+        }
+        return CubeLUT(dimension: n, rgbaTable: out, domainMin: SIMD3(0, 0, 0), domainMax: SIMD3(1, 1, 1))
+    }
+}
+
+enum CubeLUTParser {
+    enum ParseError: LocalizedError, Equatable {
+        case missingSize
+        case unsupported1D
+        case badDimension(Int)
+        case wrongRowCount(expected: Int, got: Int)
+        case malformedRow(line: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingSize: "No LUT_3D_SIZE found in .cube file"
+            case .unsupported1D: "1D LUTs are not supported yet (only LUT_3D_SIZE)"
+            case .badDimension(let n): "Unsupported LUT_3D_SIZE \(n) (expected 2…64)"
+            case .wrongRowCount(let e, let g): "Expected \(e) data rows, found \(g)"
+            case .malformedRow(let l): "Malformed data row at line \(l)"
+            }
+        }
+    }
+
+    static func parse(_ text: String) throws -> CubeLUT {
+        var dimension: Int?
+        var domainMin = SIMD3<Float>(0, 0, 0)
+        var domainMax = SIMD3<Float>(1, 1, 1)
+        var table: [Float] = []
+
+        for (idx, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+
+            let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+            guard let keyword = parts.first else { continue }
+
+            switch keyword.uppercased() {
+            case "TITLE":
+                continue
+            case "LUT_1D_SIZE":
+                throw ParseError.unsupported1D
+            case "LUT_3D_SIZE":
+                guard parts.count >= 2, let n = Int(parts[1]) else { throw ParseError.missingSize }
+                guard (2...64).contains(n) else { throw ParseError.badDimension(n) }
+                dimension = n
+                table.reserveCapacity(n * n * n * 4)
+            case "DOMAIN_MIN":
+                if let v = simd3(parts) { domainMin = v }
+            case "DOMAIN_MAX":
+                if let v = simd3(parts) { domainMax = v }
+            default:
+                // Data row: three floats r g b.
+                guard parts.count >= 3,
+                      let r = Float(parts[0]), let g = Float(parts[1]), let b = Float(parts[2]) else {
+                    throw ParseError.malformedRow(line: idx + 1)
+                }
+                table.append(contentsOf: [r, g, b, 1])
+            }
+        }
+
+        guard let dim = dimension else { throw ParseError.missingSize }
+        let expected = dim * dim * dim
+        let got = table.count / 4
+        guard got == expected else { throw ParseError.wrongRowCount(expected: expected, got: got) }
+
+        return CubeLUT(dimension: dim, rgbaTable: table, domainMin: domainMin, domainMax: domainMax)
+    }
+
+    private static func simd3(_ parts: [String]) -> SIMD3<Float>? {
+        guard parts.count >= 4,
+              let x = Float(parts[1]), let y = Float(parts[2]), let z = Float(parts[3]) else { return nil }
+        return SIMD3(x, y, z)
+    }
+}
+
+extension CubeLUT: ColorGradeProcessor {
+    func makeFilter(colorSpace: CGColorSpace) -> CIFilter? {
+        CIFilter(name: "CIColorCubeWithColorSpace", parameters: [
+            "inputCubeDimension": dimension,
+            "inputCubeData": cubeData,
+            "inputColorSpace": colorSpace,
+        ])
+    }
+
+    func process(_ image: CIImage, colorSpace: CGColorSpace) -> CIImage {
+        guard let filter = makeFilter(colorSpace: colorSpace) else { return image }
+        filter.setValue(image, forKey: kCIInputImageKey)
+        return filter.outputImage ?? image
+    }
+}

--- a/Tests/PalmierProTests/Rendering/ColorGradeRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/ColorGradeRenderTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import CoreImage
+import Foundation
+@testable import PalmierPro
+
+@Suite("Color grade rendering")
+struct ColorGradeRenderTests {
+
+    @Test func gradesFixtureAndShiftsColor() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let inPath = env["GRADE_FIXTURE"], FileManager.default.fileExists(atPath: inPath) else {
+            return
+
+        }
+        let outDir = env["GRADE_OUTDIR"] ?? NSTemporaryDirectory()
+        let ctx = CIContext(options: nil)
+        let working = CGColorSpace(name: CGColorSpace.itur_709) ?? CGColorSpaceCreateDeviceRGB()
+        let srgb = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+
+        guard let src = CIImage(contentsOf: URL(fileURLWithPath: inPath)) else {
+            Issue.record("could not load fixture at \(inPath)"); return
+        }
+
+        func avg(_ image: CIImage) -> (r: Double, g: Double, b: Double) {
+            let f = CIFilter(name: "CIAreaAverage")!
+            f.setValue(image.clamped(to: src.extent), forKey: kCIInputImageKey)
+            f.setValue(CIVector(cgRect: src.extent), forKey: "inputExtent")
+            var px = [UInt8](repeating: 0, count: 4)
+            ctx.render(f.outputImage!, toBitmap: &px, rowBytes: 4,
+                       bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: srgb)
+            return (Double(px[0]) / 255, Double(px[1]) / 255, Double(px[2]) / 255)
+        }
+
+        let base = avg(src)
+        for look in ColorGradeCatalog.all {
+            let graded = look.process(src, colorSpace: working).cropped(to: src.extent)
+            if let png = ctx.pngRepresentation(of: graded, format: .RGBA8, colorSpace: srgb) {
+                try png.write(to: URL(fileURLWithPath: "\(outDir)/grade-\(look.id).png"))
+            }
+            let a = avg(graded)
+            let delta = abs(a.r - base.r) + abs(a.g - base.g) + abs(a.b - base.b)
+            #expect(delta > 0.003, "look \(look.id) barely changed the image")
+        }
+
+        // Warm look should read warmer (higher R−B) than the cool look on the same frame.
+        let warm = avg(ColorGradeCatalog.look(id: "warm-cinematic")!.process(src, colorSpace: working))
+        let cool = avg(ColorGradeCatalog.look(id: "moody-forest")!.process(src, colorSpace: working))
+        #expect((warm.r - warm.b) > (cool.r - cool.b),
+                "warm-cinematic should be warmer than moody-forest")
+
+        // Full embedded-.cube path: parse → base64 embed → reconstruct → grade.
+        if let cubePath = env["GRADE_CUBE"], FileManager.default.fileExists(atPath: cubePath) {
+            let text = try String(contentsOf: URL(fileURLWithPath: cubePath), encoding: .utf8)
+            let parsed = try CubeLUTParser.parse(text)
+            let ref = LUTRef.cube(parsed, name: "test")
+            let processor = try #require(ref.makeProcessor())
+            let graded = processor.process(src, colorSpace: working).cropped(to: src.extent)
+            if let png = ctx.pngRepresentation(of: graded, format: .RGBA8, colorSpace: srgb) {
+                try png.write(to: URL(fileURLWithPath: "\(outDir)/grade-cube.png"))
+            }
+            let a = avg(graded)
+            #expect((a.r - a.b) > (base.r - base.b), "warm test .cube should warm the image")
+        }
+
+        var primaries = PrimaryGrade()
+        primaries.temperature = 40
+        primaries.contrast = 30
+        primaries.saturation = 25
+        primaries.shadows = 35
+        let pFilters = GradePipeline.filters(primaries: primaries, lut: nil)
+        #expect(!pFilters.isEmpty)
+        let pGraded = FilterChainProcessor(filters: pFilters).process(src, colorSpace: working).cropped(to: src.extent)
+        if let png = ctx.pngRepresentation(of: pGraded, format: .RGBA8, colorSpace: srgb) {
+            try png.write(to: URL(fileURLWithPath: "\(outDir)/grade-primaries.png"))
+        }
+        let pa = avg(pGraded)
+        #expect((pa.r - pa.b) > (base.r - base.b), "warm primaries should warm the image")
+
+        var curveGrade = PrimaryGrade()
+        curveGrade.curve = GradeCurve(master: [.init(x: 0, y: 0), .init(x: 0.5, y: 0.62), .init(x: 1, y: 1)])
+        let cFilters = GradePipeline.filters(primaries: curveGrade, lut: nil)
+        #expect(!cFilters.isEmpty)
+        let cGraded = FilterChainProcessor(filters: cFilters).process(src, colorSpace: working).cropped(to: src.extent)
+        if let png = ctx.pngRepresentation(of: cGraded, format: .RGBA8, colorSpace: srgb) {
+            try png.write(to: URL(fileURLWithPath: "\(outDir)/grade-curve.png"))
+        }
+        let ca = avg(cGraded)
+        #expect((ca.r + ca.g + ca.b) > (base.r + base.g + base.b), "midtone lift should brighten")
+    }
+}
+
+private extension CIImage {
+    func clamped(to rect: CGRect) -> CIImage { cropped(to: rect) }
+}

--- a/Tests/PalmierProTests/Rendering/CubeLUTParserTests.swift
+++ b/Tests/PalmierProTests/Rendering/CubeLUTParserTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Cube LUT parsing")
+struct CubeLUTParserTests {
+
+    // 2×2×2 identity cube; red varies fastest.
+    static let identity2 = """
+    # sample identity LUT
+    TITLE "identity"
+    LUT_3D_SIZE 2
+    0 0 0
+    1 0 0
+    0 1 0
+    1 1 0
+    0 0 1
+    1 0 1
+    0 1 1
+    1 1 1
+    """
+
+    @Test func parsesDimensionAndCount() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        #expect(lut.dimension == 2)
+        #expect(lut.rgbaTable.count == 2 * 2 * 2 * 4)   // 8 entries × RGBA
+    }
+
+    @Test func forcesAlphaToOne() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        for i in stride(from: 3, to: lut.rgbaTable.count, by: 4) {
+            #expect(lut.rgbaTable[i] == 1)
+        }
+    }
+
+    @Test func preservesFileOrderRedFastest() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        // Second entry is (1,0,0) — red advanced first.
+        #expect(lut.rgbaTable[4] == 1)
+        #expect(lut.rgbaTable[5] == 0)
+        #expect(lut.rgbaTable[6] == 0)
+    }
+
+    @Test func defaultDomainIsZeroToOne() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        #expect(!lut.hasNonDefaultDomain)
+    }
+
+    @Test func ignoresCommentsAndBlankLines() throws {
+        let text = "\n# a\n\nLUT_3D_SIZE 2\n# b\n0 0 0\n1 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 1\n0 1 1\n1 1 1\n\n"
+        #expect(throws: Never.self) { try CubeLUTParser.parse(text) }
+    }
+
+    @Test func missingSizeThrows() {
+        #expect(throws: CubeLUTParser.ParseError.missingSize) {
+            try CubeLUTParser.parse("0 0 0\n1 1 1")
+        }
+    }
+
+    @Test func oneDimensionalIsRejected() {
+        #expect(throws: CubeLUTParser.ParseError.unsupported1D) {
+            try CubeLUTParser.parse("LUT_1D_SIZE 4\n0 0 0\n1 1 1")
+        }
+    }
+
+    @Test func wrongRowCountThrows() {
+        #expect(throws: CubeLUTParser.ParseError.wrongRowCount(expected: 8, got: 3)) {
+            try CubeLUTParser.parse("LUT_3D_SIZE 2\n0 0 0\n1 0 0\n0 1 0")
+        }
+    }
+
+    @Test func malformedRowThrows() {
+        #expect(throws: (any Error).self) {
+            try CubeLUTParser.parse("LUT_3D_SIZE 2\n0 0\n1 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 1\n0 1 1\n1 1 1")
+        }
+    }
+
+    @Test func base64RoundTripPreservesTable() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        let restored = CubeLUT(base64: lut.base64, dimension: lut.dimension)
+        #expect(restored != nil)
+        #expect(restored?.dimension == lut.dimension)
+        #expect(restored?.rgbaTable == lut.rgbaTable)
+    }
+
+    @Test func base64RejectsWrongDimension() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        // Claiming dimension 3 against dimension-2 data must fail, not crash.
+        #expect(CubeLUT(base64: lut.base64, dimension: 3) == nil)
+    }
+
+    @Test func lutRefCubeSummaryOmitsBlob() throws {
+        let lut = try CubeLUTParser.parse(Self.identity2)
+        let ref = LUTRef.cube(lut, name: "myfilm", intensity: 0.8)
+        let summary = ref.summary
+        #expect(summary["cube"] as? String == "myfilm")
+        #expect(summary["dimension"] as? Int == 2)
+        #expect(summary["kind"] as? String == "cube")
+        #expect(summary["cubeBase64"] == nil)   // blob never in summary
+        #expect(ref.makeProcessor() != nil)
+    }
+
+    @Test func parsesNonDefaultDomain() throws {
+        let text = "LUT_3D_SIZE 2\nDOMAIN_MIN 0 0 0\nDOMAIN_MAX 4 4 4\n"
+            + (0..<8).map { _ in "0.5 0.5 0.5" }.joined(separator: "\n")
+        let lut = try CubeLUTParser.parse(text)
+        #expect(lut.hasNonDefaultDomain)
+        #expect(lut.domainMax == .init(4, 4, 4))
+    }
+}


### PR DESCRIPTION
![Color grading demo — looks, primary grade, and a custom .cube LUT on one frame](https://raw.githubusercontent.com/Ripwords/palmier-pro/media-assets/docs/color-grade-demo.gif)

PS: My example image isn't the best

Closes #60. Built on a fork for my own use — **optional to merge**, happy to split further or close.

### What
A project‑wide color grade that renders live on the canvas (macOS `CALayer.filters`) and bakes into export via a final Core Image pass:

- 6 built‑in looks (with a dehaze/contrast stage) + intensity
- Primary correction: temperature, tint, exposure, contrast, saturation, vibrance, highlights, shadows
- Master + R/G/B tone curves (compiled to a CubeLUT) with an interactive editor and an RGB‑parade histogram
- `.cube` LUT import (parsed + embedded) and a user‑chosen LUT‑folder browser (read in place — nothing bundled/redistributed)
- Inspector "Color Grade" panel
- Agent MCP tools: `apply_color_grade`, `adjust_color`, `set_color_curve`, `list_color_grades`, `clear_color_grade`

One unified `GradePipeline` (primaries → curves → LUT) drives preview and export identically.

<img width="421" height="742" alt="image" src="https://github.com/user-attachments/assets/f2e41693-3a2b-4e76-b6cc-0cd111e9e788" />

### Scope
Project‑wide grade only. Per‑clip grading would need a custom `AVVideoCompositing` (out of scope). No changes to existing code outside the feature.

### Verification
`swift build` clean on Swift 6.2; follows `AGENTS.md` conventions. Tests: `.cube` parse + base64 round‑trip, and a primaries/curve/LUT render check on a real frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
