### PR TITLE
Migrate deprecated AVFoundation APIs to modern async alternatives

### DIFF
--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -83,7 +83,7 @@ final class ExportService {
                 telemetry: "Export started",
                 data: ["format": "xml", "tracks": timeline.tracks.count, "clips": timeline.tracks.reduce(0) { $0 + $1.clips.count }]
             )
-            XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
+            await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
             progress = 1.0
             Log.export.notice("export ok format=xml", telemetry: "Export finished", data: ["format": "xml"])
             return

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -46,8 +46,8 @@ struct ExportView: View {
                 .background(.ultraThinMaterial)
         }
         .task {
-            loadPreview()
             palmierSummary = computePalmierSummary()
+            await loadPreview()
         }
     }
 
@@ -298,22 +298,19 @@ struct ExportView: View {
         return (collect, missing, bytes)
     }
 
-    private func loadPreview() {
+    private func loadPreview() async {
         for track in editor.timeline.tracks where track.type == .video {
             for clip in track.clips {
                 guard let url = editor.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
                 let asset = AVURLAsset(url: url)
-                guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
+                guard let tracks = try? await asset.loadTracks(withMediaType: .video),
+                      !tracks.isEmpty else { continue }
                 let generator = AVAssetImageGenerator(asset: asset)
                 generator.maximumSize = CGSize(width: 480, height: 270)
                 generator.appliesPreferredTrackTransform = true
                 let time = CMTime(value: CMTimeValue(clip.trimStartFrame), timescale: CMTimeScale(editor.timeline.fps))
-                generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) { _, image, _, _, _ in
-                    if let image {
-                        Task { @MainActor in
-                            preview = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
-                        }
-                    }
+                if let cgImage = try? await generator.image(at: time).image {
+                    preview = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
                 }
                 return
             }

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -37,9 +37,37 @@ import Foundation
 
 enum XMLExporter {
 
-    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) {
-        let xml = Builder(timeline: timeline, resolver: resolver).build()
+    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) async {
+        var startFrameCache: [String: Int?] = [:]
+        let mediaRefs = Set(timeline.tracks.flatMap { $0.clips.map { $0.mediaRef } })
+        for mediaRef in mediaRefs {
+            if let url = resolver.resolveURL(for: mediaRef) {
+                startFrameCache[mediaRef] = await readStartTimecodeFrame(url: url)
+            } else {
+                startFrameCache[mediaRef] = nil
+            }
+        }
+        let xml = Builder(timeline: timeline, resolver: resolver, startFrameCache: startFrameCache).build()
         try? xml.data(using: .utf8)?.write(to: outputURL)
+    }
+
+    private static func readStartTimecodeFrame(url: URL) async -> Int? {
+        let asset = AVURLAsset(url: url)
+        guard let tracks = try? await asset.loadTracks(withMediaType: .timecode),
+              let track = tracks.first,
+              let reader = try? AVAssetReader(asset: asset) else { return nil }
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+        guard reader.canAdd(output) else { return nil }
+        reader.add(output)
+        guard reader.startReading() else { return nil }
+        while let sample = output.copyNextSampleBuffer() {
+            guard let block = CMSampleBufferGetDataBuffer(sample) else { continue }
+            var be: UInt32 = 0
+            guard CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: 4, destination: &be) == kCMBlockBufferNoErr
+            else { return nil }
+            return Int(UInt32(bigEndian: be))
+        }
+        return nil
     }
 
     // MARK: - Builder
@@ -57,17 +85,18 @@ enum XMLExporter {
         private var clipAddresses: [String: ClipAddress] = [:]
         private var clipsByLinkGroup: [String: [Clip]] = [:]
         /// Source start timecode (frames) per media ref; nil = no timecode track. Avoids re-reading per file.
-        private var startFrameCache: [String: Int?] = [:]
+        private var startFrameCache: [String: Int?]
 
         private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
         private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
 
-        init(timeline: Timeline, resolver: MediaResolver) {
+        init(timeline: Timeline, resolver: MediaResolver, startFrameCache: [String: Int?]) {
             self.timeline = timeline
             self.resolver = resolver
             self.fps = timeline.fps
             self.seqWidth = timeline.width
             self.seqHeight = timeline.height
+            self.startFrameCache = startFrameCache
         }
 
         // MARK: - Document shell
@@ -236,29 +265,7 @@ enum XMLExporter {
 
         /// Source start timecode — one read serves both the video and audio file nodes.
         private func sourceStartFrame(for mediaRef: String) -> Int? {
-            if let cached = startFrameCache[mediaRef] { return cached }
-            let frame = resolver.resolveURL(for: mediaRef).flatMap(Builder.readStartTimecodeFrame)
-            startFrameCache[mediaRef] = frame
-            return frame
-        }
-
-        /// Start frame from the QuickTime `tmcd` track; skip the leading edit-boundary buffer (no data buffer).
-        private static func readStartTimecodeFrame(url: URL) -> Int? {
-            let asset = AVURLAsset(url: url)
-            guard let track = asset.tracks(withMediaType: .timecode).first,
-                  let reader = try? AVAssetReader(asset: asset) else { return nil }
-            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
-            guard reader.canAdd(output) else { return nil }
-            reader.add(output)
-            guard reader.startReading() else { return nil }
-            while let sample = output.copyNextSampleBuffer() {
-                guard let block = CMSampleBufferGetDataBuffer(sample) else { continue }
-                var be: UInt32 = 0
-                guard CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: 4, destination: &be) == kCMBlockBufferNoErr
-                else { return nil }
-                return Int(UInt32(bigEndian: be))
-            }
-            return nil
+            return startFrameCache[mediaRef] ?? nil
         }
 
         /// Frame count → SMPTE string; drop-frame (29.97/59.94) uses `;` separators and skips dropped frames.

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -373,20 +373,28 @@ final class VideoProject: NSDocument {
                 }
                 guard clip.mediaType == .video else { continue }
 
-                let asset = AVURLAsset(url: url)
-                guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
-                let generator = AVAssetImageGenerator(asset: asset)
-                generator.maximumSize = CGSize(width: 320, height: 180)
-                generator.appliesPreferredTrackTransform = true
                 let time = CMTime(value: CMTimeValue(clip.trimStartFrame), timescale: CMTimeScale(editorViewModel.timeline.fps))
-                nonisolated(unsafe) var result: CGImage?
                 let semaphore = DispatchSemaphore(value: 0)
-                generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) { _, image, _, _, _ in
-                    result = image
+                nonisolated(unsafe) var result: CGImage?
+                let task = Task {
+                    do {
+                        let asset = AVURLAsset(url: url)
+                        let generator = AVAssetImageGenerator(asset: asset)
+                        generator.maximumSize = CGSize(width: 320, height: 180)
+                        generator.appliesPreferredTrackTransform = true
+
+                        let tracks = try await asset.loadTracks(withMediaType: .video)
+                        if !tracks.isEmpty {
+                            let (cgImage, _) = try await generator.image(at: time)
+                            result = cgImage
+                        }
+                    } catch {
+                        Log.project.error("Thumbnail generation error: \(error)")
+                    }
                     semaphore.signal()
                 }
                 guard semaphore.wait(timeout: .now() + .seconds(5)) == .success else {
-                    generator.cancelAllCGImageGeneration()
+                    task.cancel()
                     continue
                 }
                 if let cgImage = result {

--- a/Tests/PalmierProTests/Export/XMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/XMLExporterTests.swift
@@ -49,13 +49,13 @@ struct XMLExporterTests {
 
     // MARK: - Header / sequence shell
 
-    @Test func headerHasXmemlVersionAndSequenceShell() throws {
+    @Test func headerHasXmemlVersionAndSequenceShell() async throws {
         // No clips → output is just the sequence shell. Tests the boilerplate around content.
         let timeline = Fixtures.timeline()
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.hasPrefix("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
@@ -67,14 +67,14 @@ struct XMLExporterTests {
         #expect(xml.contains("</xmeml>"))
     }
 
-    @Test func headerReportsTimelineFpsAndCanvasDimensions() throws {
+    @Test func headerReportsTimelineFpsAndCanvasDimensions() async throws {
         var timeline = Fixtures.timeline(fps: 24)
         timeline.width = 1280
         timeline.height = 720
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<timebase>24</timebase>"))
@@ -82,12 +82,12 @@ struct XMLExporterTests {
         #expect(xml.contains("<height>720</height>"))
     }
 
-    @Test func emptyTimelineProducesZeroDuration() throws {
+    @Test func emptyTimelineProducesZeroDuration() async throws {
         let timeline = Fixtures.timeline()
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<duration>0</duration>"))
@@ -95,7 +95,7 @@ struct XMLExporterTests {
 
     // MARK: - Clip emission
 
-    @Test func videoClipEmitsClipitemWithStartAndEnd() throws {
+    @Test func videoClipEmitsClipitemWithStartAndEnd() async throws {
         let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("XMLExporterTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
@@ -118,7 +118,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<clipitem id=\"clipitem-clip-1\">"))
@@ -127,7 +127,7 @@ struct XMLExporterTests {
         #expect(xml.contains("<end>90</end>")) // 30 + 60
     }
 
-    @Test func clipsReferencingUnresolvableMediaAreSkipped() throws {
+    @Test func clipsReferencingUnresolvableMediaAreSkipped() async throws {
         // No manifest entry for the clip's mediaRef → resolveURL returns nil → sortEmittable
         // drops the clip → no clipitem element in the output. Pins this fail-soft behavior
         // so a future change to "fail loudly" forces a deliberate test update.
@@ -137,14 +137,14 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("ghost-clip"))
         #expect(!xml.contains("clipitem"))
     }
 
-    @Test func repeatedMediaRefEmitsFileOnceThenReferences() throws {
+    @Test func repeatedMediaRefEmitsFileOnceThenReferences() async throws {
         // First clipitem gets the full <file> element; subsequent references collapse to
         // <file id="..."/> with no children. Catches the emittedFiles cache logic.
         let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -171,7 +171,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // The full <file> element appears exactly once; the second reference is a self-closing tag.
@@ -185,13 +185,13 @@ struct XMLExporterTests {
 
     // MARK: - Audio clips
 
-    @Test func audioClipAppearsInAudioSectionOnly() throws {
+    @Test func audioClipAppearsInAudioSectionOnly() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [audioManifestEntry(id: "media-a", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "audio-clip", mediaRef: "media-a", mediaType: .audio, start: 0, duration: 30)
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let audioSec = xml.range(of: "<audio>"), let videoSec = xml.range(of: "<video>") else {
@@ -209,7 +209,7 @@ struct XMLExporterTests {
 
     // MARK: - Links
 
-    @Test func linkedClipsEmitCrossReferences() throws {
+    @Test func linkedClipsEmitCrossReferences() async throws {
         // Video + audio sharing a linkGroupId emit <link> entries pointing at each other.
         let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("XMLExporterTests-\(UUID().uuidString)", isDirectory: true)
@@ -238,7 +238,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<linkclipref>clipitem-vc</linkclipref>"))
@@ -248,13 +248,13 @@ struct XMLExporterTests {
         #expect(xml.contains("<mediatype>audio</mediatype>"))
     }
 
-    @Test func unlinkedClipsEmitNoLinkBlocks() throws {
+    @Test func unlinkedClipsEmitNoLinkBlocks() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "lone", mediaRef: "media-v", start: 0, duration: 30)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("<link>"))
@@ -263,13 +263,13 @@ struct XMLExporterTests {
 
     // MARK: - Filters
 
-    @Test func speedNotOneEmitsTimeRemapFilter() throws {
+    @Test func speedNotOneEmitsTimeRemapFilter() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 60, speed: 2.0)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>timeremap</effectid>"))
@@ -277,51 +277,51 @@ struct XMLExporterTests {
         #expect(xml.contains("<value>200.0000</value>"))
     }
 
-    @Test func speedOneEmitsNoTimeRemapFilter() throws {
+    @Test func speedOneEmitsNoTimeRemapFilter() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 60, speed: 1.0)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("timeremap"))
     }
 
-    @Test func volumeNotOneEmitsAudioLevelsFilter() throws {
+    @Test func volumeNotOneEmitsAudioLevelsFilter() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [audioManifestEntry(id: "media-a", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-a", mediaType: .audio, start: 0, duration: 60, volume: 0.5)
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>audiolevels</effectid>"))
         #expect(xml.contains("<value>0.5000</value>"))
     }
 
-    @Test func volumeAtUnityEmitsNoAudioLevelsFilter() throws {
+    @Test func volumeAtUnityEmitsNoAudioLevelsFilter() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [audioManifestEntry(id: "media-a", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-a", mediaType: .audio, start: 0, duration: 60, volume: 1.0)
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("audiolevels"))
     }
 
-    @Test func opacityNotOneEmitsDedicatedOpacityEffect() throws {
+    @Test func opacityNotOneEmitsDedicatedOpacityEffect() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         var clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 30)
         clip.opacity = 0.5
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // FCP7 keeps opacity in its own Opacity effect, not inside Basic Motion.
@@ -331,7 +331,7 @@ struct XMLExporterTests {
         #expect(xml.contains("<value>50.0</value>"))
     }
 
-    @Test func nonDefaultTransformEmitsMotionFilterWithMatchingParams() throws {
+    @Test func nonDefaultTransformEmitsMotionFilterWithMatchingParams() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         var clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 30)
         // Centered at (0.5, 0.5) is the default; shift to (0.6, 0.6) — non-zero center offset.
@@ -339,7 +339,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>basic</effectid>"))
@@ -352,13 +352,13 @@ struct XMLExporterTests {
         #expect(xml.contains("<value>50.00</value>"))
     }
 
-    @Test func defaultClipEmitsNoMotionFilter() throws {
+    @Test func defaultClipEmitsNoMotionFilter() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 30)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Defaults (centerX/Y=0.5, width=height=1, rotation=0, opacity=1) → no filter at all.
@@ -367,7 +367,7 @@ struct XMLExporterTests {
 
     // MARK: - Text clips
 
-    @Test func textClipsAreNotEmitted() throws {
+    @Test func textClipsAreNotEmitted() async throws {
         // Text clips have no manifest entry (CATextLayer renders them at preview/export time
         // via the AVVideoComposition path, not as composition tracks). XML must skip them too.
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
@@ -378,7 +378,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("clipitem-tc"))
@@ -387,7 +387,7 @@ struct XMLExporterTests {
 
     // MARK: - Track enabled state
 
-    @Test func mutedAudioTrackEmitsEnabledFalse() throws {
+    @Test func mutedAudioTrackEmitsEnabledFalse() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [audioManifestEntry(id: "media-a", in: NSTemporaryDirectory())])
         var track = Fixtures.audioTrack(clips: [
             Fixtures.clip(id: "ac", mediaRef: "media-a", mediaType: .audio, start: 0, duration: 30),
@@ -396,7 +396,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Find the <track> block in the <audio> section and verify its enabled flag.
@@ -406,7 +406,7 @@ struct XMLExporterTests {
                 "muted audio track should produce <enabled>FALSE</enabled>")
     }
 
-    @Test func hiddenVideoTrackEmitsEnabledFalse() throws {
+    @Test func hiddenVideoTrackEmitsEnabledFalse() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         var track = Fixtures.videoTrack(clips: [
             Fixtures.clip(id: "vc", mediaRef: "media-v", start: 0, duration: 30),
@@ -415,7 +415,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let videoStart = xml.range(of: "<video>") else { Issue.record("no <video>"); return }
@@ -426,7 +426,7 @@ struct XMLExporterTests {
 
     // MARK: - Escaping
 
-    @Test func specialCharsInClipNameAreXMLEscaped() throws {
+    @Test func specialCharsInClipNameAreXMLEscaped() async throws {
         let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("XMLExporterTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
@@ -448,7 +448,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("A &amp; B &lt; C &gt; &quot;D&quot; &apos;E&apos;"))
@@ -458,13 +458,13 @@ struct XMLExporterTests {
 
     // MARK: - Trim handling
 
-    @Test func trimStartIsReflectedInInOutPoints() throws {
+    @Test func trimStartIsReflectedInInOutPoints() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "c1", mediaRef: "media-v", start: 0, duration: 60, trimStart: 10)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // in = trimStart, out = trimStart + sourceFramesConsumed (= durationFrames * speed = 60 at speed=1).
@@ -474,14 +474,14 @@ struct XMLExporterTests {
 
     // MARK: - Timeline duration
 
-    @Test func sequenceDurationEqualsTimelineTotalFrames() throws {
+    @Test func sequenceDurationEqualsTimelineTotalFrames() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clipA = Fixtures.clip(id: "a", mediaRef: "media-v", start: 0, duration: 50)
         let clipB = Fixtures.clip(id: "b", mediaRef: "media-v", start: 100, duration: 80) // ends at 180
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clipA, clipB])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Sequence <duration> appears before the first <media> block; clip <duration> entries
@@ -492,7 +492,7 @@ struct XMLExporterTests {
         #expect(xml.contains("<duration>180</duration>"))
     }
 
-    @Test func multipleClipsOnSameTrackAreSortedByStartFrame() throws {
+    @Test func multipleClipsOnSameTrackAreSortedByStartFrame() async throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoManifestEntry(id: "media-v", in: NSTemporaryDirectory())])
         // Insert in reverse order; exporter must sort by startFrame.
         let later = Fixtures.clip(id: "later", mediaRef: "media-v", start: 100, duration: 30)
@@ -500,7 +500,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [later, earlier])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let earlyRange = xml.range(of: "earlier"), let laterRange = xml.range(of: "later") else {
@@ -528,7 +528,7 @@ struct XMLExporterTests {
         #expect(FileManager.default.fileExists(atPath: outURL.path))
     }
 
-    @Test func videoTracksAreReversedForFCPConvention() throws {
+    @Test func videoTracksAreReversedForFCPConvention() async throws {
         // Our model stores video tracks top→bottom; FCP XML wants bottom→top. So the LAST
         // video track in our model should appear FIRST in the XML.
         let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -553,7 +553,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         let bottomRange = xml.range(of: "bottom-clip")
@@ -583,18 +583,18 @@ struct XMLExporterTests {
         return (MediaResolver(manifest: { manifest }, projectURL: { nil }), file)
     }
 
-    private func export(_ clip: Clip, resolver: MediaResolver) -> String {
+    private func export(_ clip: Clip, resolver: MediaResolver) async -> String {
         let track = clip.mediaType == .audio
             ? Fixtures.audioTrack(clips: [clip])
             : Fixtures.videoTrack(clips: [clip])
         let timeline = Fixtures.timeline(tracks: [track])
         let out = FileManager.default.temporaryDirectory
             .appendingPathComponent("export-\(UUID().uuidString).xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: out)
+        await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: out)
         return (try? String(contentsOf: out, encoding: .utf8)) ?? ""
     }
 
-    @Test func positionKeyframesEmitVaryingCenter() throws {
+    @Test func positionKeyframesEmitVaryingCenter() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
@@ -604,7 +604,7 @@ struct XMLExporterTests {
             Keyframe(frame: 0, value: AnimPair(a: 0.0, b: 0.0)),
             Keyframe(frame: 100, value: AnimPair(a: 0.5, b: 0.5)),
         ])
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<parameterid>center</parameterid>"))
         // Center is normalized (0 = frame center), not pixels, positive toward bottom-right.
@@ -613,7 +613,7 @@ struct XMLExporterTests {
         #expect(xml.contains("<vert>0.50000</vert>"))
     }
 
-    @Test func opacityKeyframesEmittedWithClipRelativeWhen() throws {
+    @Test func opacityKeyframesEmittedWithClipRelativeWhen() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
@@ -623,7 +623,7 @@ struct XMLExporterTests {
             Keyframe(frame: 30, value: 1.0),
             Keyframe(frame: 150, value: 0.5),
         ])
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         // Own Opacity effect, not folded into Basic Motion.
         #expect(xml.contains("<effectid>opacity</effectid>"))
@@ -634,7 +634,7 @@ struct XMLExporterTests {
         #expect(xml.contains("<value>50.0</value>"))
     }
 
-    @Test func volumeKeyframesEmittedOnAudioClip() throws {
+    @Test func volumeKeyframesEmittedOnAudioClip() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
@@ -643,7 +643,7 @@ struct XMLExporterTests {
             Keyframe(frame: 0, value: 0),    // 0 dB → linear 1
             Keyframe(frame: 50, value: -6),  // attenuated
         ])
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<effectid>audiolevels</effectid>"))
         #expect(xml.contains("<when>0</when>"))
@@ -652,14 +652,14 @@ struct XMLExporterTests {
         #expect(xml.contains("<keyframe>"))
     }
 
-    @Test func fadesEmitSingleSidedCrossDissolveTransitions() throws {
+    @Test func fadesEmitSingleSidedCrossDissolveTransitions() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         var clip = Fixtures.clip(start: 100, duration: 200)
         clip.fadeInFrames = 30
         clip.fadeOutFrames = 20
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<effectid>Cross Dissolve</effectid>"))
         // Fade-in: start-black spanning [start, start+fadeIn).
@@ -676,14 +676,14 @@ struct XMLExporterTests {
         #expect(tIdx.lowerBound < cIdx.lowerBound)
     }
 
-    @Test func audioClipFadesEmitCrossFadeTransitions() throws {
+    @Test func audioClipFadesEmitCrossFadeTransitions() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         var clip = Fixtures.clip(mediaType: .audio, start: 0, duration: 100)
         clip.fadeInFrames = 10
         clip.fadeOutFrames = 15
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         // Audio uses Cross Fade, not the video Cross Dissolve, and carries no wipe tags.
         #expect(xml.contains("<effectid>KGAudioTransCrossFade0dB</effectid>"))
@@ -697,23 +697,23 @@ struct XMLExporterTests {
         #expect(xml.contains("<end>100</end>"))
     }
 
-    @Test func noFadeEmitsNoTransition() throws {
+    @Test func noFadeEmitsNoTransition() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         let clip = Fixtures.clip(start: 0, duration: 100)
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(!xml.contains("<transitionitem>"))
     }
 
-    @Test func staticCropEmitsCropFilterAsPercentages() throws {
+    @Test func staticCropEmitsCropFilterAsPercentages() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         var clip = Fixtures.clip(start: 0, duration: 100)
         clip.crop = Crop(left: 0.1, top: 0.25, right: 0.2, bottom: 0.05)
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<effectid>crop</effectid>"))
         #expect(xml.contains("<parameterid>left</parameterid>"))
@@ -723,7 +723,7 @@ struct XMLExporterTests {
         #expect(!xml.contains("<keyframe>"))
     }
 
-    @Test func cropKeyframesEmitClipRelativeWhen() throws {
+    @Test func cropKeyframesEmitClipRelativeWhen() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
@@ -732,7 +732,7 @@ struct XMLExporterTests {
             Keyframe(frame: 0, value: Crop()),
             Keyframe(frame: 60, value: Crop(left: 0.5, top: 0, right: 0, bottom: 0)),
         ])
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<effectid>crop</effectid>"))
         #expect(xml.contains("<when>0</when>"))
@@ -740,41 +740,41 @@ struct XMLExporterTests {
         #expect(xml.contains("<value>50.00</value>"))
     }
 
-    @Test func identityCropEmitsNoFilter() throws {
+    @Test func identityCropEmitsNoFilter() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         let clip = Fixtures.clip(start: 0, duration: 100)
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(!xml.contains("<effectid>crop</effectid>"))
     }
 
-    @Test func ntscSourceMarksFileRateTrue() throws {
+    @Test func ntscSourceMarksFileRateTrue() async throws {
         // 29.97 footage → the <file> rate carries ntsc TRUE, while the sequence stays FALSE.
         let (resolver, file) = try fixture(sourceFPS: 30000.0 / 1001.0)
         defer { try? FileManager.default.removeItem(at: file) }
 
-        let xml = export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
+        let xml = await export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
         #expect(xml.contains("<ntsc>TRUE</ntsc>"))   // the source file
         #expect(xml.contains("<ntsc>FALSE</ntsc>"))  // the sequence
     }
 
-    @Test func cleanFpsSourceStaysNtscFalse() throws {
+    @Test func cleanFpsSourceStaysNtscFalse() async throws {
         let (resolver, file) = try fixture(sourceFPS: 30.0)
         defer { try? FileManager.default.removeItem(at: file) }
 
-        let xml = export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
+        let xml = await export(Fixtures.clip(start: 0, duration: 100), resolver: resolver)
         #expect(!xml.contains("<ntsc>TRUE</ntsc>"))
     }
 
-    @Test func noKeyframesStillEmitsStaticValueOnly() throws {
+    @Test func noKeyframesStillEmitsStaticValueOnly() async throws {
         let (resolver, file) = try fixture()
         defer { try? FileManager.default.removeItem(at: file) }
 
         var clip = Fixtures.clip(start: 0, duration: 100)
         clip.opacity = 0.5
-        let xml = export(clip, resolver: resolver)
+        let xml = await export(clip, resolver: resolver)
 
         #expect(xml.contains("<effectid>opacity</effectid>"))
         #expect(!xml.contains("<keyframe>"))


### PR DESCRIPTION
## What

This PR modernizes legacy AVFoundation API usages across `ExportView`, `VideoProject`, and `XMLExporter` by migrating deprecated synchronous and callback-based methods to their modern, Swift concurrency-friendly counterparts (`loadTracks(withMediaType:)` and `image(at:)`).

## Why

- legacy APIs such as `AVURLAsset.tracks(withMediaType:)` and `AVAssetImageGenerator.generateCGImagesAsynchronously(forTimes:completionHandler:)` are deprecated starting in macOS 15.0.
- Synchronous calls to load tracks block the thread and cause UI stutters or hangs during document save and preview load.
- Moving to modern async APIs ensures compatibility with the Swift 6 compiler's strict concurrency checks.

## How

- **Asynchronous Preview Generation**: Converted `ExportView.loadPreview()` to be `async`, calling it using `await` inside SwiftUI's `.task` modifier, and replaced the callback-based image generator with the `image(at:)` async method.
- **Asynchronous XML Export caching**: Refactored `XMLExporter.export()` to be `async` so that it can resolve and read start timecodes from media resources concurrently using `loadTracks(withMediaType:)` before constructing the XML. The XML `Builder` remains synchronous and pure, using the pre-cached results. Updated `ExportService` to await the export.
- **Synchronous Save Safety**: Refactored `VideoProject.captureThumbnail()`. Since `NSDocument` save callbacks run synchronously, the async AVFoundation logic is executed inside a local `Task` and synchronized via a `DispatchSemaphore` with a 5-second timeout. Both `AVURLAsset` and `AVAssetImageGenerator` are instantiated and used inside the task context to prevent data races and Sendable boundary violations.

## Changes

- **`Sources/PalmierPro/Export/ExportView.swift`**: Made `loadPreview()` async, using `loadTracks(withMediaType:)` and `image(at:)`.
- **`Sources/PalmierPro/Export/XMLExporter.swift`**: Made `export()` async, pre-caching timecodes asynchronously using the modern `loadTracks(withMediaType:)` helper, and simplified `sourceStartFrame(for:)` to read directly from the cache.
- **`Sources/PalmierPro/Export/ExportService.swift`**: Updated the XML export call site to await the async export.
- **`Sources/PalmierPro/Project/VideoProject.swift`**: Replaced legacy API calls in `captureThumbnail()` with modern equivalents inside a semaphore-synchronized `Task` to satisfy NSDocument save requirements safely.

## Testing

- [ ] Unit tests added/updated for new behavior
- [x] Integration tests pass
- [x] Manual testing steps performed:
  1. Build the project using `swift build` and verify that compilation is successful and no deprecation warnings are emitted for these components.
  2. Perform a sample video project save (triggering thumbnail generation) and ensure it succeeds without stalling.
  3. Export a project to XML format and verify the timecode frames are correctly computed and structured in the output file.

## Screenshots / Recordings

*(No UI changes, strictly an API modernization and performance cleanup)*

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the diff line-by-line
- [x] No console.log / print debugging left in
- [x] Documentation updated if public API changed
- [x] No breaking changes (or migration guide provided)
- [x] Backward compatible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches save-time thumbnail capture (semaphore + Task timeout) and XML timecode pre-read; behavior should match prior logic but save/export edge cases deserve manual verification.
> 
> **Overview**
> Replaces **deprecated macOS 15 AVFoundation APIs** (`tracks(withMediaType:)`, `generateCGImagesAsynchronously`) with **`loadTracks(withMediaType:)`** and **`image(at:)`** across export preview, XML export, and project save thumbnails.
> 
> **Export dialog preview** (`ExportView`): `loadPreview()` is now `async` and runs from `.task` with `await`; preview frames use the async image generator instead of a callback that hops to the main actor.
> 
> **XML export** (`XMLExporter` / `ExportService`): `export` is `async`. Source **timecode start frames** are read once per unique `mediaRef` up front (async `tmcd` track read), then the synchronous `Builder` only looks up the cache—no lazy per-file reads during XML emission.
> 
> **Save thumbnails** (`VideoProject.captureThumbnail`): Because `NSDocument` snapshot capture is synchronous, async AV work runs in a **`Task`** bridged with a **5s semaphore**; timeout **cancels** the task (replacing `cancelAllCGImageGeneration`). Asset and generator are created inside the task for concurrency safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c655364cdf315f0a697c95e47d7c00469ddd6642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->