### PR TITLE
Captions: accurate per-word timing + max-words-per-caption setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ models/*/.venv/
 models/*/build*/
 models/*/checkpoint*
 models/*/convert*.log
+
+# Brainstorming companion (local session output)
+.superpowers/

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -10,6 +10,7 @@ extension EditorViewModel {
         var textCase: CaptionCase = .auto
         var censorProfanity: Bool = false
         var locale: Locale? = nil
+        var wordsPerCaption: Int = 6
     }
 
     enum CaptionCase: String, CaseIterable, Sendable {
@@ -166,9 +167,13 @@ extension EditorViewModel {
         for (ref, result) in results {
             let clips = targets.filter { $0.clip.mediaRef == ref }
             guard !clips.isEmpty else { continue }
-            let phrases = result.segments.flatMap {
-                CaptionBuilder.phrases(for: $0, fits: { captionLineFits($0, style: request.style) }, minDuration: AppTheme.Caption.minDisplayDuration)
-            }
+            // Group by real per-word timestamps (accurate) rather than splitting a
+            // segment's span by character count (drifts).
+            let phrases = CaptionBuilder.phrases(
+                fromWords: result.words,
+                wordsPerCaption: request.wordsPerCaption,
+                minDuration: AppTheme.Caption.minDisplayDuration
+            )
             for p in phrases {
                 guard let owner = bestClip(for: p, among: clips) else { continue }
                 phrasesByClip[owner.id, default: []].append(p)

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -90,6 +90,50 @@ enum CaptionBuilder {
         return out
     }
 
+    /// Group words by their REAL per-word timings into phrases of up to
+    /// `wordsPerCaption`, starting a new phrase early when there's a long pause.
+    /// Far more accurate than distributing a segment's span by character count.
+    static func phrases(
+        fromWords words: [TranscriptionWord],
+        wordsPerCaption: Int,
+        minDuration: Double,
+        maxGap: Double = 0.7
+    ) -> [Phrase] {
+        let timed = normalizedWords(words)
+        guard !timed.isEmpty else { return [] }
+        let limit = max(1, wordsPerCaption)
+
+        var phrases: [Phrase] = []
+        var group: [(text: String, start: Double, end: Double)] = []
+        func flush() {
+            guard let first = group.first, let last = group.last else { return }
+            phrases.append(Phrase(text: group.map(\.text).joined(separator: " "), start: first.start, end: last.end))
+            group.removeAll(keepingCapacity: true)
+        }
+        for w in timed {
+            if let last = group.last, w.start - last.end > maxGap { flush() }
+            group.append(w)
+            if group.count >= limit { flush() }
+        }
+        flush()
+        return enforceMinDuration(phrases, minDuration: minDuration)
+    }
+
+    /// Trim word text and fill any missing timestamps from neighbours.
+    private static func normalizedWords(_ words: [TranscriptionWord]) -> [(text: String, start: Double, end: Double)] {
+        var out: [(text: String, start: Double, end: Double)] = []
+        var cursor = 0.0
+        for w in words {
+            let text = w.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            let start = w.start ?? cursor
+            let end = max(w.end ?? start, start)
+            cursor = max(cursor, end)
+            out.append((text, start, end))
+        }
+        return out
+    }
+
     static func specs(
         for phrases: [Phrase],
         sourceClip: Clip,

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -8,6 +8,7 @@ struct CaptionTab: View {
     @State private var selectedTrackId: String?
     @State private var selectedClipTargets: [String] = []
     @State private var textCase: EditorViewModel.CaptionCase = .auto
+    @State private var wordsPerCaption = 6
     @State private var censorProfanity = false
     @State private var locale: Locale?
     @State private var supportedLocales: [Locale] = []
@@ -198,6 +199,19 @@ struct CaptionTab: View {
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                 }
                 .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).fixedSize().focusable(false)
+            }
+            InspectorRow(
+                icon: "text.word.spacing",
+                label: "Max words / caption",
+                labelHelp: "Each caption holds up to this many words — or fewer when there's a pause in speech."
+            ) {
+                ScrubbableNumberField(
+                    value: Double(wordsPerCaption),
+                    range: 1...12,
+                    format: "%.0f",
+                    valueSuffix: " words",
+                    onChanged: { wordsPerCaption = max(1, Int($0.rounded())) }
+                ) { wordsPerCaption = max(1, Int($0.rounded())) }
             }
             InspectorRow(icon: "exclamationmark.bubble", label: "Censor profanity") {
                 Toggle("", isOn: $censorProfanity)
@@ -394,7 +408,8 @@ struct CaptionTab: View {
         }
         let request = EditorViewModel.CaptionRequest(
             sourceClipIds: sourceIds, autoDetect: isAutoSource, style: style, center: center,
-            textCase: textCase, censorProfanity: censorProfanity, locale: locale
+            textCase: textCase, censorProfanity: censorProfanity, locale: locale,
+            wordsPerCaption: wordsPerCaption
         )
         Task {
             isGenerating = true

--- a/Tests/PalmierProTests/Captions/CaptionWordGroupingTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionWordGroupingTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Caption word grouping")
+struct CaptionWordGroupingTests {
+
+    private func word(_ t: String, _ s: Double, _ e: Double) -> TranscriptionWord {
+        TranscriptionWord(text: t, start: s, end: e)
+    }
+
+    private var sixWords: [TranscriptionWord] {
+        [word("a", 0, 0.3), word("b", 0.3, 0.6), word("c", 0.6, 0.9),
+         word("d", 1.0, 1.3), word("e", 1.3, 1.6), word("f", 1.6, 1.9)]
+    }
+
+    @Test func groupsThreeWordsWithRealTimings() {
+        let phrases = CaptionBuilder.phrases(fromWords: sixWords, wordsPerCaption: 3, minDuration: 0.05)
+        #expect(phrases.count == 2)
+        #expect(phrases[0].text == "a b c")
+        #expect(phrases[0].start == 0)
+        #expect(abs(phrases[0].end - 0.9) < 0.001)   // real last-word end, not char-distributed
+        #expect(phrases[1].text == "d e f")
+        #expect(abs(phrases[1].start - 1.0) < 0.001)
+        #expect(abs(phrases[1].end - 1.9) < 0.001)
+    }
+
+    @Test func groupsSixWordsIntoOne() {
+        let phrases = CaptionBuilder.phrases(fromWords: sixWords, wordsPerCaption: 6, minDuration: 0.05)
+        #expect(phrases.count == 1)
+        #expect(phrases[0].text == "a b c d e f")
+    }
+
+    @Test func breaksEarlyOnLongPause() {
+        let words = [word("hello", 0, 0.4), word("there", 2.0, 2.4)] // 1.6s gap
+        let phrases = CaptionBuilder.phrases(fromWords: words, wordsPerCaption: 6, minDuration: 0.05)
+        #expect(phrases.count == 2)
+    }
+
+    @Test func emptyWordsProduceNoPhrases() {
+        #expect(CaptionBuilder.phrases(fromWords: [], wordsPerCaption: 3, minDuration: 0.05).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #91.

### Problem
Captions split each transcription *segment* and distribute its time **by character count** — an estimate that drifts off the actual speech.

### Fix
- Group by the transcriber's **real per-word timestamps** (`CaptionBuilder.phrases(fromWords:)`): each caption starts/ends on actual words, and a long pause starts a new caption.
- New **Max words / caption** field in the Captions tab (numeric, 1–12; default 6) — captions hold up to N words, or fewer at a pause.

### Tests
4 new tests (grouping by N, real timings, pause-splitting, empty input). Builds clean on the macOS 26 SDK.

Split out of #77 for easier review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how caption clip timing is computed on the timeline; behavior is localized to the caption pipeline and covered by new tests, but mis-grouping could affect sync for all generated captions.
> 
> **Overview**
> Caption generation no longer splits transcription **segments** and spreads time by character count. **`captionSpecs`** now builds phrases from **`result.words`** via **`CaptionBuilder.phrases(fromWords:)`**, so each caption’s start/end align with real word timestamps and long pauses (default **0.7s** gap) start a new caption even under the word limit.
> 
> Users get a **Max words / caption** control in the Captions tab (1–12, default 6), wired through **`CaptionRequest.wordsPerCaption`** into generation. Four unit tests cover grouping, timings, pause splits, and empty input. **`.superpowers/`** is added to **`.gitignore`** for local brainstorming output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e64cb3a75aee8575afddc9a089daa717cf31c5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->