### PR TITLE
Per-clip chroma key + blend modes (Core Image video compositor)

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -10,6 +10,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case removeTracks = "remove_tracks"
     case moveClips = "move_clips"
     case setClipProperties = "set_clip_properties"
+    case setChromaKey = "set_chroma_key"
     case setKeyframes = "set_keyframes"
     case splitClip = "split_clip"
     case rippleDeleteRanges = "ripple_delete_ranges"
@@ -244,6 +245,22 @@ enum ToolDefinitions {
                     "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text clips only."],
                 ],
                 required: ["clipIds"]
+            )
+        ),
+        AgentTool(
+            name: .setChromaKey,
+            description: "Apply or remove an Ultra Key chroma key (green-screen removal) on a visual clip. The keyed colour becomes transparent so clips on tracks below show through. Defaults to green. Set enabled=false to remove the key.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipId": ["type": "string", "description": "The visual clip to key."],
+                    "enabled": ["type": "boolean", "description": "Default true. Pass false to remove the chroma key."],
+                    "keyColorHex": ["type": "string", "description": "Key colour as '#RRGGBB' (default green '#00FF00')."],
+                    "tolerance": ["type": "number", "description": "0-100. How wide a hue range around the key colour is removed (default 40)."],
+                    "softness": ["type": "number", "description": "0-100. Softens the matte edge between kept and removed colours (default 20)."],
+                    "spill": ["type": "number", "description": "0-100. Suppresses residual key-colour cast on the subject's edges (default 50)."],
+                    "edgeFeather": ["type": "number", "description": "Blur radius in points applied to the matte edge (default 0)."],
+                ],
+                required: ["clipId"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -11,6 +11,8 @@ enum ToolName: String, CaseIterable, Sendable {
     case moveClips = "move_clips"
     case setClipProperties = "set_clip_properties"
     case setChromaKey = "set_chroma_key"
+    case setBlendMode = "set_blend_mode"
+    case setColorGrade = "set_color_grade"
     case setKeyframes = "set_keyframes"
     case splitClip = "split_clip"
     case rippleDeleteRanges = "ripple_delete_ranges"
@@ -259,6 +261,42 @@ enum ToolDefinitions {
                     "softness": ["type": "number", "description": "0-100. Softens the matte edge between kept and removed colours (default 20)."],
                     "spill": ["type": "number", "description": "0-100. Suppresses residual key-colour cast on the subject's edges (default 50)."],
                     "edgeFeather": ["type": "number", "description": "Blur radius in points applied to the matte edge (default 0)."],
+                ],
+                required: ["clipId"]
+            )
+        ),
+        AgentTool(
+            name: .setBlendMode,
+            description: "Set how a visual clip composites over the tracks below it. Use 'normal' for default source-over.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipId": ["type": "string", "description": "The visual clip."],
+                    "mode": [
+                        "type": "string",
+                        "enum": BlendMode.allCases.map(\.rawValue),
+                        "description": "Blend mode (e.g. multiply, screen, overlay, lighten, darken, softLight, luminosity).",
+                    ],
+                ],
+                required: ["clipId", "mode"]
+            )
+        ),
+        AgentTool(
+            name: .setColorGrade,
+            description: "Set a colour grade on a visual clip (per-clip) or an adjustment layer (grades everything below it). All fields optional except clipId; omitted fields keep their current value. Pass reset=true to clear the grade.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipId": ["type": "string", "description": "A visual clip or an adjustment-layer clip."],
+                    "temperature": ["type": "number", "description": "-100…100. Warmer as it rises."],
+                    "tint": ["type": "number", "description": "-100…100. Green↔magenta."],
+                    "exposure": ["type": "number", "description": "-100…100 (≈ ±2 EV)."],
+                    "contrast": ["type": "number", "description": "-100…100."],
+                    "saturation": ["type": "number", "description": "-100…100."],
+                    "lutPath": ["type": "string", "description": "Absolute path to a .cube LUT file to apply."],
+                    "lutIntensity": ["type": "number", "description": "0…1 LUT strength (default 1)."],
+                    "removeLut": ["type": "boolean", "description": "Remove the current LUT."],
+                    "basicEnabled": ["type": "boolean", "description": "Toggle the basic (temp/tint/exposure/contrast/saturation) section."],
+                    "creativeEnabled": ["type": "boolean", "description": "Toggle the LUT section."],
+                    "reset": ["type": "boolean", "description": "Clear the entire grade."],
                 ],
                 required: ["clipId"]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ChromaKey.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ChromaKey.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension ToolExecutor {
+
+    /// Apply or remove an Ultra Key chroma key on a visual clip.
+    func setChromaKey(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let clipId = try args.requireString("clipId")
+        guard let loc = editor.findClip(id: clipId) else {
+            throw ToolError("Clip not found: \(clipId)")
+        }
+        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard clip.mediaType.isVisual else {
+            throw ToolError("Chroma key only applies to visual clips (clip \(clipId) is \(clip.mediaType.rawValue)).")
+        }
+
+        if args.bool("enabled") == false {
+            editor.setChromaKey(clipId: clipId, nil)
+            return .ok("Chroma key removed from clip \(clipId).")
+        }
+
+        var key = clip.chromaKey ?? ChromaKey()
+        key.enabled = true
+        if let hex = args.string("keyColorHex"), let rgba = try parseColorHex(hex, path: "set_chroma_key") {
+            key.keyColor = rgba
+        }
+        if let t = args.double("tolerance") { key.tolerance = clampPercent(t) }
+        if let s = args.double("softness") { key.softness = clampPercent(s) }
+        if let sp = args.double("spill") { key.spill = clampPercent(sp) }
+        if let ef = args.double("edgeFeather") { key.edgeFeather = max(0, ef) }
+        editor.setChromaKey(clipId: clipId, key)
+
+        let hex = String(format: "#%02X%02X%02X",
+                         Int((key.keyColor.r * 255).rounded()),
+                         Int((key.keyColor.g * 255).rounded()),
+                         Int((key.keyColor.b * 255).rounded()))
+        return .ok("""
+            Chroma key enabled on clip \(clipId): key \(hex), tolerance \(Int(key.tolerance)), \
+            softness \(Int(key.softness)), spill \(Int(key.spill)), feather \(Int(key.edgeFeather)).
+            """)
+    }
+
+    private func clampPercent(_ v: Double) -> Double { min(100, max(0, v)) }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+extension ToolExecutor {
+
+    /// Set a visual clip's blend mode (how it composites over the layers below).
+    func setBlendMode(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let clipId = try args.requireString("clipId")
+        let clip = try visualClip(editor, clipId, feature: "Blend mode")
+        _ = clip
+        let raw = try args.requireString("mode")
+        guard let mode = BlendMode(rawValue: raw) else {
+            throw ToolError("Unknown blend mode '\(raw)'. Options: \(BlendMode.allCases.map(\.rawValue).joined(separator: ", "))")
+        }
+        editor.setBlendMode(clipId: clipId, mode)
+        return .ok("Blend mode of clip \(clipId) set to \(mode.displayName).")
+    }
+
+    /// Set the colour grade on a visual clip (per-clip) or an adjustment layer.
+    func setColorGrade(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let clipId = try args.requireString("clipId")
+        guard let loc = editor.findClip(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
+        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard clip.mediaType.isVisual || clip.mediaType == .adjustment else {
+            throw ToolError("Color grade applies to visual clips or adjustment layers (clip \(clipId) is \(clip.mediaType.rawValue)).")
+        }
+
+        if args.bool("reset") == true {
+            editor.setColorGrade(clipId: clipId, nil)
+            return .ok("Color grade cleared on clip \(clipId).")
+        }
+
+        var g = clip.colorGrade ?? ColorGrade()
+        if let v = args.double("temperature") { g.temperature = clampGrade(v) }
+        if let v = args.double("tint") { g.tint = clampGrade(v) }
+        if let v = args.double("exposure") { g.exposure = clampGrade(v) }
+        if let v = args.double("contrast") { g.contrast = clampGrade(v) }
+        if let v = args.double("saturation") { g.saturation = clampGrade(v) }
+        if let b = args.bool("basicEnabled") { g.basicEnabled = b }
+        if let b = args.bool("creativeEnabled") { g.creativeEnabled = b }
+
+        if args.bool("removeLut") == true {
+            g.lutRef = nil
+        } else if let path = args.string("lutPath") {
+            guard FileManager.default.fileExists(atPath: path) else {
+                throw ToolError("LUT file not found: \(path)")
+            }
+            do {
+                _ = try CubeLUT.parse(contentsOf: URL(fileURLWithPath: path))
+            } catch {
+                throw ToolError("Invalid .cube LUT: \(error.localizedDescription)")
+            }
+            g.lutRef = path
+            g.creativeEnabled = true
+        }
+        if let i = args.double("lutIntensity") { g.lutIntensity = min(1, max(0, i)) }
+
+        editor.setColorGrade(clipId: clipId, g)
+        let lut = g.lutRef.map { ($0 as NSString).lastPathComponent } ?? "none"
+        return .ok("""
+            Color grade on clip \(clipId): temp \(Int(g.temperature)), tint \(Int(g.tint)), \
+            exposure \(Int(g.exposure)), contrast \(Int(g.contrast)), saturation \(Int(g.saturation)), \
+            LUT \(lut) @ \(Int(g.lutIntensity * 100))%.
+            """)
+    }
+
+    private func visualClip(_ editor: EditorViewModel, _ clipId: String, feature: String) throws -> Clip {
+        guard let loc = editor.findClip(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
+        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard clip.mediaType.isVisual else {
+            throw ToolError("\(feature) only applies to visual clips (clip \(clipId) is \(clip.mediaType.rawValue)).")
+        }
+        return clip
+    }
+
+    private func clampGrade(_ v: Double) -> Double { min(100, max(-100, v)) }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -28,6 +28,8 @@ extension ToolExecutor {
             throw ToolError("Text generation is not wired through the generate tool.")
         case .lottie:
             throw ToolError("Lottie animations aren't generated through this tool.")
+        case .adjustment:
+            throw ToolError("Adjustment layers aren't generated through this tool.")
         }
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -293,6 +293,7 @@ extension ToolExecutor {
         case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping)
         case .lottie: return try await readLottie(asset: asset, args: args)
         case .text: throw ToolError("Text clips are not stored as media assets.")
+        case .adjustment: throw ToolError("Adjustment layers are not stored as media assets.")
         }
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -83,6 +83,7 @@ final class ToolExecutor {
         case .removeTracks:     return try removeTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
+        case .setChromaKey:  return try setChromaKey(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClip:        return try splitClip(editor, args)
         case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -84,6 +84,8 @@ final class ToolExecutor {
         case .moveClips:        return try moveClips(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setChromaKey:  return try setChromaKey(editor, args)
+        case .setBlendMode:  return try setBlendMode(editor, args)
+        case .setColorGrade: return try setColorGrade(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClip:        return try splitClip(editor, args)
         case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)

--- a/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
+++ b/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
@@ -130,7 +130,11 @@ private final class ChromaCubeCache: @unchecked Sendable {
     func get(_ key: String, build: () -> (fg: Data, matte: Data)) -> (fg: Data, matte: Data) {
         lock.lock()
         defer { lock.unlock() }
-        if let cached = store[key] { return cached }
+        if let cached = store[key] {
+            // Refresh recency so reused parameter sets aren't evicted before cold ones.
+            if let i = order.firstIndex(of: key) { order.remove(at: i); order.append(key) }
+            return cached
+        }
         let built = build()
         store[key] = built
         order.append(key)

--- a/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
+++ b/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
@@ -54,33 +54,13 @@ enum ChromaKeyPipeline {
         keyR: Double, keyG: Double, keyB: Double,
         tolerance: Double, softness: Double, spill: Double, edgeFeather: Double
     ) -> CIImage {
-        let keyHue = rgbToHSV(r: keyR, g: keyG, b: keyB).h
         let n = cubeSize
-
-        var fg = [Float](repeating: 0, count: n * n * n * 4)
-        var matte = [Float](repeating: 0, count: n * n * n * 4)
-        var o = 0
-        let denom = Double(n - 1)
-        for bi in 0..<n {
-            let b = Double(bi) / denom
-            for gi in 0..<n {
-                let g = Double(gi) / denom
-                for ri in 0..<n {
-                    let r = Double(ri) / denom
-                    let a = matteAlpha(r: r, g: g, b: b, keyHue: keyHue, tolerance: tolerance, softness: softness)
-                    let c = spillCorrect(r: r, g: g, b: b, keyHue: keyHue, spill: spill)
-                    // Foreground cube: opaque spill-corrected colour.
-                    fg[o] = Float(c.r); fg[o + 1] = Float(c.g); fg[o + 2] = Float(c.b); fg[o + 3] = 1
-                    // Matte cube: grayscale + alpha both = matte, so feather blurs cleanly.
-                    let af = Float(a)
-                    matte[o] = af; matte[o + 1] = af; matte[o + 2] = af; matte[o + 3] = af
-                    o += 4
-                }
-            }
-        }
-
-        let fgImage = applyCube(fg, dimension: n, to: image)
-        var matteImage = applyCube(matte, dimension: n, to: image)
+        // The cubes depend only on key colour/tolerance/softness/spill, not the frame,
+        // so build them once per parameter set and reuse across frames/clips.
+        let cubes = cachedCubes(keyR: keyR, keyG: keyG, keyB: keyB,
+                                tolerance: tolerance, softness: softness, spill: spill, n: n)
+        let fgImage = applyCube(cubes.fg, dimension: n, to: image)
+        var matteImage = applyCube(cubes.matte, dimension: n, to: image)
 
         if edgeFeather > 0 {
             let blur = CIFilter.gaussianBlur()
@@ -96,12 +76,66 @@ enum ChromaKeyPipeline {
         return (blend.outputImage ?? fgImage).cropped(to: image.extent)
     }
 
-    private static func applyCube(_ data: [Float], dimension: Int, to image: CIImage) -> CIImage {
+    private static func applyCube(_ data: Data, dimension: Int, to image: CIImage) -> CIImage {
         let f = CIFilter.colorCube()
         f.inputImage = image
         f.cubeDimension = Float(dimension)
-        f.cubeData = data.withUnsafeBufferPointer { Data(buffer: $0) }
+        f.cubeData = data
         return f.outputImage ?? image
+    }
+
+    // MARK: - Cube cache
+
+    private static let cubeCache = ChromaCubeCache()
+
+    private static func cachedCubes(
+        keyR: Double, keyG: Double, keyB: Double,
+        tolerance: Double, softness: Double, spill: Double, n: Int
+    ) -> (fg: Data, matte: Data) {
+        let keyHue = rgbToHSV(r: keyR, g: keyG, b: keyB).h
+        let key = "\(Int((keyHue * 1000).rounded()))|\(Int(tolerance.rounded()))|\(Int(softness.rounded()))|\(Int(spill.rounded()))|\(n)"
+        return cubeCache.get(key) {
+            var fg = [Float](repeating: 0, count: n * n * n * 4)
+            var matte = [Float](repeating: 0, count: n * n * n * 4)
+            var o = 0
+            let denom = Double(n - 1)
+            for bi in 0..<n {
+                let b = Double(bi) / denom
+                for gi in 0..<n {
+                    let g = Double(gi) / denom
+                    for ri in 0..<n {
+                        let r = Double(ri) / denom
+                        let a = matteAlpha(r: r, g: g, b: b, keyHue: keyHue, tolerance: tolerance, softness: softness)
+                        let c = spillCorrect(r: r, g: g, b: b, keyHue: keyHue, spill: spill)
+                        fg[o] = Float(c.r); fg[o + 1] = Float(c.g); fg[o + 2] = Float(c.b); fg[o + 3] = 1
+                        let af = Float(a)
+                        matte[o] = af; matte[o + 1] = af; matte[o + 2] = af; matte[o + 3] = af
+                        o += 4
+                    }
+                }
+            }
+            return (fg.withUnsafeBufferPointer { Data(buffer: $0) },
+                    matte.withUnsafeBufferPointer { Data(buffer: $0) })
+        }
+    }
+}
+
+/// Small thread-safe LRU-ish cache for generated chroma-key cubes.
+private final class ChromaCubeCache: @unchecked Sendable {
+    private var store: [String: (fg: Data, matte: Data)] = [:]
+    private var order: [String] = []
+    private let lock = NSLock()
+    private let limit = 12
+
+    func get(_ key: String, build: () -> (fg: Data, matte: Data)) -> (fg: Data, matte: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached = store[key] { return cached }
+        let built = build()
+        store[key] = built
+        order.append(key)
+        if order.count > limit { store.removeValue(forKey: order.removeFirst()) }
+        return built
     }
 }
 

--- a/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
+++ b/Sources/PalmierPro/Color/ChromaKeyPipeline.swift
@@ -1,0 +1,143 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+/// Pure Core Image chroma-key ("Ultra Key"). The matte and spill suppression are
+/// baked into generated `CIColorCube`s — Apple's documented keying approach — so
+/// no Metal kernel (and no SwiftPM kernel-compilation flags) is required.
+///
+/// Ranges (caller clamps): tolerance/softness/spill in 0…100, edgeFeather in points.
+enum ChromaKeyPipeline {
+
+    static let cubeSize = 64
+
+    // MARK: Pure matte math (unit-testable without rendering)
+
+    /// Alpha for one source colour: 0 = fully keyed out (transparent), 1 = kept.
+    static func matteAlpha(
+        r: Double, g: Double, b: Double,
+        keyHue: Double, tolerance: Double, softness: Double
+    ) -> Double {
+        let hsv = rgbToHSV(r: r, g: g, b: b)
+        // Greys/near-greys are never keyed — they carry no chroma to match.
+        let satGate = smoothstep(0.10, 0.25, hsv.s)
+        if satGate <= 0 { return 1 }
+
+        // 100 tolerance ≈ a quarter of the wheel (90°) — wide enough for a green
+        // screen's spread, narrow enough to spare skin/other hues.
+        let tolHue = (tolerance / 100.0) * 0.25
+        let softHue = (softness / 100.0) * 0.20
+        let dh = hueDistance(hsv.h, keyHue)
+
+        // removal: 1 inside tolerance, ramps to 0 across the soft band.
+        let removal = (1 - smoothstep(tolHue, tolHue + max(softHue, 0.0001), dh)) * satGate
+        return 1 - removal
+    }
+
+    /// Spill-suppressed colour: pulls residual key cast toward luma near the key hue.
+    static func spillCorrect(
+        r: Double, g: Double, b: Double,
+        keyHue: Double, spill: Double
+    ) -> (r: Double, g: Double, b: Double) {
+        guard spill > 0 else { return (r, g, b) }
+        let hsv = rgbToHSV(r: r, g: g, b: b)
+        let proximity = (1 - smoothstep(0.0, 0.25, hueDistance(hsv.h, keyHue))) * smoothstep(0.10, 0.25, hsv.s)
+        let amount = (spill / 100.0) * proximity
+        guard amount > 0 else { return (r, g, b) }
+        let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return (mix(r, luma, amount), mix(g, luma, amount), mix(b, luma, amount))
+    }
+
+    // MARK: Core Image application
+
+    static func apply(
+        _ image: CIImage,
+        keyR: Double, keyG: Double, keyB: Double,
+        tolerance: Double, softness: Double, spill: Double, edgeFeather: Double
+    ) -> CIImage {
+        let keyHue = rgbToHSV(r: keyR, g: keyG, b: keyB).h
+        let n = cubeSize
+
+        var fg = [Float](repeating: 0, count: n * n * n * 4)
+        var matte = [Float](repeating: 0, count: n * n * n * 4)
+        var o = 0
+        let denom = Double(n - 1)
+        for bi in 0..<n {
+            let b = Double(bi) / denom
+            for gi in 0..<n {
+                let g = Double(gi) / denom
+                for ri in 0..<n {
+                    let r = Double(ri) / denom
+                    let a = matteAlpha(r: r, g: g, b: b, keyHue: keyHue, tolerance: tolerance, softness: softness)
+                    let c = spillCorrect(r: r, g: g, b: b, keyHue: keyHue, spill: spill)
+                    // Foreground cube: opaque spill-corrected colour.
+                    fg[o] = Float(c.r); fg[o + 1] = Float(c.g); fg[o + 2] = Float(c.b); fg[o + 3] = 1
+                    // Matte cube: grayscale + alpha both = matte, so feather blurs cleanly.
+                    let af = Float(a)
+                    matte[o] = af; matte[o + 1] = af; matte[o + 2] = af; matte[o + 3] = af
+                    o += 4
+                }
+            }
+        }
+
+        let fgImage = applyCube(fg, dimension: n, to: image)
+        var matteImage = applyCube(matte, dimension: n, to: image)
+
+        if edgeFeather > 0 {
+            let blur = CIFilter.gaussianBlur()
+            blur.inputImage = matteImage.clampedToExtent()
+            blur.radius = Float(edgeFeather)
+            matteImage = (blur.outputImage ?? matteImage).cropped(to: image.extent)
+        }
+
+        let blend = CIFilter.blendWithMask()
+        blend.inputImage = fgImage
+        blend.backgroundImage = CIImage(color: .clear).cropped(to: image.extent)
+        blend.maskImage = matteImage
+        return (blend.outputImage ?? fgImage).cropped(to: image.extent)
+    }
+
+    private static func applyCube(_ data: [Float], dimension: Int, to image: CIImage) -> CIImage {
+        let f = CIFilter.colorCube()
+        f.inputImage = image
+        f.cubeDimension = Float(dimension)
+        f.cubeData = data.withUnsafeBufferPointer { Data(buffer: $0) }
+        return f.outputImage ?? image
+    }
+}
+
+// MARK: - Colour helpers
+
+private func mix(_ a: Double, _ b: Double, _ t: Double) -> Double { a + (b - a) * t }
+
+private func smoothstep(_ edge0: Double, _ edge1: Double, _ x: Double) -> Double {
+    guard edge1 > edge0 else { return x < edge0 ? 0 : 1 }
+    let t = min(1, max(0, (x - edge0) / (edge1 - edge0)))
+    return t * t * (3 - 2 * t)
+}
+
+/// Shortest distance between two hues on the 0…1 colour wheel (0…0.5).
+private func hueDistance(_ a: Double, _ b: Double) -> Double {
+    let d = abs(a - b).truncatingRemainder(dividingBy: 1)
+    return min(d, 1 - d)
+}
+
+func rgbToHSV(r: Double, g: Double, b: Double) -> (h: Double, s: Double, v: Double) {
+    let maxC = max(r, g, b)
+    let minC = min(r, g, b)
+    let delta = maxC - minC
+    let v = maxC
+    let s = maxC == 0 ? 0 : delta / maxC
+    var h = 0.0
+    if delta != 0 {
+        if maxC == r {
+            h = ((g - b) / delta).truncatingRemainder(dividingBy: 6)
+        } else if maxC == g {
+            h = (b - r) / delta + 2
+        } else {
+            h = (r - g) / delta + 4
+        }
+        h /= 6
+        if h < 0 { h += 1 }
+    }
+    return (h, s, v)
+}

--- a/Sources/PalmierPro/Color/ColorGradePipeline.swift
+++ b/Sources/PalmierPro/Color/ColorGradePipeline.swift
@@ -1,0 +1,68 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+/// Pure Core Image colour-grading chain. All slider values are neutral at `0`, so
+/// a freshly-defaulted grade is the identity transform.
+///
+/// Ranges (UI/MCP clamp before calling): temperature/tint/contrast/saturation in
+/// −100…100, exposure in −100…100 (mapped to ±2 EV), `lutIntensity` 0…1.
+enum ColorGradePipeline {
+
+    /// Basic correction: white balance (temperature/tint) → exposure → contrast/saturation.
+    static func basic(
+        _ image: CIImage,
+        temperature: Double,
+        tint: Double,
+        exposure: Double,
+        contrast: Double,
+        saturation: Double
+    ) -> CIImage {
+        var out = image
+
+        if temperature != 0 || tint != 0 {
+            let f = CIFilter.temperatureAndTint()
+            f.inputImage = out
+            f.neutral = CIVector(x: 6500, y: 0)
+            // Warmer as temperature rises; tint shifts green↔magenta.
+            f.targetNeutral = CIVector(x: 6500 + temperature * 28.5, y: tint * 1.5)
+            out = f.outputImage ?? out
+        }
+
+        if exposure != 0 {
+            let f = CIFilter.exposureAdjust()
+            f.inputImage = out
+            f.ev = Float(exposure / 50.0) // ±100 → ±2 EV
+            out = f.outputImage ?? out
+        }
+
+        if contrast != 0 || saturation != 0 {
+            let f = CIFilter.colorControls()
+            f.inputImage = out
+            f.contrast = Float(1 + contrast / 100.0)     // 0…2
+            f.saturation = Float(1 + saturation / 100.0)  // 0…2
+            f.brightness = 0
+            out = f.outputImage ?? out
+        }
+
+        return out
+    }
+
+    /// Apply a LUT, cross-dissolved with the source by `intensity` (0 = source, 1 = full LUT).
+    static func lut(_ image: CIImage, cube: CubeLUT, intensity: Double) -> CIImage {
+        let f = CIFilter.colorCube()
+        f.inputImage = image
+        f.cubeDimension = Float(cube.size)
+        f.cubeData = cube.cubeData
+        guard let full = f.outputImage else { return image }
+
+        let t = min(1, max(0, intensity))
+        if t >= 1 { return full }
+        if t <= 0 { return image }
+
+        let mix = CIFilter.dissolveTransition()
+        mix.inputImage = image
+        mix.targetImage = full
+        mix.time = Float(t)
+        return (mix.outputImage ?? full).cropped(to: image.extent)
+    }
+}

--- a/Sources/PalmierPro/Color/CubeLUT.swift
+++ b/Sources/PalmierPro/Color/CubeLUT.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// A parsed Adobe `.cube` LUT, ready for `CIColorCube`.
+///
+/// `rgbaData` is row-major with the **red index varying fastest**, then green,
+/// then blue — the ordering both the `.cube` spec and `CIColorCube` expect — so a
+/// 3D table copies straight through with an appended `a = 1`.
+struct CubeLUT: Equatable, Sendable {
+    /// Edge length of the 3D table (entries = size³).
+    let size: Int
+    /// `size³ × 4` floats, channel order RGBA, values clamped to 0…1.
+    let rgbaData: [Float]
+
+    struct ParseError: LocalizedError, Equatable {
+        let reason: String
+        var errorDescription: String? { "Invalid .cube LUT: \(reason)" }
+    }
+
+    /// `NSData` payload for `CIColorCube.inputCubeData`.
+    var cubeData: Data {
+        rgbaData.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    static func parse(contentsOf url: URL) throws -> CubeLUT {
+        try parse(String(contentsOf: url, encoding: .utf8))
+    }
+
+    static func parse(_ text: String) throws -> CubeLUT {
+        var size3D: Int?
+        var size1D: Int?
+        var triples: [(Float, Float, Float)] = []
+
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+
+            let fields = line.split(whereSeparator: \.isWhitespace).map(String.init)
+            guard let keyword = fields.first else { continue }
+
+            switch keyword.uppercased() {
+            case "TITLE", "DOMAIN_MIN", "DOMAIN_MAX":
+                continue // metadata we don't need; 0…1 domain assumed
+            case "LUT_3D_SIZE":
+                guard fields.count >= 2, let n = Int(fields[1]), n >= 2, n <= 256 else {
+                    throw ParseError(reason: "bad LUT_3D_SIZE")
+                }
+                size3D = n
+            case "LUT_1D_SIZE":
+                guard fields.count >= 2, let n = Int(fields[1]), n >= 2, n <= 65536 else {
+                    throw ParseError(reason: "bad LUT_1D_SIZE")
+                }
+                size1D = n
+            default:
+                guard fields.count >= 3,
+                      let r = Float(fields[0]), let g = Float(fields[1]), let b = Float(fields[2]) else {
+                    throw ParseError(reason: "malformed data row '\(line)'")
+                }
+                triples.append((r, g, b))
+            }
+        }
+
+        if let n = size3D {
+            guard triples.count == n * n * n else {
+                throw ParseError(reason: "expected \(n * n * n) rows for 3D size \(n), got \(triples.count)")
+            }
+            var data = [Float](repeating: 0, count: n * n * n * 4)
+            for (i, t) in triples.enumerated() {
+                let o = i * 4
+                data[o] = clamp01(t.0); data[o + 1] = clamp01(t.1)
+                data[o + 2] = clamp01(t.2); data[o + 3] = 1
+            }
+            return CubeLUT(size: n, rgbaData: data)
+        }
+
+        if let n = size1D {
+            guard triples.count == n else {
+                throw ParseError(reason: "expected \(n) rows for 1D size \(n), got \(triples.count)")
+            }
+            return expand1D(curve: triples, size: n)
+        }
+
+        throw ParseError(reason: "missing LUT_3D_SIZE / LUT_1D_SIZE")
+    }
+
+    /// Promote a 1D per-channel curve into a 3D cube: out = (curve[r].r, curve[g].g, curve[b].b).
+    private static func expand1D(curve: [(Float, Float, Float)], size n: Int) -> CubeLUT {
+        var data = [Float](repeating: 0, count: n * n * n * 4)
+        var o = 0
+        for b in 0..<n {
+            for g in 0..<n {
+                for r in 0..<n {
+                    data[o] = clamp01(curve[r].0)
+                    data[o + 1] = clamp01(curve[g].1)
+                    data[o + 2] = clamp01(curve[b].2)
+                    data[o + 3] = 1
+                    o += 4
+                }
+            }
+        }
+        return CubeLUT(size: n, rgbaData: data)
+    }
+}
+
+private func clamp01(_ v: Float) -> Float { min(1, max(0, v)) }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension EditorViewModel {
+
+    /// Set (or clear with `nil`) the chroma key on a clip. Undoable; triggers a
+    /// preview rebuild so the custom compositor picks up the change.
+    func setChromaKey(clipId: String, _ key: ChromaKey?) {
+        mutateClips(ids: [clipId], actionName: "Chroma Key") { clip in
+            clip.chromaKey = key
+        }
+    }
+
+    /// Set (or clear with `nil`) the colour grade on an adjustment clip. Undoable.
+    func setColorGrade(clipId: String, _ grade: ColorGrade?) {
+        mutateClips(ids: [clipId], actionName: "Color Grade") { clip in
+            clip.colorGrade = grade
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
@@ -17,6 +17,13 @@ extension EditorViewModel {
         }
     }
 
+    /// Set the blend mode on a visual clip (nil/normal = source-over). Undoable.
+    func setBlendMode(clipId: String, _ mode: BlendMode) {
+        mutateClips(ids: [clipId], actionName: "Blend Mode") { clip in
+            clip.blendMode = mode == .normal ? nil : mode
+        }
+    }
+
     /// Create a topmost adjustment layer spanning the current timeline and select it.
     @discardableResult
     func addAdjustmentLayer() -> String {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Color.swift
@@ -16,4 +16,21 @@ extension EditorViewModel {
             clip.colorGrade = grade
         }
     }
+
+    /// Create a topmost adjustment layer spanning the current timeline and select it.
+    @discardableResult
+    func addAdjustmentLayer() -> String {
+        let span = max(1, timeline.totalFrames)
+        var clip = Clip(mediaRef: "", startFrame: 0, durationFrames: span)
+        clip.mediaType = .adjustment
+        clip.sourceClipType = .adjustment
+        clip.colorGrade = ColorGrade()
+        let clipId = clip.id
+        let track = Track(type: .adjustment, clips: [clip])
+        withTimelineSwap(actionName: "Add Adjustment Layer") {
+            timeline.tracks.insert(track, at: 0)
+        }
+        selectedClipIds = [clipId]
+        return clipId
+    }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -433,7 +433,7 @@ extension EditorViewModel {
             mediaVisualCache.generateWaveform(for: asset)
         case .image:
             mediaVisualCache.generateImageThumbnail(for: asset)
-        case .text, .lottie:
+        case .text, .lottie, .adjustment:
             break
         }
         Log.project.notice(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -37,7 +37,7 @@ extension EditorViewModel {
         let z = zones
         let bounded = max(0, min(requested, z.trackCount))
         switch type {
-        case .video, .image, .text, .lottie:
+        case .video, .image, .text, .lottie, .adjustment:
             // Visual tracks must come at or before the first audio track.
             return min(bounded, z.firstAudioIndex)
         case .audio:

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -240,12 +240,12 @@ final class ExportService {
             fps: timeline.fps,
             renderSize: renderSize
         )
-        let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
-        mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
+        var config = result.videoCompositionConfiguration
+        config.animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,
             in: parent
         )
-        session.videoComposition = mutableVC
+        session.videoComposition = AVVideoComposition(configuration: config)
         return session
     }
 

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -92,6 +92,16 @@ final class ExportService {
         isExporting = true
         progress = 0
         error = nil
+        defer { isExporting = false }
+
+        guard let fileType = format.utType else {
+            error = "Invalid export format"
+            return
+        }
+        let renderSize = resolution.renderSize(for: CGSize(width: timeline.width, height: timeline.height))
+        let hasText = timeline.tracks.contains { $0.clips.contains { $0.mediaType == .text } }
+        let needsColor = CompositionBuilder.needsColorCompositor(timeline)
+
         Log.export.notice(
             "export requested format=\(String(describing: format)) resolution=\(resolution.rawValue)",
             telemetry: "Export started",
@@ -106,61 +116,115 @@ final class ExportService {
         )
 
         do {
-            let session = try await makeExportSession(
-                timeline: timeline, resolver: resolver,
-                format: format, resolution: resolution
-            )
-            guard let fileType = format.utType else { throw ExportError.invalidFormat }
-
-            // AVAssetExportSession fails if the file already exists
             try? FileManager.default.removeItem(at: outputURL)
+            Log.export.notice("export start format=\(String(describing: format)) resolution=\(resolution.rawValue) hasText=\(hasText) color=\(needsColor) url=\(outputURL.lastPathComponent)")
 
-            nonisolated(unsafe) let unsafeSession = session
-            let progressTask = Task { @MainActor in
-                while !Task.isCancelled {
-                    try? await Task.sleep(for: .milliseconds(200))
-                    let p = Double(unsafeSession.progress)
-                    if p != self.progress { self.progress = p }
-                }
+            if hasText && needsColor {
+                // The Core Animation text tool and the custom colour compositor can't
+                // coexist in one pass: bake colour first, then overlay text.
+                let temp = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("export-color-\(UUID().uuidString).\(format.fileExtension)")
+                defer { try? FileManager.default.removeItem(at: temp) }
+
+                let colorSession = try await makeExportSession(
+                    timeline: timeline, resolver: resolver, format: format,
+                    resolution: resolution, includeTextOverlay: false
+                )
+                try await runExport(colorSession, to: temp, as: fileType, progressRange: 0.0...0.5)
+
+                let textSession = try await makeTextOverlaySession(
+                    inputURL: temp, timeline: timeline, renderSize: renderSize,
+                    format: format, resolution: resolution
+                )
+                try await runExport(textSession, to: outputURL, as: fileType, progressRange: 0.5...1.0)
+            } else {
+                let session = try await makeExportSession(
+                    timeline: timeline, resolver: resolver, format: format,
+                    resolution: resolution, includeTextOverlay: hasText
+                )
+                try await runExport(session, to: outputURL, as: fileType, progressRange: 0.0...1.0)
             }
-
-            do {
-                try await session.export(to: outputURL, as: fileType)
-                progress = 1.0
+            progress = 1.0
+            Log.export.notice(
+                "export ok",
+                telemetry: "Export finished",
+                data: ["format": String(describing: format), "resolution": resolution.rawValue]
+            )
+        } catch {
+            if (error as NSError).domain == NSCocoaErrorDomain && (error as NSError).code == NSUserCancelledError {
+                self.error = "Export was cancelled"
                 Log.export.notice(
-                    "export ok",
-                    telemetry: "Export finished",
+                    "export cancelled",
+                    telemetry: "Export cancelled",
                     data: ["format": String(describing: format), "resolution": resolution.rawValue]
                 )
-            } catch {
-                if (error as NSError).domain == NSCocoaErrorDomain && (error as NSError).code == NSUserCancelledError {
-                    self.error = "Export was cancelled"
-                    Log.export.notice(
-                        "export cancelled",
-                        telemetry: "Export cancelled",
-                        data: ["format": String(describing: format), "resolution": resolution.rawValue]
-                    )
-                } else {
-                    self.error = Log.detail(error)
-                    Log.export.error(
-                        "export failed: \(Log.detail(error))",
-                        telemetry: "Export failed",
-                        data: ["format": String(describing: format), "resolution": resolution.rawValue, "error": Log.detail(error)]
-                    )
-                }
+            } else {
+                self.error = Log.detail(error)
+                Log.export.error(
+                    "export failed: \(Log.detail(error))",
+                    telemetry: "Export failed",
+                    data: ["format": String(describing: format), "resolution": resolution.rawValue, "error": Log.detail(error)]
+                )
             }
-
-            progressTask.cancel()
-        } catch {
-            self.error = Log.detail(error)
-            Log.export.error(
-                "export setup failed: \(Log.detail(error))",
-                telemetry: "Export setup failed",
-                data: ["format": String(describing: format), "resolution": resolution.rawValue, "error": Log.detail(error)]
-            )
         }
+    }
 
-        isExporting = false
+    /// Run one export session, mapping its 0…1 progress into `progressRange`.
+    private func runExport(
+        _ session: AVAssetExportSession, to url: URL, as fileType: AVFileType,
+        progressRange: ClosedRange<Double>
+    ) async throws {
+        try? FileManager.default.removeItem(at: url)
+        nonisolated(unsafe) let unsafeSession = session
+        let span = progressRange.upperBound - progressRange.lowerBound
+        let lower = progressRange.lowerBound
+        let progressTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(200))
+                let p = lower + Double(unsafeSession.progress) * span
+                if p != self.progress { self.progress = p }
+            }
+        }
+        defer { progressTask.cancel() }
+        try await session.export(to: url, as: fileType)
+    }
+
+    /// Second pass: overlay the timeline's text clips onto an already-rendered video
+    /// using the Core Animation tool (standard compositor, no custom compositor).
+    private func makeTextOverlaySession(
+        inputURL: URL, timeline: Timeline, renderSize: CGSize,
+        format: ExportFormat, resolution: ExportResolution
+    ) async throws -> AVAssetExportSession {
+        let asset = AVURLAsset(url: inputURL)
+        guard let session = AVAssetExportSession(asset: asset, presetName: exportPresetName(format: format, resolution: resolution)) else {
+            throw ExportError.unsupportedPreset
+        }
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw ExportError.invalidFormat
+        }
+        let duration = try await asset.load(.duration)
+        let (parent, videoLayer) = TextLayerController.buildForExport(
+            timeline: timeline, fps: timeline.fps, renderSize: renderSize
+        )
+
+        var cfg = AVVideoComposition.Configuration()
+        cfg.renderSize = renderSize
+        cfg.frameDuration = CMTime(value: 1, timescale: CMTimeScale(timeline.fps))
+        cfg.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+        cfg.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+        cfg.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+
+        var instr = AVVideoCompositionInstruction.Configuration()
+        instr.timeRange = CMTimeRange(start: .zero, duration: duration)
+        instr.layerInstructions = [
+            AVVideoCompositionLayerInstruction(
+                configuration: AVVideoCompositionLayerInstruction.Configuration(trackID: videoTrack.trackID)
+            )
+        ]
+        cfg.instructions = [AVVideoCompositionInstruction(configuration: instr)]
+        cfg.animationTool = AVVideoCompositionCoreAnimationTool(postProcessingAsVideoLayer: videoLayer, in: parent)
+        session.videoComposition = AVVideoComposition(configuration: cfg)
+        return session
     }
 
     /// Writes a self-contained `.palmier` bundle (all media collected internally).
@@ -217,7 +281,8 @@ final class ExportService {
         timeline: Timeline,
         resolver: MediaResolver,
         format: ExportFormat,
-        resolution: ExportResolution
+        resolution: ExportResolution,
+        includeTextOverlay: Bool
     ) async throws -> AVAssetExportSession {
         let timelineCanvas = CGSize(width: timeline.width, height: timeline.height)
         let renderSize = resolution.renderSize(for: timelineCanvas)
@@ -234,18 +299,22 @@ final class ExportService {
         }
         session.audioMix = result.audioMix
 
-        // Bake text clips into the export via AVVideoCompositionCoreAnimationTool
-        let (parent, videoLayer) = TextLayerController.buildForExport(
-            timeline: timeline,
-            fps: timeline.fps,
-            renderSize: renderSize
-        )
-        var config = result.videoCompositionConfiguration
-        config.animationTool = AVVideoCompositionCoreAnimationTool(
-            postProcessingAsVideoLayer: videoLayer,
-            in: parent
-        )
-        session.videoComposition = AVVideoComposition(configuration: config)
+        if includeTextOverlay {
+            // Bake text clips via the Core Animation tool (valid only without a custom compositor).
+            let (parent, videoLayer) = TextLayerController.buildForExport(
+                timeline: timeline,
+                fps: timeline.fps,
+                renderSize: renderSize
+            )
+            var config = result.videoCompositionConfiguration
+            config.animationTool = AVVideoCompositionCoreAnimationTool(
+                postProcessingAsVideoLayer: videoLayer,
+                in: parent
+            )
+            session.videoComposition = AVVideoComposition(configuration: config)
+        } else {
+            session.videoComposition = result.videoComposition
+        }
         return session
     }
 

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -17,7 +17,7 @@ enum EditAction {
         case .image: candidates = [.upscale, .edit, .rerun, .createVideo]
         case .video: candidates = [.upscale, .edit, .generateMusic, .generateSFX, .rerun]
         case .audio, .text: candidates = [.upscale, .edit, .rerun]
-        case .lottie: candidates = []
+        case .lottie, .adjustment: candidates = []
         }
         return candidates.filter {
             $0.availability(for: asset, effectiveDurationOverride: effectiveDurationOverride).isAvailable
@@ -65,6 +65,8 @@ enum EditAction {
                 return .disabled(reason: "Edit doesn't support text")
             case .lottie:
                 return .disabled(reason: "Edit doesn't support Lottie")
+            case .adjustment:
+                return .disabled(reason: "Edit doesn't support adjustment layers")
             }
             if asset.isGenerating {
                 return .disabled(reason: "Generation in progress")

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
@@ -296,7 +296,7 @@ enum EditSubmitter {
         case .image:
             guard let m = ImageModelConfig.nanoBananaPro else { return nil }
             modelId = m.id
-        case .audio, .text, .lottie:
+        case .audio, .text, .lottie, .adjustment:
             return nil
         }
         var stored = GenerationInput(prompt: "", model: modelId, duration: 0, aspectRatio: "", resolution: nil)

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -282,6 +282,7 @@ final class GenerationService {
             case .audio: return "audio/mpeg"
             case .text: return "application/octet-stream"
             case .lottie: return "application/json"
+            case .adjustment: return "application/octet-stream"
             }
         }
     }

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -966,7 +966,7 @@ struct GenerationView: View {
             case .image: assets = refImages
             case .video: assets = refVideos
             case .audio: assets = refAudios
-            case .text, .lottie: assets = []
+            case .text, .lottie, .adjustment: assets = []
             }
             let noun = tagNoun(for: type)
             return assets.enumerated().map {
@@ -980,7 +980,7 @@ struct GenerationView: View {
         case .image: videoModel.maxReferenceImages
         case .video: videoModel.maxReferenceVideos
         case .audio: videoModel.maxReferenceAudios
-        case .text, .lottie: 0
+        case .text, .lottie, .adjustment: 0
         }
     }
 
@@ -989,7 +989,7 @@ struct GenerationView: View {
         case .image: refImages.count
         case .video: refVideos.count
         case .audio: refAudios.count
-        case .text, .lottie: 0
+        case .text, .lottie, .adjustment: 0
         }
     }
 
@@ -1001,6 +1001,7 @@ struct GenerationView: View {
         case .audio: "Audio"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .adjustment: "Color"
         }
     }
 
@@ -1016,7 +1017,7 @@ struct GenerationView: View {
         case .image: selection.imageRefs.append(asset)
         case .video: selection.videoRefs.append(asset)
         case .audio: selection.audioRefs.append(asset)
-        case .text, .lottie:
+        case .text, .lottie, .adjustment:
             let supported = ClipType.allCases.filter { refCap(for: $0) > 0 }.map(\.rawValue).joined(separator: " and ")
             flashDropError("\(videoModel.displayName) only accepts \(supported) references.")
             return
@@ -1029,7 +1030,7 @@ struct GenerationView: View {
         case .image: refImages.append(asset)
         case .video: refVideos.append(asset)
         case .audio: refAudios.append(asset)
-        case .text, .lottie: break
+        case .text, .lottie, .adjustment: break
         }
     }
 
@@ -1067,7 +1068,7 @@ struct GenerationView: View {
         case .image: refImages.removeAll { $0.id == id }
         case .video: refVideos.removeAll { $0.id == id }
         case .audio: refAudios.removeAll { $0.id == id }
-        case .text, .lottie: break
+        case .text, .lottie, .adjustment: break
         }
     }
 
@@ -1080,7 +1081,7 @@ struct GenerationView: View {
     private var refCounterLabel: String {
         let total = totalRefCount
         if let cap = videoModel.maxTotalReferences {
-            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot" } }
+            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot"; case .adjustment: "col" } }
             let parts = ClipType.allCases
                 .filter { refCap(for: $0) > 0 }
                 .map { "\(refCount(for: $0)) \(shortLabel($0))" }

--- a/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
+++ b/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
@@ -2,14 +2,16 @@ import SwiftUI
 import AppKit
 import UniformTypeIdentifiers
 
-/// Lumetri-style colour panel. Adapts to the selection: grade an adjustment
-/// layer, key a video clip, or offer to add an adjustment layer.
+/// Lumetri-style colour panel. Grades the selected clip (per-clip) or adjustment
+/// layer, and keys video clips. The target clip is cached so clicking a control
+/// in this dock — which clears the timeline selection — doesn't drop the panel.
 struct ColorTab: View {
     @Environment(EditorViewModel.self) var editor
+    @State private var targetClipId: String?
     @State private var lutError: String?
 
-    private var selection: (id: String, clip: Clip)? {
-        guard let id = editor.selectedClipIds.first, let loc = editor.findClip(id: id) else { return nil }
+    private var target: (id: String, clip: Clip)? {
+        guard let id = targetClipId, let loc = editor.findClip(id: id) else { return nil }
         return (id, editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex])
     }
 
@@ -17,10 +19,13 @@ struct ColorTab: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: AppTheme.Spacing.mdLg) {
-                    if let sel = selection, sel.clip.mediaType == .adjustment {
-                        gradeSections(clipId: sel.id, grade: sel.clip.colorGrade ?? ColorGrade())
-                    } else if let sel = selection, sel.clip.mediaType.isVisual {
-                        chromaSection(clipId: sel.id, key: sel.clip.chromaKey ?? ChromaKey())
+                    if let t = target, t.clip.mediaType == .adjustment {
+                        targetHeader("Adjustment Layer", icon: "circle.lefthalf.filled")
+                        gradeSections(clipId: t.id, grade: t.clip.colorGrade ?? ColorGrade())
+                    } else if let t = target, t.clip.mediaType.isVisual {
+                        targetHeader(editor.mediaResolver.displayName(for: t.clip.mediaRef), icon: t.clip.mediaType.sfSymbolName)
+                        gradeSections(clipId: t.id, grade: t.clip.colorGrade ?? ColorGrade())
+                        chromaSection(clipId: t.id, key: t.clip.chromaKey ?? ChromaKey())
                     } else {
                         emptyState
                     }
@@ -33,15 +38,35 @@ struct ColorTab: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppTheme.Background.surfaceColor)
+        .onAppear { rememberTarget() }
+        .onChange(of: editor.selectedClipIds) { _, _ in rememberTarget() }
     }
 
-    // MARK: - Grade (adjustment layer)
+    /// Mirror CaptionTab: keep the cached target when the selection is cleared by a
+    /// click into this (media) dock; only clear it on a genuine timeline deselect.
+    private func rememberTarget() {
+        let sel = editor.selectedClipIds.first
+        guard sel != nil || editor.focusedPanel != .media else { return }
+        targetClipId = sel
+    }
+
+    private func targetHeader(_ name: String, icon: String) -> some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: icon).font(.system(size: AppTheme.FontSize.sm))
+            Text(name).lineLimit(1).truncationMode(.middle)
+        }
+        .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.semibold))
+        .foregroundStyle(AppTheme.Text.primaryColor)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Grade
 
     private func gradeSections(clipId: String, grade: ColorGrade) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.mdLg) {
             InspectorSection("Basic Correction") {
                 enableRow(isOn: grade.basicEnabled) { v in updateGrade(clipId) { $0.basicEnabled = v } }
-                slider("thermomet.medium", "Temperature", grade.temperature, -100...100) { v in updateGrade(clipId) { $0.temperature = v } }
+                slider("thermometer.medium", "Temperature", grade.temperature, -100...100) { v in updateGrade(clipId) { $0.temperature = v } }
                 slider("dial.medium", "Tint", grade.tint, -100...100) { v in updateGrade(clipId) { $0.tint = v } }
                 slider("sun.max", "Exposure", grade.exposure, -100...100) { v in updateGrade(clipId) { $0.exposure = v } }
                 slider("circle.lefthalf.filled", "Contrast", grade.contrast, -100...100) { v in updateGrade(clipId) { $0.contrast = v } }
@@ -82,7 +107,7 @@ struct ColorTab: View {
         }
     }
 
-    // MARK: - Chroma key (video clip)
+    // MARK: - Chroma key
 
     private func chromaSection(clipId: String, key: ChromaKey) -> some View {
         InspectorSection("Chroma Key (Ultra Key)") {
@@ -121,7 +146,7 @@ struct ColorTab: View {
             Text("Color")
                 .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.semibold))
                 .foregroundStyle(AppTheme.Text.primaryColor)
-            Text("Select an adjustment layer to grade, or a video clip to key out a green screen. Add an adjustment layer to apply a LUT and colour to everything below it.")
+            Text("Select a clip to grade it (LUT + colour) and key out a green screen, or add an adjustment layer to grade everything below it.")
                 .font(.system(size: AppTheme.FontSize.sm))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
                 .fixedSize(horizontal: false, vertical: true)
@@ -131,7 +156,7 @@ struct ColorTab: View {
     }
 
     private var newLayerBar: some View {
-        Button(action: { editor.addAdjustmentLayer() }) {
+        Button(action: { targetClipId = editor.addAdjustmentLayer() }) {
             HStack(spacing: AppTheme.Spacing.sm) {
                 Image(systemName: "plus")
                 Text("New Adjustment Layer")

--- a/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
+++ b/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Lumetri-style colour panel. Adapts to the selection: grade an adjustment
+/// layer, key a video clip, or offer to add an adjustment layer.
+struct ColorTab: View {
+    @Environment(EditorViewModel.self) var editor
+    @State private var lutError: String?
+
+    private var selection: (id: String, clip: Clip)? {
+        guard let id = editor.selectedClipIds.first, let loc = editor.findClip(id: id) else { return nil }
+        return (id, editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex])
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.mdLg) {
+                    if let sel = selection, sel.clip.mediaType == .adjustment {
+                        gradeSections(clipId: sel.id, grade: sel.clip.colorGrade ?? ColorGrade())
+                    } else if let sel = selection, sel.clip.mediaType.isVisual {
+                        chromaSection(clipId: sel.id, key: sel.clip.chromaKey ?? ChromaKey())
+                    } else {
+                        emptyState
+                    }
+                }
+                .padding(.horizontal, AppTheme.Spacing.lgXl)
+                .padding(.vertical, AppTheme.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            newLayerBar
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppTheme.Background.surfaceColor)
+    }
+
+    // MARK: - Grade (adjustment layer)
+
+    private func gradeSections(clipId: String, grade: ColorGrade) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.mdLg) {
+            InspectorSection("Basic Correction") {
+                enableRow(isOn: grade.basicEnabled) { v in updateGrade(clipId) { $0.basicEnabled = v } }
+                slider("thermomet.medium", "Temperature", grade.temperature, -100...100) { v in updateGrade(clipId) { $0.temperature = v } }
+                slider("dial.medium", "Tint", grade.tint, -100...100) { v in updateGrade(clipId) { $0.tint = v } }
+                slider("sun.max", "Exposure", grade.exposure, -100...100) { v in updateGrade(clipId) { $0.exposure = v } }
+                slider("circle.lefthalf.filled", "Contrast", grade.contrast, -100...100) { v in updateGrade(clipId) { $0.contrast = v } }
+                slider("drop", "Saturation", grade.saturation, -100...100) { v in updateGrade(clipId) { $0.saturation = v } }
+            }
+
+            InspectorSection("Creative (LUT)") {
+                enableRow(isOn: grade.creativeEnabled) { v in updateGrade(clipId) { $0.creativeEnabled = v } }
+                InspectorRow(icon: "camera.filters", label: "Look") {
+                    HStack(spacing: AppTheme.Spacing.sm) {
+                        Text(lutName(grade.lutRef))
+                            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                            .lineLimit(1).truncationMode(.middle)
+                        Button("Import…") { importLUT(clipId) }
+                            .buttonStyle(.plain).focusable(false)
+                            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                            .foregroundStyle(AppTheme.Accent.primary)
+                        if grade.lutRef != nil {
+                            Button { updateGrade(clipId) { $0.lutRef = nil } } label: { Image(systemName: "xmark.circle.fill") }
+                                .buttonStyle(.plain).focusable(false)
+                                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        }
+                    }
+                }
+                if grade.lutRef != nil {
+                    slider("slider.horizontal.below.square.filled.and.square", "Intensity", grade.lutIntensity * 100, 0...100) { v in
+                        updateGrade(clipId) { $0.lutIntensity = v / 100 }
+                    }
+                }
+                if let lutError {
+                    Text(lutError)
+                        .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                        .foregroundStyle(AppTheme.Status.errorColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    // MARK: - Chroma key (video clip)
+
+    private func chromaSection(clipId: String, key: ChromaKey) -> some View {
+        InspectorSection("Chroma Key (Ultra Key)") {
+            enableRow(isOn: key.enabled) { v in updateKey(clipId) { $0.enabled = v } }
+            InspectorRow(icon: "eyedropper", label: "Key Color") {
+                ColorField(displayColor: key.keyColor.swiftUIColor, onUserChange: { c in
+                    updateKey(clipId) { $0.keyColor = TextStyle.RGBA(c) }
+                }, supportsOpacity: false)
+            }
+            slider("scope", "Tolerance", key.tolerance, 0...100) { v in updateKey(clipId) { $0.tolerance = v } }
+            slider("aqi.medium", "Softness", key.softness, 0...100) { v in updateKey(clipId) { $0.softness = v } }
+            slider("paintbrush.pointed", "Spill", key.spill, 0...100) { v in updateKey(clipId) { $0.spill = v } }
+            slider("circle.dashed", "Edge Feather", key.edgeFeather, 0...50) { v in updateKey(clipId) { $0.edgeFeather = v } }
+        }
+    }
+
+    // MARK: - Shared rows
+
+    private func enableRow(isOn: Bool, set: @escaping (Bool) -> Void) -> some View {
+        InspectorRow(icon: "power", label: "Enabled") {
+            Toggle("", isOn: Binding(get: { isOn }, set: set))
+                .labelsHidden().toggleStyle(.switch).controlSize(.mini)
+                .tint(AppTheme.Text.primaryColor.opacity(AppTheme.Opacity.strong))
+        }
+    }
+
+    private func slider(_ icon: String, _ label: String, _ value: Double,
+                        _ range: ClosedRange<Double>, set: @escaping (Double) -> Void) -> some View {
+        InspectorRow(icon: icon, label: label) {
+            ScrubbableNumberField(value: value, range: range, format: "%.0f", onChanged: set, onCommit: set)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
+            Text("Color")
+                .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.semibold))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+            Text("Select an adjustment layer to grade, or a video clip to key out a green screen. Add an adjustment layer to apply a LUT and colour to everything below it.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, AppTheme.Spacing.sm)
+    }
+
+    private var newLayerBar: some View {
+        Button(action: { editor.addAdjustmentLayer() }) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Image(systemName: "plus")
+                Text("New Adjustment Layer")
+            }
+            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.semibold))
+            .foregroundStyle(AppTheme.Background.baseColor)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppTheme.Spacing.smMd)
+            .background(RoundedRectangle(cornerRadius: AppTheme.Radius.sm).fill(AppTheme.Accent.primary))
+        }
+        .buttonStyle(.plain).focusable(false)
+        .padding(.horizontal, AppTheme.Spacing.lgXl)
+        .padding(.vertical, AppTheme.Spacing.md)
+        .overlay(alignment: .top) {
+            Rectangle().fill(AppTheme.Border.subtleColor).frame(height: AppTheme.BorderWidth.hairline)
+        }
+    }
+
+    // MARK: - Mutation helpers
+
+    private func updateGrade(_ clipId: String, _ mutate: (inout ColorGrade) -> Void) {
+        guard let loc = editor.findClip(id: clipId) else { return }
+        var g = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].colorGrade ?? ColorGrade()
+        mutate(&g)
+        editor.setColorGrade(clipId: clipId, g)
+    }
+
+    private func updateKey(_ clipId: String, _ mutate: (inout ChromaKey) -> Void) {
+        guard let loc = editor.findClip(id: clipId) else { return }
+        var k = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].chromaKey ?? ChromaKey()
+        mutate(&k)
+        editor.setChromaKey(clipId: clipId, k)
+    }
+
+    private func lutName(_ ref: String?) -> String {
+        guard let ref else { return "None" }
+        return (ref as NSString).lastPathComponent
+    }
+
+    private func importLUT(_ clipId: String) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "cube") ?? .data]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.title = "Import LUT (.cube)"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                _ = try CubeLUT.parse(contentsOf: url)
+            } catch {
+                lutError = "Invalid .cube file: \(error.localizedDescription)"
+                return
+            }
+            lutError = nil
+            updateGrade(clipId) { $0.lutRef = url.path; $0.creativeEnabled = true }
+        }
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
+++ b/Sources/PalmierPro/MediaPanel/ColorTab/ColorTab.swift
@@ -24,6 +24,7 @@ struct ColorTab: View {
                         gradeSections(clipId: t.id, grade: t.clip.colorGrade ?? ColorGrade())
                     } else if let t = target, t.clip.mediaType.isVisual {
                         targetHeader(editor.mediaResolver.displayName(for: t.clip.mediaRef), icon: t.clip.mediaType.sfSymbolName)
+                        blendSection(clipId: t.id, mode: t.clip.blendMode ?? .normal)
                         gradeSections(clipId: t.id, grade: t.clip.colorGrade ?? ColorGrade())
                         chromaSection(clipId: t.id, key: t.clip.chromaKey ?? ChromaKey())
                     } else {
@@ -58,6 +59,31 @@ struct ColorTab: View {
         .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.semibold))
         .foregroundStyle(AppTheme.Text.primaryColor)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Compositing
+
+    private func blendSection(clipId: String, mode: BlendMode) -> some View {
+        InspectorSection("Compositing") {
+            InspectorRow(icon: "square.2.layers.3d.bottom.filled", label: "Blend Mode") {
+                Menu {
+                    ForEach(BlendMode.allCases, id: \.self) { m in
+                        Button(m.displayName) { editor.setBlendMode(clipId: clipId, m) }
+                    }
+                } label: { menuValueLabel(mode.displayName) }
+                .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).fixedSize().focusable(false)
+            }
+        }
+    }
+
+    private func menuValueLabel(_ text: String) -> some View {
+        HStack(spacing: AppTheme.Spacing.xxs) {
+            Text(text)
+            Image(systemName: "chevron.up.chevron.down").font(.system(size: AppTheme.FontSize.xxs))
+        }
+        .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+        .foregroundStyle(AppTheme.Text.tertiaryColor)
+        .lineLimit(1)
     }
 
     // MARK: - Grade

--- a/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
@@ -7,12 +7,13 @@ struct MediaPanelView: View {
     @State private var hoveredTab: PanelTab?
 
     enum PanelTab: String, CaseIterable {
-        case media = "Media", captions = "Captions", music = "Music"
+        case media = "Media", captions = "Captions", music = "Music", color = "Color"
         var icon: String {
             switch self {
             case .media: "folder"
             case .captions: "captions.bubble"
             case .music: "music.note"
+            case .color: "camera.filters"
             }
         }
     }
@@ -27,6 +28,7 @@ struct MediaPanelView: View {
                 case .media: MediaTab()
                 case .captions: CaptionTab()
                 case .music: MusicTab()
+                case .color: ColorTab()
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/Sources/PalmierPro/Models/ClipType.swift
+++ b/Sources/PalmierPro/Models/ClipType.swift
@@ -4,6 +4,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
     case image
     case text
     case lottie
+    case adjustment
 
     var sfSymbolName: String {
         switch self {
@@ -12,6 +13,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "photo"
         case .text: "textformat"
         case .lottie: "sparkles"
+        case .adjustment: "circle.lefthalf.filled"
         }
     }
 
@@ -22,6 +24,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "Image"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .adjustment: "Color"
         }
     }
 
@@ -30,6 +33,9 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
     var isVisual: Bool {
         self == .video || self == .image || self == .text || self == .lottie
     }
+
+    /// An adjustment layer occupies a visual track position but produces no source frame.
+    var isAdjustment: Bool { self == .adjustment }
 
     func isCompatible(with other: ClipType) -> Bool {
         self == other || (self.isVisual && other.isVisual)

--- a/Sources/PalmierPro/Models/Color.swift
+++ b/Sources/PalmierPro/Models/Color.swift
@@ -24,6 +24,56 @@ struct ColorGrade: Codable, Sendable, Equatable {
     var hasEffect: Bool { hasBasicEffect || hasLUTEffect }
 }
 
+/// How a visual clip composites over the layers below it. `normal` = source-over.
+enum BlendMode: String, Codable, Sendable, CaseIterable {
+    case normal, darken, multiply, colorBurn, lighten, screen, colorDodge
+    case overlay, softLight, hardLight, difference, exclusion
+    case hue, saturation, color, luminosity
+
+    var displayName: String {
+        switch self {
+        case .normal: "Normal"
+        case .darken: "Darken"
+        case .multiply: "Multiply"
+        case .colorBurn: "Color Burn"
+        case .lighten: "Lighten"
+        case .screen: "Screen"
+        case .colorDodge: "Color Dodge"
+        case .overlay: "Overlay"
+        case .softLight: "Soft Light"
+        case .hardLight: "Hard Light"
+        case .difference: "Difference"
+        case .exclusion: "Exclusion"
+        case .hue: "Hue"
+        case .saturation: "Saturation"
+        case .color: "Color"
+        case .luminosity: "Luminosity"
+        }
+    }
+
+    /// Core Image blend-filter name; nil for `normal` (use source-over compositing).
+    var ciFilterName: String? {
+        switch self {
+        case .normal: nil
+        case .darken: "CIDarkenBlendMode"
+        case .multiply: "CIMultiplyBlendMode"
+        case .colorBurn: "CIColorBurnBlendMode"
+        case .lighten: "CILightenBlendMode"
+        case .screen: "CIScreenBlendMode"
+        case .colorDodge: "CIColorDodgeBlendMode"
+        case .overlay: "CIOverlayBlendMode"
+        case .softLight: "CISoftLightBlendMode"
+        case .hardLight: "CIHardLightBlendMode"
+        case .difference: "CIDifferenceBlendMode"
+        case .exclusion: "CIExclusionBlendMode"
+        case .hue: "CIHueBlendMode"
+        case .saturation: "CISaturationBlendMode"
+        case .color: "CIColorBlendMode"
+        case .luminosity: "CILuminosityBlendMode"
+        }
+    }
+}
+
 /// Per-clip chroma key (Ultra Key). Defaults to a green screen.
 struct ChromaKey: Codable, Sendable, Equatable {
     var enabled: Bool = false

--- a/Sources/PalmierPro/Models/Color.swift
+++ b/Sources/PalmierPro/Models/Color.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Colour grade carried by an adjustment-layer clip. All slider values are
+/// neutral at `0`, so a default grade is the identity transform.
+struct ColorGrade: Codable, Sendable, Equatable {
+    var temperature: Double = 0    // −100…100
+    var tint: Double = 0           // −100…100
+    var exposure: Double = 0       // −100…100 (±2 EV)
+    var contrast: Double = 0       // −100…100
+    var saturation: Double = 0     // −100…100
+    var lutRef: String?            // package-relative .cube filename; nil = no LUT
+    var lutIntensity: Double = 1   // 0…1
+    var basicEnabled: Bool = true
+    var creativeEnabled: Bool = true
+
+    var hasBasicEffect: Bool {
+        basicEnabled && (temperature != 0 || tint != 0 || exposure != 0 || contrast != 0 || saturation != 0)
+    }
+
+    var hasLUTEffect: Bool {
+        creativeEnabled && lutRef != nil && lutIntensity > 0
+    }
+
+    var hasEffect: Bool { hasBasicEffect || hasLUTEffect }
+}
+
+/// Per-clip chroma key (Ultra Key). Defaults to a green screen.
+struct ChromaKey: Codable, Sendable, Equatable {
+    var enabled: Bool = false
+    var keyColor: TextStyle.RGBA = TextStyle.RGBA(r: 0, g: 1, b: 0, a: 1)
+    var tolerance: Double = 40     // 0…100
+    var softness: Double = 20      // 0…100
+    var spill: Double = 50         // 0…100
+    var edgeFeather: Double = 0    // points
+
+    var isActive: Bool { enabled }
+}

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -106,6 +106,10 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     var cropTrack: KeyframeTrack<Crop>?
     var volumeTrack: KeyframeTrack<Double>?
 
+    // Chroma key (any visual clip) and colour grade (adjustment clips only).
+    var chromaKey: ChromaKey?
+    var colorGrade: ColorGrade?
+
     private enum CodingKeys: String, CodingKey {
         case id, mediaRef, mediaType, sourceClipType, startFrame, durationFrames
         case trimStartFrame, trimEndFrame, speed, volume
@@ -113,6 +117,7 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case opacity, transform, crop
         case linkGroupId, captionGroupId, textContent, textStyle
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
+        case chromaKey, colorGrade
     }
 
     /// Frame where this clip ends on the timeline
@@ -356,7 +361,9 @@ extension Clip {
             scaleTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .scaleTrack),
             rotationTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .rotationTrack),
             cropTrack: try? c.decode(KeyframeTrack<Crop>.self, forKey: .cropTrack),
-            volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack)
+            volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack),
+            chromaKey: try? c.decode(ChromaKey.self, forKey: .chromaKey),
+            colorGrade: try? c.decode(ColorGrade.self, forKey: .colorGrade)
         )
     }
 }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -106,9 +106,10 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     var cropTrack: KeyframeTrack<Crop>?
     var volumeTrack: KeyframeTrack<Double>?
 
