### PR TITLE
docs: add missing swift test step to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,4 +28,9 @@ For a bundled debug build that launches the `.app` and streams OSLog:
 ./scripts/dev.sh
 ```
 
+### Test
+```bash
+swift test
+```
+
 By contributing, you agree your contributions are licensed under [GPLv3](LICENSE).


### PR DESCRIPTION
## Summary
- add the existing `swift test` command to the contributor setup guide
- make the local verification step visible before people open a PR

## Why
`CONTRIBUTING.md` already explains how to build and launch the app, but it skipped the repo's test command even though the Swift test suite already exists.

## Verification
- `git diff --check`