### PR TITLE
Persist editor panel sizes across launches

### DIFF
--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -35,6 +35,23 @@ class PaddedDividerSplitViewController: NSSplitViewController {
     }
 }
 
+/// Autosave keys for the editor splits, defined once so call sites can't drift.
+private enum SplitAutosave {
+    static let root         = "editor.root"
+    static let defaultH     = "editor.default.h"
+    static let mediaTop     = "editor.media.top"
+    static let mediaRight   = "editor.media.right"
+    static let verticalTop  = "editor.vertical.top"
+    static let verticalLeft = "editor.vertical.left"
+    static func preset(_ p: LayoutPreset) -> String { "editor.\(p.rawValue).preset" }
+
+    /// AppKit persists divider frames under this key; no public API queries it.
+    static func hasSavedFrames(_ name: String?) -> Bool {
+        guard let name else { return false }
+        return UserDefaults.standard.object(forKey: "NSSplitView Subview Frames \(name)") != nil
+    }
+}
+
 final class EditorSplitViewController: PaddedDividerSplitViewController {
     let editor: EditorViewModel
     private var currentPreset: LayoutPreset?
@@ -70,7 +87,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         splitView.dividerStyle = .thin
-        splitView.autosaveName = "editor.root"
+        splitView.autosaveName = SplitAutosave.root
         buildLayout(editor.layoutPreset)
     }
 
@@ -183,7 +200,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         splitView.isVertical = true
 
         // Preset layout lives in an inner VC so the agent can be a sibling column.
-        let presetRoot = makeChildSplit(isVertical: false, autosave: "editor.\(preset.rawValue).preset")
+        let presetRoot = makeChildSplit(isVertical: false, autosave: SplitAutosave.preset(preset))
         switch preset {
         case .default:  buildDefaultLayout(into: presetRoot)
         case .media:    buildMediaLayout(into: presetRoot)
@@ -208,7 +225,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildDefaultLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = false
 
-        let hSplit = makeChildSplit(isVertical: true, autosave: "editor.default.h")
+        let hSplit = makeChildSplit(isVertical: true, autosave: SplitAutosave.defaultH)
         hSplit.addSplitViewItem(makeMediaItem())
         hSplit.addSplitViewItem(makePreviewItem())
         hSplit.addSplitViewItem(makeInspectorItem())
@@ -238,11 +255,11 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildMediaLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = true
 
-        let topSplit = makeChildSplit(isVertical: true, autosave: "editor.media.top")
+        let topSplit = makeChildSplit(isVertical: true, autosave: SplitAutosave.mediaTop)
         topSplit.addSplitViewItem(makePreviewItem())
         topSplit.addSplitViewItem(makeInspectorItem())
 
-        let rightSplit = makeChildSplit(isVertical: false, autosave: "editor.media.right")
+        let rightSplit = makeChildSplit(isVertical: false, autosave: SplitAutosave.mediaRight)
         let topItem = NSSplitViewItem(viewController: topSplit)
         topItem.minimumThickness = Layout.previewMinHeight
         rightSplit.addSplitViewItem(topItem)
@@ -268,11 +285,11 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildVerticalLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = true
 
-        let topSplit = makeChildSplit(isVertical: true, autosave: "editor.vertical.top")
+        let topSplit = makeChildSplit(isVertical: true, autosave: SplitAutosave.verticalTop)
         topSplit.addSplitViewItem(makeMediaItem())
         topSplit.addSplitViewItem(makeInspectorItem())
 
-        let leftSplit = makeChildSplit(isVertical: false, autosave: "editor.vertical.left")
+        let leftSplit = makeChildSplit(isVertical: false, autosave: SplitAutosave.verticalLeft)
         leftSplit.addSplitViewItem(NSSplitViewItem(viewController: topSplit))
         leftSplit.addSplitViewItem(makeTimelineItem())
 
@@ -299,15 +316,9 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         return vc
     }
 
