### PR TITLE
multi langual readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@
 <a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Join Discord" /></a>
 <a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
 
+<p>
+  <strong>English</strong> ·
+  <a href="docs/readme/README.es.md">Español</a> ·
+  <a href="docs/readme/README.zh-CN.md">简体中文</a> ·
+  <a href="docs/readme/README.zh-TW.md">繁體中文</a> ·
+  <a href="docs/readme/README.ja.md">日本語</a> ·
+  <a href="docs/readme/README.ko.md">한국어</a> ·
+  <a href="docs/readme/README.vi.md">Tiếng Việt</a> ·
+  <a href="docs/readme/README.hi.md">हिन्दी</a> ·
+  <a href="docs/readme/README.it.md">Italiano</a> ·
+  <a href="docs/readme/README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="docs/readme/README.fr.md">Français</a> ·
+  <a href="docs/readme/README.ru.md">Русский</a>
+</p>
+
 </div>
 
 <img src="./assets/palmier-ui.png" alt="palmierpro UI" width="900" />

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   <a href="docs/readme/README.ko.md">한국어</a> ·
   <a href="docs/readme/README.vi.md">Tiếng Việt</a> ·
   <a href="docs/readme/README.hi.md">हिन्दी</a> ·
+  <a href="docs/readme/README.bn.md">বাংলা</a> ·
+  <a href="docs/readme/README.ar.md">العربية</a> ·
   <a href="docs/readme/README.it.md">Italiano</a> ·
   <a href="docs/readme/README.pt-BR.md">Português (Brasil)</a> ·
   <a href="docs/readme/README.fr.md">Français</a> ·