-    // Chroma key (any visual clip) and colour grade (adjustment clips only).
+    // Chroma key, colour grade (per-clip or adjustment), and blend mode.
     var chromaKey: ChromaKey?
     var colorGrade: ColorGrade?
+    var blendMode: BlendMode?
 
     private enum CodingKeys: String, CodingKey {
         case id, mediaRef, mediaType, sourceClipType, startFrame, durationFrames
@@ -117,7 +118,7 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case opacity, transform, crop
         case linkGroupId, captionGroupId, textContent, textStyle
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
-        case chromaKey, colorGrade
+        case chromaKey, colorGrade, blendMode
     }
 
     /// Frame where this clip ends on the timeline
@@ -363,7 +364,8 @@ extension Clip {
             cropTrack: try? c.decode(KeyframeTrack<Crop>.self, forKey: .cropTrack),
             volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack),
             chromaKey: try? c.decode(ChromaKey.self, forKey: .chromaKey),
-            colorGrade: try? c.decode(ColorGrade.self, forKey: .colorGrade)
+            colorGrade: try? c.decode(ColorGrade.self, forKey: .colorGrade),
+            blendMode: try? c.decode(BlendMode.self, forKey: .blendMode)
         )
     }
 }

--- a/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
+++ b/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
@@ -79,6 +79,9 @@ final class ColorCompositionInstruction: NSObject, AVVideoCompositionInstruction
                       let buffer = request.sourceFrame(byTrackID: trackID) else { continue }
                 var img = CIImage(cvPixelBuffer: buffer)
                 img = applyChromaKey(img, clip: rc.clip)
