### PR TITLE
style: use AppTheme constants for hardcoded font sizes

### DIFF
--- a/Sources/PalmierPro/Agent/Panel/ChatHistoryList.swift
+++ b/Sources/PalmierPro/Agent/Panel/ChatHistoryList.swift
@@ -46,7 +46,7 @@ struct ChatHistoryList: View {
                         .lineLimit(1)
                 }
                 Text(Self.formatter.localizedString(for: session.updatedAt, relativeTo: Date()))
-                    .font(.system(size: 9))
+                    .font(.system(size: AppTheme.FontSize.xxs))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
             }
             Spacer()

--- a/Sources/PalmierPro/Agent/Panel/MentionPopover.swift
+++ b/Sources/PalmierPro/Agent/Panel/MentionPopover.swift
@@ -112,7 +112,7 @@ struct MentionPopover: View {
         HStack(spacing: 0) {
             ForEach(MentionTab.allCases, id: \.self) { t in
                 Text(t.label)
-                    .font(.system(size: 10, weight: t == tab ? .semibold : .regular))
+                    .font(.system(size: AppTheme.FontSize.xs, weight: t == tab ? .semibold : .regular))
                     .foregroundStyle(t == tab ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 5)
@@ -126,7 +126,7 @@ struct MentionPopover: View {
                     .onTapGesture { tab = t }
             }
         }
-        .padding(4)
+        .padding(AppTheme.Spacing.xs)
     }
 
     private func mentionRow(asset: MediaAsset, isHighlighted: Bool) -> some View {
@@ -138,7 +138,7 @@ struct MentionPopover: View {
                     ZStack {
                         Rectangle().fill(.quaternary)
                         Image(systemName: asset.type.sfSymbolName)
-                            .font(.system(size: 10))
+                            .font(.system(size: AppTheme.FontSize.xs))
                             .foregroundStyle(AppTheme.Text.tertiaryColor)
                     }
                 }
@@ -152,7 +152,7 @@ struct MentionPopover: View {
                     .foregroundStyle(AppTheme.Text.primaryColor)
                     .lineLimit(1)
                 Text(asset.type.rawValue)
-                    .font(.system(size: 9))
+                    .font(.system(size: AppTheme.FontSize.xxs))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
             }
             Spacer()

--- a/Sources/PalmierPro/Help/HelpView.swift
+++ b/Sources/PalmierPro/Help/HelpView.swift
@@ -52,7 +52,7 @@ struct HelpView: View {
         return Button(action: { selectedTab = tab }) {
             HStack(spacing: 10) {
                 Image(systemName: tab.icon)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: AppTheme.FontSize.smMd, weight: .medium))
                     .frame(width: 16)
                 Text(tab.rawValue)
                     .font(.system(size: AppTheme.FontSize.md, weight: isActive ? .medium : .regular))

--- a/Sources/PalmierPro/Help/ShortcutsPane.swift
+++ b/Sources/PalmierPro/Help/ShortcutsPane.swift
@@ -77,7 +77,7 @@ struct ShortcutsPane: View {
             ForEach(groups, id: \.title) { group in
                 VStack(alignment: .leading, spacing: 8) {
                     Text(group.title)
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
                         .textCase(.uppercase)
                         .tracking(0.3)
@@ -92,7 +92,7 @@ struct ShortcutsPane: View {
                                     .frame(width: Self.shortcutKeyColumnWidth, alignment: .leading)
 
                                 Text(description)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: AppTheme.FontSize.sm))
                                     .foregroundStyle(AppTheme.Text.secondaryColor)
                                     .fixedSize(horizontal: true, vertical: false)
                             }


### PR DESCRIPTION
Closes #83.

Converts 8 hardcoded `.font(.system(size:))` / `.padding()` values to their existing `AppTheme` constants, per the `AGENTS.md` design system rule. Each maps to an identical numeric value, so there is no visual change.

| File | Before | After |
|------|--------|-------|
| `Agent/Panel/ChatHistoryList.swift:49` | `size: 9` | `FontSize.xxs` |
| `Agent/Panel/MentionPopover.swift:115,141` | `size: 10` | `FontSize.xs` |
| `Agent/Panel/MentionPopover.swift:155` | `size: 9` | `FontSize.xxs` |
| `Agent/Panel/MentionPopover.swift:129` | `.padding(4)` | `Spacing.xs` |
| `Help/ShortcutsPane.swift:80` | `size: 10` | `FontSize.xs` |
| `Help/ShortcutsPane.swift:95` | `size: 11` | `FontSize.sm` |
| `Help/HelpView.swift:55` | `size: 12` | `FontSize.smMd` |

Verified with `swift build` (passes).

## Question for maintainers

I left out the two `Toolbar/ToolbarView.swift` sites (`:103` serif wordmark size 17, `:115` mono timecode size 16). `FontSize` jumps from `lg=15` to `xl=18`, so there is no exact constant for 16 or 17, and these look like intentional branding. Two options:

1. Add `FontSize` constants for 16 and 17 and convert them (fully satisfies the rule).
2. Leave them as documented exceptions.

Happy to open a follow-up issue and handle whichever you prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic token swaps with identical numeric values; no logic, auth, or data changes.
> 
> **Overview**
> Replaces **8** literal `.font(.system(size:))` values and **one** `.padding(4)` with existing `AppTheme.FontSize` and `AppTheme.Spacing` constants in agent chat/history UI (`ChatHistoryList`, `MentionPopover`) and Help (`HelpView`, `ShortcutsPane`).
> 
> Each token maps to the same point size or spacing as before, so typography and layout should be unchanged; the goal is consistency with the design system rule in `AGENTS.md`. Toolbar wordmark/timecode sizes (16–17) are intentionally left as literals pending maintainer decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d3b3749cab4a45679865694f4459c9ac7ed19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->