### PR TITLE
[fix] silent macOS sign-in failure (bump clerk-ios to 1.2.4)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5270b739dd88bb6350dc1cc41806487cfcdaa2f2ff360081e2bbd4960063968d",
+  "originHash" : "9cea4e06af93ec4e9468a1239c6feb73249f1373664f3daf6aa8fec20701023b",
   "pins" : [
     {
       "identity" : "clerk-convex-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clerk/clerk-ios",
       "state" : {
-        "revision" : "5f9567a1ef4cd47ac4cfe9b1d4c0d400af62202b",
-        "version" : "1.1.3"
+        "revision" : "9b6c83e780c48af3a5cb8c40305674d9d8cb0fc6",
+        "version" : "1.2.4"
       }
     },
     {
@@ -60,17 +60,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke.git",
       "state" : {
-        "revision" : "83e19143355b02e9261edb2323b3e1e93287ebb9",
-        "version" : "12.9.0"
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
       }
     },
     {
       "identity" : "phonenumberkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/marmelroy/PhoneNumberKit",
+      "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit",
       "state" : {
-        "revision" : "2d547ffe38f61009219e34e5378d2aa4c13b6e51",
-        "version" : "4.2.12"
+        "revision" : "c93fb1c3eef581fbd08acf99d4886dea12b5c1dc",
+        "version" : "5.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.40.0"),
         .package(url: "https://github.com/clerk/clerk-convex-swift", from: "0.1.0"),
-        .package(url: "https://github.com/clerk/clerk-ios", from: "1.0.0"),
+        .package(url: "https://github.com/clerk/clerk-ios", from: "1.2.1"),
         .package(url: "https://github.com/get-convex/convex-swift", from: "0.8.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.6.1"),


### PR DESCRIPTION
## Summary

Fixes #113. Sign in could silently fail on macOS because clerk-ios **1.1.3** lacked the `@Sendable` fix on the `ASWebAuthenticationSession` completion handler ([clerk/clerk-ios#460](https://github.com/clerk/clerk-ios/pull/460), released in **1.2.1**). Under Swift 6 strict concurrency the handler inherited `@MainActor` isolation while the OS invokes it on a background queue, tripping `_dispatch_assert_queue_fail` → `EXC_BREAKPOINT`. `AccountService` is `@MainActor`, so the OAuth path was susceptible.

## Changes

- `Package.resolved`: clerk-ios **1.1.3 → 1.2.4** (first release ≥1.2.1; verified the #460 merge commit is in the 1.2.1 tag, not 1.2.0).
- `Package.swift`: floor raised `from: "1.0.0"` → `from: "1.2.1"` to document the minimum required version.
- Transitive bumps pulled in by 1.2.4: **Nuke 12.9.0 → 13.0.6**, **PhoneNumberKit 4.2.12 → 5.0.3** (repo also moved `marmelroy` → `PhoneNumberKit` org).

## Verification

- `swift build` succeeds; `swift package resolve` clean.
- Sign in / OAuth flow confirmed working on a configured build.

## Notes / follow-ups (not in this PR)

The "Sign in does nothing" symptom can also be produced by the `isMisconfigured` guard in `AccountService.signInWithGoogle()` when `BackendConfig` keys are missing (it silently returns) — unrelated to the SDK, worth tracking separately. Other minor edge cases observed but left alone: canceling OAuth surfaces a red error, and the popover dismisses before errors can show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication SDK and major-version transitive deps (Nuke, PhoneNumberKit) with no app code changes—regression risk is mainly OAuth/sign-in and Clerk UI image/phone formatting paths.
> 
> **Overview**
> Addresses **silent macOS sign-in failure** by upgrading **clerk-ios** from **1.1.3** to **1.2.4**, which includes the Swift 6 concurrency fix for `ASWebAuthenticationSession` completion handlers (needed because `@MainActor` `AccountService` drives Google OAuth via `Clerk.shared.auth.signInWithOAuth`).
> 
> **`Package.swift`** now requires clerk-ios **≥ 1.2.1** (`from: "1.2.1"`). **`Package.resolved`** also picks up transitive updates: **Nuke 13.0.6**, **PhoneNumberKit 5.0.3** (upstream repo URL change to the `PhoneNumberKit` org).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8bc1777c75c923898b7b1c48e16e25fba66bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->