### PR TITLE
[fixes] app hangs on open projects

### DIFF
--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -28,6 +28,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
+    @objc func newProject(_ sender: Any?) {
+        AppState.shared.createNewProject()
+    }
+
+    @MainActor
+    @objc func openProject(_ sender: Any?) {
+        AppState.shared.openProjectFromPanel()
+    }
+
+    @MainActor
     @objc func showSettings(_ sender: Any?) {
         SettingsWindowController.shared.show()
     }

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -141,16 +141,44 @@ final class AppState {
     }
 
     func openProject(at url: URL, register: Bool = true, options: ProjectOpenOptions = .init()) {
-        do {
-            let doc = try VideoProject(contentsOf: url, ofType: VideoProject.typeIdentifier)
-            doc.makeWindowControllers()
-            doc.showWindows()
-            NSDocumentController.shared.addDocument(doc)
-            if register { ProjectRegistry.shared.register(url) }
-            apply(options, to: doc.editorViewModel)
-        } catch {
-            NSAlert(error: error).runModal()
+        Task {
+            do {
+                try await openProjectAsync(at: url, register: register, options: options)
+            } catch {
+                NSAlert(error: error).runModal()
+            }
         }
+    }
+
+    @discardableResult
+    private func openProjectAsync(at url: URL, register: Bool = true, options: ProjectOpenOptions = .init()) async throws -> VideoProject {
+        let resolved = url.standardizedFileURL
+        if let existing = showExistingProject(at: resolved, register: register, options: options) {
+            return existing
+        }
+        let doc = try await VideoProject.load(from: resolved)
+        if let existing = showExistingProject(at: resolved, register: register, options: options) {
+            return existing
+        }
+
+        doc.makeWindowControllers()
+        doc.showWindows()
+        NSDocumentController.shared.addDocument(doc)
+        if register { ProjectRegistry.shared.register(resolved) }
+        apply(options, to: doc.editorViewModel)
+        return doc
+    }
+
+    private func showExistingProject(at url: URL, register: Bool, options: ProjectOpenOptions) -> VideoProject? {
+        if let existing = NSDocumentController.shared.documents
+            .compactMap({ $0 as? VideoProject })
+            .first(where: { Self.sameFile($0.fileURL, url) }) {
+            showEditor(for: existing)
+            if register { ProjectRegistry.shared.register(url) }
+            apply(options, to: existing.editorViewModel)
+            return existing
+        }
+        return nil
     }
 
     private func apply(_ options: ProjectOpenOptions, to editor: EditorViewModel) {
@@ -162,11 +190,11 @@ final class AppState {
     func openSample(slug: String, startTutorial: Bool, onProgress: @escaping (Double) -> Void = { _ in }) async throws {
         let options = ProjectOpenOptions(startTutorial: startTutorial)
         if let cached = SampleProjectService.shared.cachedURL(slug: slug) {
-            openProject(at: cached, register: false, options: options)
+            try await openProjectAsync(at: cached, register: false, options: options)
             return
         }
         let url = try await SampleProjectService.shared.materialize(slug: slug, onProgress: onProgress)
-        openProject(at: url, register: false, options: options)
+        try await openProjectAsync(at: url, register: false, options: options)
     }
 
     func openProjectFromPanel() {

--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -38,8 +38,10 @@ enum MainMenuBuilder {
     private static func fileMenu() -> NSMenuItem {
         let item = NSMenuItem()
         let menu = NSMenu(title: "File")
-        menu.addItem(withTitle: "New", action: #selector(NSDocumentController.newDocument(_:)), keyEquivalent: "n")
-        menu.addItem(withTitle: "Open…", action: #selector(NSDocumentController.openDocument(_:)), keyEquivalent: "o")
+        let newItem = menu.addItem(withTitle: "New", action: #selector(AppDelegate.newProject(_:)), keyEquivalent: "n")
+        newItem.target = NSApp.delegate
+        let openItem = menu.addItem(withTitle: "Open…", action: #selector(AppDelegate.openProject(_:)), keyEquivalent: "o")
+        openItem.target = NSApp.delegate
         menu.addItem(.separator())
         menu.addItem(withTitle: "Save", action: #selector(NSDocument.save(_:)), keyEquivalent: "s")
         menu.addItem(withTitle: "Save As…", action: #selector(NSDocument.saveAs(_:)), keyEquivalent: "S")

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -3,6 +3,20 @@ import SwiftUI
 import AVFoundation
 import UniformTypeIdentifiers
 
+private struct ProjectPackageContents: Sendable {
+    var timeline: Timeline
+    var manifest: MediaManifest?
+    var generationLog: GenerationLog?
+}
+
+private struct ProjectPackageSnapshot: Sendable {
+    var timeline: Data
+    var manifest: Data?
+    var generationLog: Data?
+    var thumbnail: Data?
+    var chatSessionFiles: [(name: String, data: Data)]
+}
+
 final class VideoProject: NSDocument {
 
     static let typeIdentifier = Project.typeIdentifier
@@ -14,43 +28,39 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var loadedManifest: MediaManifest?
     private nonisolated(unsafe) var loadedGenerationLog: GenerationLog?
 
-    private nonisolated(unsafe) var packageWrapper = FileWrapper(directoryWithFileWrappers: [:])
-
-    /// Captured on main thread before fileWrapper runs (possibly off-main).
+    /// Captured on main thread before writes may continue off-main.
     private nonisolated(unsafe) var snapshotTimeline: Data?
     private nonisolated(unsafe) var snapshotManifest: Data?
     private nonisolated(unsafe) var snapshotGenerationLog: Data?
     private nonisolated(unsafe) var snapshotThumbnail: Data?
     private nonisolated(unsafe) var snapshotChatSessionFiles: [(name: String, data: Data)] = []
-    private nonisolated(unsafe) var snapshotPreparedForFileWrapper = false
+    private nonisolated(unsafe) var snapshotSourceProjectURL: URL?
+    private nonisolated(unsafe) var snapshotPreparedForWrite = false
 
     // MARK: - Persistence
 
     override class var autosavesInPlace: Bool { true }
 
-    override func read(from fileWrapper: FileWrapper, ofType typeName: String) throws {
-        guard let data = fileWrapper.fileWrappers?[Project.timelineFilename]?.regularFileContents else {
-            Log.project.error("read: missing \(Project.timelineFilename) in package")
-            throw CocoaError(.fileReadCorruptFile)
-        }
-        packageWrapper = fileWrapper
-        do {
-            loadedTimeline = try JSONDecoder().decode(Timeline.self, from: data)
-        } catch {
-            Log.project.error("read: timeline decode failed: \(String(describing: error))")
-            throw error
-        }
-        if let manifestData = fileWrapper.fileWrappers?[Project.manifestFilename]?.regularFileContents {
-            do {
-                loadedManifest = try JSONDecoder().decode(MediaManifest.self, from: manifestData)
-            } catch {
-                Log.project.error("read manifest decode failed bytes=\(manifestData.count) error=\(error)")
-                throw CocoaError(.fileReadCorruptFile)
-            }
-        }
-        if let logData = fileWrapper.fileWrappers?[Project.generationLogFilename]?.regularFileContents {
-            loadedGenerationLog = try? JSONDecoder().decode(GenerationLog.self, from: logData)
-        }
+    @MainActor
+    static func load(from url: URL) async throws -> VideoProject {
+        let contents = try await Task.detached(priority: .userInitiated) {
+            try readProjectPackage(at: url)
+        }.value
+        let doc = VideoProject()
+        doc.fileURL = url
+        doc.fileType = typeIdentifier
+        doc.applyLoadedContents(contents)
+        return doc
+    }
+
+    override func read(from url: URL, ofType typeName: String) throws {
+        applyLoadedContents(try Self.readProjectPackage(at: url))
+    }
+
+    private nonisolated func applyLoadedContents(_ contents: ProjectPackageContents) {
+        loadedTimeline = contents.timeline
+        loadedManifest = contents.manifest
+        loadedGenerationLog = contents.generationLog
         Log.project.notice(
             "read ok tracks=\(self.loadedTimeline?.tracks.count ?? 0)",
             telemetry: "Project read",
@@ -63,37 +73,79 @@ final class VideoProject: NSDocument {
         )
     }
 
+    private nonisolated static func readProjectPackage(at url: URL) throws -> ProjectPackageContents {
+        let data = try requiredData(Project.timelineFilename, in: url)
+        let timeline: Timeline
+        do {
+            timeline = try JSONDecoder().decode(Timeline.self, from: data)
+        } catch {
+            Log.project.error("read: timeline decode failed: \(String(describing: error))")
+            throw error
+        }
+
+        let manifest: MediaManifest?
+        if let manifestData = try optionalData(Project.manifestFilename, in: url) {
+            do {
+                manifest = try JSONDecoder().decode(MediaManifest.self, from: manifestData)
+            } catch {
+                Log.project.error("read manifest decode failed bytes=\(manifestData.count) error=\(error)")
+                throw CocoaError(.fileReadCorruptFile)
+            }
+        } else {
+            manifest = nil
+        }
+
+        let generationLog = try optionalData(Project.generationLogFilename, in: url)
+            .flatMap { try? JSONDecoder().decode(GenerationLog.self, from: $0) }
+
+        return ProjectPackageContents(
+            timeline: timeline,
+            manifest: manifest,
+            generationLog: generationLog
+        )
+    }
+
     override func save(to url: URL, ofType typeName: String, for saveOperation: NSDocument.SaveOperationType, completionHandler: @escaping (Error?) -> Void) {
         if let date = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate {
             fileModificationDate = date
         }
 
         captureSaveSnapshot()
+        snapshotSourceProjectURL = fileURL
         super.save(to: url, ofType: typeName, for: saveOperation, completionHandler: completionHandler)
     }
 
-    override func fileWrapper(ofType typeName: String) throws -> FileWrapper {
-        if !snapshotPreparedForFileWrapper {
+    override func write(to url: URL, ofType typeName: String) throws {
+        if !snapshotPreparedForWrite {
             guard Thread.isMainThread else {
-                Log.project.error("save: snapshot not prepared for off-main fileWrapper()")
+                Log.project.error("save: snapshot not prepared for off-main write()")
                 throw CocoaError(.fileWriteUnknown)
             }
-            captureSaveSnapshot()
+            MainActor.assumeIsolated {
+                captureSaveSnapshot()
+                snapshotSourceProjectURL = fileURL
+            }
         }
-        defer { snapshotPreparedForFileWrapper = false }
+        defer {
+            snapshotPreparedForWrite = false
+            snapshotSourceProjectURL = nil
+        }
         guard let data = snapshotTimeline else {
-            Log.project.error("save: snapshotTimeline missing at fileWrapper()")
+            Log.project.error("save: snapshotTimeline missing at write()")
             throw CocoaError(.fileWriteUnknown)
         }
 
-        replaceChild(Project.timelineFilename, with: data)
-        if let manifest = snapshotManifest { replaceChild(Project.manifestFilename, with: manifest) }
-        if let log = snapshotGenerationLog { replaceChild(Project.generationLogFilename, with: log) }
-        if let thumb = snapshotThumbnail { replaceChild(Project.thumbnailFilename, with: thumb) }
-        replaceChild(ChatSessionStore.dirName, with: chatDirWrapper())
-        if let mediaDir = mediaDirWrapper() { replaceChild(Project.mediaDirectoryName, with: mediaDir) }
-
-        return packageWrapper
+        try Self.writeProjectPackage(
+            ProjectPackageSnapshot(
+                timeline: data,
+                manifest: snapshotManifest,
+                generationLog: snapshotGenerationLog,
+                thumbnail: snapshotThumbnail,
+                chatSessionFiles: snapshotChatSessionFiles
+            ),
+            to: url,
+            sourceURL: snapshotSourceProjectURL
+        )
     }
 
     private func captureSaveSnapshot() {
@@ -106,25 +158,87 @@ final class VideoProject: NSDocument {
             .compactMap { session in
                 ChatSessionStore.encodeSession(session).map { (name: "\(session.id.uuidString).json", data: $0) }
             }
-        snapshotPreparedForFileWrapper = true
+        snapshotPreparedForWrite = true
     }
 
-    private func mediaDirWrapper() -> FileWrapper? {
-        guard let projectURL = fileURL else { return nil }
-        let mediaDir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-        guard FileManager.default.fileExists(atPath: mediaDir.path) else { return nil }
-        return try? FileWrapper(url: mediaDir, options: .immediate)
-    }
-
-    private nonisolated func chatDirWrapper() -> FileWrapper {
-        let dir = FileWrapper(directoryWithFileWrappers: [:])
-        for file in snapshotChatSessionFiles {
-            let child = FileWrapper(regularFileWithContents: file.data)
-            child.preferredFilename = file.name
-            dir.addFileWrapper(child)
+    private nonisolated static func requiredData(_ name: String, in packageURL: URL) throws -> Data {
+        do {
+            return try Data(contentsOf: packageURL.appendingPathComponent(name, isDirectory: false), options: [.mappedIfSafe])
+        } catch {
+            Log.project.error("read: missing \(name) in package")
+            throw CocoaError(.fileReadCorruptFile)
         }
-        dir.preferredFilename = ChatSessionStore.dirName
-        return dir
+    }
+
+    private nonisolated static func optionalData(_ name: String, in packageURL: URL) throws -> Data? {
+        let url = packageURL.appendingPathComponent(name, isDirectory: false)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try Data(contentsOf: url, options: [.mappedIfSafe])
+    }
+
+    private nonisolated static func writeProjectPackage(_ snapshot: ProjectPackageSnapshot, to packageURL: URL, sourceURL: URL?) throws {
+        let fm = FileManager.default
+        try createPackageDirectory(at: packageURL, fm: fm)
+        try snapshot.timeline.write(to: packageURL.appendingPathComponent(Project.timelineFilename), options: .atomic)
+        if let manifest = snapshot.manifest {
+            try manifest.write(to: packageURL.appendingPathComponent(Project.manifestFilename), options: .atomic)
+        }
+        if let log = snapshot.generationLog {
+            try log.write(to: packageURL.appendingPathComponent(Project.generationLogFilename), options: .atomic)
+        }
+        if let thumbnail = snapshot.thumbnail {
+            try thumbnail.write(to: packageURL.appendingPathComponent(Project.thumbnailFilename), options: .atomic)
+        } else {
+            try copyPreservedFile(Project.thumbnailFilename, from: sourceURL, to: packageURL, fm: fm)
+        }
+        try writeChatDirectory(snapshot.chatSessionFiles, to: packageURL, fm: fm)
+        try copyMediaDirectoryIfNeeded(from: sourceURL, to: packageURL, fm: fm)
+    }
+
+    private nonisolated static func createPackageDirectory(at url: URL, fm: FileManager) throws {
+        var isDirectory = ObjCBool(false)
+        if fm.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+            if isDirectory.boolValue { return }
+            try fm.removeItem(at: url)
+        }
+        try fm.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    private nonisolated static func writeChatDirectory(_ files: [(name: String, data: Data)], to packageURL: URL, fm: FileManager) throws {
+        let chatURL = packageURL.appendingPathComponent(ChatSessionStore.dirName, isDirectory: true)
+        if fm.fileExists(atPath: chatURL.path) {
+            try fm.removeItem(at: chatURL)
+        }
+        try fm.createDirectory(at: chatURL, withIntermediateDirectories: true)
+        for file in files {
+            try file.data.write(to: chatURL.appendingPathComponent(file.name, isDirectory: false), options: .atomic)
+        }
+    }
+
+    private nonisolated static func copyPreservedFile(_ name: String, from sourceURL: URL?, to packageURL: URL, fm: FileManager) throws {
+        guard let sourceURL, !sameFile(sourceURL, packageURL) else { return }
+        let source = sourceURL.appendingPathComponent(name, isDirectory: false)
+        guard fm.fileExists(atPath: source.path) else { return }
+        let destination = packageURL.appendingPathComponent(name, isDirectory: false)
+        if fm.fileExists(atPath: destination.path) {
+            try fm.removeItem(at: destination)
+        }
+        try fm.copyItem(at: source, to: destination)
+    }
+
+    private nonisolated static func copyMediaDirectoryIfNeeded(from sourceURL: URL?, to packageURL: URL, fm: FileManager) throws {
+        guard let sourceURL, !sameFile(sourceURL, packageURL) else { return }
+        let source = sourceURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+        let destination = packageURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+        if fm.fileExists(atPath: destination.path) {
+            try fm.removeItem(at: destination)
+        }
+        guard fm.fileExists(atPath: source.path) else { return }
+        try fm.copyItem(at: source, to: destination)
+    }
+
+    private nonisolated static func sameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.standardizedFileURL.path == rhs.standardizedFileURL.path
     }
 
     override func updateChangeCount(_ change: NSDocument.ChangeType) {
@@ -154,20 +268,6 @@ final class VideoProject: NSDocument {
                 }
             }
         }
-    }
-
-    private nonisolated func replaceChild(_ name: String, with data: Data) {
-        let wrapper = FileWrapper(regularFileWithContents: data)
-        wrapper.preferredFilename = name
-        replaceChild(name, with: wrapper)
-    }
-
-    private nonisolated func replaceChild(_ name: String, with wrapper: FileWrapper) {
-        if let old = packageWrapper.fileWrappers?[name] {
-            packageWrapper.removeFileWrapper(old)
-        }
-        wrapper.preferredFilename = name
-        packageWrapper.addFileWrapper(wrapper)
     }
 
     // MARK: - Close

--- a/Tests/PalmierProTests/Media/ProjectDocumentIOTests.swift
+++ b/Tests/PalmierProTests/Media/ProjectDocumentIOTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Project document IO")
+@MainActor
+struct ProjectDocumentIOTests {
+    private let fm = FileManager.default
+
+    @Test func directWritePreservesExistingPackageMediaAndThumbnail() throws {
+        let root = fm.temporaryDirectory.appendingPathComponent("pp-doc-io-\(UUID().uuidString)", isDirectory: true)
+        let package = root.appendingPathComponent("Project.palmier", isDirectory: true)
+        try makePackage(at: package)
+        defer { try? fm.removeItem(at: root) }
+
+        let doc = configuredDocument(fileURL: package)
+        try doc.write(to: package, ofType: VideoProject.typeIdentifier)
+
+        #expect(try String(contentsOf: package.appendingPathComponent("media/clip.mp4"), encoding: .utf8) == "MEDIA")
+        #expect(try String(contentsOf: package.appendingPathComponent(Project.thumbnailFilename), encoding: .utf8) == "THUMB")
+        #expect(fm.fileExists(atPath: package.appendingPathComponent(ChatSessionStore.dirName).path))
+    }
+
+    @Test func directWriteCopiesPackageMediaAndThumbnailToNewDestination() throws {
+        let root = fm.temporaryDirectory.appendingPathComponent("pp-doc-io-\(UUID().uuidString)", isDirectory: true)
+        let source = root.appendingPathComponent("Source.palmier", isDirectory: true)
+        let destination = root.appendingPathComponent("Destination.palmier", isDirectory: true)
+        try makePackage(at: source)
+        defer { try? fm.removeItem(at: root) }
+
+        let doc = configuredDocument(fileURL: source)
+        try doc.write(to: destination, ofType: VideoProject.typeIdentifier)
+
+        #expect(try String(contentsOf: destination.appendingPathComponent("media/clip.mp4"), encoding: .utf8) == "MEDIA")
+        #expect(try String(contentsOf: destination.appendingPathComponent(Project.thumbnailFilename), encoding: .utf8) == "THUMB")
+        #expect(fm.fileExists(atPath: destination.appendingPathComponent(Project.timelineFilename).path))
+        #expect(fm.fileExists(atPath: destination.appendingPathComponent(Project.manifestFilename).path))
+    }
+
+    private func makePackage(at url: URL) throws {
+        let media = url.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+        try fm.createDirectory(at: media, withIntermediateDirectories: true)
+        try Data("MEDIA".utf8).write(to: media.appendingPathComponent("clip.mp4"))
+        try Data("THUMB".utf8).write(to: url.appendingPathComponent(Project.thumbnailFilename))
+    }
+
+    private func configuredDocument(fileURL: URL) -> VideoProject {
+        let doc = VideoProject()
+        doc.fileURL = fileURL
+        doc.fileType = VideoProject.typeIdentifier
+        doc.editorViewModel.timeline = Fixtures.timeline()
+        var manifest = MediaManifest()
+        manifest.entries = [
+            MediaManifestEntry(
+                id: "clip",
+                name: "Clip",
+                type: .video,
+                source: .project(relativePath: "media/clip.mp4"),
+                duration: 1
+            )
+        ]
+        doc.editorViewModel.mediaManifest = manifest
+        return doc
+    }
+}


### PR DESCRIPTION
### problem

when opening projects, we used `NSFileWrapper` to enumerate the entire `.palmier` (including all the media) in main thread. it works badly with large projects or icloud.

### fix

1. loads only project metadata files off-main: timeline, meedia manifest, log.
2. writes package metadata directly instead of a full rebuild package
3. routes new/open menu actions through AppState

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core project persistence and open lifecycle; incorrect copy/preserve logic could lose media on save, though new IO tests cover the main paths.
> 
> **Overview**
> Fixes UI hangs when opening large or iCloud-backed `.palmier` projects by **not** walking the whole package via `NSFileWrapper` on the main thread.
> 
> **`VideoProject`** now reads only metadata (`timeline`, manifest, generation log) from disk and decodes it off-main via `VideoProject.load(from:)` / `readProjectPackage`. Saves use **`write(to:ofType:)`** with atomic file writes: updated JSON/chat are written directly, and **media + thumbnail are copied or preserved** from the source package instead of rebuilding the entire wrapper tree.
> 
> **`AppState`** opens projects asynchronously (`openProjectAsync`), dedupes already-open documents by path, and surfaces load errors in an alert. Sample opens use the same async path. **File → New/Open** menu items target **`AppDelegate`** → **`AppState`** instead of `NSDocumentController` defaults.
> 
> Adds **`ProjectDocumentIOTests`** for in-place save preserving media/thumbnail and Save As–style writes to a new destination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510665ba3c432c29acdb7ce688eda6f55050c92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->