### PR TITLE
docs(readme): fix product name casing in image alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **The video editor built for AI.**
 
 <a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
-  <img src="./assets/macos-badge.png" alt="Download palmierpro for macOS" width="180" />
+  <img src="./assets/macos-badge.png" alt="Download Palmier Pro for macOS" width="180" />
 </a>
 
 <sub><i>Requires macOS 26 (Tahoe) on Apple Silicon</i></sub>
@@ -33,7 +33,7 @@
 
 </div>
 
-<img src="./assets/palmier-ui.png" alt="palmierpro UI" width="900" />
+<img src="./assets/palmier-ui.png" alt="Palmier Pro UI" width="900" />
 
 ---
 


### PR DESCRIPTION
## Summary
The two `<img>` `alt` attributes in the English `README.md` use `palmierpro` (lowercase, no space). Every other reference to the product — the `# Palmier Pro` H1, the tagline, the `PalmierPro.dmg` download filename, and all 13 localized READMEs added in #86 — uses the correct brand name **Palmier Pro**. This aligns the alt text with the established branding.

## Problem
`README.md`:

```html
<img src="./assets/macos-badge.png" alt="Download palmierpro for macOS" width="180" />
...
<img src="./assets/palmier-ui.png" alt="palmierpro UI" width="900" />
```

For contrast, the localized READMEs already use the proper name in the same alt slots, e.g. `docs/readme/README.es.md` (`alt="Descargar Palmier Pro para macOS"`, `alt="Interfaz de Palmier Pro"`) and `docs/readme/README.ja.md` (`alt="Palmier Pro for macOS をダウンロード"`, `alt="Palmier Pro の UI"`). The English original is the lone outlier.

## Solution
- `alt="Download palmierpro for macOS"` → `alt="Download Palmier Pro for macOS"`
- `alt="palmierpro UI"` → `alt="Palmier Pro UI"`

This text is user-visible to screen-reader users and as the broken-image fallback, so the correct casing matters for accessibility and brand consistency.

## Out of scope
- No changes to the localized READMEs — they already use the correct name.
- No prose, layout, or link changes.

## Test plan
- [x] `git diff` shows only the two alt attributes changed (+2/−2, one file).
- [x] Verified the corrected casing matches the H1, tagline, DMG filename, and all 13 localized READMEs.
- [ ] CI to confirm the rest.

## Related
- #86 — the multilingual README PR whose localized files already use "Palmier Pro" in these alt slots.

Made with [Cursor](https://cursor.com)