### PR TITLE
[fix] App hangs from clerk macOS via data-protection keychain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ AuthKey_*.p8
 credentials.json
 secrets.json
 *.local
+*.provisionprofile
 
 # mcpb shim dependencies (vendored only inside the packed .mcpb)
 mcpb/server/node_modules/

--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -153,9 +153,12 @@ final class AccountService {
             return
         }
 
+        let keychainConfig = BackendConfig.clerkKeychainAccessGroup
+            .map { Clerk.Options.KeychainConfig(accessGroup: $0) } ?? .init()
         Clerk.configure(
             publishableKey: publishableKey,
             options: Clerk.Options(
+                keychainConfig: keychainConfig,
                 redirectConfig: .init(
                     redirectUrl: "palmier://callback",
                     callbackUrlScheme: "palmier"

--- a/Sources/PalmierPro/Account/BackendConfig.swift
+++ b/Sources/PalmierPro/Account/BackendConfig.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum BackendConfig {
     static let clerkPublishableKey: String? = string("PalmierClerkPublishableKey")
+    static let clerkKeychainAccessGroup: String? = string("PalmierClerkKeychainAccessGroup")
     static let convexDeploymentURL: URL? = string("PalmierConvexDeploymentURL").flatMap { URL(string: $0) }
     static let convexHttpURL: URL? = string("PalmierConvexHttpURL").flatMap { URL(string: $0) }
 

--- a/scripts/PalmierPro.entitlements
+++ b/scripts/PalmierPro.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>MMFLRC7562.io.palmier.pro</string>
+	</array>
+	<key>com.apple.application-identifier</key>
+	<string>MMFLRC7562.io.palmier.pro</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>MMFLRC7562</string>
+</dict>
+</plist>

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -36,6 +36,9 @@ fi
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application: Palmier, Inc. (MMFLRC7562)}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-palmier-notary}"
 SENTRY_DSN="${SENTRY_DSN:-}"
+PROVISION_PROFILE="${PROVISION_PROFILE:-$ROOT/scripts/Palmier_Pro_Developer_ID.provisionprofile}"
+ENTITLEMENTS="$ROOT/scripts/PalmierPro.entitlements"
+KEYCHAIN_ACCESS_GROUP="${KEYCHAIN_ACCESS_GROUP:-MMFLRC7562.io.palmier.pro}"
 RESOURCES="$ROOT/Sources/PalmierPro/Resources"
 APP="$ROOT/.build/PalmierPro.app"
 ZIP="$ROOT/.build/PalmierPro.zip"
@@ -156,8 +159,17 @@ codesign --force --options runtime --timestamp \
   --sign "$SIGNING_IDENTITY" \
   "$APP/Contents/Frameworks/Sparkle.framework"
 
+echo "==> Embedding provisioning profile + keychain access group"
+if [ ! -f "$PROVISION_PROFILE" ]; then
+  echo "!! provisioning profile not found at $PROVISION_PROFILE" >&2
+  exit 1
+fi
+cp "$PROVISION_PROFILE" "$APP/Contents/embedded.provisionprofile"
+inject_plist PalmierClerkKeychainAccessGroup "$KEYCHAIN_ACCESS_GROUP"
+
 echo "==> Codesigning main app"
 codesign --force --options runtime --timestamp \
+  --entitlements "$ENTITLEMENTS" \
   --sign "$SIGNING_IDENTITY" \
   "$APP"
 codesign --verify --strict --verbose=2 "$APP"


### PR DESCRIPTION
if accessgroup is not passed to clerk config, it uses legacy file-based keychain on @MainActor (every authed request + ~52s session poll), which blocks on securityd (CDSA/CSSM) for 8s+.

passing accessgroup routes Clerk to the fast data-protection keychain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth credential storage and Developer ID signing/notarization; misconfigured entitlements or plist values could break sign-in in production builds.
> 
> **Overview**
> Fixes **main-thread hangs** during Clerk session/auth work by passing a **keychain access group** into `Clerk.configure` instead of the default legacy keychain path.
> 
> **Runtime:** `BackendConfig` reads `PalmierClerkKeychainAccessGroup` from Info.plist; `AccountService` maps it to `Clerk.Options.KeychainConfig(accessGroup:)` when present.
> 
> **Release pipeline:** `bundle.sh` (sign/dist) embeds the Developer ID provisioning profile, injects the access group into Info.plist, and codesigns the app with new `PalmierPro.entitlements` (`keychain-access-groups` + app/team IDs). `*.provisionprofile` is gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18149b9d16bd3fd24c3b91c0d87c8dd370628b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->