+                if let grade = rc.clip.colorGrade, grade.hasEffect {
+                    img = applyGrade(img, grade) // per-clip grade
+                }
                 img = applyCrop(img, clip: rc.clip, natSize: rc.natSize,
                                 preferredTransform: rc.preferredTransform, frame: frame)
                 img = img.transformed(by: ciTransform(rc, frame: frame))

--- a/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
+++ b/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
@@ -86,7 +86,7 @@ final class ColorCompositionInstruction: NSObject, AVVideoCompositionInstruction
                                 preferredTransform: rc.preferredTransform, frame: frame)
                 img = img.transformed(by: ciTransform(rc, frame: frame))
                 img = applyOpacity(img, value: rc.clip.opacityAt(frame: frame))
-                acc = compose(img, over: acc)
+                acc = compose(img, over: acc, mode: rc.clip.blendMode ?? .normal)
 
             case .adjustment(let clips):
                 guard let base = acc,
@@ -102,9 +102,14 @@ final class ColorCompositionInstruction: NSObject, AVVideoCompositionInstruction
         clips.first { $0.clip.startFrame <= frame && frame < $0.clip.endFrame }
     }
 
-    private func compose(_ image: CIImage, over background: CIImage?) -> CIImage {
+    private func compose(_ image: CIImage, over background: CIImage?, mode: BlendMode = .normal) -> CIImage {
         guard let background else { return image }
-        return image.composited(over: background)
+        guard let name = mode.ciFilterName, let filter = CIFilter(name: name) else {
+            return image.composited(over: background)
+        }
+        filter.setValue(image, forKey: kCIInputImageKey)
+        filter.setValue(background, forKey: kCIInputBackgroundImageKey)
+        return filter.outputImage ?? image.composited(over: background)
     }
 
     /// Convert the AVFoundation (top-left, y-down) clip transform into Core Image's

--- a/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
+++ b/Sources/PalmierPro/Preview/ColorCompositionInstruction.swift
@@ -1,0 +1,165 @@
+import AVFoundation
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+/// Custom video-composition instruction carrying everything `ColorVideoCompositor`
+/// needs to render a frame: the z-ordered visual layers (top → bottom), per-clip
+/// geometry, chroma-key settings, adjustment-layer grades, and pre-baked LUTs.
+///
+/// Geometry reuses `CompositionBuilder.affineTransform`, the same maths the
+/// built-in compositor's layer instructions use, converted into Core Image's
+/// bottom-left coordinate space (see `ciTransform`).
+final class ColorCompositionInstruction: NSObject, AVVideoCompositionInstructionProtocol, @unchecked Sendable {
+
+    let timeRange: CMTimeRange
+    let enablePostProcessing = false
+    let containsTweening = true
+    let requiredSourceTrackIDs: [NSValue]?
+    let passthroughTrackID = kCMPersistentTrackID_Invalid
+
+    let fps: Int
+    let renderSize: CGSize
+    /// Top → bottom. The compositor composites bottom-first so index 0 ends up on top.
+    let layers: [Layer]
+    let luts: [String: CubeLUT]
+
+    struct RenderClip: Sendable {
+        let clip: Clip
+        let natSize: CGSize
+        let preferredTransform: CGAffineTransform
+    }
+
+    enum Layer: Sendable {
+        /// A full-frame opaque backdrop track (rendered at identity).
+        case background(trackID: CMPersistentTrackID)
+        /// A timeline video/image track and the clips occupying it.
+        case source(trackID: CMPersistentTrackID, clips: [RenderClip])
+        /// An adjustment layer that grades everything beneath it for each clip's span.
+        case adjustment(clips: [Clip])
+    }
+
+    init(
+        timeRange: CMTimeRange,
+        fps: Int,
+        renderSize: CGSize,
+        layers: [Layer],
+        luts: [String: CubeLUT]
+    ) {
+        self.timeRange = timeRange
+        self.fps = fps
+        self.renderSize = renderSize
+        self.layers = layers
+        self.luts = luts
+        var ids: [NSValue] = []
+        for layer in layers {
+            switch layer {
+            case .background(let id), .source(let id, _):
+                ids.append(NSNumber(value: id))
+            case .adjustment:
+                break
+            }
+        }
+        self.requiredSourceTrackIDs = ids.isEmpty ? nil : ids
+    }
+
+    // MARK: - Rendering
+
+    func composite(at frame: Int, request: AVAsynchronousVideoCompositionRequest) -> CIImage? {
+        var acc: CIImage?
+        // Bottom-up so the first (top) layer is composited last.
+        for layer in layers.reversed() {
+            switch layer {
+            case .background(let trackID):
+                guard let buffer = request.sourceFrame(byTrackID: trackID) else { continue }
+                let img = CIImage(cvPixelBuffer: buffer).cropped(to: CGRect(origin: .zero, size: renderSize))
+                acc = compose(img, over: acc)
+
+            case .source(let trackID, let clips):
+                guard let rc = activeClip(clips, at: frame),
+                      let buffer = request.sourceFrame(byTrackID: trackID) else { continue }
+                var img = CIImage(cvPixelBuffer: buffer)
+                img = applyChromaKey(img, clip: rc.clip)
+                img = applyCrop(img, clip: rc.clip, natSize: rc.natSize,
+                                preferredTransform: rc.preferredTransform, frame: frame)
+                img = img.transformed(by: ciTransform(rc, frame: frame))
+                img = applyOpacity(img, value: rc.clip.opacityAt(frame: frame))
+                acc = compose(img, over: acc)
+
+            case .adjustment(let clips):
+                guard let base = acc,
+                      let clip = clips.first(where: { $0.startFrame <= frame && frame < $0.endFrame }),
+                      let grade = clip.colorGrade, grade.hasEffect else { continue }
+                acc = applyGrade(base, grade)
+            }
+        }
+        return acc
+    }
+
+    private func activeClip(_ clips: [RenderClip], at frame: Int) -> RenderClip? {
+        clips.first { $0.clip.startFrame <= frame && frame < $0.clip.endFrame }
+    }
+
+    private func compose(_ image: CIImage, over background: CIImage?) -> CIImage {
+        guard let background else { return image }
+        return image.composited(over: background)
+    }
+
+    /// Convert the AVFoundation (top-left, y-down) clip transform into Core Image's
+    /// bottom-left, y-up space: flip source vertically → apply AV transform → flip render.
+    private func ciTransform(_ rc: RenderClip, frame: Int) -> CGAffineTransform {
+        let avTransform = rc.preferredTransform.concatenating(
+            CompositionBuilder.affineTransform(for: rc.clip.transformAt(frame: frame),
+                                               natSize: rc.natSize, renderSize: renderSize)
+        )
+        // Flip in the source's natural-size frame (matches the non-rotated common case).
+        let flipSrc = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: rc.natSize.height)
+        let flipRender = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: renderSize.height)
+        return flipSrc.concatenating(avTransform).concatenating(flipRender)
+    }
+
+    private func applyOpacity(_ image: CIImage, value: Double) -> CIImage {
+        let o = min(1, max(0, value))
+        guard o < 1 else { return image }
+        let f = CIFilter.colorMatrix()
+        f.inputImage = image
+        f.rVector = CIVector(x: CGFloat(o), y: 0, z: 0, w: 0)
+        f.gVector = CIVector(x: 0, y: CGFloat(o), z: 0, w: 0)
+        f.bVector = CIVector(x: 0, y: 0, z: CGFloat(o), w: 0)
+        f.aVector = CIVector(x: 0, y: 0, z: 0, w: CGFloat(o))
+        return f.outputImage ?? image
+    }
+
+    private func applyCrop(_ image: CIImage, clip: Clip, natSize: CGSize,
+                           preferredTransform: CGAffineTransform, frame: Int) -> CIImage {
+        let crop = clip.cropAt(frame: frame)
+        guard !crop.isIdentity else { return image }
+        // Crop is in normalized source coords with the top-left origin; image is y-up.
+        let h = image.extent.height
+        let x = crop.left * image.extent.width
+        let w = max(1, crop.visibleWidthFraction * image.extent.width)
+        let ch = max(1, crop.visibleHeightFraction * h)
+        let y = h - (crop.top * h) - ch
+        return image.cropped(to: CGRect(x: image.extent.origin.x + x, y: image.extent.origin.y + y, width: w, height: ch))
+    }
+
+    private func applyChromaKey(_ image: CIImage, clip: Clip) -> CIImage {
+        guard let key = clip.chromaKey, key.isActive else { return image }
+        return ChromaKeyPipeline.apply(
+            image,
+            keyR: key.keyColor.r, keyG: key.keyColor.g, keyB: key.keyColor.b,
+            tolerance: key.tolerance, softness: key.softness, spill: key.spill, edgeFeather: key.edgeFeather
+        )
+    }
+
+    private func applyGrade(_ image: CIImage, _ grade: ColorGrade) -> CIImage {
+        var out = image
+        if grade.hasBasicEffect {
+            out = ColorGradePipeline.basic(out, temperature: grade.temperature, tint: grade.tint,
+                                           exposure: grade.exposure, contrast: grade.contrast, saturation: grade.saturation)
+        }
+        if grade.hasLUTEffect, let ref = grade.lutRef, let cube = luts[ref] {
+            out = ColorGradePipeline.lut(out, cube: cube, intensity: grade.lutIntensity)
+        }
+        return out.cropped(to: image.extent)
+    }
+}

