### PR TITLE
fix(text): trim newlines in RGBA(hex:) so color args with a trailing newline parse

### DIFF
--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -90,7 +90,7 @@ extension TextStyle.RGBA {
 
     /// Accepts `#RGB`, `#RRGGBB`, or `#RRGGBBAA`. Leading `#` optional.
     init?(hex: String) {
-        var s = hex.trimmingCharacters(in: .whitespaces)
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if s.hasPrefix("#") { s.removeFirst() }
         let chars = Array(s)
         func component(_ start: Int, _ len: Int) -> Double? {

--- a/Tests/PalmierProTests/Rendering/RGBAHexTests.swift
+++ b/Tests/PalmierProTests/Rendering/RGBAHexTests.swift
@@ -68,6 +68,20 @@ struct RGBAHexTests {
         #expect(c?.b == 0)
     }
 
+    @Test func surroundingNewlinesAreTrimmed() {
+        // A trailing newline should be trimmed just like the trailing spaces above.
+        // Reaches RGBA(hex:) untrimmed via parseColorHex (ToolExecutor) on agent tool args.
+        let trailing = TextStyle.RGBA(hex: "#00FF00\n")
+        #expect(trailing?.r == 0)
+        #expect(trailing?.g == 1)
+        #expect(trailing?.b == 0)
+
+        let surrounding = TextStyle.RGBA(hex: "\r\n  #00FF00  \n")
+        #expect(surrounding?.r == 0)
+        #expect(surrounding?.g == 1)
+        #expect(surrounding?.b == 0)
+    }
+
     // MARK: - Invalid inputs
 
     @Test func emptyStringReturnsNil() {


### PR DESCRIPTION
## What
`TextStyle.RGBA(hex:)` trims `.whitespaces`, which in Foundation is only space + horizontal tab — it does **not** include `\n` or `\r`. So a hex color with a surrounding newline (e.g. `"#00FF00\n"`) fails the length check and returns `nil`, even though the initializer already intends to tolerate surrounding whitespace (it trims spaces, and there's a `surroundingWhitespaceIsTrimmed` test).

## Why it matters
The value reaches `RGBA(hex:)` **untrimmed** via the agent tool path: `args.string("color")` (no trimming) → `parseColorHex` → `RGBA(hex:)` (`ToolExecutor.swift:231/233`; used by `add_captions`, `add_texts`, `set_clip_properties`). A `color` argument arriving with a stray trailing newline is wrongly rejected with `invalid color`.

## Fix
One line — use `.whitespacesAndNewlines`, matching the initializer's existing whitespace-tolerance intent:
```diff
- var s = hex.trimmingCharacters(in: .whitespaces)
+ var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
```

## Tests
Added `surroundingNewlinesAreTrimmed` to `RGBAHexTests` (fails before, passes after). Full suite green: **645 tests in 105 suites pass**, including `rejectsEmbeddedWhitespace` — internal whitespace is still correctly rejected; only surrounding newlines are now trimmed.

## Notes for reviewers
- Behavior change is limited to surrounding `\n`/`\r`; valid hex, embedded whitespace, wrong length, and empty inputs behave exactly as before.
- Per CONTRIBUTING, keeping this tiny and test-backed. Addresses #71 — happy to close if it's not worth the review.

Environment: macOS 26.5.1, Xcode 26.4, Swift 6.3.