### PR TITLE
Add variable font weight axis support

### DIFF
--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -73,7 +73,7 @@ struct TextTab: View {
         }
     }
 
-    private var weightSlider: some View {
+ private var weightSlider: some View {
     InspectorRow(icon: "bold", label: "Weight") {
         ScrubbableNumberField(
             value: style.fontWeight,
@@ -86,12 +86,12 @@ struct TextTab: View {
             }
         ) { newVal in
             editor.commitTextStyle(clipId: clip.id) { $0.fontWeight = newVal }
+            editor.fitTextClipToContent(clipId: clip.id) 
         }
         .disabled(!style.fontSupportsWeightAxis)
         .opacity(style.fontSupportsWeightAxis ? 1.0 : 0.4)
     }
 }
-
     private var sizeSlider: some View {
         InspectorRow(icon: "textformat.size", label: "Size") {
             ScrubbableNumberField(

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -11,6 +11,7 @@ struct TextTab: View {
             contentField
             InspectorSection("Typography") {
                 fontRow
+                weightSlider
                 sizeSlider
             }
             InspectorSection("Appearance") {
@@ -55,7 +56,7 @@ struct TextTab: View {
     }
 
     private var fontRow: some View {
-        InspectorRow(icon: "character", label: "Font") {
+    return InspectorRow(icon: "character", label: "Font") {
             FontPickerField(
                 current: style.fontName,
                 onPreview: { name in
@@ -71,6 +72,25 @@ struct TextTab: View {
             )
         }
     }
+
+    private var weightSlider: some View {
+    InspectorRow(icon: "bold", label: "Weight") {
+        ScrubbableNumberField(
+            value: style.fontWeight,
+            range: 100...900,
+            format: "%.0f",
+            valueSuffix: "",
+            fieldWidth: 50,
+            onChanged: { newVal in
+                editor.applyTextStyle(clipId: clip.id) { $0.fontWeight = newVal }
+            }
+        ) { newVal in
+            editor.commitTextStyle(clipId: clip.id) { $0.fontWeight = newVal }
+        }
+        .disabled(!style.fontSupportsWeightAxis)
+        .opacity(style.fontSupportsWeightAxis ? 1.0 : 0.4)
+    }
+}
 
     private var sizeSlider: some View {
         InspectorRow(icon: "textformat.size", label: "Size") {

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -122,8 +122,8 @@ extension TextStyle.RGBA {
 
 extension TextStyle {
     func resolvedFont(size: CGFloat) -> NSFont {
-        // 1. Load the base font
-        let baseFont = NSFont(name: self.fontName, size: size) ?? .systemFont(ofSize: size)
+        // 1. Load the base font, falling back to bold system font if missing
+        let baseFont = NSFont(name: self.fontName, size: size) ?? .boldSystemFont(ofSize: size)
         
         // 2. Sanitize the weight to protect against Infinity math crashes
         var safeWeight = self.fontWeight
@@ -152,7 +152,6 @@ extension TextStyle {
         // Fallback if the font doesn't support the variation
         return baseFont
     }
-
     /// True if `fontName` resolves to a font with a `wght` variation axis.
     var fontSupportsWeightAxis: Bool {
     guard let base = NSFont(name: fontName, size: 12) else { return false }

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -1,10 +1,13 @@
 import AppKit
 import SwiftUI
+import Foundation
+import CoreText
 
 struct TextStyle: Codable, Sendable, Equatable {
     var fontName: String = "Helvetica-Bold"
     var fontSize: Double = 96
     var fontScale: Double = 1.0
+    var fontWeight: Double = 400
     var color: RGBA = RGBA()
     var alignment: Alignment = .center
     var shadow: Shadow = Shadow()
@@ -41,7 +44,7 @@ struct TextStyle: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case fontName, fontSize, fontScale, color, alignment, shadow, background, border
+        case fontName, fontSize, fontScale, fontWeight, color, alignment, shadow, background, border
     }
 }
 
@@ -53,6 +56,7 @@ extension TextStyle {
             fontName: (try? c.decode(String.self, forKey: .fontName)) ?? "Helvetica-Bold",
             fontSize: (try? c.decode(Double.self, forKey: .fontSize)) ?? 96,
             fontScale: (try? c.decode(Double.self, forKey: .fontScale)) ?? 1.0,
+            fontWeight: (try? c.decode(Double.self, forKey: .fontWeight)) ?? 400,
             color: (try? c.decode(RGBA.self, forKey: .color)) ?? RGBA(),
             alignment: (try? c.decode(Alignment.self, forKey: .alignment)) ?? .center,
             shadow: (try? c.decode(Shadow.self, forKey: .shadow)) ?? Shadow(),
@@ -118,7 +122,44 @@ extension TextStyle.RGBA {
 
 extension TextStyle {
     func resolvedFont(size: CGFloat) -> NSFont {
-        NSFont(name: fontName, size: size) ?? NSFont.boldSystemFont(ofSize: size)
+        // 1. Load the base font
+        let baseFont = NSFont(name: self.fontName, size: size) ?? .systemFont(ofSize: size)
+        
+        // 2. Sanitize the weight to protect against Infinity math crashes
+        var safeWeight = self.fontWeight
+        if safeWeight.isNaN || safeWeight.isInfinite { safeWeight = 400.0 }
+        safeWeight = max(1.0, min(1000.0, safeWeight))
+
+        // 3. AppKit strictly requires NSNumber for variation tags and values
+        let variation: [NSNumber: NSNumber] = [
+            NSNumber(value: 0x77676874): NSNumber(value: safeWeight) // 'wght' axis
+        ]
+        
+        // 4. Inject the variation directly into the font's descriptor
+        let descriptor = baseFont.fontDescriptor.addingAttributes([
+            .variation: variation
+        ])
+        
+        // 5. Ask AppKit to resolve a completely fresh font instance
+        if let variableFont = NSFont(descriptor: descriptor, size: size) {
+            // Safety net: ensure the font resolved with valid geometry
+            let height = variableFont.boundingRectForFont.height
+            if height > 0 && !height.isNaN && !height.isInfinite {
+                return variableFont
+            }
+        }
+        
+        // Fallback if the font doesn't support the variation
+        return baseFont
+    }
+
+    /// True if `fontName` resolves to a font with a `wght` variation axis.
+    var fontSupportsWeightAxis: Bool {
+    guard let base = NSFont(name: fontName, size: 12) else { return false }
+    guard let axes = CTFontCopyVariationAxes(base) as? [[String: Any]] else { return false }
+    return axes.contains { axis in
+        (axis[kCTFontVariationAxisIdentifierKey as String] as? NSNumber)?.intValue == 0x77676874
+    }
     }
 
     var nsColor: NSColor { color.nsColor }
@@ -130,17 +171,17 @@ extension TextStyle {
         case .center: p.alignment = .center
         case .right: p.alignment = .right
         }
-        p.lineBreakMode = .byWordWrapping
         return p
     }
 
-    /// `includeColor: false` for bounding measurement (color doesn't affect size).
     func attributes(size: CGFloat, includeColor: Bool = true) -> [NSAttributedString.Key: Any] {
         var attrs: [NSAttributedString.Key: Any] = [
             .font: resolvedFont(size: size),
-            .paragraphStyle: paragraphStyle,
+            .paragraphStyle: paragraphStyle
         ]
-        if includeColor { attrs[.foregroundColor] = nsColor }
+        if includeColor {
+            attrs[.foregroundColor] = nsColor
+        }
         return attrs
     }
 }

--- a/Tests/PalmierProTests/TextStyleTests.swift
+++ b/Tests/PalmierProTests/TextStyleTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+import Foundation
+@testable import PalmierPro
+
+final class TextStyleTests: XCTestCase {
+    
+    func testFontWeightDefaultsAndRoundTrips() throws {
+        var style = TextStyle()
+        XCTAssertEqual(style.fontWeight, 400)
+        
+        style.fontWeight = 700
+        let data = try JSONEncoder().encode(style)
+        let decoded = try JSONDecoder().decode(TextStyle.self, from: data)
+        XCTAssertEqual(decoded.fontWeight, 700)
+    }
+    
+}


### PR DESCRIPTION
Closes #50.
Adds a `fontWeight` property to `TextStyle` and a Weight slider in the text inspector's Typography section, applied via CoreText's `wght` variation axis in `resolvedFont`.
`BundledFonts.swift` already handled variable font registration correctly (dedups by family, per the existing comments) — the actual gap was downstream: the font picker and `TextStyle` only ever carried a font name, so nothing could select or apply a font's weight range even though it loaded correctly.
The slider is disabled (and visually dimmed) for fonts with no `wght` axis, detected via `CTFontCopyVariationAxes` — so static fonts like Poppins or Skia don't show a control that silently does nothing.
Scoped to static weight selection, addressing #50. Full animatable motion typography (keyframing weight/width over time) would be a separate, larger follow-up.
Tested locally and verified that: — confirmed the slider visibly changes rendered weight on bundled variable fonts (Geist, Inter, SpaceGrotesk, etc.), correctly stays disabled on static fonts (Poppins, Skia, Anton), and that existing saved project files without a `fontWeight` field still load correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized text styling and rendering changes with safe fallbacks; minor layout risk from removing explicit word-wrap on paragraph style.
> 
> **Overview**
> Adds **`fontWeight`** (default 400) to **`TextStyle`** with backward-compatible decoding, and a **Weight** scrubber in the text inspector Typography section that previews/commits through the existing text-style editor and refits clip bounds like font size.
> 
> Rendering now applies weight via CoreText’s **`wght`** variation axis in **`resolvedFont`**, with NaN/infinity clamping and a safe fallback when variation resolution fails. **`fontSupportsWeightAxis`** uses **`CTFontCopyVariationAxes`** so the slider is disabled and dimmed for fonts without a weight axis.
> 
> **`paragraphStyle`** no longer sets **`lineBreakMode`** to word wrapping. A small unit test covers **`fontWeight`** default and JSON round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84363a318d33e39c1d8f9e085167f94c620029ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->