### PR TITLE
[fix] import folder hangs on main thread

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -8,7 +8,7 @@ extension ToolExecutor {
     private static let importMediaAllowedKeys: Set<String> = ["source", "name", "folderId"]
     private static let importSourceAllowedKeys: Set<String> = ["url", "path", "bytes", "mimeType"]
 
-    func importMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+    func importMedia(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.importMediaAllowedKeys, path: "import_media")
         guard let source = args["source"] as? [String: Any] else {
             throw ToolError("Missing required 'source' object")
@@ -29,7 +29,7 @@ extension ToolExecutor {
         let providedName = args.string("name")
 
         if let pathStr {
-            return try importFromPath(editor: editor, path: pathStr, name: providedName, folderId: folderId)
+            return try await importFromPath(editor: editor, path: pathStr, name: providedName, folderId: folderId)
         }
         if let bytesStr {
             guard let mimeType else {
@@ -43,14 +43,14 @@ extension ToolExecutor {
         throw ToolError("unreachable")
     }
 
-    private func importFromPath(editor: EditorViewModel, path: String, name: String?, folderId: String?) throws -> ToolResult {
+    private func importFromPath(editor: EditorViewModel, path: String, name: String?, folderId: String?) async throws -> ToolResult {
         let fileURL = URL(fileURLWithPath: path)
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDir) else {
             throw ToolError("File not found: \(path)")
         }
         if isDir.boolValue {
-            let summary = editor.importFinderItems([fileURL], into: folderId)
+            let summary = await editor.importFinderItems([fileURL], into: folderId)
             guard summary.assetCount > 0 else {
                 throw ToolError("No supported media found in folder: \(path)")
             }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -93,7 +93,7 @@ final class ToolExecutor {
         case .generateImage: return try generate(editor, args, type: .image)
         case .generateAudio: return try await generateAudio(editor, args)
         case .upscaleMedia:  return try upscaleMedia(editor, args)
-        case .importMedia:   return try importMedia(editor, args)
+        case .importMedia:   return try await importMedia(editor, args)
         case .listModels:    return listModels(args)
         case .listFolders:   return listFolders(editor)
         case .createFolder:  return try createFolder(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -14,8 +14,117 @@ enum MediaPanelItemKey {
     }
 }
 
-/// Media library bookkeeping: import, rename, and manifest metadata sync for
-/// the in-memory asset catalog and the persisted `MediaManifest`.
+private struct MediaImportPlan: Sendable {
+    enum Parent: Sendable {
+        case existingFolderId(String?)
+        case plannedFolder(Int)
+    }
+
+    struct Folder: Sendable {
+        let name: String
+        let parent: Parent
+    }
+
+    struct File: Sendable {
+        let url: URL
+        let type: ClipType
+        let name: String
+        let parent: Parent
+    }
+
+    var folders: [Folder] = []
+    var files: [File] = []
+    var rejectedUnsupportedNames: [String] = []
+    var rejectedLottieNames: [String] = []
+}
+
+private enum MediaImportScanner {
+    struct Root: Sendable {
+        let url: URL
+        let parentFolderId: String?
+    }
+
+    static func scan(roots: [Root]) -> MediaImportPlan {
+        var plan = MediaImportPlan()
+        for root in roots {
+            let parent = MediaImportPlan.Parent.existingFolderId(root.parentFolderId)
+            if isDirectory(root.url) {
+                scanFolderContents(at: root.url, parent: parent, into: &plan)
+            } else {
+                scanFile(at: root.url, parent: parent, isRootItem: true, into: &plan)
+            }
+        }
+        return plan
+    }
+
+    static func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+    }
+
+    private static func scanFolderContents(
+        at url: URL,
+        parent: MediaImportPlan.Parent,
+        into plan: inout MediaImportPlan
+    ) {
+        guard let entries = directoryEntries(at: url) else { return }
+        scan(entries: entries, parent: parent, into: &plan)
+    }
+
+    private static func scan(entries: [URL], parent: MediaImportPlan.Parent, into plan: inout MediaImportPlan) {
+        let sorted = entries.sorted {
+            $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
+        }
+        for entry in sorted {
+            if isDirectory(entry) {
+                scanFolder(at: entry, parent: parent, into: &plan)
+            } else {
+                scanFile(at: entry, parent: parent, isRootItem: false, into: &plan)
+            }
+        }
+    }
+
+    private static func scanFolder(
+        at url: URL,
+        parent: MediaImportPlan.Parent,
+        into plan: inout MediaImportPlan
+    ) {
+        guard let entries = directoryEntries(at: url) else { return }
+        let folderIndex = plan.folders.count
+        plan.folders.append(.init(name: url.lastPathComponent, parent: parent))
+        scan(entries: entries, parent: .plannedFolder(folderIndex), into: &plan)
+    }
+
+    private static func directoryEntries(at url: URL) -> [URL]? {
+        try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+    }
+
+    private static func scanFile(
+        at url: URL,
+        parent: MediaImportPlan.Parent,
+        isRootItem: Bool,
+        into plan: inout MediaImportPlan
+    ) {
+        guard let type = ClipType(fileExtension: url.pathExtension.lowercased()) else {
+            if isRootItem { plan.rejectedUnsupportedNames.append(url.lastPathComponent) }
+            return
+        }
+        if type == .lottie, !LottieVideoGenerator.isLottie(at: url) {
+            plan.rejectedLottieNames.append(url.lastPathComponent)
+            return
+        }
+        plan.files.append(.init(
+            url: url,
+            type: type,
+            name: url.deletingPathExtension().lastPathComponent,
+            parent: parent
+        ))
+    }
+}
+
 extension EditorViewModel {
 
     func importMediaAsset(_ asset: MediaAsset, skipAppend: Bool = false) {
@@ -70,6 +179,11 @@ extension EditorViewModel {
             mediaPanelToast = "Can't import \"\(url.lastPathComponent)\" — not a Lottie animation."
             return nil
         }
+        return addMediaAsset(from: url, type: type, folderId: folderId)
+    }
+
+    @discardableResult
+    private func addMediaAsset(from url: URL, type: ClipType, folderId: String? = nil) -> MediaAsset {
         let name = url.deletingPathExtension().lastPathComponent
         let asset = MediaAsset(url: url, type: type, name: name)
         asset.folderId = folderId
@@ -85,17 +199,63 @@ extension EditorViewModel {
 
     /// Import files and folders from the open panel or a Finder drop as one undo step
     @discardableResult
-    func importFinderItems(_ urls: [URL], into folderId: String?) -> MediaImportSummary {
+    func importFinderItems(_ urls: [URL], into folderId: String?) async -> MediaImportSummary {
         let before = mediaLibraryUndoSnapshot()
         undoManager?.disableUndoRegistration()
+        var roots: [MediaImportScanner.Root] = []
         for url in urls {
-            if isDirectory(url) {
-                importFolder(at: url, into: folderId)
+            if MediaImportScanner.isDirectory(url) {
+                let rootFolderId = createFolder(name: url.lastPathComponent, in: folderId)
+                roots.append(.init(url: url, parentFolderId: rootFolderId))
             } else {
-                addMediaAsset(from: url, folderId: folderId)
+                roots.append(.init(url: url, parentFolderId: folderId))
             }
         }
         undoManager?.enableUndoRegistration()
+
+        let plan = await Task.detached(priority: .userInitiated) {
+            MediaImportScanner.scan(roots: roots)
+        }.value
+        return applyMediaImportPlan(plan, restoringFrom: before)
+    }
+
+    @discardableResult
+    private func applyMediaImportPlan(_ plan: MediaImportPlan, restoringFrom before: MediaLibraryUndoSnapshot) -> MediaImportSummary {
+        undoManager?.disableUndoRegistration()
+
+        var folderIds = Array(repeating: "", count: plan.folders.count)
+        for (index, folder) in plan.folders.enumerated() {
+            let parentId = parentFolderId(for: folder.parent, plannedFolderIds: folderIds)
+            folderIds[index] = createFolder(name: folder.name, in: parentId)
+        }
+
+        let importedAssets = plan.files.map { file in
+            let folderId = parentFolderId(for: file.parent, plannedFolderIds: folderIds)
+            let asset = MediaAsset(url: file.url, type: file.type, name: file.name)
+            asset.folderId = folderId
+            return asset
+        }
+        if !importedAssets.isEmpty {
+            mediaAssets.append(contentsOf: importedAssets)
+            mediaManifest.entries.append(contentsOf: importedAssets.map { $0.toManifestEntry(projectURL: projectURL) })
+            Log.project.notice(
+                "media import applied assets=\(importedAssets.count) folders=\(plan.folders.count)",
+                telemetry: "Media import applied",
+                data: [
+                    "assets": importedAssets.count,
+                    "folders": plan.folders.count,
+                    "media": mediaAssets.count,
+                    "manifestEntries": mediaManifest.entries.count
+                ]
+            )
+        }
+        undoManager?.enableUndoRegistration()
+
+        if let name = plan.rejectedUnsupportedNames.last {
+            mediaPanelToast = "Can't import \"\(name)\" — unsupported file type."
+        } else if let name = plan.rejectedLottieNames.last {
+            mediaPanelToast = "Can't import \"\(name)\" — not a Lottie animation."
+        }
 
         let summary = MediaImportSummary(
             assetCount: mediaAssets.count - before.mediaAssets.count,
@@ -106,33 +266,19 @@ extension EditorViewModel {
             vm.restoreMediaLibraryUndoSnapshot(before, actionName: "Import Media")
         }
         undoManager?.setActionName("Import Media")
+        for asset in importedAssets {
+            Task { await finalizeImportedAsset(asset) }
+        }
         return summary
     }
 
-    /// Mirror a directory tree into media folders
-    func importFolder(at url: URL, into parentFolderId: String?) {
-        let fm = FileManager.default
-        guard let entries = try? fm.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else { return }
-
-        let folderId = createFolder(name: url.lastPathComponent, in: parentFolderId)
-        let sorted = entries.sorted {
-            $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
+    private func parentFolderId(for parent: MediaImportPlan.Parent, plannedFolderIds: [String]) -> String? {
+        switch parent {
+        case .existingFolderId(let id):
+            id
+        case .plannedFolder(let index):
+            plannedFolderIds[index]
         }
-        for entry in sorted {
-            if isDirectory(entry) {
-                importFolder(at: entry, into: folderId)
-            } else if ClipType(fileExtension: entry.pathExtension.lowercased()) != nil {
-                addMediaAsset(from: entry, folderId: folderId)
-            }
-        }
-    }
-
-    private func isDirectory(_ url: URL) -> Bool {
-        (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
     }
 
     @discardableResult

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -49,7 +49,7 @@ private enum MediaImportScanner {
         for root in roots {
             let parent = MediaImportPlan.Parent.existingFolderId(root.parentFolderId)
             if isDirectory(root.url) {
-                scanFolderContents(at: root.url, parent: parent, into: &plan)
+                scanFolder(at: root.url, parent: parent, into: &plan)
             } else {
                 scanFile(at: root.url, parent: parent, isRootItem: true, into: &plan)
             }
@@ -59,15 +59,6 @@ private enum MediaImportScanner {
 
     static func isDirectory(_ url: URL) -> Bool {
         (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
-    }
-
-    private static func scanFolderContents(
-        at url: URL,
-        parent: MediaImportPlan.Parent,
-        into plan: inout MediaImportPlan
-    ) {
-        guard let entries = directoryEntries(at: url) else { return }
-        scan(entries: entries, parent: parent, into: &plan)
     }
 
     private static func scan(entries: [URL], parent: MediaImportPlan.Parent, into plan: inout MediaImportPlan) {
@@ -192,7 +183,7 @@ extension EditorViewModel {
         return asset
     }
 
-    struct MediaImportSummary {
+    struct MediaImportSummary: Sendable {
         var assetCount: Int
         var folderCount: Int
     }
@@ -200,18 +191,26 @@ extension EditorViewModel {
     /// Import files and folders from the open panel or a Finder drop as one undo step
     @discardableResult
     func importFinderItems(_ urls: [URL], into folderId: String?) async -> MediaImportSummary {
-        let before = mediaLibraryUndoSnapshot()
-        undoManager?.disableUndoRegistration()
-        var roots: [MediaImportScanner.Root] = []
-        for url in urls {
-            if MediaImportScanner.isDirectory(url) {
-                let rootFolderId = createFolder(name: url.lastPathComponent, in: folderId)
-                roots.append(.init(url: url, parentFolderId: rootFolderId))
-            } else {
-                roots.append(.init(url: url, parentFolderId: folderId))
-            }
+        let previous = mediaImportTail
+        mediaImportSequence &+= 1
+        let sequence = mediaImportSequence
+        let task = Task { @MainActor in
+            _ = await previous?.value
+            return await performFinderImport(urls, into: folderId)
         }
-        undoManager?.enableUndoRegistration()
+        mediaImportTail = task
+
+        let summary = await task.value
+        if mediaImportSequence == sequence {
+            mediaImportTail = nil
+        }
+        return summary
+    }
+
+    @discardableResult
+    private func performFinderImport(_ urls: [URL], into folderId: String?) async -> MediaImportSummary {
+        let before = mediaLibraryUndoSnapshot()
+        let roots = urls.map { MediaImportScanner.Root(url: $0, parentFolderId: folderId) }
 
         let plan = await Task.detached(priority: .userInitiated) {
             MediaImportScanner.scan(roots: roots)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -167,6 +167,8 @@ final class EditorViewModel {
     var mediaPanelPasteRequestTick: Int = 0
     var mediaPanelShowMediaTabTick: Int = 0
     var mediaPanelToast: String?
+    @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Never>?
+    @ObservationIgnored var mediaImportSequence: Int = 0
 
     func showMediaPanelMediaTab() { mediaPanelShowMediaTabTick += 1 }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
@@ -98,12 +98,14 @@ extension MediaTab {
 extension MediaTab {
     @MainActor
     func handlePanelFinderDrop(urls: [URL]) {
-        Self.handlePanelFinderDrop(urls: urls, into: currentFolderId, editor: editor)
+        Task { @MainActor in
+            await Self.handlePanelFinderDrop(urls: urls, into: currentFolderId, editor: editor)
+        }
     }
 
     @MainActor
-    static func handlePanelFinderDrop(urls: [URL], into destFolderId: String?, editor: EditorViewModel) {
-        editor.importFinderItems(urls, into: destFolderId)
+    static func handlePanelFinderDrop(urls: [URL], into destFolderId: String?, editor: EditorViewModel) async {
+        await editor.importFinderItems(urls, into: destFolderId)
     }
 
     func handleProviderDrop(_ providers: [NSItemProvider], into destFolderId: String?) {
@@ -113,7 +115,7 @@ extension MediaTab {
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                     guard let url else { return }
                     Task { @MainActor in
-                        editor.importFinderItems([url], into: destFolderId)
+                        await Self.handlePanelFinderDrop(urls: [url], into: destFolderId, editor: editor)
                     }
                 }
                 continue
@@ -137,13 +139,15 @@ extension MediaTab {
 
     @MainActor
     func handleClipboardPaste() {
-        Self.handleClipboardPaste(pasteboard: .general, into: currentFolderId, editor: editor)
+        Task { @MainActor in
+            await Self.handleClipboardPaste(pasteboard: .general, into: currentFolderId, editor: editor)
+        }
     }
 
     @MainActor
-    static func handleClipboardPaste(pasteboard pb: NSPasteboard, into destFolderId: String?, editor: EditorViewModel) {
+    static func handleClipboardPaste(pasteboard pb: NSPasteboard, into destFolderId: String?, editor: EditorViewModel) async {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL], !urls.isEmpty {
-            handlePanelFinderDrop(urls: urls, into: destFolderId, editor: editor)
+            await handlePanelFinderDrop(urls: urls, into: destFolderId, editor: editor)
             return
         }
         for (type, ext): (NSPasteboard.PasteboardType, String) in [(.png, "png"), (.tiff, "tiff")] {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -756,7 +756,11 @@ struct MediaTab: View {
         panel.allowedContentTypes = types
         panel.begin { response in
             guard response == .OK else { return }
-            editor.importFinderItems(panel.urls, into: currentFolderId)
+            let urls = panel.urls
+            let folderId = currentFolderId
+            Task { @MainActor in
+                await Self.handlePanelFinderDrop(urls: urls, into: folderId, editor: editor)
+            }
         }
     }
 }

--- a/Sources/PalmierPro/Preview/LottieVideoGenerator.swift
+++ b/Sources/PalmierPro/Preview/LottieVideoGenerator.swift
@@ -13,6 +13,8 @@ enum LottieVideoGenerator {
 
     /// Final frame is held out to here so a clip can be extended past the animation (freeze-frame).
     private static let holdTailSeconds: Double = 1800
+    private static let jsonSniffByteLimit = 256 * 1024
+    private static let jsonSignatureKeys = ["layers", "v", "w", "h", "op"]
 
     struct Metadata {
         let size: CGSize
@@ -28,11 +30,23 @@ enum LottieVideoGenerator {
             defer { try? handle.close() }
             return (try? handle.read(upToCount: 4)) == Data([0x50, 0x4B, 0x03, 0x04])
         }
-        guard let data = try? Data(contentsOf: url),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: jsonSniffByteLimit),
+              let first = data.first(where: { !isJSONWhitespace($0) }),
+              first == UInt8(ascii: "{")
         else { return false }
-        return obj["layers"] is [Any] && obj["v"] != nil
-            && obj["w"] != nil && obj["h"] != nil && obj["op"] != nil
+        let text = String(decoding: data, as: UTF8.self)
+        return jsonSignatureKeys.allSatisfy { containsJSONKey($0, in: text) }
+    }
+
+    private static func containsJSONKey(_ key: String, in text: String) -> Bool {
+        let escaped = NSRegularExpression.escapedPattern(for: key)
+        return text.range(of: #""\#(escaped)"\s*:"#, options: .regularExpression) != nil
+    }
+
+    private static func isJSONWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
     }
 
     private static func metadata(for animation: LottieAnimation) -> Metadata {

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -79,6 +79,24 @@ struct FolderReadTests {
         #expect(e.assetsIn(folderId: rootFolder.id).map(\.name) == ["root"])
         #expect(e.assetsIn(folderId: nestedFolder.id).map(\.name) == ["child"])
     }
+
+    @Test func importFinderItemsDoesNotCreateRootFolderWhenDirectoryCannotBeRead() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-denied-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: root.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let summary = await e.importFinderItems([root], into: nil)
+
+        #expect(summary.assetCount == 0)
+        #expect(summary.folderCount == 0)
+        #expect(e.folders.isEmpty)
+    }
 }
 
 @Suite("EditorViewModel — deleteFolders")

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -56,6 +56,29 @@ struct FolderReadTests {
         #expect(e.assetsIn(folderId: folderId).map(\.name) == ["in"])
         #expect(e.assetsIn(folderId: nil).map(\.name) == ["out"])
     }
+
+    @Test func importFinderItemsMirrorsFolderTree() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-\(UUID().uuidString)", isDirectory: true)
+        let nested = root.appendingPathComponent("Nested", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data().write(to: root.appendingPathComponent("root.mp4"))
+        try Data().write(to: nested.appendingPathComponent("child.wav"))
+        try Data().write(to: nested.appendingPathComponent("ignored.txt"))
+
+        let summary = await e.importFinderItems([root], into: nil)
+
+        #expect(summary.assetCount == 2)
+        #expect(summary.folderCount == 2)
+        let rootFolder = try #require(e.folders.first { $0.name == root.lastPathComponent })
+        let nestedFolder = try #require(e.folders.first { $0.name == "Nested" })
+        #expect(nestedFolder.parentFolderId == rootFolder.id)
+        #expect(e.assetsIn(folderId: rootFolder.id).map(\.name) == ["root"])
+        #expect(e.assetsIn(folderId: nestedFolder.id).map(\.name) == ["child"])
+    }
 }
 
 @Suite("EditorViewModel — deleteFolders")
@@ -545,44 +568,44 @@ struct MoveMediaSelectionTests {
 @MainActor
 struct HandlePanelFinderDropTests {
 
-    @Test func addsAssetAtRootWhenDestinationIsNil() {
+    @Test func addsAssetAtRootWhenDestinationIsNil() async {
         let e = editor()
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
 
-        MediaTab.handlePanelFinderDrop(urls: [url], into: nil, editor: e)
+        await MediaTab.handlePanelFinderDrop(urls: [url], into: nil, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.folderId == nil)
     }
 
-    @Test func addsAssetAndMovesIntoDestinationFolder() {
+    @Test func addsAssetAndMovesIntoDestinationFolder() async {
         let e = editor()
         let dest = e.createFolder(name: "Dest")
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
 
-        MediaTab.handlePanelFinderDrop(urls: [url], into: dest, editor: e)
+        await MediaTab.handlePanelFinderDrop(urls: [url], into: dest, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.folderId == dest)
     }
 
-    @Test func skipsUnsupportedFileExtensions() {
+    @Test func skipsUnsupportedFileExtensions() async {
         let e = editor()
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-readme.txt")
 
-        MediaTab.handlePanelFinderDrop(urls: [url], into: nil, editor: e)
+        await MediaTab.handlePanelFinderDrop(urls: [url], into: nil, editor: e)
 
         #expect(e.mediaAssets.isEmpty)
     }
 
-    @Test func addsMultipleAssetsIntoDestination() {
+    @Test func addsMultipleAssetsIntoDestination() async {
         let e = editor()
         let dest = e.createFolder(name: "Dest")
         let urls = (0..<3).map { _ in
             URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
         }
 
-        MediaTab.handlePanelFinderDrop(urls: urls, into: dest, editor: e)
+        await MediaTab.handlePanelFinderDrop(urls: urls, into: dest, editor: e)
 
         #expect(e.mediaAssets.count == 3)
         #expect(e.mediaAssets.allSatisfy { $0.folderId == dest })
@@ -645,12 +668,12 @@ struct HandleClipboardPasteTests {
         return pb
     }
 
-    @Test func pngBytesImportAtRootWhenDestinationIsNil() {
+    @Test func pngBytesImportAtRootWhenDestinationIsNil() async {
         let e = editor()
         let pb = freshPasteboard()
         pb.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.type == .image)
@@ -658,49 +681,49 @@ struct HandleClipboardPasteTests {
         #expect(e.mediaAssets.first?.folderId == nil)
     }
 
-    @Test func pngBytesLandInDestinationFolder() {
+    @Test func pngBytesLandInDestinationFolder() async {
         let e = editor()
         let dest = e.createFolder(name: "Dest")
         let pb = freshPasteboard()
         pb.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: dest, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: dest, editor: e)
 
         #expect(e.mediaAssets.first?.folderId == dest)
         #expect(e.mediaManifest.entries.first?.folderId == dest)
     }
 
-    @Test func tiffBytesImportWithTiffExtension() {
+    @Test func tiffBytesImportWithTiffExtension() async {
         let e = editor()
         let pb = freshPasteboard()
         pb.setData(Data([0x4D, 0x4D, 0x00, 0x2A]), forType: .tiff)
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.url.pathExtension == "tiff")
     }
 
-    @Test func fileURLRoutesThroughFinderDrop() {
+    @Test func fileURLRoutesThroughFinderDrop() async {
         let e = editor()
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
         let pb = freshPasteboard()
         pb.writeObjects([url as NSURL])
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.type == .video)
     }
 
-    @Test func fileURLLandsInDestinationFolder() {
+    @Test func fileURLLandsInDestinationFolder() async {
         let e = editor()
         let dest = e.createFolder(name: "Dest")
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
         let pb = freshPasteboard()
         pb.writeObjects([url as NSURL])
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: dest, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: dest, editor: e)
 
         #expect(e.mediaAssets.first?.folderId == dest)
     }
@@ -709,44 +732,44 @@ struct HandleClipboardPasteTests {
     /// items always carry a TIFF preview alongside the file URL), the URL wins —
     /// avoids creating both the file-imported asset and a duplicate "pasted-*"
     /// image asset for the same payload.
-    @Test func fileURLTakesPrecedenceOverImageData() {
+    @Test func fileURLTakesPrecedenceOverImageData() async {
         let e = editor()
         let url = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-clip.mp4")
         let pb = freshPasteboard()
         pb.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
         pb.writeObjects([url as NSURL])
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.count == 1)
         #expect(e.mediaAssets.first?.type == .video)
     }
 
-    @Test func emptyPasteboardIsNoOp() {
+    @Test func emptyPasteboardIsNoOp() async {
         let e = editor()
         let pb = freshPasteboard()
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.isEmpty)
     }
 
-    @Test func textOnlyPasteboardIsNoOp() {
+    @Test func textOnlyPasteboardIsNoOp() async {
         let e = editor()
         let pb = freshPasteboard()
         pb.setString("just some text", forType: .string)
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.isEmpty)
     }
 
-    @Test func fileURLWithUnsupportedExtensionIsNoOp() {
+    @Test func fileURLWithUnsupportedExtensionIsNoOp() async {
         let e = editor()
         let pb = freshPasteboard()
         pb.writeObjects([URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-readme.txt") as NSURL])
 
-        MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
+        await MediaTab.handleClipboardPaste(pasteboard: pb, into: nil, editor: e)
 
         #expect(e.mediaAssets.isEmpty)
     }


### PR DESCRIPTION
 ### problem
  Folder imports recursively walked directories, sorted entries, validated Lottie JSON, and appended
  media assets on the main actor. Large folders could hang the app, especially under low-memory
  conditions.

  ### solution
  Move folder scanning and Lottie validation off-main into an async import plan. The main actor now
  creates the top-level folder immediately, applies scanned folders/assets in one batch, registers
  one undo step, and finalizes assets afterward. Also changed .json Lottie sniffing to a bounded
  prefix read instead of full-file JSON parsing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core media-library import and manifest/undo path with new concurrency; behavior is covered by new tests but large-folder edge cases and Lottie sniff false positives/negatives warrant manual check.
> 
> **Overview**
> Fixes UI freezes when importing large folder trees by **replacing synchronous recursive `importFolder` walks** with an off-main **`MediaImportScanner`** that builds a `MediaImportPlan`, then applies folders/assets on the main actor in one batch (single undo step, `finalizeImportedAsset` afterward).
> 
> **`importFinderItems`** is now **`async`** and **serializes** overlapping imports via `mediaImportTail` / `mediaImportSequence` on `EditorViewModel`. Media panel drops, paste, open panel, and the agent **`import_media`** path (directory `source.path`) all **`await`** this flow.
> 
> **`LottieVideoGenerator.isLottie`** no longer loads whole `.json` files: it reads a **256KB prefix** and checks for Bodymovin-style keys with regex instead of full `JSONSerialization`.
> 
> Adds tests for mirrored folder import, unreadable directories, and updates existing import tests for async APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951f3fe0f9ee28e9dab83b1132e83d1aee9decc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->