### PR TITLE
fix(preview): use naturalTimeScale for clip inserts to prevent export…

### DIFF
--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -308,7 +308,9 @@ enum CompositionBuilder {
     ) async -> Bool {
         let clipStart = CMTime(value: CMTimeValue(clip.startFrame), timescale: timescale)
         let trimStartFrame = clip.mediaType == .image ? max(0, clip.trimStartFrame) : clip.trimStartFrame
-        let trimStart = CMTime(value: CMTimeValue(trimStartFrame), timescale: timescale)
+        let sourceTimescale = (try? await sourceTrack.load(.naturalTimeScale)) ?? timescale
+        let startSeconds = Double(trimStartFrame) / Double(timescale)
+        let trimStart = CMTime(seconds: startSeconds, preferredTimescale: sourceTimescale)
         let clipDuration = CMTime(value: CMTimeValue(clip.durationFrames), timescale: timescale)
 
         if clipStart > cursor {
@@ -319,7 +321,8 @@ enum CompositionBuilder {
         let sourceFrames = clip.speed == 1.0
             ? clip.durationFrames
             : max(1, Int(Double(clip.durationFrames) * clip.speed))
-        let sourceDuration = CMTime(value: CMTimeValue(sourceFrames), timescale: timescale)
+        let durationSeconds = Double(sourceFrames) / Double(timescale)
+        let sourceDuration = CMTime(seconds: durationSeconds, preferredTimescale: sourceTimescale)
         let sourceRange = CMTimeRange(start: trimStart, duration: sourceDuration)
 
         do {


### PR DESCRIPTION
### What

Aligns the time ranges inserted into composition tracks with the source track's own `naturalTimeScale` instead of rounding them to the timeline's timescale (e.g. 30 fps).

### Why

Resolves **Issue #68** where exporting a project containing high-frame-rate sources (e.g., 60fps 4K HEVC) with deep seeks (e.g., 50s+) causes `AVAssetExportSession` to hang indefinitely.

When we create the source time range (`sourceRange`) with the timeline's low-precision timescale, the start time and duration are rounded to 1/30th of a second. When AVFoundation maps this onto a 60fps (or 23.976fps) source, the timestamps land between frame boundaries. For deep seeks, these sub-frame rounding errors accumulate. During hardware-accelerated export, request for frame decoding at fractional offsets triggers a deadlock or hang in the hardware HEVC decoder/resampler.

Using the source track's own `naturalTimeScale` (e.g., 60000) keeps the `CMTime` values precise and perfectly aligned with frame boundaries, avoiding fractional decode requests and preventing hangs.

### How

In `CompositionBuilder.insertClip`, we fetch the source track's timescale using:
```swift
let sourceTimescale = (try? await sourceTrack.load(.naturalTimeScale)) ?? timescale
```
We then calculate `trimStart` and `sourceDuration` using `CMTime(seconds:preferredTimescale:)` with this `sourceTimescale`, ensuring maximum precision and alignment with native frame offsets when inserting track segments.

### Changes

- **`Sources/PalmierPro/Preview/CompositionBuilder.swift`**: Load the source track's `naturalTimeScale` and use it to construct `trimStart` and `sourceDuration` in `insertClip`.

### Testing

- [x] Compilation succeeds
- [x] Verification:
  1. Open a 30fps project
  2. Add a 60fps 4K HEVC source clip with a deep seek (e.g., 50s+ offset)
  3. Export to H.264/H.265 MP4
  4. Confirm the export completes successfully without hanging

### Checklist

- [x] Code follows project style guidelines (AGENTS.md)
- [x] Self-reviewed the diff line-by-line
- [x] Minimal change set — 5 lines added, 2 removed

---