--- a/Sources/PalmierPro/Preview/ColorVideoCompositor.swift
+++ b/Sources/PalmierPro/Preview/ColorVideoCompositor.swift
@@ -31,7 +31,11 @@ final class ColorVideoCompositor: NSObject, AVVideoCompositing, @unchecked Senda
 
     func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
         renderQueue.async { [weak self] in
-            guard let self else { return }
+            // Never leave a request unfinished — the pipeline would stall.
+            guard let self else {
+                request.finish(with: CompositorError.deallocated)
+                return
+            }
             autoreleasepool {
                 guard let instruction = request.videoCompositionInstruction as? ColorCompositionInstruction,
                       let dest = request.renderContext.newPixelBuffer() else {
@@ -41,18 +45,15 @@ final class ColorVideoCompositor: NSObject, AVVideoCompositing, @unchecked Senda
                 let frame = Int((request.compositionTime.seconds * Double(instruction.fps)).rounded())
                 let bounds = CGRect(origin: .zero, size: request.renderContext.size)
 
-                if let image = instruction.composite(at: frame, request: request) {
-                    self.ciContext.render(
-                        image.cropped(to: bounds),
-                        to: dest,
-                        bounds: bounds,
-                        colorSpace: self.workingColorSpace
-                    )
-                }
+                // Always render something: a produced frame, or a cleared frame so the
+                // output buffer never shows uninitialised/stale pixels.
+                let output = instruction.composite(at: frame, request: request)?.cropped(to: bounds)
+                    ?? CIImage(color: .clear).cropped(to: bounds)
+                self.ciContext.render(output, to: dest, bounds: bounds, colorSpace: self.workingColorSpace)
                 request.finish(withComposedVideoFrame: dest)
             }
         }
     }
 
