### PR TITLE
Fix set_clip_properties silently zeroing clip rotation on partial transform update

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -551,6 +551,7 @@ extension ToolExecutor {
                     width: t.width ?? cur.width,
                     height: t.height ?? cur.height
                 )
+                next.rotation = cur.rotation
                 next.flipHorizontal = t.flipHorizontal ?? cur.flipHorizontal
                 next.flipVertical = t.flipVertical ?? cur.flipVertical
                 clip.transform = next

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1580,3 +1580,23 @@ struct ToolExecutorTextFolderTests {
         #expect(ToolHarness.textOf(result).contains("less than"))
     }
 }
+
+@Suite("ToolExecutor — set_clip_properties")
+@MainActor
+struct SetClipPropertiesTests {
+
+    @Test func transformPreservesRotation() async {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.transform.rotation = 45.0
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+
+        _ = await h.runRaw("set_clip_properties", args: [
+            "clipIds": ["c1"],
+            "transform": ["centerX": 0.3]
+        ])
+
+        let updated = h.editor.timeline.tracks[0].clips[0]
+        // Bug: Transform(center:width:height:) defaults rotation to 0, discarding cur.rotation.
+        #expect(updated.transform.rotation == 45.0)
+    }
+}


### PR DESCRIPTION
`set_clip_properties` builds a new `Transform` via `Transform(center:width:height:)`, which defaults `rotation` to `0`. `flipHorizontal` and `flipVertical` were explicitly copied from the existing clip transform, but `rotation` was not.

Trigger: user sets clip rotation in the inspector, then the agent calls `set_clip_properties` with any transform fields (centerX, width, etc.). Rotation is silently reset to 0°.

Fix: copy `cur.rotation` into the new transform, matching the existing pattern for the flip flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in agent clip property merging with a regression test; no auth or persistence changes.
> 
> **Overview**
> **`set_clip_properties`** no longer wipes clip rotation when the agent sends a **partial** `transform` (e.g. only `centerX`). Merging now copies **`cur.rotation`** into the new transform, same as **`flipHorizontal`** / **`flipVertical`**.
> 
> A regression test asserts rotation stays at 45° after updating only `centerX`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df8aad6387606d685507d4a9bc698764fab3049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->