### PR TITLE
[fix] project storage directory launch hang

### DIFF
--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -10,6 +10,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = Updater.shared
 
         HomeWindowController.shared.showWindow(nil)
+        Task.detached(priority: .utility) {
+            Project.ensureStorageDirectory()
+        }
 
         AppNotifications.configure()
 

--- a/Sources/PalmierPro/Project/ProjectRegistry.swift
+++ b/Sources/PalmierPro/Project/ProjectRegistry.swift
@@ -125,7 +125,8 @@ final class ProjectRegistry {
 
 private actor ProjectRegistryDisk {
     func load(from fileURL: URL) -> [ProjectEntry] {
-        ProjectRegistry.loadEntries(from: fileURL)
+        Project.ensureStorageDirectory()
+        return ProjectRegistry.loadEntries(from: fileURL)
     }
 
     func trashIfPresent(_ url: URL) -> Bool {

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -112,12 +112,15 @@ enum Project {
     static let thumbnailFilename = "thumbnail.jpg"
     static let mediaDirectoryName = "media"
 
-    static let storageDirectory: URL = {
-        let url = FileManager.default.homeDirectoryForCurrentUser
+    static var storageDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Documents/Palmier Pro", isDirectory: true)
+    }
+
+    nonisolated static func ensureStorageDirectory() {
+        let url = storageDirectory
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }()
+    }
 }
 
 func gcd(_ a: Int, _ b: Int) -> Int {


### PR DESCRIPTION
### problem
Sentry showed the hung stack going through:
`AppDelegate.applicationDidFinishLaunching` ->
`HomeWindowController.shared` ->
`HomeView.projectGrid` ->
`ProjectRegistry.shared` ->
 `Project.storageDirectory`, where the static initializer synchronously called
  `FileManager.createDirectory`. Under low memory / slow filesystem conditions, that directory
  creation stalled the main thread during first home-window construction.

### solution

  The fix makes `Project.storageDirectory` a pure URL getter with no filesystem side effects.
  Directory creation moved to `Project.ensureStorageDirectory()`, which is called from a detached
  utility task at startup and from the `ProjectRegistryDisk` actor before registry loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup/filesystem refactor with no auth or data-model changes; registry load still ensures the directory exists before read.
> 
> **Overview**
> Fixes a **launch hang** where the home window path touched `Project.storageDirectory` while its static initializer synchronously ran `FileManager.createDirectory` on the main thread.
> 
> **`Project.storageDirectory`** is now a side-effect-free URL getter. **`Project.ensureStorageDirectory()`** performs directory creation and is invoked from a **detached utility `Task`** after `applicationDidFinishLaunching` shows the home window, and from **`ProjectRegistryDisk.load`** before reading the registry so persistence still works if startup races ahead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c10e2462e18bce812399d4d17afc9cf5f198aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->