### PR TITLE
fix(export): cancel stalled exports instead of hanging (#68)

### DIFF
--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -70,6 +70,20 @@ final class ExportService {
     }
     var error: String?
 
+    /// Cancel an export whose progress has been frozen this long. Turns the
+    /// indefinite AVAssetExportSession hang on deep seeks into high-frame-rate
+    /// sources inside a lower-frame-rate timeline (#68) into a surfaced error.
+    static let exportStallLimit: Duration = .seconds(120)
+    static let exportStalledMessage = """
+        Export stalled — no progress for two minutes and was cancelled. \
+        This can happen when exporting clips that seek deep into a high-frame-rate \
+        (e.g. 60 fps) source inside a lower-frame-rate timeline (a known AVFoundation \
+        limitation). Converting those sources to proxies at the project's frame rate \
+        avoids it.
+        """
+    private var stallWatcher = ExportStallWatcher()
+    private var stallCancelled = false
+
     func export(
         timeline: Timeline,
         resolver: MediaResolver,
@@ -116,11 +130,28 @@ final class ExportService {
             try? FileManager.default.removeItem(at: outputURL)
 
             nonisolated(unsafe) let unsafeSession = session
+            let exportStart = ContinuousClock.now
+            stallWatcher = ExportStallWatcher()
+            stallCancelled = false
             let progressTask = Task { @MainActor in
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .milliseconds(200))
                     let p = Double(unsafeSession.progress)
                     if p != self.progress { self.progress = p }
+                    guard !self.stallCancelled else { continue }
+                    if self.stallWatcher.update(
+                        progress: p,
+                        now: exportStart.duration(to: .now),
+                        stallLimit: Self.exportStallLimit
+                    ) {
+                        self.stallCancelled = true
+                        Log.export.warning(
+                            "export stalled — no progress for \(Self.exportStallLimit.components.seconds)s; cancelling",
+                            telemetry: "Export stalled",
+                            data: ["format": String(describing: format), "resolution": resolution.rawValue, "progress": p]
+                        )
+                        unsafeSession.cancelExport()
+                    }
                 }
             }
 
@@ -133,7 +164,14 @@ final class ExportService {
                     data: ["format": String(describing: format), "resolution": resolution.rawValue]
                 )
             } catch {
-                if (error as NSError).domain == NSCocoaErrorDomain && (error as NSError).code == NSUserCancelledError {
+                if stallCancelled {
+                    self.error = Self.exportStalledMessage
+                    Log.export.warning(
+                        "export cancelled after stall",
+                        telemetry: "Export cancelled after stall",
+                        data: ["format": String(describing: format), "resolution": resolution.rawValue]
+                    )
+                } else if (error as NSError).domain == NSCocoaErrorDomain && (error as NSError).code == NSUserCancelledError {
                     self.error = "Export was cancelled"
                     Log.export.notice(
                         "export cancelled",

--- a/Sources/PalmierPro/Export/ExportStallWatcher.swift
+++ b/Sources/PalmierPro/Export/ExportStallWatcher.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Decides when an export has stalled based on `AVAssetExportSession.progress`
+/// samples. Pure logic — time is fed in as a `Duration` so it is fully testable.
+///
+/// `AVAssetExportSession` can hang indefinitely on deep seeks into high-frame-rate
+/// sources inside a lower-frame-rate timeline (#68); this turns that into a
+/// cancellable error instead of a frozen progress bar.
+struct ExportStallWatcher {
+    static let defaultEpsilon: Double = 0.0005
+
+    let epsilon: Double
+    private(set) var lastProgress: Double?
+    private(set) var lastAdvancedAt: Duration
+
+    init(epsilon: Double = ExportStallWatcher.defaultEpsilon, startOffset: Duration = .zero) {
+        self.epsilon = epsilon
+        self.lastAdvancedAt = startOffset
+    }
+
+    /// Feed one progress sample taken at absolute monotonic offset `now`.
+    /// Returns true when progress has been frozen for at least `stallLimit`.
+    @discardableResult
+    mutating func update(progress: Double, now: Duration, stallLimit: Duration) -> Bool {
+        if let last = lastProgress, abs(progress - last) > epsilon {
+            lastAdvancedAt = now
+        }
+        lastProgress = progress
+        return stallLimit > .zero && now - lastAdvancedAt >= stallLimit
+    }
+}

--- a/Tests/PalmierProTests/Export/ExportStallWatcherTests.swift
+++ b/Tests/PalmierProTests/Export/ExportStallWatcherTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// Pure-logic tests for the export stall watchdog (#68). Time is fed in as a
+/// `Duration` offset so no real clock is needed.
+@Suite("ExportStallWatcher")
+struct ExportStallWatcherTests {
+
+    private let limit = Duration.seconds(10)
+
+    @Test func advancingProgressNeverStalls() {
+        var w = ExportStallWatcher()
+        // Progress climbs every tick; even after many× the limit, no stall.
+        for i in 0...200 {
+            let now = Duration.milliseconds(200) * i
+            let stalled = w.update(progress: Double(i) * 0.001, now: now, stallLimit: limit)
+            #expect(!stalled)
+        }
+    }
+
+    @Test func frozenProgressStallsAfterLimit() {
+        var w = ExportStallWatcher()
+        // First sample establishes baseline at t=0.
+        _ = w.update(progress: 0.5, now: .zero, stallLimit: limit)
+        // Frozen just under the limit: still ok.
+        let under = w.update(progress: 0.5, now: .seconds(9), stallLimit: limit)
+        #expect(!under)
+        // At the limit with no movement: stall.
+        let atLimit = w.update(progress: 0.5, now: .seconds(10), stallLimit: limit)
+        #expect(atLimit)
+    }
+
+    @Test func advanceResetsTheStallClock() {
+        var w = ExportStallWatcher()
+        _ = w.update(progress: 0.0, now: .zero, stallLimit: limit)
+        // Sit frozen for most of the limit.
+        let under = w.update(progress: 0.0, now: .seconds(8), stallLimit: limit)
+        #expect(!under)
+        // Move just in time — clock resets.
+        let afterMove = w.update(progress: 0.1, now: .seconds(9), stallLimit: limit)
+        #expect(!afterMove)
+        // Another window of stillness since the last advance: ok under, stall over.
+        let underAgain = w.update(progress: 0.1, now: .seconds(18), stallLimit: limit)
+        #expect(!underAgain)
+        let over = w.update(progress: 0.1, now: .seconds(19), stallLimit: limit)
+        #expect(over)
+    }
+
+    @Test func firstSampleDoesNotCountAsProgress() {
+        var w = ExportStallWatcher()
+        // A single sample at the limit boundary: never advanced, so it stalls.
+        let stalled = w.update(progress: 0.3, now: limit, stallLimit: limit)
+        #expect(stalled)
+    }
+
+    @Test func neverMovingStallsFromZero() {
+        var w = ExportStallWatcher()
+        for s in 0...60 {
+            let stalled = w.update(progress: 0.0, now: Duration.seconds(s), stallLimit: limit)
+            #expect(stalled == (s >= 10))
+        }
+    }
+
+    @Test func subEpsilonJitterIsNotMovement() {
+        var w = ExportStallWatcher(epsilon: 0.001)
+        _ = w.update(progress: 0.5, now: .zero, stallLimit: limit)
+        // Jitter below epsilon must not reset the clock.
+        let stalled = w.update(progress: 0.5005, now: .seconds(11), stallLimit: limit)
+        #expect(stalled)
+    }
+
+    @Test func meaningfulMovementPastEpsilonResets() {
+        var w = ExportStallWatcher(epsilon: 0.001)
+        _ = w.update(progress: 0.5, now: .zero, stallLimit: limit)
+        // A real advance just before the limit resets, so no stall at the boundary.
+        let moved = w.update(progress: 0.52, now: .seconds(9), stallLimit: limit)
+        #expect(!moved)
+        let stillOk = w.update(progress: 0.52, now: .seconds(18), stallLimit: limit)
+        #expect(!stillOk)
+    }
+}


### PR DESCRIPTION
## Summary

`AVAssetExportSession` hangs **indefinitely** (one core pinned, progress bar + output file frozen) on clips that **seek deep into a high-frame-rate source inside a lower-frame-rate timeline** — e.g. a 60 fps HEVC source in a 30 fps project. The in-app preview renders these fine; only the file export hangs. Re-encoding to 1080p while keeping 60 fps did **not** fix it; a 30 fps proxy did. This matches #68's isolation exactly.

The framework's internal decode stall on repeated deep seeks into long-GOP high-fps media isn't deterministically fixable from app code without a transcode proxy (a much larger change). But the app can stop waiting on it, which is what #68 explicitly asks for: *"Add an export watchdog/timeout so a stuck decode surfaces as an error rather than an indefinite hang."*

## Change

- New `ExportStallWatcher` — pure logic that decides when progress has been frozen for a limit. Time is fed in as a `Duration`, so it's fully unit-testable with no clock.
- `ExportService` watches `AVAssetExportSession.progress` each poll; if it doesn't advance for **two minutes**, it calls `cancelExport()` and surfaces an actionable error pointing at the same-frame-rate-proxy workaround.

The two-minute limit is deliberately generous — `AVAssetExportSession.progress` updates repeatedly during healthy encodes, so two minutes of zero movement is a real stall, not a slow section.

## Why not fix the decode itself

Per #68, the hang is tied to **60→30 fps resampling + a non-zero source seek**, not codec/resolution/disk. That's an `AVAssetExportSession` pipeline behavior; the deterministic fix is a conform/proxy transcode pass, which is a much bigger architectural change and out of scope for an outside PR. This watchdog is the safe, additive mitigation #68 requests.

## Test plan

- [x] `swift test --filter ExportStallWatcher` → 7/7 pure-logic tests: advancing-never-stalls, frozen→stalls-at-limit, advance-resets-clock, first-sample-isn't-an-advance, never-moving-stalls-from-zero, sub-epsilon-jitter-ignored, real-movement-resets.
- [x] `swift test` (full) → **656/656 pass**, no regressions.
- [x] `swift build` → clean.

The stall path itself can't be unit-tested headlessly (needs a real hanging `AVAssetExportSession`), but the decision logic it depends on is fully covered.

Closes #68.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive export-path behavior with a generous stall threshold; only risk is a false-positive cancel if progress truly flatlines for two minutes on a slow but healthy encode.
> 
> **Overview**
> Adds an **export stall watchdog** so `AVAssetExportSession` jobs that freeze progress (known issue with deep seeks into high-fps sources in lower-fps timelines) end with a clear error instead of hanging forever.
> 
> A new **`ExportStallWatcher`** tracks progress samples with injectable monotonic time and a small epsilon so jitter does not reset the clock. **`ExportService`** polls session progress every 200ms; if nothing meaningful advances for **two minutes**, it calls **`cancelExport()`**, sets a dedicated user-facing message (proxy / frame-rate workaround), and logs telemetry separately from a normal user cancel.
> 
> **Unit tests** cover advancing progress, frozen stall at the limit, clock reset on real movement, first-sample behavior, and epsilon handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6d6bef4c1e6a6fab693569adfd303f6f0eae17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->