### PR TITLE
Add duplicate project from home screen context menu

### DIFF
--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -169,6 +169,23 @@ final class AppState {
         openProject(at: url, register: false, options: options)
     }
 
+    func duplicateProject(at url: URL) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [Self.projectContentType]
+        panel.nameFieldStringValue = "\(url.deletingPathExtension().lastPathComponent) Copy"
+        panel.directoryURL = url.deletingLastPathComponent()
+        panel.title = "Duplicate Project"
+        panel.begin { response in
+            guard response == .OK, let dest = panel.url else { return }
+            do {
+                try FileManager.default.copyItem(at: url, to: dest)
+                AppState.shared.openProject(at: dest)
+            } catch {
+                NSAlert(error: error).runModal()
+            }
+        }
+    }
+
     func openProjectFromPanel() {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [Self.projectContentType]

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -77,6 +77,7 @@ struct HomeView: View {
                         ProjectCard(
                             entry: entry,
                             onOpen: { AppState.shared.openProject(at: $0) },
+                            onDuplicate: { AppState.shared.duplicateProject(at: $0) },
                             onRemove: { ProjectRegistry.shared.remove($0) }
                         )
                     }

--- a/Sources/PalmierPro/Project/ProjectCard.swift
+++ b/Sources/PalmierPro/Project/ProjectCard.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ProjectCard: View {
     let entry: ProjectEntry
     let onOpen: (URL) -> Void
+    let onDuplicate: (URL) -> Void
     let onRemove: (URL) -> Void
 
     @State private var isHovered = false
@@ -101,6 +102,7 @@ struct ProjectCard: View {
         .contextMenu {
             if entry.isAccessible {
                 Button("Open") { onOpen(entry.url) }
+                Button("Duplicate") { onDuplicate(entry.url) }
                 Button("Reveal in Finder") {
                     NSWorkspace.shared.selectFile(entry.url.path, inFileViewerRootedAtPath: entry.url.deletingLastPathComponent().path)
                 }


### PR DESCRIPTION
## Summary

- Adds a `duplicateProject(at:)` method to `AppState` that shows a save panel pre-filled with the original project name + " Copy", copies the `.palmier` bundle to the chosen location, registers it, and opens it immediately
- Adds `onDuplicate` callback to `ProjectCard` and a "Duplicate" button in the right-click context menu (between "Open" and "Reveal in Finder")
- Wires the callback through `HomeView`

## Why

There's currently no way to duplicate a project from within the app. This is useful for using a finished project as a template — keeping the timeline structure and clip timing while swapping in new footage.

## Test plan

- [ ] Right-click a project card on the home screen → "Duplicate" appears in the context menu
- [ ] Clicking it opens a save panel with "[Project Name] Copy" pre-filled
- [ ] Confirming creates a copy and opens it in the editor
- [ ] Cancelling the panel does nothing
- [ ] Original project is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)