### PR TITLE
Export: add 2K and Match-Timeline resolutions

### DIFF
--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -24,24 +24,34 @@ enum ExportFormat {
 enum ExportResolution: String, CaseIterable, Identifiable {
     case r720p = "720p"
     case r1080p = "1080p"
+    case r1440p = "2K"
     case r4k = "4K"
+    case native = "Match Timeline"
 
     var id: String { rawValue }
 
-    var shortSidePixels: Int {
+    /// Target short-side height for the fixed presets; nil for `.native` (uses the timeline size).
+    var shortSidePixels: Int? {
         switch self {
         case .r720p: 720
         case .r1080p: 1080
+        case .r1440p: 1440
         case .r4k: 2160
+        case .native: nil
         }
     }
 
     func renderSize(for canvas: CGSize) -> CGSize {
+        guard let shortSidePixels else { return evenSize(canvas) }
         let canvasShort = min(canvas.width, canvas.height)
         guard canvasShort > 0 else { return canvas }
         let scale = Double(shortSidePixels) / Double(canvasShort)
-        let w = (Int((canvas.width * scale).rounded()) / 2) * 2
-        let h = (Int((canvas.height * scale).rounded()) / 2) * 2
+        return evenSize(CGSize(width: canvas.width * scale, height: canvas.height * scale))
+    }
+
+    private func evenSize(_ size: CGSize) -> CGSize {
+        let w = (Int(size.width.rounded()) / 2) * 2
+        let h = (Int(size.height.rounded()) / 2) * 2
         return CGSize(width: max(2, w), height: max(2, h))
     }
 }
@@ -258,12 +268,16 @@ final class ExportService {
             case .r720p: AVAssetExportPreset1280x720
             case .r1080p: AVAssetExportPreset1920x1080
             case .r4k: AVAssetExportPreset3840x2160
+            // Size-named presets clamp dimensions; HighestQuality honours the
+            // composition's renderSize, so 2K / native export at their true size.
+            case .r1440p, .native: AVAssetExportPresetHighestQuality
             }
         case .h265:
             switch resolution {
             case .r720p: AVAssetExportPresetHEVC1920x1080
             case .r1080p: AVAssetExportPresetHEVC1920x1080
             case .r4k: AVAssetExportPresetHEVC3840x2160
+            case .r1440p, .native: AVAssetExportPresetHEVCHighestQuality
             }
         case .prores:
             AVAssetExportPresetAppleProRes422LPCM

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -256,17 +256,15 @@ struct ExportView: View {
 
     private var estimatedFileSize: String {
         let seconds = Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps))
-        let bytesPerSec: Double = switch (codec, resolution) {
-        case (.h264, .r720p):    0.85e6
-        case (.h264, .r1080p):   1.3e6
-        case (.h264, .r4k):      2.8e6
-        case (.h265, .r720p):    0.45e6
-        case (.h265, .r1080p):   0.65e6
-        case (.h265, .r4k):      2.2e6
-        case (.prores, .r720p):  8.0e6
-        case (.prores, .r1080p): 18.5e6
-        case (.prores, .r4k):    65.0e6
+        // Bitrate scales with output pixel area, so any resolution (incl. 2K / native) is covered.
+        let out = resolution.renderSize(for: CGSize(width: editor.timeline.width, height: editor.timeline.height))
+        let megapixels = Double(out.width * out.height) / 1_000_000
+        let bytesPerSecPerMP: Double = switch codec {
+        case .h264:   0.63e6
+        case .h265:   0.32e6
+        case .prores: 9.0e6
         }
+        let bytesPerSec = bytesPerSecPerMP * max(0.1, megapixels)
         return ByteCountFormatter.string(fromByteCount: Int64(bytesPerSec * seconds), countStyle: .file)
     }
 


### PR DESCRIPTION
Closes #93.

- Adds `ExportResolution.r1440p` (2K) and `.native` (Match Timeline).
- native/2K use `AVAssetExportPresetHighestQuality` / `…HEVCHighestQuality` (which honour the composition's render size) instead of the dimension-clamping size presets; ProRes was already size-agnostic.
- File-size estimate refactored to a per-megapixel calc so it covers any resolution.

Split out of #77 for easier review. Builds clean on the macOS 26 SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized export UI and preset mapping changes; no auth, security, or data-path impact beyond video export behavior.
> 
> **Overview**
> Adds **2K** and **Match Timeline** to video export resolution options, with sizing and encoder preset behavior aligned to those choices.
> 
> **2K** scales the timeline canvas so the short side is 1440px (same scaling model as 720p/1080p/4K). **Match Timeline** keeps the timeline’s dimensions (even-rounded), with `shortSidePixels` now optional (`nil` for native).
> 
> For **H.264** and **H.265**, 2K and Match Timeline use `AVAssetExportPresetHighestQuality` / `AVAssetExportPresetHEVCHighestQuality` so export respects the composition `renderSize` instead of fixed dimension presets that can clamp output.
> 
> The export dialog’s **estimated file size** no longer hard-codes resolution×codec bitrates; it derives megapixels from `renderSize` and applies per-codec bytes/sec per megapixel so estimates cover arbitrary resolutions including the new presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c82a801b14a3684c02191bffd295bb54738f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->