-    enum CompositorError: Error { case badRequest }
+    enum CompositorError: Error { case badRequest, deallocated }
 }

--- a/Sources/PalmierPro/Preview/ColorVideoCompositor.swift
+++ b/Sources/PalmierPro/Preview/ColorVideoCompositor.swift
@@ -1,0 +1,58 @@
+import AVFoundation
+import CoreImage
+
+/// Custom `AVVideoCompositing` that renders timelines containing colour grades or
+/// chroma keys. Used only when those features are present (`CompositionBuilder`
+/// keeps the built-in compositor otherwise), so existing projects are unaffected.
+final class ColorVideoCompositor: NSObject, AVVideoCompositing, @unchecked Sendable {
+
+    private let ciContext: CIContext = {
+        let device = MTLCreateSystemDefaultDevice()
+        if let device {
+            return CIContext(mtlDevice: device, options: [.cacheIntermediates: false])
+        }
+        return CIContext(options: [.cacheIntermediates: false])
+    }()
+
+    private let renderQueue = DispatchQueue(label: "io.palmier.pro.color-compositor", qos: .userInitiated)
+    private let workingColorSpace = CGColorSpaceCreateDeviceRGB()
+
+    let sourcePixelBufferAttributes: [String: any Sendable]? = [
+        kCVPixelBufferPixelFormatTypeKey as String: [kCVPixelFormatType_32BGRA],
+        kCVPixelBufferMetalCompatibilityKey as String: true,
+    ]
+
+    let requiredPixelBufferAttributesForRenderContext: [String: any Sendable] = [
+        kCVPixelBufferPixelFormatTypeKey as String: [kCVPixelFormatType_32BGRA],
+        kCVPixelBufferMetalCompatibilityKey as String: true,
+    ]
+
+    func renderContextChanged(_ newRenderContext: AVVideoCompositionRenderContext) {}
+
+    func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
+        renderQueue.async { [weak self] in
+            guard let self else { return }
+            autoreleasepool {
+                guard let instruction = request.videoCompositionInstruction as? ColorCompositionInstruction,
+                      let dest = request.renderContext.newPixelBuffer() else {
+                    request.finish(with: CompositorError.badRequest)
+                    return
+                }
+                let frame = Int((request.compositionTime.seconds * Double(instruction.fps)).rounded())
+                let bounds = CGRect(origin: .zero, size: request.renderContext.size)
+
+                if let image = instruction.composite(at: frame, request: request) {
+                    self.ciContext.render(
+                        image.cropped(to: bounds),
+                        to: dest,
+                        bounds: bounds,
+                        colorSpace: self.workingColorSpace
+                    )
+                }
+                request.finish(withComposedVideoFrame: dest)
+            }
+        }
+    }
+
+    enum CompositorError: Error { case badRequest }
+}

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -21,6 +21,7 @@ struct CompositionResult {
     let clipTransforms: [String: CGAffineTransform]
     let offlineMediaRefs: Set<String>
     let unprocessableMediaRefs: Set<String>
+    let luts: [String: CubeLUT]
 }
 
 /// Builds an AVFoundation composition from a Timeline.
