### PR TITLE
Fix font registration when launched via dev.sh

### DIFF
--- a/Sources/PalmierPro/Utilities/BundledFonts.swift
+++ b/Sources/PalmierPro/Utilities/BundledFonts.swift
@@ -83,17 +83,16 @@ enum BundledFonts {
         return result
     }
 
-    /// One path per environment — no cross-environment fallbacks.
+     /// Checks both possible layouts — `dev.sh`'s assembled `.app` flattens
+    /// Fonts/ into Contents/Resources/ even in debug builds, while a raw
+    /// `swift run` leaves it inside the SwiftPM-generated resource bundle.
     private static func findFontsRoot() -> URL? {
         guard let resourceURL = Bundle.main.resourceURL else { return nil }
-        #if DEBUG
-        // `swift run`: SwiftPM writes the resource bundle beside the binary.
-        let url = resourceURL.appendingPathComponent("PalmierPro_PalmierPro.bundle/Fonts")
-        #else
-        // .app release: bundle.sh flattens Fonts/ into Contents/Resources/.
-        let url = resourceURL.appendingPathComponent("Fonts")
-        #endif
-        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        let candidates = [
+            resourceURL.appendingPathComponent("Fonts"),
+            resourceURL.appendingPathComponent("PalmierPro_PalmierPro.bundle/Fonts"),
+        ]
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
     }
 
     /// False for symbol/emoji/dingbat fonts — they'd render the family name


### PR DESCRIPTION
Fixes #63 .
`findFontsRoot()` assumed debug builds always use the raw SwiftPM resource-bundle layout, but `scripts/dev.sh` assembles a flattened `.app` even in debug mode, so fonts silently failed to register when using the officially recommended dev workflow.
Replaced the `#if DEBUG/#else` branch with a check against both possible locations, picking whichever exists. 
Tested locally and confirmed that bundled fonts now register correctly when launched via `./scripts/dev.sh`, with the expected log output:

```text
BundledFonts: registered 18 files across 13 families
```