### PR TITLE
Fix writePosition corrupting fallback transform when position keyframes are active

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -167,9 +167,10 @@ extension EditorViewModel {
         let sz = clip.sizeAt(frame: frame)
         if clip.positionTrack?.isActive == true {
             clip.upsertKeyframe(in: \.positionTrack, frame: frame, value: AnimPair(a: newX, b: newY))
+        } else {
+            clip.transform.centerX = newX + sz.width / 2
+            clip.transform.centerY = newY + sz.height / 2
         }
-        clip.transform.centerX = newX + sz.width / 2
-        clip.transform.centerY = newY + sz.height / 2
     }
 
     func applyScale(clipId: String, newScale: Double) {

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -287,6 +287,33 @@ struct MoveClipsTests {
     }
 }
 
+@Suite("EditorViewModel — writePosition")
+@MainActor
+struct WritePositionTests {
+
+    @Test func writePositionWithActiveKeyframesPreservesFallbackTransform() {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.transform.centerX = 0.5
+        clip.transform.centerY = 0.5
+        clip.transform.width = 0.4
+        clip.transform.height = 0.4
+        clip.positionTrack = KeyframeTrack(keyframes: [Keyframe(frame: 0, value: AnimPair(a: 0.1, b: 0.1))])
+
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.currentFrame = 0
+
+        e.commitPosition(clipId: "c1", setX: 0.4, setY: 0.4)
+
+        let updated = e.timeline.tracks[0].clips[0]
+        let kf = updated.positionTrack?.keyframes.first(where: { $0.frame == 0 })
+        #expect(kf?.value == AnimPair(a: 0.4, b: 0.4))
+        // Fallback transform must not be touched while keyframes are active.
+        // Bug: without the else-guard, centerX/Y become 0.6 (0.4 + width/2).
+        #expect(updated.transform.centerX == 0.5)
+        #expect(updated.transform.centerY == 0.5)
+    }
+}
+
 @Suite("EditorViewModel — clearRegion")
 @MainActor
 struct ClearRegionTests {


### PR DESCRIPTION
## Summary

- `writePosition` unconditionally overwrote `transform.centerX/Y` even when `positionTrack` had active keyframes
- After clearing position animation, the clip jumped to the last animated position instead of restoring the original static position
- Fix: wrap the `transform` writes in an `else` block — identical pattern to `writeRotation`, `writeScale`, and `writeTransform`

## Root cause

```swift
// Before (buggy): always runs, even when positionTrack is active
if clip.positionTrack?.isActive == true {
    clip.upsertKeyframe(in: \.positionTrack, frame: frame, value: AnimPair(a: newX, b: newY))
}
clip.transform.centerX = newX + sz.width / 2  // ← always executed
clip.transform.centerY = newY + sz.height / 2  // ← always executed

// After (fixed): matches writeRotation / writeScale / writeTransform pattern
if clip.positionTrack?.isActive == true {
    clip.upsertKeyframe(in: \.positionTrack, frame: frame, value: AnimPair(a: newX, b: newY))
} else {
    clip.transform.centerX = newX + sz.width / 2
    clip.transform.centerY = newY + sz.height / 2
}
```

## Test plan

- New `@Test writePositionWithActiveKeyframesPreservesFallbackTransform` in `ClipMutationsTests.swift` — **red** on original code (centerX becomes 0.6), **green** after fix
- Full suite: 651 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in editor clip mutation logic with a targeted regression test; no auth, persistence, or API surface changes.
> 
> **Overview**
> **`writePosition`** no longer overwrites **`transform.centerX/Y`** when **`positionTrack`** is active. Position edits now only upsert keyframes in that case; static transform updates run in an **`else`** branch, matching **`writeRotation`**, **`writeScale`**, and **`writeTransform`**.
> 
> This fixes clips **jumping** to the last animated position after **clearing position animation**, because the fallback transform had been polluted during keyed edits.
> 
> Adds **`WritePositionTests.writePositionWithActiveKeyframesPreservesFallbackTransform`** to assert keyframes update while **`centerX/Y`** stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb73504e26618b85803146f6104ecda3bb69cc5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->