### PR TITLE
fix(export): use correct HEVC preset for 720p exports

### DIFF
--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -261,7 +261,7 @@ final class ExportService {
             }
         case .h265:
             switch resolution {
-            case .r720p: AVAssetExportPresetHEVC1920x1080
+            case .r720p: AVAssetExportPresetHEVCHighestQuality
             case .r1080p: AVAssetExportPresetHEVC1920x1080
             case .r4k: AVAssetExportPresetHEVC3840x2160
             }


### PR DESCRIPTION
### What

Fixes H.265 720p exports silently using a 1080p-targeted HEVC encoder preset. The one-line change replaces `AVAssetExportPresetHEVC1920x1080` with `AVAssetExportPresetHEVCHighestQuality` for the 720p H.265 case.

### Why

Apple's `AVFoundation` does not provide an `AVAssetExportPresetHEVC1280x720` constant. The current code maps both 720p and 1080p H.265 exports to the same `AVAssetExportPresetHEVC1920x1080` preset:

```swift
case .h265:
    switch resolution {
    case .r720p: AVAssetExportPresetHEVC1920x1080  // ← bug: same as 1080p
    case .r1080p: AVAssetExportPresetHEVC1920x1080
    case .r4k: AVAssetExportPresetHEVC3840x2160
    }
```

While the `videoComposition.renderSize` correctly scales to 1280×720 via `ExportResolution.renderSize(for:)`, the 1080p preset applies bitrate/quality parameters tuned for 1080p frames to a 720p render — producing suboptimal bitrate allocation and unnecessarily large files.

The H.264 path does not have this issue because Apple provides resolution-specific presets for all three tiers (`AVAssetExportPreset1280x720`, `1920x1080`, `3840x2160`).

### How

Use `AVAssetExportPresetHEVCHighestQuality` for the H.265 720p case. This preset lets the encoder adapt its quality parameters to the actual `renderSize` (1280×720) set on the video composition, rather than targeting a 1080p profile.

**Alternative considered:** Using `AVAssetWriter` with custom HEVC settings for full control. Rejected because it would require a significant rewrite of the export pipeline for a problem that `HEVCHighestQuality` solves cleanly within the existing `AVAssetExportSession` architecture.

### Changes

- **`Sources/PalmierPro/Export/ExportService.swift`**: Changed H.265 720p preset from `AVAssetExportPresetHEVC1920x1080` to `AVAssetExportPresetHEVCHighestQuality` in `exportPresetName(format:resolution:)`.

### Testing

- [x] `swift build` passes
- [x] Existing export tests pass (`ExportResolutionTests`, `ExportServiceRoundTripTests`, etc.)
- [ ] Manual testing steps:
  1. Open a project with a 1920×1080 timeline
  2. Export → H.265 → 720p
  3. Inspect the output file dimensions (should be 1280×720, not 1920×1080-profiled)
  4. Compare file size against a 1080p H.265 export (720p should be noticeably smaller)

### Checklist

- [x] Code follows project style guidelines (AGENTS.md)
- [x] Self-reviewed the diff line-by-line
- [x] No console.log / print debugging left in
- [x] No breaking changes
- [x] Backward compatible
- [x] Minimal change set — one line, single concern
```