### PR TITLE
fix(preview): flag unplayable media when previewing a standalone asset

### DIFF
--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -101,6 +101,32 @@ final class VideoEngine {
             return
         }
         replacePlayerItem(AVPlayerItem(url: asset.url), reason: "previewAsset")
+        verifyAssetPlayable(asset)
+    }
+
+    /// `AVPlayerItem(url:)` fails silently — a corrupt or unsupported file just
+    /// leaves the preview blank with no error. Probe the tracks so we can flag
+    /// it through the same offline/unprocessable UI the timeline path uses.
+    private func verifyAssetPlayable(_ asset: MediaAsset) {
+        let mediaType: AVMediaType = asset.type == .audio ? .audio : .video
+        let url = asset.url
+        let assetId = asset.id
+        Task { @MainActor [weak self] in
+            let hasTrack: Bool
+            do {
+                hasTrack = try await AVURLAsset(url: url).loadTracks(withMediaType: mediaType).first != nil
+            } catch {
+                hasTrack = false
+            }
+            guard let self, !Task.isCancelled, let editor = self.editor else { return }
+            guard case .mediaAsset(let activeId, _, _) = editor.activePreviewTab, activeId == assetId else { return }
+            if hasTrack {
+                editor.unprocessableMediaRefs.remove(assetId)
+            } else {
+                Log.preview.error("previewAsset: media unplayable assetId=\(assetId.prefix(8))")
+                editor.unprocessableMediaRefs.insert(assetId)
+            }
+        }
     }
 
     func activateTab(_ tab: PreviewTab) {


### PR DESCRIPTION
## Summary
- `VideoEngine.previewAsset()` builds `AVPlayerItem(url: asset.url)` directly with no error handling. If the source file can't actually decode (corrupt, truncated, unsupported codec variant), the preview just sits blank/frozen with no feedback anywhere — no log, no UI state change.
- This detection already exists for the timeline composition path: `CompositionBuilder` probes each clip's tracks and records failures into `offlineMediaRefs`/`unprocessableMediaRefs`, which `PreviewContainerView` uses to show a "Couldn't Prepare Media" overlay with an explanation and a report button. That path never ran for an asset previewed standalone (before being placed on the timeline).
- Reproduced the failure mode directly: `AVURLAsset(url:).loadTracks(withMediaType: .video)` on a garbage/corrupt file throws `AVErrorFailedDependenciesKey "Cannot Open"` — exactly the case that silently fails today.

## Fix
After swapping in the player item in `previewAsset()`, probe the asset's tracks in the background. On failure, insert the asset id into `editor.unprocessableMediaRefs`, reusing the existing offline/unprocessable UI instead of leaving a silent blank player.

## Test plan
- [x] `swift build` — clean build
- [x] `swift test` — full suite passes (one pre-existing failure in `CompositionBuilderTests.fractionalSpeedAudioUsesTruncatedSourceFramesForCompositionInsertion` confirmed present on unmodified `main` too, unrelated to this change)
- [x] Verified `AVURLAsset.loadTracks` throws on a corrupt file with a video extension, matching the failure mode this fix detects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, preview-only change that toggles existing editor UI state; no auth, export, or timeline composition logic is modified.
> 
> **Overview**
> Standalone media previews no longer fail silently when `AVPlayerItem(url:)` cannot decode the file. After swapping in the player item in **`previewAsset()`**, the engine asynchronously probes **`AVURLAsset.loadTracks(withMediaType:)`** for the correct audio or video track.
> 
> If decoding fails or no track is found, the asset id is added to **`editor.unprocessableMediaRefs`** (with a preview log); if the file becomes playable, the id is removed. That reuses the same unprocessable/offline overlay the timeline composition path already drives via **`CompositionBuilder`**, which never ran for library-only asset preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c99a333dade991a972037c753d2662c0117fe29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->