--- a/docs/readme/README.ar.md
+++ b/docs/readme/README.ar.md
@@ -1,0 +1,132 @@
+> تمت ترجمة هذا الملف بواسطة AI. إذا لاحظت خطأ، افتح PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**محرر فيديو مصمم لـ AI.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="تنزيل Palmier Pro لنظام macOS" width="180" />
+</a>
+
+<sub><i>يتطلب macOS 26 (Tahoe) على Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="تابع على X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="انضم إلى Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <strong>العربية</strong> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="واجهة Palmier Pro" width="900" />
+
+---
+
+Palmier Pro هو محرر فيديو open source لنظام Mac. يمكنك أنت والـ agent الخاص بك إنشاء الفيديوهات وتحريرها معًا داخل timeline.
+
+### محرر فيديو Swift-native
+
+بنينا Palmier Pro من الصفر باستخدام Swift. المرجع الأساسي هو Premiere Pro، مع طريقتنا الخاصة في دمج AI داخل workflow.
+
+### Generative AI مدمج
+
+أنشئ فيديوهات وصورًا باستخدام نماذج SOTA مثل Seedance وKling وNano Banana Pro داخل محرر timeline.
+
+### يتكامل مع agents الخاصة بك
+
+صل Claude أو Codex أو Cursor عبر MCP، أو استخدم الـ agent داخل التطبيق للعمل معًا على المشروع نفسه.
+
+## MCP server
+
+عندما يكون التطبيق مفتوحًا، فإنه يوفّر MCP server على `http://127.0.0.1:19789/mcp` عبر HTTP. للاتصال:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+أسهل طريقة هي فتح `Help` -> `MCP Instructions` -> `Install in Cursor` داخل التطبيق، أو التثبيت يدويًا بإضافة هذا إلى `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+نضمّن [mcpb](https://github.com/modelcontextprotocol/mcpb) مع التطبيق، ما يسمح بتثبيت Desktop Extension على Claude Desktop بنقرة واحدة. افتح `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**هل Palmier Pro بالكامل open source؟**
+
+محرر الفيديو، بدون ميزات generative AI، مفتوح المصدر بالكامل. MCP server وagent chat مفتوحا المصدر أيضًا. الجزء الوحيد closed source هو معالجة generative AI.
+
+**هل هو مجاني؟**
+
+المحرر مجاني. يمكنك تنزيله دون تسجيل دخول واستخدامه كمحرر فيديو مثل CapCut أو Adobe Premiere. يمكنك أيضًا استخدام MCP server مجانًا والبدء بالتجربة مع Claude Code أو Claude Desktop أو Cursor للتفاعل مع محرر timeline.
+
+ميزات generative AI تتطلب تسجيل الدخول والاشتراك.
+
+**ما المنصات المدعومة؟**
+
+macOS 26 (Tahoe) على Apple Silicon فقط.
+
+راجع [FAQ.md](../../FAQ.md) للمزيد.
+
+## Development
+
+راجع [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Community والدعم
+
+- **Discord:** انضم إلى المجتمع على **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** تابع **[@Palmier_io](https://x.com/Palmier_io)** للحصول على التحديثات والإعلانات.
+- **Instagram:** تابع [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback والدعم:** افتح [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) أو راسلنا على founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="مخطط Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## License
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro مفتوح المصدر بموجب [GPLv3](../../LICENSE).

--- a/docs/readme/README.bn.md
+++ b/docs/readme/README.bn.md
@@ -1,0 +1,132 @@
+> এই অনুবাদটি AI দিয়ে তৈরি। কোনো ভুল দেখলে অনুগ্রহ করে একটি PR খুলুন।
+
+<div align="center">
+
+# Palmier Pro
+
+**AI-এর জন্য তৈরি ভিডিও এডিটর।**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="macOS-এর জন্য Palmier Pro ডাউনলোড করুন" width="180" />
+</a>
+
+<sub><i>Apple Silicon-এ macOS 26 (Tahoe) প্রয়োজন</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="X-এ অনুসরণ করুন" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord-এ যোগ দিন" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <strong>বাংলা</strong> ·
+  <a href="README.ar.md">العربية</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro UI" width="900" />
+
+---
+
+Palmier Pro Mac-এর জন্য একটি open source ভিডিও এডিটর। আপনি এবং আপনার agent timeline-এর ভিতরে একসঙ্গে ভিডিও generate ও edit করতে পারেন।
+
+### Swift-native ভিডিও এডিটর
+
+আমরা Swift দিয়ে Palmier Pro একদম শুরু থেকে তৈরি করেছি। আমাদের উত্তর তারা Premiere Pro, তবে workflow-তে AI যুক্ত করার নিজস্ব পদ্ধতি নিয়ে।
+
+### Built-in Generative AI
+
+Timeline editor-এর ভিতর Seedance, Kling, Nano Banana Pro-এর মতো SOTA models দিয়ে ভিডিও এবং ছবি generate করুন।
+
+### আপনার agents-এর সঙ্গে integration
+
+MCP-এর মাধ্যমে Claude, Codex বা Cursor connect করুন, অথবা একই project-এ একসঙ্গে কাজ করতে in-app agent ব্যবহার করুন।
+
+## MCP server
+
+App খোলা থাকলে, এটি HTTP-এর মাধ্যমে `http://127.0.0.1:19789/mcp`-এ একটি MCP server expose করে। Connect করতে:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+সবচেয়ে সহজ উপায় হলো app-এর ভিতরে `Help` -> `MCP Instructions` -> `Install in Cursor`-এ যাওয়া। Manual install করতে `~/.cursor/mcp.json`-এ এটি যোগ করুন:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+App-এর সঙ্গে আমরা একটি [mcpb](https://github.com/modelcontextprotocol/mcpb) bundle করি, যা Claude Desktop-এ Desktop Extension এক click-এ install করতে দেয়। `Help` -> `MCP Instructions` -> `Install in Claude Desktop` খুলুন।
+
+## FAQ
+
+**Palmier Pro কি পুরোপুরি open source?**
+
+Generative AI features ছাড়া ভিডিও এডিটরটি পুরোপুরি open source। MCP server এবং agent chat-ও open source। শুধু generative AI processing closed source।
+
+**এটি কি free?**
+
+Editor free। Login ছাড়াই আপনি এটি download করতে পারেন এবং CapCut বা Adobe Premiere-এর মতো ভিডিও এডিটর হিসেবে ব্যবহার করতে পারেন। MCP server-ও free, এবং Claude Code, Claude Desktop বা Cursor দিয়ে timeline editor-এর সঙ্গে experiment শুরু করতে পারেন।
+
+Generative AI features-এর জন্য login এবং subscription প্রয়োজন।
+
+**কোন platforms support করে?**
+
+শুধু Apple Silicon-এ macOS 26 (Tahoe)।
+
+আরও জানতে [FAQ.md](../../FAQ.md) দেখুন।
+
+## Development
+
+[CONTRIBUTING.md](../../CONTRIBUTING.md) দেখুন।
+
+## Community এবং support
+
+- **Discord:** **[Discord](https://discord.com/invite/SMVW6pKYmg)**-এ community-তে যোগ দিন।
+- **Twitter / X:** Updates এবং announcements-এর জন্য **[@Palmier_io](https://x.com/Palmier_io)** follow করুন।
+- **Instagram:** [@palmier.io](https://www.instagram.com/palmier.io) follow করুন।
+- **Feedback এবং support:** একটি [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) তৈরি করুন অথবা founders@palmier.io-এ email করুন।
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## License
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro [GPLv3](../../LICENSE)-এর অধীনে open source।

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -1,0 +1,130 @@
+> Esta traducción fue generada por IA. Si encuentras un error, abre un PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**El editor de video creado para IA.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Descargar Palmier Pro para macOS" width="180" />
+</a>
+
+<sub><i>Requiere macOS 26 (Tahoe) en Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Seguir en X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Unirse a Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <strong>Español</strong> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Interfaz de Palmier Pro" width="900" />
+
+---
+
+Palmier Pro es un editor de video de código abierto para Mac. Tú y tu agente pueden generar y editar videos juntos dentro de la línea de tiempo.
+
+### Editor de video nativo en Swift
+
+Construimos Palmier Pro desde cero con Swift. La referencia es Premiere Pro, con nuestra forma de integrar IA en el flujo de trabajo.
+
+### IA generativa integrada
+
+Genera videos e imágenes con modelos de vanguardia como Seedance, Kling y Nano Banana Pro dentro del editor de línea de tiempo.
+
+### Integración con tus agentes
+
+Conecta Claude, Codex o Cursor mediante MCP, o usa el agente integrado en la app para trabajar juntos en el mismo proyecto.
+
+## Servidor MCP
+
+Cuando la app está abierta, expone un servidor MCP en `http://127.0.0.1:19789/mcp` mediante HTTP. Para conectarlo:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+La forma más fácil es abrir `Help` -> `MCP Instructions` -> `Install in Cursor` dentro de la app, o instalarlo manualmente agregando esto a `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Incluimos un [mcpb](https://github.com/modelcontextprotocol/mcpb) con la app que permite instalar la extensión de escritorio en Claude Desktop con un clic. Abre `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**¿Palmier Pro es completamente de código abierto?**
+
+El editor de video, sin las funciones de IA generativa, es completamente de código abierto. El servidor MCP y el chat del agente también son de código abierto. Lo único cerrado es el procesamiento de IA generativa.
+
+**¿Es gratis?**
+
+El editor es gratis. Puedes descargarlo sin iniciar sesión y usarlo como editor de video, como CapCut o Adobe Premiere. También puedes usar el servidor MCP gratis y empezar a experimentar con Claude Code, Claude Desktop o Cursor para interactuar con tu editor de línea de tiempo.
+
+Las funciones de IA generativa requieren inicio de sesión y suscripción.
+
+**¿Qué plataformas admite?**
+
+Solo macOS 26 (Tahoe) en Apple Silicon.
+
+Consulta [FAQ.md](../../FAQ.md) para más información.
+
+## Desarrollo
+
+Consulta [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Comunidad y soporte
+
+- **Discord:** Únete a la comunidad en **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** Sigue a **[@Palmier_io](https://x.com/Palmier_io)** para novedades y anuncios.
+- **Instagram:** Sigue a [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback y soporte:** Crea un [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) o escríbenos a founders@palmier.io.
+
+## Historial de estrellas
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Gráfico del historial de estrellas" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Licencia
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro es de código abierto bajo [GPLv3](../../LICENSE).

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <strong>Français</strong> ·

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -1,0 +1,130 @@
+> Cette traduction a été générée par IA. Si vous repérez une erreur, ouvrez une PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**L'éditeur vidéo conçu pour l'IA.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Télécharger Palmier Pro pour macOS" width="180" />
+</a>
+
+<sub><i>Nécessite macOS 26 (Tahoe) sur Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Suivre sur X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Rejoindre Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <strong>Français</strong> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Interface de Palmier Pro" width="900" />
+
+---
+
+Palmier Pro est un éditeur vidéo open source pour Mac. Vous et votre agent pouvez générer et monter des vidéos ensemble dans la timeline.
+
+### Éditeur vidéo natif Swift
+
+Nous avons construit Palmier Pro de zéro avec Swift. La référence est Premiere Pro, avec notre façon d'intégrer l'IA dans le workflow.
+
+### IA générative intégrée
+
+Générez des vidéos et des images avec des modèles de pointe comme Seedance, Kling et Nano Banana Pro directement dans l'éditeur de timeline.
+
+### Intégration avec vos agents
+
+Connectez Claude, Codex ou Cursor via MCP, ou utilisez l'agent intégré à l'app pour travailler ensemble sur le même projet.
+
+## Serveur MCP
+
+Lorsque l'app est ouverte, elle expose un serveur MCP à `http://127.0.0.1:19789/mcp` via HTTP. Pour vous connecter :
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+Le plus simple est d'ouvrir dans l'app `Help` -> `MCP Instructions` -> `Install in Cursor`, ou de l'installer manuellement en ajoutant ceci à `~/.cursor/mcp.json` :
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Nous fournissons un [mcpb](https://github.com/modelcontextprotocol/mcpb) avec l'app, ce qui permet d'installer en un clic la Desktop Extension dans Claude Desktop. Ouvrez `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**Palmier Pro est-il entièrement open source ?**
+
+L'éditeur vidéo, sans les fonctions d'IA générative, est entièrement open source. Le serveur MCP et le chat de l'agent sont aussi open source. La seule partie closed source est le traitement d'IA générative.
+
+**Est-ce gratuit ?**
+
+L'éditeur est gratuit. Vous pouvez le télécharger sans vous connecter et l'utiliser comme éditeur vidéo, comme CapCut ou Adobe Premiere. Vous pouvez aussi utiliser le serveur MCP gratuitement et commencer à expérimenter avec Claude Code, Claude Desktop ou Cursor pour interagir avec votre éditeur de timeline.
+
+Les fonctions d'IA générative nécessitent une connexion et un abonnement.
+
+**Quelles plateformes sont prises en charge ?**
+
+macOS 26 (Tahoe) sur Apple Silicon uniquement.
+
+Voir [FAQ.md](../../FAQ.md) pour plus d'informations.
+
+## Développement
+
+Voir [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Communauté et support
+
+- **Discord :** Rejoignez la communauté sur **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X :** Suivez **[@Palmier_io](https://x.com/Palmier_io)** pour les mises à jour et annonces.
+- **Instagram :** Suivez [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback et support :** Créez une [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) ou envoyez-nous un email à founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Graphique Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Licence
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro est open source sous [GPLv3](../../LICENSE).

--- a/docs/readme/README.hi.md
+++ b/docs/readme/README.hi.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <strong>हिन्दी</strong> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.hi.md
+++ b/docs/readme/README.hi.md
@@ -1,0 +1,130 @@
+> यह अनुवाद AI से बनाया गया है। अगर आपको कोई त्रुटि दिखे, तो कृपया PR खोलें।
+
+<div align="center">
+
+# Palmier Pro
+
+**AI के लिए बनाया गया वीडियो एडिटर।**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="macOS के लिए Palmier Pro डाउनलोड करें" width="180" />
+</a>
+
+<sub><i>Apple Silicon पर macOS 26 (Tahoe) आवश्यक</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="X पर फॉलो करें" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord से जुड़ें" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <strong>हिन्दी</strong> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro UI" width="900" />
+
+---
+
+Palmier Pro Mac के लिए एक open source वीडियो एडिटर है। आप और आपका agent timeline के अंदर साथ मिलकर वीडियो generate और edit कर सकते हैं।
+
+### Swift-native वीडियो एडिटर
+
+हमने Palmier Pro को Swift में scratch से बनाया है। हमारा संदर्भ Premiere Pro है, लेकिन AI को workflow में शामिल करने का तरीका हमारा अपना है।
+
+### Built-in Generative AI
+
+Timeline editor के अंदर Seedance, Kling और Nano Banana Pro जैसे उन्नत models से वीडियो और images generate करें।
+
+### आपके agents के साथ integration
+
+Claude, Codex या Cursor को MCP के जरिए connect करें, या उसी project पर साथ काम करने के लिए in-app agent इस्तेमाल करें।
+
+## MCP server
+
+जब app खुली होती है, यह HTTP के जरिए `http://127.0.0.1:19789/mcp` पर MCP server expose करती है। Connect करने के लिए:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+सबसे आसान तरीका है app के अंदर `Help` -> `MCP Instructions` -> `Install in Cursor` खोलना। Manual install के लिए इसे `~/.cursor/mcp.json` में जोड़ें:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+App के साथ एक [mcpb](https://github.com/modelcontextprotocol/mcpb) शामिल है, जिससे Claude Desktop में Desktop Extension one-click install हो सकता है। `Help` -> `MCP Instructions` -> `Install in Claude Desktop` खोलें।
+
+## FAQ
+
+**क्या Palmier Pro पूरी तरह open source है?**
+
+वीडियो एडिटर, generative AI features को छोड़कर, पूरी तरह open source है। MCP server और agent chat भी open source हैं। सिर्फ generative AI processing closed source है।
+
+**क्या यह free है?**
+
+एडिटर free है। आप इसे बिना login डाउनलोड कर सकते हैं और CapCut या Adobe Premiere जैसे वीडियो एडिटर की तरह इस्तेमाल कर सकते हैं। MCP server भी free है, और आप Claude Code, Claude Desktop या Cursor से अपने timeline editor के साथ experiment शुरू कर सकते हैं।
+
+Generative AI features के लिए login और subscription चाहिए।
+
+**यह किन platforms को support करता है?**
+
+सिर्फ Apple Silicon पर macOS 26 (Tahoe)।
+
+और जानकारी के लिए [FAQ.md](../../FAQ.md) देखें।
+
+## Development
+
+[CONTRIBUTING.md](../../CONTRIBUTING.md) देखें।
+
+## Community और support
+
+- **Discord:** **[Discord](https://discord.com/invite/SMVW6pKYmg)** पर community से जुड़ें।
+- **Twitter / X:** Updates और announcements के लिए **[@Palmier_io](https://x.com/Palmier_io)** को follow करें।
+- **Instagram:** [@palmier.io](https://www.instagram.com/palmier.io) को follow करें।
+- **Feedback और support:** [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) बनाएं या founders@palmier.io पर email करें।
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## License
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro [GPLv3](../../LICENSE) के तहत open source है।

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -1,0 +1,130 @@
+> Questa traduzione è stata generata con l'AI. Se trovi un errore, apri una PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**Il video editor creato per l'AI.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Scarica Palmier Pro per macOS" width="180" />
+</a>
+
+<sub><i>Richiede macOS 26 (Tahoe) su Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Segui su X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Entra su Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <strong>Italiano</strong> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Interfaccia di Palmier Pro" width="900" />
+
+---
+
+Palmier Pro è un video editor open source per Mac. Tu e il tuo agent potete generare e modificare video insieme dentro la timeline.
+
+### Video editor nativo Swift
+
+Abbiamo costruito Palmier Pro da zero con Swift. Il riferimento è Premiere Pro, con il nostro modo di integrare l'AI nel workflow.
+
+### AI generativa integrata
+
+Genera video e immagini con modelli all'avanguardia come Seedance, Kling e Nano Banana Pro direttamente nell'editor timeline.
+
+### Integrazione con i tuoi agent
+
+Collega Claude, Codex o Cursor tramite MCP, oppure usa l'agent integrato nell'app per lavorare insieme sullo stesso progetto.
+
+## Server MCP
+
+Quando l'app è aperta, espone un server MCP su `http://127.0.0.1:19789/mcp` tramite HTTP. Per connetterti:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+Il modo più semplice è aprire nell'app `Help` -> `MCP Instructions` -> `Install in Cursor`, oppure installarlo manualmente aggiungendo questo a `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Includiamo un [mcpb](https://github.com/modelcontextprotocol/mcpb) con l'app che consente l'installazione con un clic della Desktop Extension su Claude Desktop. Apri `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**Palmier Pro è completamente open source?**
+
+Il video editor, senza le funzioni di AI generativa, è completamente open source. Anche il server MCP e la chat dell'agent sono open source. L'unica parte closed source è l'elaborazione dell'AI generativa.
+
+**È gratis?**
+
+L'editor è gratuito. Puoi scaricarlo senza login e usarlo come video editor, come CapCut o Adobe Premiere. Puoi anche usare gratis il server MCP e iniziare a sperimentare con Claude Code, Claude Desktop o Cursor per interagire con il tuo editor timeline.
+
+Le funzioni di AI generativa richiedono login e abbonamento.
+
+**Quali piattaforme supporta?**
+
+Solo macOS 26 (Tahoe) su Apple Silicon.
+
+Vedi [FAQ.md](../../FAQ.md) per maggiori dettagli.
+
+## Sviluppo
+
+Vedi [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Community e supporto
+
+- **Discord:** Entra nella community su **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** Segui **[@Palmier_io](https://x.com/Palmier_io)** per aggiornamenti e annunci.
+- **Instagram:** Segui [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback e supporto:** Crea una [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) o scrivici a founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Grafico Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Licenza
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro è open source sotto [GPLv3](../../LICENSE).

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <strong>Italiano</strong> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -1,0 +1,130 @@
+> この翻訳は AI によって生成されました。誤りを見つけた場合は PR を開いてください。
+
+<div align="center">
+
+# Palmier Pro
+
+**AI のために作られた動画エディタ。**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Palmier Pro for macOS をダウンロード" width="180" />
+</a>
+
+<sub><i>Apple Silicon 搭載の macOS 26 (Tahoe) が必要</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="X でフォロー" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord に参加" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <strong>日本語</strong> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro の UI" width="900" />
+
+---
+
+Palmier Pro は Mac 向けのオープンソース動画エディタです。ユーザーと agent がタイムライン上で一緒に動画を生成、編集できます。
+
+### Swift ネイティブ動画エディタ
+
+Palmier Pro は Swift でゼロから構築しました。目指す基準は Premiere Pro で、AI をワークフローに統合する独自の形をとっています。
+
+### 内蔵の生成 AI
+
+タイムラインエディタ内で Seedance、Kling、Nano Banana Pro などの最先端モデルを使い、動画と画像を生成できます。
+
+### agent との連携
+
+MCP で Claude、Codex、Cursor と接続できます。アプリ内 agent を使って、同じプロジェクトで一緒に作業することもできます。
+
+## MCP サーバー
+
+アプリが開いている間、HTTP 経由で `http://127.0.0.1:19789/mcp` に MCP サーバーを公開します。接続方法：
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+最も簡単な方法は、アプリ内で `Help` -> `MCP Instructions` -> `Install in Cursor` を開くことです。手動で設定する場合は、`~/.cursor/mcp.json` に以下を追加します。
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+アプリには [mcpb](https://github.com/modelcontextprotocol/mcpb) が同梱されており、Claude Desktop の Desktop Extension をワンクリックでインストールできます。`Help` -> `MCP Instructions` -> `Install in Claude Desktop` を開いてください。
+
+## FAQ
+
+**Palmier Pro は完全にオープンソースですか？**
+
+動画エディタは、生成 AI 機能を除いて完全にオープンソースです。MCP サーバーと agent チャットもオープンソースです。クローズドソースなのは生成 AI 処理だけです。
+
+**無料ですか？**
+
+エディタは無料です。ログインなしでダウンロードでき、CapCut や Adobe Premiere のような動画エディタとして使えます。MCP サーバーも無料で使え、Claude Code、Claude Desktop、Cursor からタイムラインエディタを操作して試せます。
+
+生成 AI 機能にはログインとサブスクリプションが必要です。
+
+**対応プラットフォームは？**
+
+Apple Silicon 搭載の macOS 26 (Tahoe) のみです。
+
+詳細は [FAQ.md](../../FAQ.md) を参照してください。
+
+## 開発
+
+[CONTRIBUTING.md](../../CONTRIBUTING.md) を参照してください。
+
+## コミュニティとサポート
+
+- **Discord:** **[Discord](https://discord.com/invite/SMVW6pKYmg)** でコミュニティに参加できます。
+- **Twitter / X:** 更新と告知は **[@Palmier_io](https://x.com/Palmier_io)** をフォローしてください。
+- **Instagram:** [@palmier.io](https://www.instagram.com/palmier.io) をフォローしてください。
+- **フィードバックとサポート:** [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) を作成するか、founders@palmier.io にメールしてください。
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## ライセンス
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro は [GPLv3](../../LICENSE) のもとでオープンソースとして公開されています。

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -1,0 +1,130 @@
+> 이 번역은 AI로 생성되었습니다. 오류를 발견하면 PR을 열어 주세요.
+
+<div align="center">
+
+# Palmier Pro
+
+**AI를 위해 만든 비디오 편집기.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="macOS용 Palmier Pro 다운로드" width="180" />
+</a>
+
+<sub><i>Apple Silicon 기반 macOS 26 (Tahoe) 필요</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="X에서 팔로우" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord 참여" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <strong>한국어</strong> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro UI" width="900" />
+
+---
+
+Palmier Pro는 Mac용 오픈 소스 비디오 편집기입니다. 사용자와 agent가 타임라인 안에서 함께 비디오를 생성하고 편집할 수 있습니다.
+
+### Swift 네이티브 비디오 편집기
+
+Palmier Pro는 Swift로 처음부터 만들었습니다. 기준은 Premiere Pro이며, AI를 워크플로에 통합하는 Palmier Pro만의 방식을 적용했습니다.
+
+### 내장 생성형 AI
+
+타임라인 편집기 안에서 Seedance, Kling, Nano Banana Pro 같은 최신 모델로 비디오와 이미지를 생성할 수 있습니다.
+
+### agent와 통합
+
+MCP로 Claude, Codex, Cursor를 연결하거나, 앱 안의 agent를 사용해 같은 프로젝트에서 함께 작업할 수 있습니다.
+
+## MCP 서버
+
+앱이 열려 있으면 HTTP를 통해 `http://127.0.0.1:19789/mcp`에서 MCP 서버를 제공합니다. 연결 방법:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+가장 쉬운 방법은 앱 안에서 `Help` -> `MCP Instructions` -> `Install in Cursor`를 여는 것입니다. 수동으로 설치하려면 `~/.cursor/mcp.json`에 다음을 추가하세요.
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+앱에는 Claude Desktop에 Desktop Extension을 한 번에 설치할 수 있는 [mcpb](https://github.com/modelcontextprotocol/mcpb)가 포함되어 있습니다. `Help` -> `MCP Instructions` -> `Install in Claude Desktop`를 여세요.
+
+## FAQ
+
+**Palmier Pro는 완전히 오픈 소스인가요?**
+
+비디오 편집기는 생성형 AI 기능을 제외하고 완전히 오픈 소스입니다. MCP 서버와 agent 채팅도 오픈 소스입니다. 비공개 소스인 부분은 생성형 AI 처리뿐입니다.
+
+**무료인가요?**
+
+편집기는 무료입니다. 로그인 없이 다운로드할 수 있으며 CapCut이나 Adobe Premiere 같은 비디오 편집기로 사용할 수 있습니다. MCP 서버도 무료로 사용할 수 있고, Claude Code, Claude Desktop, Cursor로 타임라인 편집기와 상호작용을 시작할 수 있습니다.
+
+생성형 AI 기능은 로그인과 구독이 필요합니다.
+
+**어떤 플랫폼을 지원하나요?**
+
+Apple Silicon 기반 macOS 26 (Tahoe)만 지원합니다.
+
+자세한 내용은 [FAQ.md](../../FAQ.md)를 참조하세요.
+
+## 개발
+
+[CONTRIBUTING.md](../../CONTRIBUTING.md)를 참조하세요.
+
+## 커뮤니티 및 지원
+
+- **Discord:** **[Discord](https://discord.com/invite/SMVW6pKYmg)**에서 커뮤니티에 참여하세요.
+- **Twitter / X:** 업데이트와 공지는 **[@Palmier_io](https://x.com/Palmier_io)**를 팔로우하세요.
+- **Instagram:** [@palmier.io](https://www.instagram.com/palmier.io)를 팔로우하세요.
+- **피드백 및 지원:** [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues)를 만들거나 founders@palmier.io로 이메일을 보내세요.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## 라이선스
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro는 [GPLv3](../../LICENSE)에 따라 오픈 소스로 제공됩니다.

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -25,6 +25,8 @@
   <strong>한국어</strong> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -1,0 +1,130 @@
+> Esta tradução foi gerada por IA. Se encontrar um erro, abra um PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**O editor de vídeo criado para IA.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Baixar Palmier Pro para macOS" width="180" />
+</a>
+
+<sub><i>Requer macOS 26 (Tahoe) em Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Seguir no X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Entrar no Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <strong>Português (Brasil)</strong> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Interface do Palmier Pro" width="900" />
+
+---
+
+Palmier Pro é um editor de vídeo open source para Mac. Você e seu agente podem gerar e editar vídeos juntos dentro da linha do tempo.
+
+### Editor de vídeo nativo em Swift
+
+Construímos o Palmier Pro do zero com Swift. A referência é o Premiere Pro, com a nossa forma de integrar IA ao fluxo de trabalho.
+
+### IA generativa integrada
+
+Gere vídeos e imagens com modelos de ponta como Seedance, Kling e Nano Banana Pro dentro do editor de linha do tempo.
+
+### Integração com seus agentes
+
+Conecte Claude, Codex ou Cursor via MCP, ou use o agente dentro do app para trabalhar no mesmo projeto junto com você.
+
+## Servidor MCP
+
+Quando o app está aberto, ele expõe um servidor MCP em `http://127.0.0.1:19789/mcp` via HTTP. Para conectar:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+A forma mais fácil é abrir no app `Help` -> `MCP Instructions` -> `Install in Cursor`, ou instalar manualmente adicionando isto a `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Incluímos um [mcpb](https://github.com/modelcontextprotocol/mcpb) com o app que permite instalar a Desktop Extension no Claude Desktop com um clique. Abra `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**O Palmier Pro é totalmente open source?**
+
+O editor de vídeo, sem os recursos de IA generativa, é totalmente open source. O servidor MCP e o chat do agente também são open source. A única parte fechada é o processamento de IA generativa.
+
+**É gratuito?**
+
+O editor é gratuito. Você pode baixá-lo sem login e usá-lo como editor de vídeo, como CapCut ou Adobe Premiere. Você também pode usar o servidor MCP gratuitamente e começar a experimentar com Claude Code, Claude Desktop ou Cursor para interagir com seu editor de linha do tempo.
+
+Os recursos de IA generativa exigem login e assinatura.
+
+**Quais plataformas são compatíveis?**
+
+Apenas macOS 26 (Tahoe) em Apple Silicon.
+
+Veja [FAQ.md](../../FAQ.md) para mais detalhes.
+
+## Desenvolvimento
+
+Veja [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Comunidade e suporte
+
+- **Discord:** Entre na comunidade no **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** Siga **[@Palmier_io](https://x.com/Palmier_io)** para atualizações e anúncios.
+- **Instagram:** Siga [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback e suporte:** Crie uma [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) ou envie um email para founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Gráfico Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Licença
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro é open source sob [GPLv3](../../LICENSE).

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <strong>Português (Brasil)</strong> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -1,0 +1,130 @@
+> Этот перевод создан с помощью AI. Если заметите ошибку, откройте PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**Видеоредактор, созданный для AI.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Скачать Palmier Pro для macOS" width="180" />
+</a>
+
+<sub><i>Требуется macOS 26 (Tahoe) на Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Подписаться в X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Присоединиться к Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <strong>Русский</strong>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Интерфейс Palmier Pro" width="900" />
+
+---
+
+Palmier Pro — open source видеоредактор для Mac. Вы и ваш agent можете вместе генерировать и редактировать видео прямо на таймлайне.
+
+### Видеоредактор, нативный для Swift
+
+Мы построили Palmier Pro с нуля на Swift. Ориентир — Premiere Pro, но с нашим подходом к интеграции AI в рабочий процесс.
+
+### Встроенный generative AI
+
+Генерируйте видео и изображения с помощью передовых моделей, таких как Seedance, Kling и Nano Banana Pro, прямо в редакторе таймлайна.
+
+### Интеграция с вашими agent
+
+Подключайте Claude, Codex или Cursor через MCP либо используйте встроенного agent в приложении, чтобы работать вместе над одним проектом.
+
+## MCP server
+
+Когда приложение открыто, оно предоставляет MCP server по адресу `http://127.0.0.1:19789/mcp` через HTTP. Для подключения:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+Самый простой способ — открыть в приложении `Help` -> `MCP Instructions` -> `Install in Cursor`. Также можно установить вручную, добавив это в `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Мы поставляем [mcpb](https://github.com/modelcontextprotocol/mcpb) вместе с приложением, чтобы Desktop Extension для Claude Desktop можно было установить в один клик. Откройте `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**Palmier Pro полностью open source?**
+
+Видеоредактор, без функций generative AI, полностью open source. MCP server и agent chat тоже open source. Закрытой остается только обработка generative AI.
+
+**Это бесплатно?**
+
+Редактор бесплатный. Его можно скачать без входа в аккаунт и использовать как видеоредактор, например CapCut или Adobe Premiere. MCP server тоже можно использовать бесплатно и начать экспериментировать с Claude Code, Claude Desktop или Cursor для взаимодействия с редактором таймлайна.
+
+Функции generative AI требуют входа в аккаунт и подписки.
+
+**Какие платформы поддерживаются?**
+
+Только macOS 26 (Tahoe) на Apple Silicon.
+
+Подробнее см. [FAQ.md](../../FAQ.md).
+
+## Разработка
+
+См. [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Сообщество и поддержка
+
+- **Discord:** Присоединяйтесь к сообществу в **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** Подписывайтесь на **[@Palmier_io](https://x.com/Palmier_io)**, чтобы получать обновления и анонсы.
+- **Instagram:** Подписывайтесь на [@palmier.io](https://www.instagram.com/palmier.io).
+- **Feedback и поддержка:** Создайте [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) или напишите нам на founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="График Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Лицензия
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro распространяется как open source по лицензии [GPLv3](../../LICENSE).

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -1,0 +1,130 @@
+> Bản dịch này được tạo bằng AI. Nếu phát hiện lỗi, hãy mở PR.
+
+<div align="center">
+
+# Palmier Pro
+
+**Trình biên tập video được xây dựng cho AI.**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="Tải Palmier Pro cho macOS" width="180" />
+</a>
+
+<sub><i>Yêu cầu macOS 26 (Tahoe) trên Apple Silicon</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="Theo dõi trên X" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Tham gia Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <strong>Tiếng Việt</strong> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Giao diện Palmier Pro" width="900" />
+
+---
+
+Palmier Pro là trình biên tập video mã nguồn mở cho Mac. Bạn và agent của bạn có thể cùng tạo và chỉnh sửa video ngay trong timeline.
+
+### Trình biên tập video thuần Swift
+
+Chúng tôi xây dựng Palmier Pro từ đầu bằng Swift. Mốc tham chiếu là Premiere Pro, với cách riêng của chúng tôi để tích hợp AI vào quy trình làm việc.
+
+### AI tạo sinh tích hợp sẵn
+
+Tạo video và hình ảnh bằng các mô hình tiên tiến như Seedance, Kling và Nano Banana Pro ngay trong trình biên tập timeline.
+
+### Tích hợp với agent của bạn
+
+Kết nối Claude, Codex hoặc Cursor qua MCP, hoặc dùng agent trong app để cùng làm việc trên một dự án.
+
+## MCP server
+
+Khi app đang mở, Palmier Pro cung cấp MCP server tại `http://127.0.0.1:19789/mcp` qua HTTP. Cách kết nối:
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+Cách dễ nhất là mở `Help` -> `MCP Instructions` -> `Install in Cursor` trong app, hoặc cài thủ công bằng cách thêm phần sau vào `~/.cursor/mcp.json`:
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+Chúng tôi đóng gói một [mcpb](https://github.com/modelcontextprotocol/mcpb) cùng app để cài Desktop Extension trên Claude Desktop bằng một cú nhấp. Mở `Help` -> `MCP Instructions` -> `Install in Claude Desktop`.
+
+## FAQ
+
+**Palmier Pro có hoàn toàn mã nguồn mở không?**
+
+Trình biên tập video, không bao gồm các tính năng AI tạo sinh, hoàn toàn là mã nguồn mở. MCP server và agent chat cũng là mã nguồn mở. Phần duy nhất đóng nguồn là xử lý AI tạo sinh.
+
+**Có miễn phí không?**
+
+Trình biên tập miễn phí. Bạn có thể tải xuống mà không cần đăng nhập và dùng như một trình biên tập video, tương tự CapCut hoặc Adobe Premiere. Bạn cũng có thể dùng MCP server miễn phí và bắt đầu thử nghiệm với Claude Code, Claude Desktop hoặc Cursor để tương tác với trình biên tập timeline.
+
+Các tính năng AI tạo sinh yêu cầu đăng nhập và gói đăng ký.
+
+**Hỗ trợ nền tảng nào?**
+
+Chỉ hỗ trợ macOS 26 (Tahoe) trên Apple Silicon.
+
+Xem thêm tại [FAQ.md](../../FAQ.md).
+
+## Phát triển
+
+Xem [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Cộng đồng và hỗ trợ
+
+- **Discord:** Tham gia cộng đồng trên **[Discord](https://discord.com/invite/SMVW6pKYmg)**.
+- **Twitter / X:** Theo dõi **[@Palmier_io](https://x.com/Palmier_io)** để nhận cập nhật và thông báo.
+- **Instagram:** Theo dõi [@palmier.io](https://www.instagram.com/palmier.io).
+- **Phản hồi và hỗ trợ:** Tạo [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) hoặc gửi email tới founders@palmier.io.
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Biểu đồ Star History" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## Giấy phép
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro là mã nguồn mở theo [GPLv3](../../LICENSE).

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <strong>Tiếng Việt</strong> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -1,0 +1,130 @@
+> 此翻译由 AI 生成。如发现错误，欢迎提交 PR。
+
+<div align="center">
+
+# Palmier Pro
+
+**专为 AI 打造的视频编辑器。**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="下载 macOS 版 Palmier Pro" width="180" />
+</a>
+
+<sub><i>需要搭载 Apple Silicon 的 macOS 26 (Tahoe)</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="在 X 上关注" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="加入 Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <strong>简体中文</strong> ·
+  <a href="README.zh-TW.md">繁體中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro 界面" width="900" />
+
+---
+
+Palmier Pro 是面向 Mac 的开源视频编辑器。你和你的 agent 可以在时间线中一起生成和编辑视频。
+
+### Swift 原生视频编辑器
+
+我们用 Swift 从零构建了 Palmier Pro。参考目标是 Premiere Pro，并以我们自己的方式把 AI 融入工作流。
+
+### 内置生成式 AI
+
+在时间线编辑器内使用 Seedance、Kling、Nano Banana Pro 等前沿模型生成视频和图像。
+
+### 与你的 agent 集成
+
+通过 MCP 连接 Claude、Codex 或 Cursor，或使用应用内 agent 在同一个项目中协作。
+
+## MCP 服务器
+
+应用打开时，会通过 HTTP 在 `http://127.0.0.1:19789/mcp` 暴露 MCP 服务器。连接方式：
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+最简单的方法是在应用内打开 `Help` -> `MCP Instructions` -> `Install in Cursor`，也可以手动把以下内容添加到 `~/.cursor/mcp.json`：
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+应用内置了一个 [mcpb](https://github.com/modelcontextprotocol/mcpb)，可在 Claude Desktop 中一键安装桌面扩展。打开 `Help` -> `MCP Instructions` -> `Install in Claude Desktop`。
+
+## FAQ
+
+**Palmier Pro 是否完全开源？**
+
+视频编辑器本身完全开源，不包括生成式 AI 功能。MCP 服务器和 agent 聊天也开源。唯一闭源的是生成式 AI 处理部分。
+
+**是否免费？**
+
+编辑器免费。你可以无需登录直接下载，并像使用 CapCut 或 Adobe Premiere 一样把它用作视频编辑器。你也可以免费使用 MCP 服务器，并通过 Claude Code、Claude Desktop 或 Cursor 与时间线编辑器交互。
+
+生成式 AI 功能需要登录和订阅。
+
+**支持哪些平台？**
+
+仅支持搭载 Apple Silicon 的 macOS 26 (Tahoe)。
+
+更多内容请查看 [FAQ.md](../../FAQ.md)。
+
+## 开发
+
+查看 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+## 社区与支持
+
+- **Discord:** 在 **[Discord](https://discord.com/invite/SMVW6pKYmg)** 加入社区。
+- **Twitter / X:** 关注 **[@Palmier_io](https://x.com/Palmier_io)** 获取更新和公告。
+- **Instagram:** 关注 [@palmier.io](https://www.instagram.com/palmier.io)。
+- **反馈与支持:** 创建 [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) 或发送邮件至 founders@palmier.io。
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History 图表" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## 许可证
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro 基于 [GPLv3](../../LICENSE) 开源。

--- a/docs/readme/README.zh-TW.md
+++ b/docs/readme/README.zh-TW.md
@@ -25,6 +25,8 @@
   <a href="README.ko.md">한국어</a> ·
   <a href="README.vi.md">Tiếng Việt</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.bn.md">বাংলা</a> ·
+  <a href="README.ar.md">العربية</a> ·
   <a href="README.it.md">Italiano</a> ·
   <a href="README.pt-BR.md">Português (Brasil)</a> ·
   <a href="README.fr.md">Français</a> ·

--- a/docs/readme/README.zh-TW.md
+++ b/docs/readme/README.zh-TW.md
@@ -1,0 +1,130 @@
+> 此翻譯由 AI 生成。如發現錯誤，歡迎提交 PR。
+
+<div align="center">
+
+# Palmier Pro
+
+**專為 AI 打造的影片剪輯器。**
+
+<a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
+  <img src="../../assets/macos-badge.png" alt="下載 macOS 版 Palmier Pro" width="180" />
+</a>
+
+<sub><i>需要搭載 Apple Silicon 的 macOS 26 (Tahoe)</i></sub>
+
+<a href="https://x.com/Palmier_io"><img src="https://img.shields.io/badge/Follow-%40Palmier__io-000000?style=flat&logo=x&logoColor=white" alt="在 X 上追蹤" /></a>
+<a href="https://discord.com/invite/SMVW6pKYmg"><img src="https://img.shields.io/badge/Join-Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="加入 Discord" /></a>
+<a href="https://www.ycombinator.com/companies/palmier"><img src="https://img.shields.io/badge/Y%20Combinator-S24-orange" alt="Y Combinator S24" /></a>
+
+<p>
+  <a href="../../README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <strong>繁體中文</strong> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.vi.md">Tiếng Việt</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.it.md">Italiano</a> ·
+  <a href="README.pt-BR.md">Português (Brasil)</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ru.md">Русский</a>
+</p>
+
+</div>
+
+<img src="../../assets/palmier-ui.png" alt="Palmier Pro 介面" width="900" />
+
+---
+
+Palmier Pro 是 Mac 的開源影片剪輯器。你和你的 agent 可以在時間軸中一起生成和剪輯影片。
+
+### Swift 原生影片剪輯器
+
+我們用 Swift 從零打造 Palmier Pro。參考目標是 Premiere Pro，並以我們自己的方式把 AI 融入工作流程。
+
+### 內建生成式 AI
+
+在時間軸編輯器內使用 Seedance、Kling、Nano Banana Pro 等前沿模型生成影片和影像。
+
+### 與你的 agent 整合
+
+透過 MCP 連接 Claude、Codex 或 Cursor，或使用 app 內建 agent 在同一個專案中協作。
+
+## MCP 伺服器
+
+app 開啟時，會透過 HTTP 在 `http://127.0.0.1:19789/mcp` 暴露 MCP 伺服器。連接方式：
+
+**Claude Code**
+```bash
+claude mcp add --transport http palmier-pro http://127.0.0.1:19789/mcp
+```
+
+**Codex**
+```bash
+codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
+```
+
+**Cursor**
+
+最簡單的方法是在 app 內開啟 `Help` -> `MCP Instructions` -> `Install in Cursor`，也可以手動把以下內容加入 `~/.cursor/mcp.json`：
+
+```
+{
+  "mcpServers": {
+    "palmier-pro": {
+      "type": "http",
+      "url": "http://127.0.0.1:19789/mcp"
+    }
+  }
+}
+```
+
+**Claude Desktop**
+
+app 內建一個 [mcpb](https://github.com/modelcontextprotocol/mcpb)，可在 Claude Desktop 中一鍵安裝桌面擴充功能。開啟 `Help` -> `MCP Instructions` -> `Install in Claude Desktop`。
+
+## FAQ
+
+**Palmier Pro 是否完全開源？**
+
+影片剪輯器本身完全開源，不包含生成式 AI 功能。MCP 伺服器和 agent 聊天也開源。唯一閉源的是生成式 AI 處理部分。
+
+**是否免費？**
+
+編輯器免費。你可以無需登入直接下載，並像使用 CapCut 或 Adobe Premiere 一樣把它當作影片剪輯器使用。你也可以免費使用 MCP 伺服器，並透過 Claude Code、Claude Desktop 或 Cursor 與時間軸編輯器互動。
+
+生成式 AI 功能需要登入和訂閱。
+
+**支援哪些平台？**
+
+僅支援搭載 Apple Silicon 的 macOS 26 (Tahoe)。
+
+更多內容請查看 [FAQ.md](../../FAQ.md)。
+
+## 開發
+
+查看 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+## 社群與支援
+
+- **Discord:** 在 **[Discord](https://discord.com/invite/SMVW6pKYmg)** 加入社群。
+- **Twitter / X:** 追蹤 **[@Palmier_io](https://x.com/Palmier_io)** 取得更新和公告。
+- **Instagram:** 追蹤 [@palmier.io](https://www.instagram.com/palmier.io)。
+- **回饋與支援:** 建立 [GitHub Issue](https://github.com/palmier-io/palmier-pro/issues) 或寄信到 founders@palmier.io。
+
+## Star History
+
+<a href="https://www.star-history.com/?type=date&repos=palmier-io%2Fpalmier-pro">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+   <img alt="Star History 圖表" src="https://api.star-history.com/chart?repos=palmier-io/palmier-pro&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## 授權
+
+Copyright (C) 2026 Palmier, Inc.
+
+Palmier Pro 基於 [GPLv3](../../LICENSE) 開源。


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or runtime impact; main review concern is translation accuracy and link correctness.
> 
> **Overview**
> Adds **multilingual project documentation** by introducing translated READMEs under `docs/readme/` and wiring them from the root `README.md`.
> 
> The root README now includes a **language switcher** (English plus 13 locales) linking to `docs/readme/README.*.md`. Each new file mirrors the English README content in the target language, with an **AI-generated translation disclaimer**, a reciprocal language nav bar, and **relative paths** adjusted for assets (`../../assets/`) and shared docs (`../../FAQ.md`, `../../CONTRIBUTING.md`, `../../LICENSE`).
> 
> Also fixes a **missing trailing newline** on the license line at the end of `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1ea23271e25a9de0f619cadc04dcf45c97203a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->