### PR TITLE
Fix writePosition corrupting fallback transform when position keyframes are active

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -551,6 +551,7 @@ extension ToolExecutor {
                     width: t.width ?? cur.width,
                     height: t.height ?? cur.height
                 )
+                next.rotation = cur.rotation
                 next.flipHorizontal = t.flipHorizontal ?? cur.flipHorizontal
                 next.flipVertical = t.flipVertical ?? cur.flipVertical
                 clip.transform = next

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -167,9 +167,10 @@ extension EditorViewModel {
         let sz = clip.sizeAt(frame: frame)
         if clip.positionTrack?.isActive == true {
             clip.upsertKeyframe(in: \.positionTrack, frame: frame, value: AnimPair(a: newX, b: newY))
+        } else {
+            clip.transform.centerX = newX + sz.width / 2
+            clip.transform.centerY = newY + sz.height / 2
         }
-        clip.transform.centerX = newX + sz.width / 2
-        clip.transform.centerY = newY + sz.height / 2
     }
 
     func applyScale(clipId: String, newScale: Double) {

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1580,3 +1580,23 @@ struct ToolExecutorTextFolderTests {
         #expect(ToolHarness.textOf(result).contains("less than"))
     }
 }
+
+@Suite("ToolExecutor — set_clip_properties")
+@MainActor
+struct SetClipPropertiesTests {
+
+    @Test func transformPreservesRotation() async {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.transform.rotation = 45.0
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+
+        _ = await h.runRaw("set_clip_properties", args: [
+            "clipIds": ["c1"],
+            "transform": ["centerX": 0.3]
+        ])
+
+        let updated = h.editor.timeline.tracks[0].clips[0]
+        // Bug: Transform(center:width:height:) defaults rotation to 0, discarding cur.rotation.
+        #expect(updated.transform.rotation == 45.0)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -287,6 +287,33 @@ struct MoveClipsTests {
     }
 }
 
+@Suite("EditorViewModel — writePosition")
+@MainActor
+struct WritePositionTests {
+
+    @Test func writePositionWithActiveKeyframesPreservesFallbackTransform() {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.transform.centerX = 0.5
+        clip.transform.centerY = 0.5
+        clip.transform.width = 0.4
+        clip.transform.height = 0.4
+        clip.positionTrack = KeyframeTrack(keyframes: [Keyframe(frame: 0, value: AnimPair(a: 0.1, b: 0.1))])
+
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.currentFrame = 0
+
+        e.commitPosition(clipId: "c1", setX: 0.4, setY: 0.4)
+
+        let updated = e.timeline.tracks[0].clips[0]
+        let kf = updated.positionTrack?.keyframes.first(where: { $0.frame == 0 })
+        #expect(kf?.value == AnimPair(a: 0.4, b: 0.4))
+        // Fallback transform must not be touched while keyframes are active.
+        // Bug: without the else-guard, centerX/Y become 0.6 (0.4 + width/2).
+        #expect(updated.transform.centerX == 0.5)
+        #expect(updated.transform.centerY == 0.5)
+    }
+}
+
 @Suite("EditorViewModel — clearRegion")
 @MainActor
 struct ClearRegionTests {


### PR DESCRIPTION
`writePosition` always overwrote `transform.centerX/Y` even when `positionTrack` had active keyframes. Clearing position animation afterward caused the clip to jump to the last animated position instead of restoring the original static value.

Every other write helper (`writeRotation`, `writeScale`, `writeTransform`) guards the fallback write with `else`. `writePosition` was missing it.

Fix: wrap the two `transform` assignments in `else`.