@@ -51,6 +52,8 @@ enum CompositionBuilder {
         var unprocessableMediaRefs: Set<String> = []
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
+            // Adjustment layers carry no media; the custom compositor applies them.
+            guard track.type != .adjustment else { continue }
             // Text renders via CATextLayer overlay (preview) + animation tool (export) — never as composition tracks.
             let sortedClips = track.clips
                 .sorted { $0.startFrame < $1.startFrame }
@@ -215,13 +218,16 @@ enum CompositionBuilder {
             }
         }
 
+        let luts = prebakeLUTs(timeline: timeline, resolveURL: resolveURL)
+
         let (audioMix, videoComposition) = buildVisuals(
             timeline: timeline,
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
             compositionDuration: composition.duration,
-            renderSize: renderSize
+            renderSize: renderSize,
+            luts: luts
         )
 
         return CompositionResult(
@@ -232,8 +238,30 @@ enum CompositionBuilder {
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
             offlineMediaRefs: offlineMediaRefs,
-            unprocessableMediaRefs: unprocessableMediaRefs
+            unprocessableMediaRefs: unprocessableMediaRefs,
+            luts: luts
         )
+    }
+
+    /// Resolve + parse every `.cube` referenced by an adjustment layer, once.
+    private static func prebakeLUTs(
+        timeline: Timeline,
+        resolveURL: @Sendable (String) -> URL?
+    ) -> [String: CubeLUT] {
+        var luts: [String: CubeLUT] = [:]
+        for track in timeline.tracks where track.type == .adjustment {
+            for clip in track.clips {
+                guard let grade = clip.colorGrade, grade.hasLUTEffect,
+                      let ref = grade.lutRef, luts[ref] == nil,
+                      let url = resolveURL(ref) else { continue }
+                if let cube = try? CubeLUT.parse(contentsOf: url) {
+                    luts[ref] = cube
+                } else {
+                    Log.preview.error("failed to parse LUT \(ref)")
+                }
+            }
+        }
+        return luts
     }
 
     private enum LoadOutcome {
@@ -378,7 +406,8 @@ enum CompositionBuilder {
         clipNaturalSizes: [String: CGSize] = [:],
         clipTransforms: [String: CGAffineTransform] = [:],
         compositionDuration: CMTime,
-        renderSize: CGSize
+        renderSize: CGSize,
+        luts: [String: CubeLUT] = [:]
     ) -> (audioMix: AVMutableAudioMix, videoComposition: AVVideoComposition) {
         let timescale = CMTimeScale(timeline.fps)
 
@@ -400,6 +429,31 @@ enum CompositionBuilder {
                 prevEndFrame = clip.startFrame + clip.durationFrames
             }
             return params
+        }
+
+        let timeRange = CMTimeRange(start: .zero, duration: compositionDuration)
+
+        var vcConfig = AVVideoComposition.Configuration()
+        vcConfig.renderSize = renderSize
+        vcConfig.frameDuration = CMTime(value: 1, timescale: timescale)
+        vcConfig.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+        vcConfig.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+        vcConfig.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+
+        // Colour grades / chroma keys need per-source access during compositing →
+        // route through the custom compositor. Otherwise keep the built-in path.
+        if let colorInstruction = colorCompositionInstruction(
+            timeRange: timeRange,
+            timeline: timeline,
+            trackMappings: trackMappings,
+            clipNaturalSizes: clipNaturalSizes,
+            clipTransforms: clipTransforms,
+            renderSize: renderSize,
+            luts: luts
+        ) {
+            vcConfig.customVideoCompositorClass = ColorVideoCompositor.self
+            vcConfig.instructions = [colorInstruction]
+            return (audioMix, AVVideoComposition(configuration: vcConfig))
         }
 
         let layerInstructions: [AVVideoCompositionLayerInstruction] = trackMappings.filter { $0.isVideo }.map { mapping in
@@ -445,19 +499,77 @@ enum CompositionBuilder {
         }
 
         var instrConfig = AVVideoCompositionInstruction.Configuration()
-        instrConfig.timeRange = CMTimeRange(start: .zero, duration: compositionDuration)
+        instrConfig.timeRange = timeRange
         instrConfig.layerInstructions = layerInstructions
-        let instruction = AVVideoCompositionInstruction(configuration: instrConfig)
-
-        var vcConfig = AVVideoComposition.Configuration()
-        vcConfig.renderSize = renderSize
-        vcConfig.frameDuration = CMTime(value: 1, timescale: timescale)
-        vcConfig.instructions = [instruction]
-        vcConfig.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
-        vcConfig.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
-        vcConfig.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        vcConfig.instructions = [AVVideoCompositionInstruction(configuration: instrConfig)]
 
         return (audioMix, AVVideoComposition(configuration: vcConfig))
+    }
+
+    /// Build the custom-compositor instruction when any clip carries a colour grade
+    /// or an active chroma key; returns nil to keep the built-in compositor.
+    private static func colorCompositionInstruction(
+        timeRange: CMTimeRange,
+        timeline: Timeline,
+        trackMappings: [TrackMapping],
+        clipNaturalSizes: [String: CGSize],
+        clipTransforms: [String: CGAffineTransform],
+        renderSize: CGSize,
+        luts: [String: CubeLUT]
+    ) -> ColorCompositionInstruction? {
+        let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
+        let hasGrade = timeline.tracks.contains { track in
+            track.type == .adjustment && track.clips.contains { $0.colorGrade?.hasEffect == true }
+        }
+        guard hasChroma || hasGrade else { return nil }
+
+        var videoMappingByIndex: [Int: TrackMapping] = [:]
+        for mapping in trackMappings where mapping.isVideo {
+            if case .timeline(let idx, _) = mapping.kind { videoMappingByIndex[idx] = mapping }
+        }
+
+        var layers: [ColorCompositionInstruction.Layer] = []
+        for (idx, track) in timeline.tracks.enumerated() {
+            if track.type == .adjustment {
+                let clips = track.clips.filter { $0.colorGrade != nil }
+                if !clips.isEmpty { layers.append(.adjustment(clips: clips)) }
+                continue
+            }
+            guard track.type != .audio, !track.hidden,
+                  let mapping = videoMappingByIndex[idx],
+                  case .timeline(_, let clipIds) = mapping.kind else { continue }
+
+            var renderClips: [ColorCompositionInstruction.RenderClip] = []
+            var prevEndFrame = Int.min
+            for clip in track.clips.sorted(by: { $0.startFrame < $1.startFrame }) where clip.mediaType != .text {
+                if let clipIds, !clipIds.contains(clip.id) { continue }
+                guard clip.durationFrames > 0, clip.startFrame >= prevEndFrame else { continue }
+                renderClips.append(.init(
+                    clip: clip,
+                    natSize: clipNaturalSizes[clip.id] ?? mapping.naturalSize,
+                    preferredTransform: clipTransforms[clip.id] ?? .identity
+                ))
+                prevEndFrame = clip.endFrame
+            }
+            if !renderClips.isEmpty {
+                layers.append(.source(trackID: mapping.compositionTrack.trackID, clips: renderClips))
+            }
+        }
+
+        if let bg = trackMappings.first(where: {
+            if case .blackBackground = $0.kind { return true } else { return false }
+        }) {
+            layers.append(.background(trackID: bg.compositionTrack.trackID))
+        }
+
+        guard !layers.isEmpty else { return nil }
+        return ColorCompositionInstruction(
+            timeRange: timeRange,
+            fps: timeline.fps,
+            renderSize: renderSize,
+            layers: layers,
+            luts: luts
+        )
     }
 
     /// Smooth-curve subdivision count for non-linear keyframe segments.

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -551,7 +551,8 @@ enum CompositionBuilder {
         let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
         // Grades apply on adjustment layers (over everything below) and per-clip.
         let hasGrade = timeline.tracks.contains { $0.clips.contains { $0.colorGrade?.hasEffect == true } }
-        guard hasChroma || hasGrade else { return nil }
+        let hasBlend = timeline.tracks.contains { $0.clips.contains { ($0.blendMode ?? .normal) != .normal } }
+        guard hasChroma || hasGrade || hasBlend else { return nil }
 
         var videoMappingByIndex: [Int: TrackMapping] = [:]
         for mapping in trackMappings where mapping.isVideo {

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -16,6 +16,7 @@ struct CompositionResult {
     let composition: AVMutableComposition
     let audioMix: AVMutableAudioMix
     let videoComposition: AVVideoComposition
+    let videoCompositionConfiguration: AVVideoComposition.Configuration
     let trackMappings: [TrackMapping]
     let clipNaturalSizes: [String: CGSize]
     let clipTransforms: [String: CGAffineTransform]
@@ -220,7 +221,7 @@ enum CompositionBuilder {
 
         let luts = prebakeLUTs(timeline: timeline, resolveURL: resolveURL)
 
-        let (audioMix, videoComposition) = buildVisuals(
+        let (audioMix, vcConfiguration) = visualConfiguration(
             timeline: timeline,
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
@@ -229,11 +230,13 @@ enum CompositionBuilder {
             renderSize: renderSize,
             luts: luts
         )
+        let videoComposition = AVVideoComposition(configuration: vcConfiguration)
 
         return CompositionResult(
             composition: composition,
             audioMix: audioMix,
             videoComposition: videoComposition,
+            videoCompositionConfiguration: vcConfiguration,
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
@@ -402,7 +405,7 @@ enum CompositionBuilder {
         )
     }
 
-    /// Rebuild only visual properties (transforms, opacity, volume)
+    /// Rebuild only visual properties (transforms, opacity, volume).
     static func buildVisuals(
         timeline: Timeline,
         trackMappings: [TrackMapping],
@@ -412,6 +415,31 @@ enum CompositionBuilder {
         renderSize: CGSize,
         luts: [String: CubeLUT] = [:]
     ) -> (audioMix: AVMutableAudioMix, videoComposition: AVVideoComposition) {
+        let (audioMix, config) = visualConfiguration(
+            timeline: timeline,
+            trackMappings: trackMappings,
+            clipNaturalSizes: clipNaturalSizes,
+            clipTransforms: clipTransforms,
+            compositionDuration: compositionDuration,
+            renderSize: renderSize,
+            luts: luts
+        )
+        return (audioMix, AVVideoComposition(configuration: config))
+    }
+
+    /// Build the audio mix and the video-composition **configuration**. Returning
+    /// the configuration (instead of a built `AVVideoComposition`) lets render
+    /// paths attach an `animationTool` and rebuild without the deprecated
+    /// `AVMutableVideoComposition`.
+    static func visualConfiguration(
+        timeline: Timeline,
+        trackMappings: [TrackMapping],
+        clipNaturalSizes: [String: CGSize] = [:],
+        clipTransforms: [String: CGAffineTransform] = [:],
+        compositionDuration: CMTime,
+        renderSize: CGSize,
+        luts: [String: CubeLUT] = [:]
+    ) -> (audioMix: AVMutableAudioMix, configuration: AVVideoComposition.Configuration) {
         let timescale = CMTimeScale(timeline.fps)
 
         let audioMix = AVMutableAudioMix()
@@ -456,7 +484,7 @@ enum CompositionBuilder {
         ) {
             vcConfig.customVideoCompositorClass = ColorVideoCompositor.self
             vcConfig.instructions = [colorInstruction]
-            return (audioMix, AVVideoComposition(configuration: vcConfig))
+            return (audioMix, vcConfig)
         }
 
         let layerInstructions: [AVVideoCompositionLayerInstruction] = trackMappings.filter { $0.isVideo }.map { mapping in
@@ -506,7 +534,7 @@ enum CompositionBuilder {
         instrConfig.layerInstructions = layerInstructions
         vcConfig.instructions = [AVVideoCompositionInstruction(configuration: instrConfig)]
 
-        return (audioMix, AVVideoComposition(configuration: vcConfig))
+        return (audioMix, vcConfig)
     }
 
     /// Build the custom-compositor instruction when any clip carries a colour grade

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -568,6 +568,7 @@ enum CompositionBuilder {
         var layers: [ColorCompositionInstruction.Layer] = []
         for (idx, track) in timeline.tracks.enumerated() {
             if track.type == .adjustment {
+                guard !track.hidden else { continue }
                 let clips = track.clips.filter { $0.colorGrade != nil }
                 if !clips.isEmpty { layers.append(.adjustment(clips: clips)) }
                 continue

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -541,10 +541,21 @@ enum CompositionBuilder {
     /// non-normal blend mode), i.e. the custom compositor will be used. The Core
     /// Animation text tool can't coexist with it, so callers (export) two-pass.
     static func needsColorCompositor(_ timeline: Timeline) -> Bool {
-        let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
-        let hasGrade = timeline.tracks.contains { $0.clips.contains { $0.colorGrade?.hasEffect == true } }
-        let hasBlend = timeline.tracks.contains { $0.clips.contains { ($0.blendMode ?? .normal) != .normal } }
-        return hasChroma || hasGrade || hasBlend
+        // Only count effects the custom compositor actually renders: visible tracks,
+        // and (for chroma/blend) non-text source clips. Mirrors colorCompositionInstruction,
+        // so we don't activate the compositor — and force a two-pass export — for nothing.
+        for track in timeline.tracks where !track.hidden {
+            if track.type == .adjustment {
+                if track.clips.contains(where: { $0.colorGrade?.hasEffect == true }) { return true }
+            } else {
+                for clip in track.clips where clip.mediaType != .text {
+                    if clip.chromaKey?.isActive == true { return true }
+                    if clip.colorGrade?.hasEffect == true { return true }
+                    if (clip.blendMode ?? .normal) != .normal { return true }
+                }
+            }
+        }
+        return false
     }
 
     /// Build the custom-compositor instruction when any clip carries a colour grade

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -252,7 +252,7 @@ enum CompositionBuilder {
         resolveURL: @Sendable (String) -> URL?
     ) -> [String: CubeLUT] {
         var luts: [String: CubeLUT] = [:]
-        for track in timeline.tracks where track.type == .adjustment {
+        for track in timeline.tracks {
             for clip in track.clips {
                 guard let grade = clip.colorGrade, grade.hasLUTEffect,
                       let ref = grade.lutRef, luts[ref] == nil else { continue }
@@ -549,9 +549,8 @@ enum CompositionBuilder {
         luts: [String: CubeLUT]
     ) -> ColorCompositionInstruction? {
         let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
-        let hasGrade = timeline.tracks.contains { track in
-            track.type == .adjustment && track.clips.contains { $0.colorGrade?.hasEffect == true }
-        }
+        // Grades apply on adjustment layers (over everything below) and per-clip.
+        let hasGrade = timeline.tracks.contains { $0.clips.contains { $0.colorGrade?.hasEffect == true } }
         guard hasChroma || hasGrade else { return nil }
 
         var videoMappingByIndex: [Int: TrackMapping] = [:]

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -252,8 +252,11 @@ enum CompositionBuilder {
         for track in timeline.tracks where track.type == .adjustment {
             for clip in track.clips {
                 guard let grade = clip.colorGrade, grade.hasLUTEffect,
-                      let ref = grade.lutRef, luts[ref] == nil,
-                      let url = resolveURL(ref) else { continue }
+                      let ref = grade.lutRef, luts[ref] == nil else { continue }
+                // LUTs may be a manifest asset id or an absolute file path.
+                guard let url = resolveURL(ref)
+                    ?? (FileManager.default.fileExists(atPath: ref) ? URL(fileURLWithPath: ref) : nil)
+                else { continue }
                 if let cube = try? CubeLUT.parse(contentsOf: url) {
                     luts[ref] = cube
                 } else {

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -537,6 +537,16 @@ enum CompositionBuilder {
         return (audioMix, vcConfig)
     }
 
+    /// True when any clip needs Core Image compositing (grade, chroma key, or a
+    /// non-normal blend mode), i.e. the custom compositor will be used. The Core
+    /// Animation text tool can't coexist with it, so callers (export) two-pass.
+    static func needsColorCompositor(_ timeline: Timeline) -> Bool {
+        let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
+        let hasGrade = timeline.tracks.contains { $0.clips.contains { $0.colorGrade?.hasEffect == true } }
+        let hasBlend = timeline.tracks.contains { $0.clips.contains { ($0.blendMode ?? .normal) != .normal } }
+        return hasChroma || hasGrade || hasBlend
+    }
+
     /// Build the custom-compositor instruction when any clip carries a colour grade
     /// or an active chroma key; returns nil to keep the built-in compositor.
     private static func colorCompositionInstruction(
@@ -548,11 +558,7 @@ enum CompositionBuilder {
         renderSize: CGSize,
         luts: [String: CubeLUT]
     ) -> ColorCompositionInstruction? {
-        let hasChroma = timeline.tracks.contains { $0.clips.contains { $0.chromaKey?.isActive == true } }
-        // Grades apply on adjustment layers (over everything below) and per-clip.
-        let hasGrade = timeline.tracks.contains { $0.clips.contains { $0.colorGrade?.hasEffect == true } }
-        let hasBlend = timeline.tracks.contains { $0.clips.contains { ($0.blendMode ?? .normal) != .normal } }
-        guard hasChroma || hasGrade || hasBlend else { return nil }
+        guard needsColorCompositor(timeline) else { return nil }
 
         var videoMappingByIndex: [Int: TrackMapping] = [:]
         for mapping in trackMappings where mapping.isVideo {

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -31,45 +31,101 @@ enum TimelineRenderer {
             resolveURL: { resolver.resolveURL(for: $0) },
             renderSize: renderSize
         )
-
-        guard let session = AVAssetExportSession(asset: result.composition, presetName: preset) else {
-            throw RenderError(reason: "export preset unsupported")
-        }
-        if includeAudio {
-            session.audioMix = result.audioMix
-        } else {
+        if !includeAudio {
             for track in result.composition.tracks(withMediaType: .audio) {
                 result.composition.removeTrack(track)
             }
         }
 
-        // Bake text clips in via the animation tool, same as ExportService.
-        let (parent, videoLayer) = TextLayerController.buildForExport(
-            timeline: timeline,
-            fps: timeline.fps,
-            renderSize: renderSize
-        )
-        var config = result.videoCompositionConfiguration
-        config.animationTool = AVVideoCompositionCoreAnimationTool(
-            postProcessingAsVideoLayer: videoLayer,
-            in: parent
-        )
-        session.videoComposition = AVVideoComposition(configuration: config)
-
         let timescale = CMTimeScale(timeline.fps)
-        session.timeRange = CMTimeRange(
+        let range = CMTimeRange(
             start: CMTime(value: CMTimeValue(startFrame), timescale: timescale),
             duration: CMTime(value: CMTimeValue(frameCount), timescale: timescale)
         )
+        let endFrame = startFrame + frameCount
+        let hasText = timeline.tracks.contains { t in
+            t.clips.contains { $0.mediaType == .text && $0.startFrame < endFrame && $0.endFrame > startFrame }
+        }
+        let needsColor = CompositionBuilder.needsColorCompositor(timeline)
 
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("timeline-render-\(UUID().uuidString).mp4")
         try? FileManager.default.removeItem(at: outputURL)
 
-        Log.generation.notice("timeline-render start frames=\(startFrame)..<\(startFrame + frameCount) fps=\(timeline.fps)")
-        try await session.export(to: outputURL, as: .mp4)
+        Log.generation.notice("timeline-render start frames=\(startFrame)..<\(endFrame) fps=\(timeline.fps) text=\(hasText) color=\(needsColor)")
+
+        if hasText && needsColor {
+            // Same constraint as export: the Core Animation text tool can't share a pass
+            // with the custom colour compositor. Bake colour over the range, then overlay text.
+            let temp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("timeline-render-color-\(UUID().uuidString).mp4")
+            defer { try? FileManager.default.removeItem(at: temp) }
+
+            let colorSession = try makeSession(asset: result.composition, audioMix: includeAudio ? result.audioMix : nil, preset: preset)
+            colorSession.videoComposition = result.videoComposition
+            colorSession.timeRange = range
+            try await colorSession.export(to: temp, as: .mp4)
+
+            // Text rebased to the range (temp starts at frame 0).
+            let rebased = Self.rebased(timeline, by: startFrame)
+            let textSession = try await makeTextOverlaySession(inputURL: temp, timeline: rebased, fps: timeline.fps, renderSize: renderSize, preset: preset)
+            try await textSession.export(to: outputURL, as: .mp4)
+        } else {
+            let session = try makeSession(asset: result.composition, audioMix: includeAudio ? result.audioMix : nil, preset: preset)
+            var config = result.videoCompositionConfiguration
+            if hasText {
+                let (parent, videoLayer) = TextLayerController.buildForExport(timeline: timeline, fps: timeline.fps, renderSize: renderSize)
+                config.animationTool = AVVideoCompositionCoreAnimationTool(postProcessingAsVideoLayer: videoLayer, in: parent)
+            }
+            session.videoComposition = AVVideoComposition(configuration: config)
+            session.timeRange = range
+            try await session.export(to: outputURL, as: .mp4)
+        }
+
         Log.generation.notice("timeline-render ok url=\(outputURL.lastPathComponent)")
         return outputURL
+    }
+
+    private static func makeSession(asset: AVAsset, audioMix: AVMutableAudioMix?, preset: String) throws -> AVAssetExportSession {
+        guard let session = AVAssetExportSession(asset: asset, presetName: preset) else {
+            throw RenderError(reason: "export preset unsupported")
+        }
+        session.audioMix = audioMix
+        return session
+    }
+
+    /// Second pass: overlay text onto an already-rendered (colour-baked) clip.
+    @MainActor
+    private static func makeTextOverlaySession(inputURL: URL, timeline: Timeline, fps: Int, renderSize: CGSize, preset: String) async throws -> AVAssetExportSession {
+        let asset = AVURLAsset(url: inputURL)
+        let session = try makeSession(asset: asset, audioMix: nil, preset: preset)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw RenderError(reason: "intermediate has no video track")
+        }
+        let duration = try await asset.load(.duration)
+        let (parent, videoLayer) = TextLayerController.buildForExport(timeline: timeline, fps: fps, renderSize: renderSize)
+
+        var cfg = AVVideoComposition.Configuration()
+        cfg.renderSize = renderSize
+        cfg.frameDuration = CMTime(value: 1, timescale: CMTimeScale(fps))
+        var instr = AVVideoCompositionInstruction.Configuration()
+        instr.timeRange = CMTimeRange(start: .zero, duration: duration)
+        instr.layerInstructions = [AVVideoCompositionLayerInstruction(configuration: .init(trackID: videoTrack.trackID))]
+        cfg.instructions = [AVVideoCompositionInstruction(configuration: instr)]
+        cfg.animationTool = AVVideoCompositionCoreAnimationTool(postProcessingAsVideoLayer: videoLayer, in: parent)
+        session.videoComposition = AVVideoComposition(configuration: cfg)
+        return session
+    }
+
+    /// Shift every clip's start by `-frames` so text aligns when the range is rebased to 0.
+    private static func rebased(_ timeline: Timeline, by frames: Int) -> Timeline {
+        var t = timeline
+        t.tracks = timeline.tracks.map { track in
+            var tr = track
+            tr.clips = track.clips.map { var c = $0; c.startFrame -= frames; return c }
+            return tr
+        }
+        return t
     }
 
     /// Render size for the given short side

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -49,12 +49,12 @@ enum TimelineRenderer {
             fps: timeline.fps,
             renderSize: renderSize
         )
-        let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
-        mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
+        var config = result.videoCompositionConfiguration
+        config.animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,
             in: parent
         )
-        session.videoComposition = mutableVC
+        session.videoComposition = AVVideoComposition(configuration: config)
 
         let timescale = CMTimeScale(timeline.fps)
         session.timeRange = CMTimeRange(

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -23,6 +23,7 @@ final class VideoEngine {
     private var clipNaturalSizes: [String: CGSize] = [:]
     private var clipTransforms: [String: CGAffineTransform] = [:]
     private var compositionDuration: CMTime = .zero
+    private var luts: [String: CubeLUT] = [:]
 
     private var pendingInteractiveSeek: (time: CMTime, tolerance: CMTime)?
     private var interactiveThrottleTask: Task<Void, Never>?
@@ -170,6 +171,7 @@ final class VideoEngine {
             clipNaturalSizes = result.clipNaturalSizes
             clipTransforms = result.clipTransforms
             compositionDuration = result.composition.duration
+            luts = result.luts
             editor.offlineMediaRefs = result.offlineMediaRefs
             editor.unprocessableMediaRefs = result.unprocessableMediaRefs
 
@@ -198,7 +200,8 @@ final class VideoEngine {
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
             compositionDuration: compositionDuration,
-            renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
+            renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height),
+            luts: luts
         )
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -312,6 +312,7 @@ extension ClipType {
         case .image: AppTheme.TrackColor.image
         case .text: AppTheme.TrackColor.text
         case .lottie: AppTheme.TrackColor.lottie
+        case .adjustment: AppTheme.TrackColor.lottie
         }
     }
 }

--- a/Tests/PalmierProTests/Agent/ChromaKeyToolTests.swift
+++ b/Tests/PalmierProTests/Agent/ChromaKeyToolTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import PalmierPro
+
+@MainActor
+@Suite("set_chroma_key tool")
+struct ChromaKeyToolTests {
+
+    private func harness() -> ToolHarness {
+        let clip = Fixtures.clip(id: "v1", mediaType: .video, start: 0, duration: 30)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        return ToolHarness(timeline: timeline)
+    }
+
+    @Test func enablesChromaKeyWithGreenDefault() async {
+        let h = harness()
+        let r = await h.runRaw("set_chroma_key", args: ["clipId": "v1"])
+        #expect(r.isError == false)
+        let key = h.editor.timeline.tracks[0].clips[0].chromaKey
+        #expect(key?.enabled == true)
+        #expect(key?.keyColor == TextStyle.RGBA(r: 0, g: 1, b: 0, a: 1))
+    }
+
+    @Test func parsesCustomParameters() async {
+        let h = harness()
+        _ = await h.runRaw("set_chroma_key", args: [
+            "clipId": "v1", "keyColorHex": "#0000FF", "tolerance": 60.0, "spill": 10.0,
+        ])
+        let key = h.editor.timeline.tracks[0].clips[0].chromaKey
+        #expect(key?.tolerance == 60)
+        #expect(key?.spill == 10)
+        #expect(key?.keyColor.b == 1)
+        #expect(key?.keyColor.r == 0)
+    }
+
+    @Test func disableRemovesKey() async {
+        let h = harness()
+        _ = await h.runRaw("set_chroma_key", args: ["clipId": "v1"])
+        _ = await h.runRaw("set_chroma_key", args: ["clipId": "v1", "enabled": false])
+        #expect(h.editor.timeline.tracks[0].clips[0].chromaKey == nil)
+    }
+
+    @Test func unknownClipIsError() async {
+        let r = await harness().runRaw("set_chroma_key", args: ["clipId": "nope"])
+        #expect(r.isError == true)
+    }
+
+    @Test func rejectsAudioClip() async {
+        let audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 30)
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [audio])]))
+        let r = await h.runRaw("set_chroma_key", args: ["clipId": "a1"])
+        #expect(r.isError == true)
+    }
+}

--- a/Tests/PalmierProTests/Agent/ColorToolTests.swift
+++ b/Tests/PalmierProTests/Agent/ColorToolTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import PalmierPro
+
+@MainActor
+@Suite("set_blend_mode / set_color_grade tools")
+struct ColorToolTests {
+
+    private func harness() -> ToolHarness {
+        let clip = Fixtures.clip(id: "v1", mediaType: .video, start: 0, duration: 30)
+        return ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+    }
+
+    @Test func setsBlendMode() async {
+        let h = harness()
+        let r = await h.runRaw("set_blend_mode", args: ["clipId": "v1", "mode": "multiply"])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.tracks[0].clips[0].blendMode == .multiply)
+    }
+
+    @Test func normalBlendModeClearsToNil() async {
+        let h = harness()
+        _ = await h.runRaw("set_blend_mode", args: ["clipId": "v1", "mode": "screen"])
+        _ = await h.runRaw("set_blend_mode", args: ["clipId": "v1", "mode": "normal"])
+        #expect(h.editor.timeline.tracks[0].clips[0].blendMode == nil)
+    }
+
+    @Test func unknownBlendModeErrors() async {
+        let r = await harness().runRaw("set_blend_mode", args: ["clipId": "v1", "mode": "bogus"])
+        #expect(r.isError == true)
+    }
+
+    @Test func setsColorGradeFields() async {
+        let h = harness()
+        let r = await h.runRaw("set_color_grade", args: ["clipId": "v1", "contrast": 30.0, "saturation": -20.0])
+        #expect(r.isError == false)
+        let g = h.editor.timeline.tracks[0].clips[0].colorGrade
+        #expect(g?.contrast == 30)
+        #expect(g?.saturation == -20)
+    }
+
+    @Test func resetClearsGrade() async {
+        let h = harness()
+        _ = await h.runRaw("set_color_grade", args: ["clipId": "v1", "contrast": 30.0])
+        _ = await h.runRaw("set_color_grade", args: ["clipId": "v1", "reset": true])
+        #expect(h.editor.timeline.tracks[0].clips[0].colorGrade == nil)
+    }
+
+    @Test func clampsOutOfRangeGrade() async {
+        let h = harness()
+        _ = await h.runRaw("set_color_grade", args: ["clipId": "v1", "exposure": 999.0])
+        #expect(h.editor.timeline.tracks[0].clips[0].colorGrade?.exposure == 100)
+    }
+}

--- a/Tests/PalmierProTests/Color/ChromaKeyPipelineTests.swift
+++ b/Tests/PalmierProTests/Color/ChromaKeyPipelineTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import CoreImage
+@testable import PalmierPro
+
+@Suite("ChromaKeyPipeline matte")
+struct ChromaKeyPipelineTests {
+
+    static let greenHue = rgbToHSV(r: 0, g: 1, b: 0).h
+
+    @Test func pureGreenIsKeyedOut() {
+        let a = ChromaKeyPipeline.matteAlpha(r: 0, g: 1, b: 0, keyHue: Self.greenHue, tolerance: 40, softness: 20)
+        #expect(a < 0.05)
+    }
+
+    @Test func skinToneIsKept() {
+        let a = ChromaKeyPipeline.matteAlpha(r: 0.85, g: 0.6, b: 0.5, keyHue: Self.greenHue, tolerance: 40, softness: 20)
+        #expect(a > 0.9)
+    }
+
+    @Test func redIsKept() {
+        let a = ChromaKeyPipeline.matteAlpha(r: 1, g: 0, b: 0, keyHue: Self.greenHue, tolerance: 40, softness: 20)
+        #expect(a > 0.95)
+    }
+
+    @Test func grayIsNeverKeyed() {
+        let a = ChromaKeyPipeline.matteAlpha(r: 0.5, g: 0.5, b: 0.5, keyHue: Self.greenHue, tolerance: 100, softness: 0)
+        #expect(a > 0.95)
+    }
+
+    @Test func spillPullsGreenCastTowardLuma() {
+        let cast = ChromaKeyPipeline.spillCorrect(r: 0.4, g: 0.8, b: 0.4, keyHue: Self.greenHue, spill: 100)
+        #expect(cast.g < 0.8) // green reduced
+    }
+
+    @Test func spillZeroIsNoOp() {
+        let c = ChromaKeyPipeline.spillCorrect(r: 0.4, g: 0.8, b: 0.4, keyHue: Self.greenHue, spill: 0)
+        #expect(c.g == 0.8)
+    }
+
+    @Test func renderedGreenBecomesTransparent() {
+        let src = solidImage(r: 0, g: 1, b: 0)
+        let out = ChromaKeyPipeline.apply(src, keyR: 0, keyG: 1, keyB: 0,
+                                          tolerance: 40, softness: 20, spill: 50, edgeFeather: 0)
+        let p = renderPixel(out)
+        #expect(p.a < 0.1)
+    }
+
+    @Test func renderedSubjectStaysOpaque() {
+        let src = solidImage(r: 1, g: 0, b: 0)
+        let out = ChromaKeyPipeline.apply(src, keyR: 0, keyG: 1, keyB: 0,
+                                          tolerance: 40, softness: 20, spill: 50, edgeFeather: 0)
+        let p = renderPixel(out)
+        #expect(p.a > 0.9)
+    }
+}

--- a/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
+++ b/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import AVFoundation
+@testable import PalmierPro
+
+@Suite("Custom compositor switching")
+struct ColorCompositorWiringTests {
+
+    private func videoComposition(for timeline: Timeline, trackMappings: [TrackMapping] = []) -> AVVideoComposition {
+        CompositionBuilder.buildVisuals(
+            timeline: timeline,
+            trackMappings: trackMappings,
+            compositionDuration: CMTime(value: 30, timescale: 30),
+            renderSize: CGSize(width: 1920, height: 1080)
+        ).videoComposition
+    }
+
+    /// A real composition video track mapped to `trackIndex`, so a source layer can be built.
+    private func videoMapping(trackIndex: Int) -> TrackMapping {
+        let comp = AVMutableComposition()
+        let track = comp.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)!
+        return TrackMapping(
+            compositionTrack: track,
+            kind: .timeline(trackIndex: trackIndex, clipIds: nil),
+            naturalSize: CGSize(width: 1920, height: 1080),
+            endTime: CMTime(value: 30, timescale: 30),
+            isVideo: true
+        )
+    }
+
+    @Test func plainTimelineKeepsBuiltInCompositor() {
+        var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
+        clip.mediaType = .video
+        let timeline = Timeline(tracks: [Track(type: .video, clips: [clip])])
+        #expect(videoComposition(for: timeline).customVideoCompositorClass == nil)
+    }
+
+    @Test func adjustmentGradeEnablesCustomCompositor() {
+        var adj = Clip(mediaRef: "", startFrame: 0, durationFrames: 30)
+        adj.mediaType = .adjustment
+        adj.colorGrade = ColorGrade(contrast: 25)
+        let timeline = Timeline(tracks: [Track(type: .adjustment, clips: [adj])])
+        #expect(videoComposition(for: timeline).customVideoCompositorClass == ColorVideoCompositor.self)
+    }
+
+    @Test func inactiveAdjustmentKeepsBuiltInCompositor() {
+        var adj = Clip(mediaRef: "", startFrame: 0, durationFrames: 30)
+        adj.mediaType = .adjustment
+        adj.colorGrade = ColorGrade() // no effect
+        let timeline = Timeline(tracks: [Track(type: .adjustment, clips: [adj])])
+        #expect(videoComposition(for: timeline).customVideoCompositorClass == nil)
+    }
+
+    @Test func chromaKeyEnablesCustomCompositor() {
+        var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
+        clip.mediaType = .video
+        clip.chromaKey = ChromaKey(enabled: true)
+        let timeline = Timeline(tracks: [Track(type: .video, clips: [clip])])
+        #expect(videoComposition(for: timeline, trackMappings: [videoMapping(trackIndex: 0)])
+            .customVideoCompositorClass == ColorVideoCompositor.self)
+    }
+}

--- a/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
+++ b/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
@@ -27,6 +27,17 @@ struct ColorCompositorWiringTests {
         )
     }
 
+    @Test func needsColorCompositorGate() {
+        var plain = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30); plain.mediaType = .video
+        #expect(CompositionBuilder.needsColorCompositor(Timeline(tracks: [Track(type: .video, clips: [plain])])) == false)
+
+        var graded = plain; graded.colorGrade = ColorGrade(contrast: 10)
+        #expect(CompositionBuilder.needsColorCompositor(Timeline(tracks: [Track(type: .video, clips: [graded])])))
+
+        var blended = plain; blended.blendMode = .screen
+        #expect(CompositionBuilder.needsColorCompositor(Timeline(tracks: [Track(type: .video, clips: [blended])])))
+    }
+
     @Test func plainTimelineKeepsBuiltInCompositor() {
         var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
         clip.mediaType = .video

--- a/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
+++ b/Tests/PalmierProTests/Color/ColorCompositorWiringTests.swift
@@ -50,6 +50,24 @@ struct ColorCompositorWiringTests {
         #expect(videoComposition(for: timeline).customVideoCompositorClass == nil)
     }
 
+    @Test func blendModeEnablesCustomCompositor() {
+        var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
+        clip.mediaType = .video
+        clip.blendMode = .multiply
+        let timeline = Timeline(tracks: [Track(type: .video, clips: [clip])])
+        #expect(videoComposition(for: timeline, trackMappings: [videoMapping(trackIndex: 0)])
+            .customVideoCompositorClass == ColorVideoCompositor.self)
+    }
+
+    @Test func normalBlendKeepsBuiltInCompositor() {
+        var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
+        clip.mediaType = .video
+        clip.blendMode = .normal
+        let timeline = Timeline(tracks: [Track(type: .video, clips: [clip])])
+        #expect(videoComposition(for: timeline, trackMappings: [videoMapping(trackIndex: 0)])
+            .customVideoCompositorClass == nil)
+    }
+
     @Test func chromaKeyEnablesCustomCompositor() {
         var clip = Clip(mediaRef: "v", startFrame: 0, durationFrames: 30)
         clip.mediaType = .video

--- a/Tests/PalmierProTests/Color/ColorGradePipelineTests.swift
+++ b/Tests/PalmierProTests/Color/ColorGradePipelineTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import CoreImage
+@testable import PalmierPro
+
+@Suite("ColorGradePipeline")
+struct ColorGradePipelineTests {
+
+    @Test func neutralBasicIsIdentity() {
+        let src = solidImage(r: 0.3, g: 0.5, b: 0.7)
+        let out = ColorGradePipeline.basic(src, temperature: 0, tint: 0, exposure: 0, contrast: 0, saturation: 0)
+        let p = renderPixel(out)
+        #expect(abs(p.r - 0.3) < 0.02)
+        #expect(abs(p.g - 0.5) < 0.02)
+        #expect(abs(p.b - 0.7) < 0.02)
+    }
+
+    @Test func positiveExposureBrightens() {
+        let src = solidImage(r: 0.3, g: 0.3, b: 0.3)
+        let out = ColorGradePipeline.basic(src, temperature: 0, tint: 0, exposure: 50, contrast: 0, saturation: 0)
+        let p = renderPixel(out)
+        #expect(p.r > 0.35)
+    }
+
+    @Test func lutIntensityZeroReturnsSource() throws {
+        let lut = try CubeLUT.parse(CubeLUTTests.identity2)
+        let src = solidImage(r: 0.4, g: 0.2, b: 0.6)
+        let out = ColorGradePipeline.lut(src, cube: lut, intensity: 0)
+        let p = renderPixel(out)
+        #expect(abs(p.r - 0.4) < 0.02)
+        #expect(abs(p.g - 0.2) < 0.02)
+        #expect(abs(p.b - 0.6) < 0.02)
+    }
+
+    @Test func identityLUTLeavesColorUnchanged() throws {
+        let lut = try CubeLUT.parse(CubeLUTTests.identity2)
+        let src = solidImage(r: 0.4, g: 0.2, b: 0.6)
+        let out = ColorGradePipeline.lut(src, cube: lut, intensity: 1)
+        let p = renderPixel(out)
+        #expect(abs(p.r - 0.4) < 0.03)
+        #expect(abs(p.g - 0.2) < 0.03)
+        #expect(abs(p.b - 0.6) < 0.03)
+    }
+}

--- a/Tests/PalmierProTests/Color/ColorModelTests.swift
+++ b/Tests/PalmierProTests/Color/ColorModelTests.swift
@@ -52,6 +52,15 @@ struct ColorModelTests {
         #expect(clip.opacity == 1.0)
     }
 
+    @Test func blendModeRoundTripsAndMapsToFilter() throws {
+        var clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 30)
+        clip.blendMode = .multiply
+        let decoded = try JSONDecoder().decode(Clip.self, from: JSONEncoder().encode(clip))
+        #expect(decoded.blendMode == .multiply)
+        #expect(BlendMode.normal.ciFilterName == nil)
+        #expect(BlendMode.screen.ciFilterName == "CIScreenBlendMode")
+    }
+
     @Test func adjustmentClipTypeIsNotVisualSource() {
         #expect(ClipType.adjustment.isAdjustment)
         #expect(ClipType.adjustment.isVisual == false)

--- a/Tests/PalmierProTests/Color/ColorModelTests.swift
+++ b/Tests/PalmierProTests/Color/ColorModelTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import PalmierPro
+
+@Suite("Colour model")
+struct ColorModelTests {
+
+    @Test func colorGradeDefaultIsNoEffect() {
+        #expect(ColorGrade().hasEffect == false)
+    }
+
+    @Test func colorGradeBasicEffectGate() {
+        var g = ColorGrade()
+        g.contrast = 10
+        #expect(g.hasBasicEffect)
+        g.basicEnabled = false
+        #expect(g.hasBasicEffect == false)
+        #expect(g.hasEffect == false)
+    }
+
+    @Test func colorGradeLUTEffectGate() {
+        var g = ColorGrade()
+        g.lutRef = "look.cube"
+        #expect(g.hasLUTEffect)
+        g.lutIntensity = 0
+        #expect(g.hasLUTEffect == false)
+    }
+
+    @Test func chromaKeyDefaultsToInactiveGreen() {
+        let k = ChromaKey()
+        #expect(k.isActive == false)
+        #expect(k.keyColor == TextStyle.RGBA(r: 0, g: 1, b: 0, a: 1))
+    }
+
+    @Test func clipRoundTripsColorFields() throws {
+        var clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 30)
+        clip.chromaKey = ChromaKey(enabled: true, tolerance: 55)
+        clip.colorGrade = ColorGrade(contrast: 20, lutRef: "look.cube")
+
+        let data = try JSONEncoder().encode(clip)
+        let decoded = try JSONDecoder().decode(Clip.self, from: data)
+
+        #expect(decoded.chromaKey == clip.chromaKey)
+        #expect(decoded.colorGrade == clip.colorGrade)
+    }
+
+    @Test func oldClipJSONDecodesWithNilColorFields() throws {
+        let json = #"{"mediaRef":"m","startFrame":0,"durationFrames":30}"#
+        let clip = try JSONDecoder().decode(Clip.self, from: Data(json.utf8))
+        #expect(clip.chromaKey == nil)
+        #expect(clip.colorGrade == nil)
+        #expect(clip.opacity == 1.0)
+    }
+
+    @Test func adjustmentClipTypeIsNotVisualSource() {
+        #expect(ClipType.adjustment.isAdjustment)
+        #expect(ClipType.adjustment.isVisual == false)
+    }
+}

--- a/Tests/PalmierProTests/Color/ColorTestSupport.swift
+++ b/Tests/PalmierProTests/Color/ColorTestSupport.swift
@@ -1,0 +1,23 @@
+import CoreImage
+import Foundation
+@testable import PalmierPro
+
+/// Render a single pixel with colour management disabled so values pass through verbatim.
+func renderPixel(_ image: CIImage, at point: CGPoint = .zero) -> (r: Double, g: Double, b: Double, a: Double) {
+    let ctx = CIContext(options: [.workingColorSpace: NSNull()])
+    var buf = [UInt8](repeating: 0, count: 4)
+    let rect = CGRect(x: point.x, y: point.y, width: 1, height: 1)
+    ctx.render(
+        image,
+        toBitmap: &buf,
+        rowBytes: 4,
+        bounds: rect,
+        format: .RGBA8,
+        colorSpace: CGColorSpaceCreateDeviceRGB()
+    )
+    return (Double(buf[0]) / 255, Double(buf[1]) / 255, Double(buf[2]) / 255, Double(buf[3]) / 255)
+}
+
+func solidImage(r: Double, g: Double, b: Double, a: Double = 1) -> CIImage {
+    CIImage(color: CIColor(red: r, green: g, blue: b, alpha: a)).cropped(to: CGRect(x: 0, y: 0, width: 2, height: 2))
+}

--- a/Tests/PalmierProTests/Color/CubeLUTTests.swift
+++ b/Tests/PalmierProTests/Color/CubeLUTTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import PalmierPro
+
+@Suite("CubeLUT parsing")
+struct CubeLUTTests {
+
+    static let identity2 = """
+    # identity 2x2x2
+    TITLE "id"
+    LUT_3D_SIZE 2
+    0 0 0
+    1 0 0
+    0 1 0
+    1 1 0
+    0 0 1
+    1 0 1
+    0 1 1
+    1 1 1
+    """
+
+    @Test func parsesSizeAndLength() throws {
+        let lut = try CubeLUT.parse(Self.identity2)
+        #expect(lut.size == 2)
+        #expect(lut.rgbaData.count == 2 * 2 * 2 * 4)
+    }
+
+    @Test func firstAndLastEntriesIncludeAlpha() throws {
+        let lut = try CubeLUT.parse(Self.identity2)
+        #expect(Array(lut.rgbaData.prefix(4)) == [0, 0, 0, 1])
+        #expect(Array(lut.rgbaData.suffix(4)) == [1, 1, 1, 1])
+    }
+
+    @Test func redVariesFastest() throws {
+        let lut = try CubeLUT.parse(Self.identity2)
+        // Second entry is r=1,g=0,b=0.
+        #expect(Array(lut.rgbaData[4..<8]) == [1, 0, 0, 1])
+    }
+
+    @Test func clampsOutOfRangeValues() throws {
+        let text = "LUT_3D_SIZE 2\n-0.5 0 0\n2 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 1\n0 1 1\n1 1 1"
+        let lut = try CubeLUT.parse(text)
+        #expect(lut.rgbaData[0] == 0)  // -0.5 clamped
+        #expect(lut.rgbaData[4] == 1)  // 2 clamped
+    }
+
+    @Test func missingSizeThrows() {
+        #expect(throws: CubeLUT.ParseError.self) {
+            try CubeLUT.parse("0 0 0\n1 1 1")
+        }
+    }
+
+    @Test func wrongRowCountThrows() {
+        #expect(throws: CubeLUT.ParseError.self) {
+            try CubeLUT.parse("LUT_3D_SIZE 2\n0 0 0\n1 1 1")
+        }
+    }
+
+    @Test func parses1DAsExpandedCube() throws {
+        // 1D ramp of size 2: black→white per channel.
+        let lut = try CubeLUT.parse("LUT_1D_SIZE 2\n0 0 0\n1 1 1")
+        #expect(lut.size == 2)
+        #expect(lut.rgbaData.count == 2 * 2 * 2 * 4)
+        // Corner (r=1,g=1,b=1) maps to white.
+        #expect(Array(lut.rgbaData.suffix(4)) == [1, 1, 1, 1])
+    }
+}


### PR DESCRIPTION
Closes #97. Closes #98.

Adds a custom `AVVideoCompositing` (Core Image) that activates only when a clip uses an effect — existing projects keep the built-in compositor. Applies in preview **and** export.

### Chroma key (Ultra Key) — #97
Per-clip key colour, tolerance, softness, spill suppression, edge feather (matte + spill baked into a generated `CIColorCube`). UI + MCP `set_chroma_key`.

### Blend modes — #98
16 Premiere-style per-clip blend modes. UI + MCP `set_blend_mode`.

### Also included
- Export **two-pass** fix so text overlays still render when the custom compositor is active (the Core Animation text tool can't share a pass with a custom compositor).
- Replaces deprecated `AVMutableVideoComposition` with `AVVideoComposition.Configuration`.

### ⚠️ Overlap with #62
The shared compositor also carries colour **grading** (LUT + primaries + adjustment layers + `set_color_grade`), which overlaps @Ripwords' #62 (a different, CALayer-based grading approach). They're entangled here, so grading rides along — **pick one grading implementation**; happy to strip grading from this PR if you prefer #62's.

Split out of #77. 689 tests pass; builds clean on the macOS 26 SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the preview/export video composition path (custom compositor, two-pass export/render) and persists new clip fields; incorrect wiring would affect every export/preview with effects or text.
> 
> **Overview**
> Adds **per-clip chroma key (Ultra Key)**, **16 blend modes**, and **colour grading** (basic sliders + `.cube` LUTs), with **adjustment layers** that grade everything below. Clip model gains `chromaKey`, `colorGrade`, and `blendMode`; a new **Color** media-panel tab and MCP tools `set_chroma_key`, `set_blend_mode`, and `set_color_grade` drive the same undoable editor APIs.
> 
> Rendering goes through a **custom `AVVideoCompositing`** (`ColorVideoCompositor` + Core Image matte/LUT pipelines) only when `CompositionBuilder.needsColorCompositor` sees an active effect; otherwise timelines keep the **built-in compositor**. **Export** and **timeline render** use a **two-pass** path when both **text overlays** and the colour compositor are required, because the Core Animation text tool cannot share a pass with a custom compositor. Export also moves off deprecated `AVMutableVideoComposition` to **`AVVideoComposition.Configuration`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637c2c03fe8b5fba5a3ff4043715605c3b4906b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->