### PR TITLE
Fix writePosition corrupting fallback transform when position keyframes are active

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -167,9 +167,10 @@ extension EditorViewModel {
         let sz = clip.sizeAt(frame: frame)
         if clip.positionTrack?.isActive == true {
             clip.upsertKeyframe(in: \.positionTrack, frame: frame, value: AnimPair(a: newX, b: newY))
+        } else {
+            clip.transform.centerX = newX + sz.width / 2
+            clip.transform.centerY = newY + sz.height / 2
         }
-        clip.transform.centerX = newX + sz.width / 2
-        clip.transform.centerY = newY + sz.height / 2
     }
 
     func applyScale(clipId: String, newScale: Double) {

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -287,6 +287,33 @@ struct MoveClipsTests {
     }
 }
 
+@Suite("EditorViewModel — writePosition")
+@MainActor
+struct WritePositionTests {
+
+    @Test func writePositionWithActiveKeyframesPreservesFallbackTransform() {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.transform.centerX = 0.5
+        clip.transform.centerY = 0.5
+        clip.transform.width = 0.4
+        clip.transform.height = 0.4
+        clip.positionTrack = KeyframeTrack(keyframes: [Keyframe(frame: 0, value: AnimPair(a: 0.1, b: 0.1))])
+
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.currentFrame = 0
+
+        e.commitPosition(clipId: "c1", setX: 0.4, setY: 0.4)
+
+        let updated = e.timeline.tracks[0].clips[0]
+        let kf = updated.positionTrack?.keyframes.first(where: { $0.frame == 0 })
+        #expect(kf?.value == AnimPair(a: 0.4, b: 0.4))
+        // Fallback transform must not be touched while keyframes are active.
+        // Bug: without the else-guard, centerX/Y become 0.6 (0.4 + width/2).
+        #expect(updated.transform.centerX == 0.5)
+        #expect(updated.transform.centerY == 0.5)
+    }
+}
+
 @Suite("EditorViewModel — clearRegion")
 @MainActor
 struct ClearRegionTests {


### PR DESCRIPTION
`writePosition` always overwrote `transform.centerX/Y` even when `positionTrack` had active keyframes. Clearing position animation afterward caused the clip to jump to the last animated position instead of restoring the original static value.

Every other write helper (`writeRotation`, `writeScale`, `writeTransform`) guards the fallback write with `else`. `writePosition` was missing it.

Fix: wrap the two `transform` assignments in `else`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in editor clip mutation with a targeted test; no auth, persistence, or export pipeline changes.
> 
> **Overview**
> **`writePosition`** now only updates **`clip.transform.centerX/Y`** when position animation is **not** active, matching **`writeRotation`**, **`writeScale`**, and **`writeTransform`**.
> 
> Previously, position edits with an active **`positionTrack`** still overwrote the static fallback transform (e.g. center became top-left plus half size). After clearing position animation, clips could jump to the wrong place instead of restoring the original static position.
> 
> A regression test asserts that **`commitPosition`** updates the keyframe but leaves **`transform.centerX/Y`** unchanged while keyframes are active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ab47b9b29ff42a86a2e604d5177f58c60ea6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->