-    /// Once a split has autosaved frames, they're restored on launch, so the hardcoded defaults must be skipped.
-    private func hasSavedFrames(_ name: String?) -> Bool {
-        guard let name else { return false }
-        return UserDefaults.standard.object(forKey: "NSSplitView Subview Frames \(name)") != nil
-    }
-
     /// Default positions apply per split: each is skipped independently once it has autosaved frames.
     private func positionIfUnsaved(_ controller: NSSplitViewController, _ apply: (NSSplitView) -> Void) {
-        guard !hasSavedFrames(controller.splitView.autosaveName) else { return }
+        guard !SplitAutosave.hasSavedFrames(controller.splitView.autosaveName) else { return }
         apply(controller.splitView)
     }
 

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -70,6 +70,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         splitView.dividerStyle = .thin
+        splitView.autosaveName = "editor.root"
         buildLayout(editor.layoutPreset)
     }
 
@@ -182,7 +183,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         splitView.isVertical = true
 
         // Preset layout lives in an inner VC so the agent can be a sibling column.
-        let presetRoot = makeChildSplit(isVertical: false)
+        let presetRoot = makeChildSplit(isVertical: false, autosave: "editor.\(preset.rawValue).preset")
         switch preset {
         case .default:  buildDefaultLayout(into: presetRoot)
         case .media:    buildMediaLayout(into: presetRoot)
@@ -207,7 +208,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildDefaultLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = false
 
-        let hSplit = makeChildSplit(isVertical: true)
+        let hSplit = makeChildSplit(isVertical: true, autosave: "editor.default.h")
         hSplit.addSplitViewItem(makeMediaItem())
         hSplit.addSplitViewItem(makePreviewItem())
         hSplit.addSplitViewItem(makeInspectorItem())
@@ -219,8 +220,9 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
 
         // Positions are set against each inner split's own bounds — not
         // self.view.bounds, which includes the agent column's width.
-        applyAfterLayout { [weak target, weak hSplit] in
-            guard let target, let hSplit else { return }
+        applyAfterLayout { [weak self, weak target, weak hSplit] in
+            guard let self, let target, let hSplit else { return }
+            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetH = target.view.bounds.height
             let hW = hSplit.view.bounds.width
             target.splitView.setPosition(round(targetH * 0.7), ofDividerAt: 0)
@@ -235,11 +237,11 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildMediaLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = true
 
-        let topSplit = makeChildSplit(isVertical: true)
+        let topSplit = makeChildSplit(isVertical: true, autosave: "editor.media.top")
         topSplit.addSplitViewItem(makePreviewItem())
         topSplit.addSplitViewItem(makeInspectorItem())
 
-        let rightSplit = makeChildSplit(isVertical: false)
+        let rightSplit = makeChildSplit(isVertical: false, autosave: "editor.media.right")
         let topItem = NSSplitViewItem(viewController: topSplit)
         topItem.minimumThickness = Layout.previewMinHeight
         rightSplit.addSplitViewItem(topItem)
@@ -248,8 +250,9 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         target.addSplitViewItem(makeMediaItem())
         target.addSplitViewItem(NSSplitViewItem(viewController: rightSplit))
 
-        applyAfterLayout { [weak target, weak rightSplit, weak topSplit] in
-            guard let target, let rightSplit, let topSplit else { return }
+        applyAfterLayout { [weak self, weak target, weak rightSplit, weak topSplit] in
+            guard let self, let target, let rightSplit, let topSplit else { return }
+            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetW = target.view.bounds.width
             let rightH = rightSplit.view.bounds.height
             let topW = topSplit.view.bounds.width
@@ -266,19 +269,20 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func buildVerticalLayout(into target: NSSplitViewController) {
         target.splitView.isVertical = true
 
-        let topSplit = makeChildSplit(isVertical: true)
+        let topSplit = makeChildSplit(isVertical: true, autosave: "editor.vertical.top")
         topSplit.addSplitViewItem(makeMediaItem())
         topSplit.addSplitViewItem(makeInspectorItem())
 
-        let leftSplit = makeChildSplit(isVertical: false)
+        let leftSplit = makeChildSplit(isVertical: false, autosave: "editor.vertical.left")
         leftSplit.addSplitViewItem(NSSplitViewItem(viewController: topSplit))
         leftSplit.addSplitViewItem(makeTimelineItem())
 
         target.addSplitViewItem(NSSplitViewItem(viewController: leftSplit))
         target.addSplitViewItem(makePreviewItem())
 
-        applyAfterLayout { [weak target, weak leftSplit, weak topSplit] in
-            guard let target, let leftSplit, let topSplit else { return }
+        applyAfterLayout { [weak self, weak target, weak leftSplit, weak topSplit] in
+            guard let self, let target, let leftSplit, let topSplit else { return }
+            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetW = target.view.bounds.width
             let leftH = leftSplit.view.bounds.height
             target.splitView.setPosition(round(targetW * 0.5), ofDividerAt: 0)
@@ -289,11 +293,18 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
 
     // MARK: - Shared item builders
 
-    private func makeChildSplit(isVertical: Bool) -> NSSplitViewController {
+    private func makeChildSplit(isVertical: Bool, autosave: String? = nil) -> NSSplitViewController {
         let vc = PaddedDividerSplitViewController()
         vc.splitView.isVertical = isVertical
         vc.splitView.dividerStyle = .thin
+        vc.splitView.autosaveName = autosave
         return vc
+    }
+
+    /// Once a split has autosaved frames, they're restored on launch, so the hardcoded defaults must be skipped.
+    private func hasSavedFrames(_ name: String?) -> Bool {
+        guard let name else { return false }
+        return UserDefaults.standard.object(forKey: "NSSplitView Subview Frames \(name)") != nil
     }
 
     private func makeMediaItem() -> NSSplitViewItem {

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -222,12 +222,13 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         // self.view.bounds, which includes the agent column's width.
         applyAfterLayout { [weak self, weak target, weak hSplit] in
             guard let self, let target, let hSplit else { return }
-            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetH = target.view.bounds.height
             let hW = hSplit.view.bounds.width
-            target.splitView.setPosition(round(targetH * 0.7), ofDividerAt: 0)
-            hSplit.splitView.setPosition(Layout.mediaPanelDefault, ofDividerAt: 0)
-            hSplit.splitView.setPosition(hW - Layout.inspectorDefault, ofDividerAt: 1)
+            self.positionIfUnsaved(target) { $0.setPosition(round(targetH * 0.7), ofDividerAt: 0) }
+            self.positionIfUnsaved(hSplit) {
+                $0.setPosition(Layout.mediaPanelDefault, ofDividerAt: 0)
+                $0.setPosition(hW - Layout.inspectorDefault, ofDividerAt: 1)
+            }
         }
     }
 
@@ -252,14 +253,12 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
 
         applyAfterLayout { [weak self, weak target, weak rightSplit, weak topSplit] in
             guard let self, let target, let rightSplit, let topSplit else { return }
-            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetW = target.view.bounds.width
             let rightH = rightSplit.view.bounds.height
             let topW = topSplit.view.bounds.width
-            let mediaWidth = round(targetW * 0.3)
-            target.splitView.setPosition(mediaWidth, ofDividerAt: 0)
-            rightSplit.splitView.setPosition(round(rightH * 0.55), ofDividerAt: 0)
-            topSplit.splitView.setPosition(topW - Layout.inspectorDefault, ofDividerAt: 0)
+            self.positionIfUnsaved(target) { $0.setPosition(round(targetW * 0.3), ofDividerAt: 0) }
+            self.positionIfUnsaved(rightSplit) { $0.setPosition(round(rightH * 0.55), ofDividerAt: 0) }
+            self.positionIfUnsaved(topSplit) { $0.setPosition(topW - Layout.inspectorDefault, ofDividerAt: 0) }
         }
     }
 
@@ -282,12 +281,11 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
 
         applyAfterLayout { [weak self, weak target, weak leftSplit, weak topSplit] in
             guard let self, let target, let leftSplit, let topSplit else { return }
-            guard !self.hasSavedFrames(target.splitView.autosaveName) else { return }
             let targetW = target.view.bounds.width
             let leftH = leftSplit.view.bounds.height
-            target.splitView.setPosition(round(targetW * 0.5), ofDividerAt: 0)
-            leftSplit.splitView.setPosition(round(leftH * 0.55), ofDividerAt: 0)
-            topSplit.splitView.setPosition(Layout.mediaPanelDefault, ofDividerAt: 0)
+            self.positionIfUnsaved(target) { $0.setPosition(round(targetW * 0.5), ofDividerAt: 0) }
+            self.positionIfUnsaved(leftSplit) { $0.setPosition(round(leftH * 0.55), ofDividerAt: 0) }
+            self.positionIfUnsaved(topSplit) { $0.setPosition(Layout.mediaPanelDefault, ofDividerAt: 0) }
         }
     }
 
@@ -305,6 +303,12 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private func hasSavedFrames(_ name: String?) -> Bool {
         guard let name else { return false }
         return UserDefaults.standard.object(forKey: "NSSplitView Subview Frames \(name)") != nil
+    }
+
+    /// Default positions apply per split: each is skipped independently once it has autosaved frames.
+    private func positionIfUnsaved(_ controller: NSSplitViewController, _ apply: (NSSplitView) -> Void) {
+        guard !hasSavedFrames(controller.splitView.autosaveName) else { return }
+        apply(controller.splitView)
     }
 
     private func makeMediaItem() -> NSSplitViewItem {


### PR DESCRIPTION
Fixes #101.

## Problem
Editor panel sizes were not preserved. `EditorSplitViewController.buildLayout` recomputes divider positions from proportional defaults (`applyAfterLayout`) on every launch, so any manual resize is discarded. The active layout preset and panel visibility already persist via `UserDefaults`; only the sizes did not.

## Fix
Use AppKit's built-in split persistence:
- Set `NSSplitView.autosaveName` on the root split (`editor.root`) and on each per-preset child split (`editor.<preset>.*`). AppKit then saves/restores divider positions automatically.
- Add `hasSavedFrames(_:)` and gate the hardcoded default positioning behind `guard !hasSavedFrames(...)`, so the proportional defaults only apply on first launch and restored positions are not clobbered afterward. Sizes are saved per-preset, so switching layouts and returning also restores that layout's last sizes.

One file, +24/-13. No new UI.

## Testing
Built and ran the app, then verified the full quit/relaunch cycle:
- Confirmed the autosave keys (`NSSplitView Subview Frames editor.*`) are written to the `PalmierPro` defaults domain during normal use.
- Resized a panel, quit, relaunched: the layout came back at the saved size instead of reverting to the default. Removing the change reproduces the reset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file UI layout persistence with no auth, data, or API changes; main risk is relying on AppKit’s undocumented UserDefaults key for the unsaved check.
> 
> **Overview**
> Editor panel sizes now survive quit/relaunch by wiring **AppKit `NSSplitView` autosave** on the root split and each nested split in the default, media, and vertical presets, with stable `editor.*` keys centralized in `SplitAutosave`.
> 
> **Default divider positioning** in `applyAfterLayout` is wrapped in `positionIfUnsaved`, which skips `setPosition` when `UserDefaults` already has AppKit’s `NSSplitView Subview Frames …` entry for that split—so first-run proportional defaults still apply, but restored sizes are not overwritten on later launches or when switching back to a preset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b747944777298c6300f36cb615e9396a8dd7c973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->