### PR TITLE
Add experimental Intel editor-only build support

### DIFF
--- a/.github/workflows/intel-editor-only-build.yml
+++ b/.github/workflows/intel-editor-only-build.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 45
     env:
       PALMIER_EDITOR_ONLY: "1"
+      SWIFTPM_FLAGS: "--disable-dependency-cache --scratch-path .build/editor-only --manifest-cache local"
 
     steps:
       - name: Check out repository
@@ -36,17 +37,23 @@ jobs:
           echo "Available Xcode apps:"
           find /Applications -maxdepth 1 -type d -iname "Xcode*.app" -print | sort
 
+      - name: Prepare editor-only SwiftPM workspace
+        run: |
+          set -euxo pipefail
+          rm -f Package.resolved
+          rm -rf .build/editor-only
+
       - name: Resolve packages
         run: |
           set -euxo pipefail
-          PALMIER_EDITOR_ONLY=1 swift package resolve
+          PALMIER_EDITOR_ONLY=1 swift package $SWIFTPM_FLAGS resolve
 
       - name: Build Intel editor-only target
         run: |
           set -euxo pipefail
-          PALMIER_EDITOR_ONLY=1 swift build --arch x86_64
+          PALMIER_EDITOR_ONLY=1 swift build $SWIFTPM_FLAGS --arch x86_64
 
       - name: Test Intel editor-only target
         run: |
           set -euxo pipefail
-          PALMIER_EDITOR_ONLY=1 swift test --arch x86_64
+          PALMIER_EDITOR_ONLY=1 swift test $SWIFTPM_FLAGS --arch x86_64

--- a/.github/workflows/intel-editor-only-build.yml
+++ b/.github/workflows/intel-editor-only-build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - intel-mac-support-experiment
+    paths-ignore:
+      - "**/*.md"
 
 concurrency:
   group: intel-editor-only-${{ github.ref }}
@@ -74,6 +76,21 @@ jobs:
             echo "::endgroup::"
           fi
           exit "$status"
+
+      - name: Assemble Intel editor-only app artifact
+        run: |
+          set -euxo pipefail
+          PALMIER_EDITOR_ONLY=1 SIGNING_IDENTITY=- SWIFT_BUILD_ARGS="--arch x86_64" ./scripts/bundle.sh debug --fast
+          file .build/PalmierPro.app/Contents/MacOS/PalmierPro
+          lipo -info .build/PalmierPro.app/Contents/MacOS/PalmierPro
+          /usr/bin/ditto -c -k --keepParent .build/PalmierPro.app .build/PalmierPro-intel-editor-only.app.zip
+
+      - name: Upload Intel editor-only app
+        uses: actions/upload-artifact@v4
+        with:
+          name: palmier-pro-intel-editor-only-app
+          path: .build/PalmierPro-intel-editor-only.app.zip
+          if-no-files-found: error
 
       - name: Upload SwiftPM logs
         if: always()

--- a/.github/workflows/intel-editor-only-build.yml
+++ b/.github/workflows/intel-editor-only-build.yml
@@ -42,6 +42,7 @@ jobs:
           set -euxo pipefail
           rm -f Package.resolved
           rm -rf .build/editor-only
+          mkdir -p .build/ci-logs
 
       - name: Resolve packages
         run: |
@@ -50,10 +51,34 @@ jobs:
 
       - name: Build Intel editor-only target
         run: |
-          set -euxo pipefail
-          PALMIER_EDITOR_ONLY=1 swift build $SWIFTPM_FLAGS --arch x86_64
+          set -uo pipefail
+          log=".build/ci-logs/swift-build-x86_64.log"
+          PALMIER_EDITOR_ONLY=1 swift build $SWIFTPM_FLAGS --arch x86_64 2>&1 | tee "$log"
+          status="${PIPESTATUS[0]}"
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Swift build error summary"
+            grep -nE "error:|fatal error:" "$log" || true
+            echo "::endgroup::"
+          fi
+          exit "$status"
 
       - name: Test Intel editor-only target
         run: |
-          set -euxo pipefail
-          PALMIER_EDITOR_ONLY=1 swift test $SWIFTPM_FLAGS --arch x86_64
+          set -uo pipefail
+          log=".build/ci-logs/swift-test-x86_64.log"
+          PALMIER_EDITOR_ONLY=1 swift test $SWIFTPM_FLAGS --arch x86_64 2>&1 | tee "$log"
+          status="${PIPESTATUS[0]}"
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Swift test error summary"
+            grep -nE "error:|fatal error:|failed:" "$log" || true
+            echo "::endgroup::"
+          fi
+          exit "$status"
+
+      - name: Upload SwiftPM logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: intel-editor-only-swiftpm-logs
+          path: .build/ci-logs
+          if-no-files-found: ignore

--- a/.github/workflows/intel-editor-only-build.yml
+++ b/.github/workflows/intel-editor-only-build.yml
@@ -1,0 +1,52 @@
+name: Intel Editor-Only Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - intel-mac-support-experiment
+
+concurrency:
+  group: intel-editor-only-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  intel-editor-only:
+    name: Intel editor-only SwiftPM build
+    # GitHub-hosted x64 macOS 26 runner with Xcode 26 / Swift 6.2 tooling.
+    runs-on: macos-26-intel
+    timeout-minutes: 45
+    env:
+      PALMIER_EDITOR_ONLY: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show runner and toolchain
+        run: |
+          set -euxo pipefail
+          sw_vers
+          uname -m
+          xcode-select -p
+          xcodebuild -version
+          xcrun --show-sdk-version --sdk macosx
+          xcrun --find swift
+          swift --version
+          echo "Available Xcode apps:"
+          find /Applications -maxdepth 1 -type d -iname "Xcode*.app" -print | sort
+
+      - name: Resolve packages
+        run: |
+          set -euxo pipefail
+          PALMIER_EDITOR_ONLY=1 swift package resolve
+
+      - name: Build Intel editor-only target
+        run: |
+          set -euxo pipefail
+          PALMIER_EDITOR_ONLY=1 swift build --arch x86_64
+
+      - name: Test Intel editor-only target
+        run: |
+          set -euxo pipefail
+          PALMIER_EDITOR_ONLY=1 swift test --arch x86_64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PalmierPro
 
-AI-native macOS video editor. Swift 6.2, SwiftUI + AppKit, AVFoundation. macOS 26 only, arm64 only. Non-sandboxed Developer ID app.
+AI-native macOS video editor. Swift 6.2, SwiftUI + AppKit, AVFoundation. Default app is macOS 26 only, arm64 only. The experimental `PALMIER_EDITOR_ONLY=1` build targets Intel/macOS 15+ with backend and generative features disabled. Non-sandboxed Developer ID app.
 
 ## Build
 
@@ -41,4 +41,3 @@ Rule: **any drop target that spans an area containing other drop targets must us
 Palmier Pro speaks like a quietly capable native Mac app for filmmakers: direct, technical, calm, and 
 confident. Prefer Apple HIG-style terseness over warmth. Never chatty or cute. Never marketing. When the
 product needs to ask for action, lead with the action verb; when it reports state, name the thing.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,16 @@ swift build
 swift run
 ```
 
+### Experimental Intel editor-only build
+
+The reduced Intel build is opt-in and excludes Clerk/Convex backend features:
+
+```bash
+PALMIER_EDITOR_ONLY=1 swift build --arch x86_64
+```
+
+It still requires Swift 6.2 and a macOS 26 SDK because compatibility wrappers must reference macOS 26 SwiftUI APIs before guarding them at runtime.
+
 For a bundled debug build that launches the `.app` and streams OSLog:
 
 ```bash

--- a/INTEL_EDITOR_ONLY_STATUS.md
+++ b/INTEL_EDITOR_ONLY_STATUS.md
@@ -2,8 +2,8 @@
 
 This branch contains an experimental Intel Mac editor-only build mode for Palmier Pro.
 It is not official Palmier support. The GitHub Actions build has produced an
-Intel app artifact, and that artifact has been smoke-tested on an Intel iMac,
-but the branch is still a reduced editor-only experiment.
+Intel app artifact, and that artifact has been runtime-tested on an Intel iMac
+running macOS 15.7.7, but the branch is still a reduced editor-only experiment.
 
 The normal Palmier Pro build path is unchanged when `PALMIER_EDITOR_ONLY` is not
 set: it remains the full macOS 26 Apple Silicon build with the normal backend and
@@ -63,12 +63,12 @@ show a disabled state instead of silently disappearing.
 
 | Area | Intel editor-only status | Notes |
 | --- | --- | --- |
-| Launch | Working in smoke test | The app launched on an Intel iMac running macOS 15.7.7. |
-| Media import | Working in smoke test | A screen recording imported into the timeline. More formats still need runtime testing. |
-| Timeline editing | Expected to work | Core timeline build and tests pass. Trim, split, move, snapping, text, and multi-track editing still need manual runtime testing. |
-| Preview/playback | Expected to work | Uses local AVFoundation/editor code paths. Needs runtime playback testing with video, audio, and text layers. |
-| Export dialog | Working in smoke test | The export dialog opens. Actual export, output playback, and error handling still need runtime testing. |
-| Project save/reopen | Expected to work | Project document IO tests pass. Manual save/reopen testing is still required. |
+| Launch | Working in runtime test | The app launched on an Intel iMac running macOS 15.7.7. |
+| Media import | Working in runtime test | A screen recording imported into the timeline. More formats still need broader testing. |
+| Timeline editing | Working in runtime test | Basic edit, playback, and audio worked. Broader edit coverage still needs maintainer QA. |
+| Preview/playback | Working in runtime test | Timeline playback and audio worked on Intel macOS 15.7.7. |
+| Export | Working in runtime test | Export completed and the exported file opened in QuickTime Player. |
+| Project save/reopen | Working in runtime test | Save/reopen worked on Intel macOS 15.7.7. |
 | Local project export | Expected to work | Palmier project export tests pass. Needs runtime verification with real imported media. |
 | Visual search/indexing | Partially available | Local search/indexing code and tests build for x86_64. Core ML model download/load and real Intel performance are unverified. |
 | Spoken search | Partially available | Searching existing transcript data can work, but editor-only builds cannot currently generate transcripts from media. |
@@ -96,7 +96,7 @@ with clear disabled states:
 - Media panel > Music
 - Media panel > Captions > Generate Captions
 - Inspector > AI tab for visual assets and clips
-- App menu > Check for Updates
+- App menu > Check for Updates Unavailable
 
 Disabled feature paths should include the shared message:
 

--- a/INTEL_EDITOR_ONLY_STATUS.md
+++ b/INTEL_EDITOR_ONLY_STATUS.md
@@ -40,6 +40,25 @@ For editor-only app bundles, `scripts/bundle.sh` also lowers
 `LSMinimumSystemVersion` to `15.0` and disables Sparkle's automatic checks
 against the official Palmier update feed.
 
+## Capability Source Of Truth
+
+Runtime feature visibility is centralized in:
+
+```text
+Sources/PalmierPro/Utilities/FeatureGate.swift
+```
+
+`FeatureGate` answers:
+
+- whether this is the official full build or experimental Intel editor-only build
+- whether the current binary is Apple Silicon or Intel
+- whether macOS 26 APIs are available at runtime
+- whether Palmier backend/auth is available
+- whether transcription, hosted AI generation, cloud sync, model catalog, feedback, and official update checks are available
+
+UI entry points should stay visible where practical and use `FeatureGate` to
+show a disabled state instead of silently disappearing.
+
 ## Feature Status
 
 | Area | Intel editor-only status | Notes |
@@ -65,6 +84,26 @@ against the official Palmier update feed.
 | Cloud/backend sync | Disabled | No Convex backend connection is available in editor-only mode. Local project files remain the intended persistence path. |
 | Sparkle updates | Disabled for editor-only artifacts | Official Sparkle metadata stays in the source plist, but the editor-only bundle removes the official feed and disables automatic checks. |
 
+## Visible Disabled States
+
+The experimental Intel editor-only build keeps the following entry points visible
+with clear disabled states:
+
+- Settings > Account
+- Settings > Models
+- Help > Send Feedback
+- Media panel > Generate
+- Media panel > Music
+- Media panel > Captions > Generate Captions
+- Inspector > AI tab for visual assets and clips
+- App menu > Check for Updates
+
+Disabled feature paths should include the shared message:
+
+```text
+This feature is unavailable in the experimental Intel editor-only build.
+```
+
 ## Disabled Features
 
 The following features are disabled or stubbed only when `PALMIER_EDITOR_ONLY=1`:
@@ -77,7 +116,7 @@ The following features are disabled or stubbed only when `PALMIER_EDITOR_ONLY=1`
 - Backend-dependent feedback submission.
 - Sparkle automatic update checks against the official Palmier feed in editor-only artifacts.
 
-Disabled feature paths should report:
+Disabled feature paths should report or include:
 
 ```text
 This feature is unavailable in the experimental Intel editor-only build.
@@ -94,7 +133,12 @@ The current official transcription path uses `SpeechTranscriber`,
 Those APIs are not safe to compile into the macOS 15 Intel editor-only build.
 
 A macOS 15-compatible fallback appears realistic, but it should be implemented
-as a separate focused change after runtime testing. A possible design is:
+as a separate focused change after runtime testing. Apple documents
+`SFSpeechRecognizer` as the older recognizer object, `SFSpeechURLRecognitionRequest`
+as the path for recognition from an audio file, and `SpeechTranscriber` /
+`SpeechAnalyzer` as the newer macOS 26 path.
+
+A possible internal provider shape is:
 
 - Keep using AVFoundation to extract an imported video's audio track to a
   temporary audio file.
@@ -115,6 +159,79 @@ the macOS 26 transcription stack. In particular, product review is needed before
 allowing server-backed recognition as a fallback, and the Intel app needs real
 runtime validation of permission prompts, long media files, locale handling, and
 caption timing quality.
+
+### Speech Provider Options
+
+| Provider path | Pros | Cons / risks | Status for this branch |
+| --- | --- | --- | --- |
+| Apple `SpeechTranscriber` / `SpeechAnalyzer` | Modern first-party path, designed for the current Palmier implementation. | Requires macOS 26 APIs and Swift 6.2/macOS 26 SDK. | Official build path only. |
+| Apple `SFSpeechRecognizer` + `SFSpeechURLRecognitionRequest` | First-party macOS 15-compatible fallback for prerecorded audio files; can reuse Palmier's AVFoundation audio extraction. | Different permission flow, locale availability, server-vs-on-device behavior, timing quality, and long-file behavior. Needs Intel runtime testing. | Recommended next transcription spike. |
+| OpenAI transcription API | High-quality hosted transcription; official API supports file transcription. | Sends user media to a third party, requires explicit consent and user or Palmier API configuration, may have cost/file-size constraints. | Future optional provider only; do not make mandatory. |
+| Deepgram prerecorded audio API | Mature hosted STT path with prerecorded audio support. | Requires API key, network upload, consent, cost, and vendor configuration. | Future optional provider only; do not make mandatory. |
+| Local Whisper / whisper.cpp | Can run offline and preserve media privacy; plausible on macOS 15 Intel. | Adds binary/model distribution complexity, model downloads, CPU/GPU performance risk on Intel, and packaging/review work. | Future local provider spike. |
+
+External providers must be opt-in, must not hardcode API keys, and must not send
+user media off-device without explicit consent.
+
+Useful references:
+
+- Apple Speech framework: https://developer.apple.com/documentation/speech/
+- Apple `SFSpeechRecognizer`: https://developer.apple.com/documentation/speech/sfspeechrecognizer
+- Apple `SFSpeechURLRecognitionRequest`: https://developer.apple.com/documentation/speech/sfspeechurlrecognitionrequest
+- Apple `SpeechTranscriber`: https://developer.apple.com/documentation/speech/speechtranscriber
+- OpenAI speech-to-text: https://developers.openai.com/api/docs/guides/speech-to-text
+- Deepgram prerecorded audio: https://developers.deepgram.com/docs/pre-recorded-audio
+- whisper.cpp: https://github.com/ggml-org/whisper.cpp
+
+## Two-Download Strategy
+
+Recommended release shape for maintainers:
+
+1. Official Apple Silicon / macOS 26 Palmier Pro build
+   - Keep the current full backend/auth/generation feature set.
+   - Keep the official Sparkle feed and existing signing/notarization process.
+   - Publish using the normal Palmier release channel.
+
+2. Experimental Intel editor-only build
+   - Publish separately and label clearly as experimental.
+   - Keep artifact name `palmier-pro-intel-editor-only-app`.
+   - Do not connect this artifact to the official Apple Silicon Sparkle feed.
+   - Keep hosted backend, account, generation, and advanced transcription
+     unavailable until maintainers validate Intel-compatible backend and
+     transcription paths.
+
+Maintainers can later choose a universal release, but separate downloads are
+safer while the Intel build is editor-only and differently supported.
+
+## Maintainer Path To Restore Full Intel Features
+
+- Account/login: restore Clerk support only after `clerk-ios` and related auth
+  flows compile and run on x86_64/macOS 15, including keychain access groups and
+  OAuth callback testing.
+- Convex/ConvexMobile: either validate `ConvexMobile` on x86_64/macOS 15 or
+  introduce an Intel-compatible backend client abstraction for subscriptions,
+  mutations, storage tickets, and account sync.
+- Cloud sync: re-enable only after auth and Convex/backend state are stable on
+  Intel, then test local/offline project file behavior alongside remote sync.
+- Hosted AI generation: re-enable only after account auth, upload tickets,
+  model catalog sync, generation job subscriptions, billing, credits, and
+  download/rerun/upscale paths work on Intel.
+- Billing/credits: re-enable after account state, plan catalog, subscription
+  management links, top-offs, and credit accounting are validated.
+- Model catalog: re-enable after backend model subscription works on Intel, or
+  after maintainers provide a signed/static catalog suitable for editor-only
+  review builds.
+- Transcription: add a `TranscriptionProvider` abstraction, keep the macOS 26
+  `SpeechTranscriber` provider for the official build, and add a tested legacy
+  Apple Speech or optional external/local provider for macOS 15.
+- Official update checks: use a separate signed Intel appcast/feed or a universal
+  release feed that only offers compatible updates to compatible machines.
+- Release packaging: keep separate Intel and Apple Silicon artifacts until the
+  support matrix, updater feed, signing, notarization, and QA plan are unified.
+- Before declaring official Intel support, run GitHub Actions, launch testing,
+  import/edit/playback, save/reopen, export/open-in-QuickTime, disabled-feature
+  checks, transcription tests if restored, backend account tests if restored, and
+  crash/Console log review on real Intel macOS 15 hardware.
 
 ## Known Risks
 

--- a/INTEL_EDITOR_ONLY_STATUS.md
+++ b/INTEL_EDITOR_ONLY_STATUS.md
@@ -1,0 +1,118 @@
+# Intel Editor-Only Status
+
+This branch contains an experimental Intel Mac editor-only build mode for Palmier Pro.
+It is not official Palmier support, and it has not been proven to launch on Intel
+hardware until the GitHub Actions build passes and the resulting app is tested.
+
+The normal Palmier Pro build path is unchanged when `PALMIER_EDITOR_ONLY` is not
+set: it remains the full macOS 26 Apple Silicon build with the normal backend and
+AI features.
+
+## Build Mode
+
+Enable the experimental mode with:
+
+```bash
+PALMIER_EDITOR_ONLY=1
+```
+
+In this mode, `Package.swift` lowers the package platform target to macOS 15.0,
+defines `PALMIER_EDITOR_ONLY`, and removes Clerk/Convex backend package products
+from the SwiftPM dependency graph.
+
+Local SwiftPM build command:
+
+```bash
+PALMIER_EDITOR_ONLY=1 swift build --arch x86_64
+```
+
+Local debug app bundle command:
+
+```bash
+PALMIER_EDITOR_ONLY=1 SIGNING_IDENTITY=- SWIFT_BUILD_ARGS="--arch x86_64" ./scripts/bundle.sh debug --fast
+```
+
+This creates `.build/PalmierPro.app` using ad-hoc signing. It does not notarize
+the app, install it globally, use Apple IDs, or use signing certificates.
+
+## Disabled Features
+
+The following features are disabled or stubbed only when `PALMIER_EDITOR_ONLY=1`:
+
+- Palmier account login, Clerk sessions, subscriptions, billing, credits, and plan management.
+- Convex/ConvexMobile backend subscriptions, mutations, storage tickets, and hosted model catalog sync.
+- Generative AI submission, rerun, upscale, download, and hosted generation job updates.
+- Hosted Palmier agent streaming that depends on Clerk/Convex authentication.
+- On-device Speech framework transcription and automatic caption generation from audio.
+- Backend-dependent feedback submission.
+
+Disabled feature paths should report:
+
+```text
+This feature is unavailable in the experimental Intel editor-only build.
+```
+
+The intended first working surface is the local editor core: project open/save,
+timeline editing, media import, preview/export, local resources, and local MCP or
+BYOK paths that do not require Palmier's hosted backend.
+
+## Known Risks
+
+- The branch requires a Swift 6.2-capable toolchain and macOS 26 SDK to compile
+  guarded macOS 26 SwiftUI APIs, even though the editor-only package target is
+  macOS 15.0.
+- The GitHub Actions runner can prove compilation and artifact assembly, but it
+  does not prove launch behavior on a 2019 Intel iMac running macOS 15.7.7.
+- The uploaded app artifact is ad-hoc signed and not notarized.
+- More macOS 26-only API calls may still exist and only surface after the next
+  compiler pass.
+- Dependencies such as Sparkle, Lottie, Sentry, MCP, and swift-transformers still
+  need the runner to confirm x86_64 compatibility in this package shape.
+- Runtime behavior around Core ML model downloads, local visual search, export,
+  and media frameworks still needs real Intel hardware testing.
+
+## GitHub Actions
+
+Workflow:
+
+```text
+.github/workflows/intel-editor-only-build.yml
+```
+
+It can be run from GitHub:
+
+1. Open the fork on GitHub.
+2. Go to Actions.
+3. Select "Intel Editor-Only Build".
+4. Select "Run workflow".
+5. Choose branch `intel-mac-support-experiment`.
+
+The workflow also runs on pushes to `intel-mac-support-experiment`, except for
+Markdown-only changes.
+
+The workflow runs:
+
+```bash
+PALMIER_EDITOR_ONLY=1 swift package --disable-dependency-cache --scratch-path .build/editor-only --manifest-cache local resolve
+PALMIER_EDITOR_ONLY=1 swift build --disable-dependency-cache --scratch-path .build/editor-only --manifest-cache local --arch x86_64
+PALMIER_EDITOR_ONLY=1 swift test --disable-dependency-cache --scratch-path .build/editor-only --manifest-cache local --arch x86_64
+```
+
+If the build or tests fail, the workflow uploads:
+
+```text
+intel-editor-only-swiftpm-logs
+```
+
+If the build and tests pass, the workflow assembles and uploads:
+
+```text
+palmier-pro-intel-editor-only-app
+```
+
+That artifact should contain:
+
+```text
+PalmierPro-intel-editor-only.app.zip
+```
+

--- a/INTEL_EDITOR_ONLY_STATUS.md
+++ b/INTEL_EDITOR_ONLY_STATUS.md
@@ -1,8 +1,9 @@
 # Intel Editor-Only Status
 
 This branch contains an experimental Intel Mac editor-only build mode for Palmier Pro.
-It is not official Palmier support, and it has not been proven to launch on Intel
-hardware until the GitHub Actions build passes and the resulting app is tested.
+It is not official Palmier support. The GitHub Actions build has produced an
+Intel app artifact, and that artifact has been smoke-tested on an Intel iMac,
+but the branch is still a reduced editor-only experiment.
 
 The normal Palmier Pro build path is unchanged when `PALMIER_EDITOR_ONLY` is not
 set: it remains the full macOS 26 Apple Silicon build with the normal backend and
@@ -35,6 +36,35 @@ PALMIER_EDITOR_ONLY=1 SIGNING_IDENTITY=- SWIFT_BUILD_ARGS="--arch x86_64" ./scri
 This creates `.build/PalmierPro.app` using ad-hoc signing. It does not notarize
 the app, install it globally, use Apple IDs, or use signing certificates.
 
+For editor-only app bundles, `scripts/bundle.sh` also lowers
+`LSMinimumSystemVersion` to `15.0` and disables Sparkle's automatic checks
+against the official Palmier update feed.
+
+## Feature Status
+
+| Area | Intel editor-only status | Notes |
+| --- | --- | --- |
+| Launch | Working in smoke test | The app launched on an Intel iMac running macOS 15.7.7. |
+| Media import | Working in smoke test | A screen recording imported into the timeline. More formats still need runtime testing. |
+| Timeline editing | Expected to work | Core timeline build and tests pass. Trim, split, move, snapping, text, and multi-track editing still need manual runtime testing. |
+| Preview/playback | Expected to work | Uses local AVFoundation/editor code paths. Needs runtime playback testing with video, audio, and text layers. |
+| Export dialog | Working in smoke test | The export dialog opens. Actual export, output playback, and error handling still need runtime testing. |
+| Project save/reopen | Expected to work | Project document IO tests pass. Manual save/reopen testing is still required. |
+| Local project export | Expected to work | Palmier project export tests pass. Needs runtime verification with real imported media. |
+| Visual search/indexing | Partially available | Local search/indexing code and tests build for x86_64. Core ML model download/load and real Intel performance are unverified. |
+| Spoken search | Partially available | Searching existing transcript data can work, but editor-only builds cannot currently generate transcripts from media. |
+| Manual text/captions | Expected to work | Text/caption clip infrastructure remains in the editor. |
+| Automatic captions | Disabled | Depends on the disabled transcription path. |
+| Transcription | Disabled | The official implementation uses macOS 26-only `SpeechTranscriber` and `SpeechAnalyzer`. |
+| AI image/video/audio generation | Disabled | Depends on Palmier hosted backend, Clerk auth, Convex subscriptions, upload tickets, credits, and hosted model catalog. |
+| Upscale/rerun/download hosted generation | Disabled | Depends on the same hosted generation backend. |
+| Hosted model catalog | Disabled | Editor-only mode removes `ConvexMobile` and returns an empty loaded catalog. |
+| Account/login/billing/credits | Disabled | Editor-only mode removes Clerk/Convex packages from the SwiftPM graph. |
+| Palmier hosted agent streaming | Disabled | Hosted Palmier agent calls require backend auth. BYOK/local tool paths may still be usable but need runtime testing. |
+| Feedback submission | Disabled | Depends on backend submission. |
+| Cloud/backend sync | Disabled | No Convex backend connection is available in editor-only mode. Local project files remain the intended persistence path. |
+| Sparkle updates | Disabled for editor-only artifacts | Official Sparkle metadata stays in the source plist, but the editor-only bundle removes the official feed and disables automatic checks. |
+
 ## Disabled Features
 
 The following features are disabled or stubbed only when `PALMIER_EDITOR_ONLY=1`:
@@ -45,6 +75,7 @@ The following features are disabled or stubbed only when `PALMIER_EDITOR_ONLY=1`
 - Hosted Palmier agent streaming that depends on Clerk/Convex authentication.
 - On-device Speech framework transcription and automatic caption generation from audio.
 - Backend-dependent feedback submission.
+- Sparkle automatic update checks against the official Palmier feed in editor-only artifacts.
 
 Disabled feature paths should report:
 
@@ -56,18 +87,47 @@ The intended first working surface is the local editor core: project open/save,
 timeline editing, media import, preview/export, local resources, and local MCP or
 BYOK paths that do not require Palmier's hosted backend.
 
+## Transcription Fallback Research
+
+The current official transcription path uses `SpeechTranscriber`,
+`SpeechAnalyzer`, and speech asset installation APIs that require macOS 26.
+Those APIs are not safe to compile into the macOS 15 Intel editor-only build.
+
+A macOS 15-compatible fallback appears realistic, but it should be implemented
+as a separate focused change after runtime testing. A possible design is:
+
+- Keep using AVFoundation to extract an imported video's audio track to a
+  temporary audio file.
+- Request Speech authorization with `SFSpeechRecognizer`.
+- Select a locale from `SFSpeechRecognizer.supportedLocales()`.
+- Use `SFSpeechURLRecognitionRequest` for extracted audio files.
+- Prefer on-device recognition by setting `requiresOnDeviceRecognition` only
+  when `supportsOnDeviceRecognition` is true.
+- Map `SFTranscriptionSegment` values into Palmier's existing
+  `TranscriptionWord` and `TranscriptionSegment` models.
+- Show a clear disabled/unavailable message when permission is denied, the
+  recognizer is unavailable, the locale is unsupported, or on-device recognition
+  is not available.
+
+The fallback was not implemented in this branch because the older Speech API has
+different privacy, availability, timing, language, and duration behavior from
+the macOS 26 transcription stack. In particular, product review is needed before
+allowing server-backed recognition as a fallback, and the Intel app needs real
+runtime validation of permission prompts, long media files, locale handling, and
+caption timing quality.
+
 ## Known Risks
 
 - The branch requires a Swift 6.2-capable toolchain and macOS 26 SDK to compile
   guarded macOS 26 SwiftUI APIs, even though the editor-only package target is
   macOS 15.0.
 - The GitHub Actions runner can prove compilation and artifact assembly, but it
-  does not prove launch behavior on a 2019 Intel iMac running macOS 15.7.7.
+  does not prove all runtime behavior on a 2019 Intel iMac running macOS 15.7.7.
 - The uploaded app artifact is ad-hoc signed and not notarized.
-- More macOS 26-only API calls may still exist and only surface after the next
-  compiler pass.
-- Dependencies such as Sparkle, Lottie, Sentry, MCP, and swift-transformers still
-  need the runner to confirm x86_64 compatibility in this package shape.
+- Future upstream macOS 26-only API calls may still need availability guards.
+- Dependencies such as Sparkle, Lottie, Sentry, MCP, and swift-transformers have
+  compiled in the current editor-only package shape, but their runtime behavior
+  still needs broader Intel testing.
 - Runtime behavior around Core ML model downloads, local visual search, export,
   and media frameworks still needs real Intel hardware testing.
 
@@ -115,4 +175,3 @@ That artifact should contain:
 ```text
 PalmierPro-intel-editor-only.app.zip
 ```
-

--- a/INTEL_RUNTIME_TEST_CHECKLIST.md
+++ b/INTEL_RUNTIME_TEST_CHECKLIST.md
@@ -91,6 +91,17 @@ Expected message:
 This feature is unavailable in the experimental Intel editor-only build.
 ```
 
+Specific entry points to check:
+
+- Settings > Account shows account, billing, credits, and cloud sync as unavailable.
+- Settings > Models shows the hosted model catalog as unavailable.
+- Help > Send Feedback opens a feedback-unavailable message.
+- Media panel > Generate opens an AI generation-unavailable panel.
+- Media panel > Music keeps the tab visible and disables Generate with the unavailable message.
+- Media panel > Captions disables Generate Captions with the transcription unavailable message.
+- Inspector > AI tab remains visible for visual assets/clips and disables AI actions.
+- App menu > Check for Updates is disabled for the experimental Intel artifact.
+
 ## Stability Pass
 
 - Use the app for 20 to 30 minutes with a small project.

--- a/INTEL_RUNTIME_TEST_CHECKLIST.md
+++ b/INTEL_RUNTIME_TEST_CHECKLIST.md
@@ -1,0 +1,111 @@
+# Intel Editor-Only Runtime Test Checklist
+
+This checklist is for the experimental Intel editor-only app artifact. It is not
+official Palmier Intel support.
+
+## Test Setup
+
+- Download the latest `palmier-pro-intel-editor-only-app` artifact from the
+  passing GitHub Actions run on branch `intel-mac-support-experiment`.
+- Confirm the app is running on an Intel Mac, not through Rosetta on Apple
+  Silicon.
+- Confirm the machine is running macOS 15.7.7 or the target macOS 15 version.
+- Keep the app outside `/Applications` unless intentionally testing install
+  behavior.
+- Do not bypass macOS security beyond normal user-controlled open prompts.
+
+## Smoke Tests
+
+- Launch the app.
+- Confirm the main editor window opens.
+- Confirm no account, generation, or updater error appears on launch.
+- Open About or Settings if available and check for obvious broken controls.
+- Quit and relaunch once.
+
+## Import And Timeline
+
+- Import a short screen recording with audio.
+- Import a short video without audio.
+- Import an image.
+- Import an audio-only file if supported by the UI.
+- Drag imported media into the timeline.
+- Play and pause the timeline.
+- Scrub the playhead.
+- Split a clip.
+- Trim a clip start and end.
+- Move a clip on the same track.
+- Move a clip to another track.
+- Add a text or caption clip manually.
+- Undo and redo a few edits.
+- Confirm no editor-only disabled-feature message appears during local editing.
+
+## Project Save And Reopen
+
+- Save a new `.palmier` project.
+- Close the project.
+- Reopen the saved project.
+- Confirm imported media references remain connected.
+- Confirm timeline clips, text, timing, and tracks are preserved.
+- Move the project package to another folder and reopen it if the app supports
+  that workflow.
+
+## Export
+
+- Export a short H.264 `.mp4`.
+- Open the exported video in QuickTime Player.
+- Confirm video duration, resolution, audio, and text overlays.
+- Export a short HEVC file if available.
+- Export XML if available.
+- Export a Palmier project package if available.
+- Try canceling an export and confirm the app remains usable.
+
+## Search And Indexing
+
+- Let the app finish any local visual indexing work.
+- Search for visual content in an imported video or image.
+- Confirm the search UI handles missing or downloading models gracefully.
+- Confirm spoken/audio search does not crash when no transcript exists.
+- If a project already has transcript data, test spoken search against it.
+
+## Disabled Feature Behavior
+
+These features are expected to be unavailable in the experimental Intel
+editor-only build. Each should show a clear message and should not crash:
+
+- Account login or profile management.
+- Subscription, billing, credits, or plan management.
+- Hosted AI image generation.
+- Hosted AI video generation.
+- Hosted AI audio/music generation.
+- Upscale, rerun, or hosted generation download flows.
+- Hosted model catalog loading.
+- Automatic transcription.
+- Automatic caption generation from audio.
+- Backend feedback submission.
+- Hosted Palmier agent streaming that requires Palmier auth.
+- Sparkle automatic update checks against the official Palmier feed.
+
+Expected message:
+
+```text
+This feature is unavailable in the experimental Intel editor-only build.
+```
+
+## Stability Pass
+
+- Use the app for 20 to 30 minutes with a small project.
+- Watch for beachballs, crashes, runaway CPU, or memory growth.
+- Check Console.app for repeated crashes or sandbox/security errors.
+- Confirm quitting the app does not leave export or indexing work stuck.
+
+## Results To Record
+
+- GitHub Actions run URL.
+- Artifact name and download time.
+- Mac model, CPU, RAM, and macOS version.
+- Whether launch passed.
+- Whether import/edit/playback passed.
+- Whether save/reopen passed.
+- Whether export passed.
+- Whether disabled features showed clear messages.
+- Any crash logs, Console messages, or exact UI errors.

--- a/INTEL_RUNTIME_TEST_CHECKLIST.md
+++ b/INTEL_RUNTIME_TEST_CHECKLIST.md
@@ -3,6 +3,25 @@
 This checklist is for the experimental Intel editor-only app artifact. It is not
 official Palmier Intel support.
 
+## Recorded Intel Runtime Result
+
+Runtime smoke testing passed on an Intel iMac running macOS 15.7.7.
+
+- App opened.
+- Import worked.
+- Timeline playback worked.
+- Audio worked.
+- Basic editing worked.
+- Save/reopen worked.
+- Export worked.
+- Export opened in QuickTime Player.
+- No crashes were observed.
+
+Disabled feature testing passed for Account, Feedback, Models, Generate, Music,
+and Captions. AI Edit now shows a visible unavailable notice in addition to
+disabled controls. Update checks are intentionally unavailable in the
+experimental Intel artifact.
+
 ## Test Setup
 
 - Download the latest `palmier-pro-intel-editor-only-app` artifact from the
@@ -99,8 +118,8 @@ Specific entry points to check:
 - Media panel > Generate opens an AI generation-unavailable panel.
 - Media panel > Music keeps the tab visible and disables Generate with the unavailable message.
 - Media panel > Captions disables Generate Captions with the transcription unavailable message.
-- Inspector > AI tab remains visible for visual assets/clips and disables AI actions.
-- App menu > Check for Updates is disabled for the experimental Intel artifact.
+- Inspector > AI tab remains visible for visual assets/clips, shows an unavailable notice, and disables AI actions.
+- App menu > Check for Updates shows an unavailable disabled item for the experimental Intel artifact.
 
 ## Stability Pass
 

--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,23 @@
 
 import PackageDescription
 
+let editorOnly = Context.environment["PALMIER_EDITOR_ONLY"] == "1"
+
+let backendPackages: [Package.Dependency] = editorOnly ? [] : [
+    .package(url: "https://github.com/clerk/clerk-convex-swift", from: "0.1.0"),
+    .package(url: "https://github.com/clerk/clerk-ios", from: "1.0.0"),
+    .package(url: "https://github.com/get-convex/convex-swift", from: "0.8.0"),
+]
+
+let backendProducts: [Target.Dependency] = editorOnly ? [] : [
+    .product(name: "ClerkConvex", package: "clerk-convex-swift"),
+    .product(name: "ClerkKit", package: "clerk-ios"),
+    .product(name: "ConvexMobile", package: "convex-swift"),
+]
+
 let package = Package(
     name: "PalmierPro",
-    platforms: [.macOS(.v26)],
+    platforms: editorOnly ? [.macOS("15.0")] : [.macOS(.v26)],
     products: [
         .executable(name: "PalmierPro", targets: ["PalmierPro"]),
     ],
@@ -13,12 +27,9 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.40.0"),
-        .package(url: "https://github.com/clerk/clerk-convex-swift", from: "0.1.0"),
-        .package(url: "https://github.com/clerk/clerk-ios", from: "1.0.0"),
-        .package(url: "https://github.com/get-convex/convex-swift", from: "0.8.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.6.1"),
-    ],
+    ] + backendPackages,
     targets: [
         .executableTarget(
             name: "PalmierPro",
@@ -27,12 +38,9 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk"),
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
-                .product(name: "ClerkConvex", package: "clerk-convex-swift"),
-                .product(name: "ClerkKit", package: "clerk-ios"),
-                .product(name: "ConvexMobile", package: "convex-swift"),
                 .product(name: "Tokenizers", package: "swift-transformers"),
                 .product(name: "Lottie", package: "lottie-ios"),
-            ],
+            ] + backendProducts,
             path: "Sources/PalmierPro",
             exclude: [
                 "Resources/Info.plist",
@@ -45,7 +53,8 @@ let package = Package(
                 .copy("Resources/MCPB/palmier-pro.mcpb"),
                 .copy("Resources/Images"),
                 .copy("Resources/Changelog"),
-            ]
+            ],
+            swiftSettings: editorOnly ? [.define("PALMIER_EDITOR_ONLY")] : []
         ),
         .testTarget(
             name: "PalmierProTests",

--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ Generative AI features require login and subscription.
 
 macOS 26 (Tahoe) on Apple Silicon only.
 
+## Experimental Intel editor-only build
+
+The default build remains the full Palmier Pro app for macOS 26 on Apple Silicon. There is an experimental opt-in editor-only build mode for Intel Macs:
+
+```bash
+PALMIER_EDITOR_ONLY=1 swift build --arch x86_64
+```
+
+To assemble a local debug `.app` without Developer ID signing or notarization:
+
+```bash
+PALMIER_EDITOR_ONLY=1 ./scripts/bundle.sh debug --fast
+```
+
+This mode targets macOS 15+ and intentionally disables Palmier account, Clerk/Convex backend, generative AI, hosted model catalog, billing, hosted agent chat, and feedback submission. The local editor, project, timeline, import, export, MCP, and BYOK Anthropic agent paths are the intended first compatibility surface.
+
+Requirements and limitations:
+
+- Requires a Swift 6.2-capable toolchain and macOS 26 SDK to compile guarded macOS 26 SwiftUI APIs.
+- Does not link `ConvexMobile`; the upstream Convex binary currently has no macOS x86_64 slice.
+- macOS 15 fallback UI replaces macOS 26 glass effects where guarded.
+- This is experimental until the Intel editor-only build is verified by `swift build`, `swift test`, and launch testing on Intel hardware.
+
 See [FAQ.md](FAQ.md) for more.
 
 ## Development

--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -1,9 +1,11 @@
 import AppKit
 import Foundation
 import Combine
+#if !PALMIER_EDITOR_ONLY
 import ClerkKit
 import ClerkConvex
 @preconcurrency import ConvexMobile
+#endif
 
 enum AccountTier: String, Decodable, Sendable {
     case none, pro, max
@@ -88,6 +90,72 @@ private struct OkResponse: Decodable, Sendable {
     let ok: Bool
 }
 
+#if PALMIER_EDITOR_ONLY
+@Observable
+@MainActor
+final class AccountService {
+    static let shared = AccountService()
+
+    private(set) var isLoading: Bool = false
+    private(set) var isMisconfigured: Bool = true
+    private(set) var account: AccountResponse?
+    private(set) var availablePlans: [AvailablePlan] = []
+    private(set) var lastError: String? = BuildMode.editorOnlyUnavailableMessage
+    private(set) var isBuyingCredits: Bool = false
+
+    var isSignedIn: Bool { false }
+    var aiAllowed: Bool { false }
+    var tier: AccountTier { .none }
+    var isPaid: Bool { false }
+    var spentCredits: Int { 0 }
+    var budgetCredits: Int? { nil }
+    var remainingCredits: Int { 0 }
+    var hasCredits: Bool { false }
+
+    private init() {}
+
+    func configure() {
+        isLoading = false
+        isMisconfigured = true
+        lastError = BuildMode.editorOnlyUnavailableMessage
+    }
+
+    func signInWithGoogle() async {
+        lastError = BuildMode.editorOnlyUnavailableMessage
+    }
+
+    func signOut() async {
+        lastError = nil
+    }
+
+    func subscribe(tier: AccountTier) async {
+        lastError = BuildMode.editorOnlyUnavailableMessage
+    }
+
+    func buyCredits(dollars: Int) {
+        lastError = BuildMode.editorOnlyUnavailableMessage
+    }
+
+    func sendFeedback(
+        message: String,
+        email: String?,
+        mayContact: Bool,
+        screenshotPngBase64: String?,
+        appVersion: String,
+        osVersion: String
+    ) async throws {
+        throw NSError(
+            domain: "Palmier.EditorOnly",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: BuildMode.editorOnlyUnavailableMessage]
+        )
+    }
+
+    func manageSubscription() async {
+        lastError = BuildMode.editorOnlyUnavailableMessage
+    }
+}
+#else
 @Observable
 @MainActor
 final class AccountService {
@@ -419,6 +487,7 @@ final class AccountService {
         NSWorkspace.shared.open(url, configuration: .init(), completionHandler: nil)
     }
 }
+#endif
 
 // MARK: - Display helpers
 

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -296,6 +296,10 @@ final class AgentService {
 
     func send(text: String, mentions: [AgentMention]) {
         guard canStream else {
+            if BuildMode.isEditorOnly {
+                streamError = .upstream(BuildMode.editorOnlyUnavailableMessage)
+                return
+            }
             streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
             return
         }

--- a/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if !PALMIER_EDITOR_ONLY
 import ClerkKit
+#endif
 
 struct PalmierClient: AgentClient {
     let model: AnthropicModel
@@ -29,6 +31,9 @@ struct PalmierClient: AgentClient {
         messages: [AnthropicMessage],
         continuation: AsyncThrowingStream<AnthropicStreamEvent, Error>.Continuation
     ) async throws {
+        #if PALMIER_EDITOR_ONLY
+        throw PalmierClientError.upstream(BuildMode.editorOnlyUnavailableMessage)
+        #else
         guard let baseURL = BackendConfig.convexHttpURL else {
             throw PalmierClientError.upstream("Backend not configured")
         }
@@ -61,6 +66,7 @@ struct PalmierClient: AgentClient {
         }
 
         try await AnthropicSSE.parse(bytes: bytes, continuation: continuation)
+        #endif
     }
 }
 

--- a/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
@@ -68,7 +68,7 @@ struct AgentInputBox<LeadingTools: View>: View {
                 .onChange(of: mentionTab) { _, _ in highlightedMentionIndex = 0 }
             bottomBar
         }
-        .glassEffect(.regular, in: .rect(cornerRadius: AppTheme.Radius.xl))
+        .palmierGlassEffect(.regular, in: RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
                 .strokeBorder(
@@ -130,7 +130,7 @@ struct AgentInputBox<LeadingTools: View>: View {
             HStack(spacing: AppTheme.Spacing.md) {
                 leadingTools
                 Spacer(minLength: 0)
-                GlassEffectContainer(spacing: AppTheme.Spacing.xs) {
+                PalmierGlassEffectContainer(spacing: AppTheme.Spacing.xs) {
                     sendStopButton
                 }
             }
@@ -147,11 +147,11 @@ struct AgentInputBox<LeadingTools: View>: View {
                     .font(.system(size: AppTheme.FontSize.xs, weight: .bold))
                     .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
             }
-            .buttonStyle(.glass)
+            .palmierGlassButtonStyle()
             .buttonBorderShape(.circle)
             .controlSize(.regular)
             .tint(AppTheme.Text.secondaryColor)
-            .glassEffectID("sendStop", in: sendStopNamespace)
+            .palmierGlassEffectID("sendStop", in: sendStopNamespace)
             .help("Stop")
             .transition(.scale.combined(with: .opacity))
         } else {
@@ -160,11 +160,11 @@ struct AgentInputBox<LeadingTools: View>: View {
                     .font(.system(size: AppTheme.FontSize.sm, weight: .bold))
                     .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
             }
-            .buttonStyle(.glassProminent)
+            .palmierGlassProminentButtonStyle()
             .buttonBorderShape(.circle)
             .controlSize(.regular)
             .tint(AppTheme.Accent.primary)
-            .glassEffectID("sendStop", in: sendStopNamespace)
+            .palmierGlassEffectID("sendStop", in: sendStopNamespace)
             .disabled(!canSend)
             .opacity(canSend ? 1 : AppTheme.Opacity.strong)
             .transition(.scale.combined(with: .opacity))

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -61,7 +61,7 @@ struct AgentPanelView: View {
     }
 
     private var floatingTabBar: some View {
-        GlassEffectContainer {
+        PalmierGlassEffectContainer {
             HStack(spacing: AppTheme.Spacing.xs) {
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -88,7 +88,7 @@ struct AgentPanelView: View {
             .padding(.horizontal, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity)
             .frame(height: Layout.panelHeaderHeight)
-            .glassEffect(.regular, in: Rectangle())
+            .palmierGlassEffect(.regular, in: Rectangle())
             .overlay(alignment: .bottom) {
                 Rectangle()
                     .fill(AppTheme.Border.subtleColor)
@@ -217,13 +217,7 @@ struct AgentPanelView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollIndicators(.never)
-            .scrollEdgeEffectStyle(.soft, for: .bottom)
-            .onScrollGeometryChange(for: Bool.self) { geo in
-                let distance = geo.contentSize.height - geo.contentOffset.y - geo.containerSize.height
-                return distance > 80
-            } action: { _, newValue in
-                withAnimation(.easeOut(duration: 0.15)) { isScrolledFromBottom = newValue }
-            }
+            .palmierBottomScrollTracking(isScrolledFromBottom: $isScrolledFromBottom)
             .onChange(of: service.messages.count) { _, _ in scrollToBottom(proxy) }
             .onChange(of: service.isStreaming) { _, _ in scrollToBottom(proxy) }
             .overlay(alignment: .bottomTrailing) {
@@ -245,7 +239,7 @@ struct AgentPanelView: View {
                 .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
                 .foregroundStyle(AppTheme.Text.secondaryColor)
                 .frame(width: AppTheme.IconSize.lgXl, height: AppTheme.IconSize.lgXl)
-                .glassEffect(.regular, in: .circle)
+                .palmierGlassEffect(.regular, in: Circle())
         }
         .buttonStyle(.plain)
         .focusable(false)
@@ -317,25 +311,41 @@ struct AgentPanelView: View {
     @ViewBuilder
     private var missingKeyState: some View {
         let account = AccountService.shared
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
-            Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
-                Text(missingKeyPrimaryAction(account: account))
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
-            }
-            .buttonStyle(.plain)
+        if BuildMode.isEditorOnly {
+            VStack(spacing: AppTheme.Spacing.xs) {
+                Text("Palmier account and generation features are unavailable in this Intel editor-only build.")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .multilineTextAlignment(.center)
 
-            Text("or use")
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
-
-            Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
-                Text("your own Anthropic key")
-                    .underline()
-                    .foregroundStyle(AppTheme.Accent.primary)
+                Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
+                    Text("Add your own Anthropic key")
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+            .font(.system(size: AppTheme.FontSize.md, weight: .medium))
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Button(action: { SettingsWindowController.shared.show(tab: .account) }) {
+                    Text(missingKeyPrimaryAction(account: account))
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
+
+                Text("or use")
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+
+                Button(action: { SettingsWindowController.shared.show(tab: .agent) }) {
+                    Text("your own Anthropic key")
+                        .underline()
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
+            }
+            .font(.system(size: AppTheme.FontSize.md, weight: .medium))
         }
-        .font(.system(size: AppTheme.FontSize.md, weight: .medium))
     }
 
     private func missingKeyPrimaryAction(account: AccountService) -> String {

--- a/Sources/PalmierPro/Agent/Panel/ChatHistoryList.swift
+++ b/Sources/PalmierPro/Agent/Panel/ChatHistoryList.swift
@@ -32,7 +32,7 @@ struct ChatHistoryList: View {
             }
         }
         .frame(width: 280)
-        .glassEffect(.clear, in: .rect(cornerRadius: AppTheme.Radius.md))
+        .palmierGlassEffect(.clear, in: RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous))
     }
 
     private func row(session: ChatSession) -> some View {

--- a/Sources/PalmierPro/Agent/Panel/MentionPopover.swift
+++ b/Sources/PalmierPro/Agent/Panel/MentionPopover.swift
@@ -50,7 +50,7 @@ struct MentionPopover: View {
                 .frame(height: 280)
         }
         .frame(width: 260)
-        .glassEffect(.clear, in: .rect(cornerRadius: AppTheme.Radius.md))
+        .palmierGlassEffect(.clear, in: RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous))
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -2,6 +2,9 @@ import Foundation
 
 extension ToolExecutor {
     func generate(_ editor: EditorViewModel, _ args: [String: Any], type: ClipType) throws -> ToolResult {
+        if BuildMode.isEditorOnly {
+            throw ToolError(BuildMode.editorOnlyUnavailableMessage)
+        }
         let prompt = try args.requireString("prompt")
         guard AccountService.shared.isSignedIn else {
             throw ToolError("Generation requires signing in to Palmier. Tell the user to sign in.")
@@ -195,6 +198,9 @@ extension ToolExecutor {
     }
 
     func generateAudio(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        if BuildMode.isEditorOnly {
+            throw ToolError(BuildMode.editorOnlyUnavailableMessage)
+        }
         guard AccountService.shared.isSignedIn else {
             throw ToolError("Generation requires signing in to Palmier. Tell the user to sign in.")
         }
@@ -311,6 +317,9 @@ extension ToolExecutor {
     }
 
     func upscaleMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        if BuildMode.isEditorOnly {
+            throw ToolError(BuildMode.editorOnlyUnavailableMessage)
+        }
         let mediaRef = try args.requireString("mediaRef")
         let asset = try asset(mediaRef, editor: editor)
         guard asset.type == .video || asset.type == .image else {
@@ -371,6 +380,17 @@ extension ToolExecutor {
     }
 
     func listModels(_ args: [String: Any]) -> ToolResult {
+        if BuildMode.isEditorOnly {
+            let body: [String: Any] = [
+                "models": [],
+                "loaded": true,
+                "disabled": BuildMode.editorOnlyUnavailableMessage,
+            ]
+            guard let json = Self.jsonString(roundJSONFloatingPointNumbers(body, toPlaces: 3)) else {
+                return .error("Failed to encode model list")
+            }
+            return .ok(json)
+        }
         let filter = args.string("type")
         var out: [[String: Any]] = []
         if filter == nil || filter == "video" {

--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -22,13 +22,16 @@ enum MainMenuBuilder {
         let menu = NSMenu(title: "Palmier Pro")
         menu.addItem(withTitle: "About Palmier Pro", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
         menu.addItem(.separator())
-        let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(Updater.checkForUpdates(_:)), keyEquivalent: "")
-        updatesItem.target = Updater.shared
         if let reason = FeatureGate.officialUpdateChecks.unavailableReason {
+            let updatesItem = NSMenuItem(title: "Check for Updates Unavailable", action: nil, keyEquivalent: "")
             updatesItem.isEnabled = false
             updatesItem.toolTip = reason
+            menu.addItem(updatesItem)
+        } else {
+            let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(Updater.checkForUpdates(_:)), keyEquivalent: "")
+            updatesItem.target = Updater.shared
+            menu.addItem(updatesItem)
         }
-        menu.addItem(updatesItem)
         menu.addItem(.separator())
         menu.addItem(withTitle: "Settings…", action: #selector(AppDelegate.showSettings(_:)), keyEquivalent: ",")
         menu.addItem(.separator())

--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -24,6 +24,10 @@ enum MainMenuBuilder {
         menu.addItem(.separator())
         let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(Updater.checkForUpdates(_:)), keyEquivalent: "")
         updatesItem.target = Updater.shared
+        if let reason = FeatureGate.officialUpdateChecks.unavailableReason {
+            updatesItem.isEnabled = false
+            updatesItem.toolTip = reason
+        }
         menu.addItem(updatesItem)
         menu.addItem(.separator())
         menu.addItem(withTitle: "Settings…", action: #selector(AppDelegate.showSettings(_:)), keyEquivalent: ",")

--- a/Sources/PalmierPro/App/UpdateBadgeView.swift
+++ b/Sources/PalmierPro/App/UpdateBadgeView.swift
@@ -36,7 +36,7 @@ struct UpdateBadgeView: View {
                 .buttonStyle(.plain)
                 .help("Dismiss")
             }
-            .glassEffect(.regular, in: .capsule)
+            .palmierGlassEffect(.regular, in: Capsule())
             .fixedSize(horizontal: true, vertical: false)
             .transition(.opacity.combined(with: .scale))
         }

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -232,7 +232,7 @@ struct ExportView: View {
             Button("Cancel") { editor.showExportDialog = false }
                 .keyboardShortcut(.cancelAction)
             Button("Export") { startExport() }
-                .buttonStyle(.glassProminent)
+                .palmierGlassProminentButtonStyle()
                 .buttonBorderShape(.capsule)
                 .disabled(service.isExporting)
                 .keyboardShortcut(.defaultAction)

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -1,6 +1,8 @@
 import Foundation
+#if !PALMIER_EDITOR_ONLY
 import Combine
 @preconcurrency import ConvexMobile
+#endif
 
 enum ModelKind: Sendable {
     case video(VideoModelConfig)
@@ -39,7 +41,9 @@ final class ModelCatalog {
     private(set) var isLoaded: Bool = false
     private(set) var lastError: String?
 
+    #if !PALMIER_EDITOR_ONLY
     @ObservationIgnored private var subscription: AnyCancellable?
+    #endif
     @ObservationIgnored private var didConfigure = false
 
     private init() {}
@@ -48,6 +52,10 @@ final class ModelCatalog {
         guard !didConfigure else { return }
         didConfigure = true
 
+        #if PALMIER_EDITOR_ONLY
+        isLoaded = true
+        lastError = BuildMode.editorOnlyUnavailableMessage
+        #else
         guard let client = AccountService.shared.convex else { return }
 
         subscription = client
@@ -64,6 +72,7 @@ final class ModelCatalog {
                     self?.apply(entries)
                 }
             )
+        #endif
     }
 
     private func apply(_ entries: [CatalogEntry]) {

--- a/Sources/PalmierPro/Generation/Edit/AIEditMenu.swift
+++ b/Sources/PalmierPro/Generation/Edit/AIEditMenu.swift
@@ -9,7 +9,9 @@ struct AIEditMenu: View {
         if availableActions.isEmpty {
             EmptyView()
         } else if !aiAllowed {
-            Button("AI Edit") {}.disabled(true)
+            Button("AI Edit") {}
+                .disabled(true)
+                .help(FeatureGate.hostedAIGeneration.unavailableReason ?? "Sign in to use AI Edit")
         } else {
             Menu("AI Edit") {
                 if availableActions.contains(.upscale) {

--- a/Sources/PalmierPro/Generation/GenerationBackend.swift
+++ b/Sources/PalmierPro/Generation/GenerationBackend.swift
@@ -1,10 +1,35 @@
 import Foundation
 import Combine
+#if !PALMIER_EDITOR_ONLY
 @preconcurrency import ConvexMobile
+#endif
 
 /// The RPC layer for the backend
 @MainActor
 enum GenerationBackend {
+    #if PALMIER_EDITOR_ONLY
+    /// Reactive generation jobs are disabled in editor-only builds.
+    static func subscribe(
+        jobId: String
+    ) -> AnyPublisher<BackendGenerationJob?, Error>? {
+        nil
+    }
+
+    static func uploadReference(
+        fileURL: URL,
+        contentType: String,
+    ) async throws -> String {
+        throw GenerationBackendError.notConfigured
+    }
+
+    static func submit(
+        model: String,
+        params: BackendGenerationParams,
+        projectId: String? = nil,
+    ) async throws -> String {
+        throw GenerationBackendError.notConfigured
+    }
+    #else
     /// Reactive subscription to a single generation job pushed by Convex.
     static func subscribe(
         jobId: String
@@ -72,6 +97,7 @@ enum GenerationBackend {
         )
         return result.jobId
     }
+    #endif
 
     private static func assertHTTPOK(respData: Data, response: URLResponse) throws {
         guard let http = response as? HTTPURLResponse else {
@@ -92,7 +118,7 @@ enum GenerationBackend {
 
 // MARK: - Backend generation types
 
-enum BackendGenerationParams: Encodable, ConvexEncodable, Sendable {
+enum BackendGenerationParams: Encodable, Sendable {
     case video(VideoGenerationParams)
     case image(ImageGenerationParams)
     case audio(AudioGenerationParams)
@@ -108,6 +134,10 @@ enum BackendGenerationParams: Encodable, ConvexEncodable, Sendable {
         }
     }
 }
+
+#if !PALMIER_EDITOR_ONLY
+extension BackendGenerationParams: ConvexEncodable {}
+#endif
 
 enum BackendGenerationStatus: String, Decodable, Sendable {
     case queued, running, succeeded, failed

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -724,7 +724,7 @@ struct GenerationView: View {
         }
         .padding(AppTheme.Spacing.xs)
         .frame(minWidth: 180)
-        .glassEffect(.clear, in: .rect(cornerRadius: AppTheme.Radius.md))
+        .palmierGlassEffect(.clear, in: RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous))
     }
 
     private func updateRefMentionQuery(from text: String) {
@@ -1303,7 +1303,7 @@ struct GenerationView: View {
                 .font(.system(size: AppTheme.FontSize.sm, weight: .bold))
                 .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
         }
-        .buttonStyle(.glassProminent)
+        .palmierGlassProminentButtonStyle()
         .buttonBorderShape(.circle)
         .controlSize(.regular)
         .tint(AppTheme.Accent.primary)

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -428,7 +428,9 @@ struct GenerationView: View {
 
     var body: some View {
         Group {
-            if catalogReady {
+            if let reason = FeatureGate.hostedAIGeneration.unavailableReason {
+                generationUnavailableView(reason: reason)
+            } else if catalogReady {
                 bodyContent
             } else {
                 catalogLoadingView
@@ -437,6 +439,53 @@ struct GenerationView: View {
     }
 
     private var aiAllowed: Bool { account.aiAllowed }
+
+    private func generationUnavailableView(reason: String) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                ForEach(GenerationType.allCases, id: \.self) { type in
+                    Label(type.rawValue, systemImage: type.icon)
+                        .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .padding(.horizontal, AppTheme.Spacing.smMd)
+                        .padding(.vertical, AppTheme.Spacing.xs)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                        )
+                }
+                Spacer()
+                Button {
+                    editor.showGenerationPanel = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+                        .hoverHighlight()
+                }
+                .buttonStyle(.plain)
+            }
+
+            UnavailableFeatureNotice(
+                title: "AI generation unavailable",
+                message: BuildMode.editorOnlyUnavailableMessage,
+                detail: "Hosted image, video, audio, upscale, rerun, and model catalog flows require Palmier auth, credits, upload tickets, and backend job updates."
+            )
+            .help(reason)
+        }
+        .padding(AppTheme.Spacing.sm)
+        .background {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.lg)
+                .fill(AppTheme.aiGradientDark)
+                .allowsHitTesting(false)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.lg))
+        .shadow(AppTheme.Shadow.sm)
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .padding(.bottom, AppTheme.Spacing.sm)
+        .frame(maxHeight: max(0, CGFloat(maxPanelHeight)), alignment: .top)
+    }
 
     private var catalogLoadingView: some View {
         VStack(spacing: AppTheme.Spacing.md) {

--- a/Sources/PalmierPro/Help/FeedbackView.swift
+++ b/Sources/PalmierPro/Help/FeedbackView.swift
@@ -43,7 +43,9 @@ struct FeedbackView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lgXl) {
-            if didSend {
+            if let reason = FeatureGate.feedbackSubmission.unavailableReason {
+                unavailableBlock(reason: reason)
+            } else if didSend {
                 successBlock
             } else {
                 formBlock
@@ -57,6 +59,24 @@ struct FeedbackView: View {
     }
 
     // MARK: - Form
+
+    private func unavailableBlock(reason: String) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+            UnavailableFeatureNotice(
+                title: "Feedback unavailable",
+                message: BuildMode.editorOnlyUnavailableMessage,
+                detail: "Feedback submission requires Palmier backend support."
+            )
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .buttonStyle(.capsule(.prominent, size: .regular))
+                    .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+                    .help(reason)
+            }
+        }
+    }
 
     private var formBlock: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {

--- a/Sources/PalmierPro/Inspector/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/AIEditTab.swift
@@ -21,6 +21,14 @@ struct AIEditTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xl) {
+                if FeatureGate.hostedAIGeneration.unavailableReason != nil {
+                    UnavailableFeatureNotice(
+                        title: "AI Edit unavailable",
+                        message: BuildMode.editorOnlyUnavailableMessage,
+                        detail: "AI Edit requires Palmier hosted AI services and account/backend support."
+                    )
+                }
+
                 if hasScopeToggles {
                     aiSection(title: "Scope") {
                         if clipId != nil { replaceToggle }

--- a/Sources/PalmierPro/Inspector/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/AIEditTab.swift
@@ -239,8 +239,9 @@ struct AIEditTab: View {
             for: asset,
             effectiveDurationOverride: effectiveDurationForAvailability
         )
-        let isEnabled = availability.isAvailable
-        let disabledReason = availability.reason
+        let featureUnavailableReason = FeatureGate.hostedAIGeneration.unavailableReason
+        let isEnabled = availability.isAvailable && featureUnavailableReason == nil
+        let disabledReason = availability.reason ?? featureUnavailableReason
 
         HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
             Image(systemName: icon)
@@ -257,7 +258,7 @@ struct AIEditTab: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: AppTheme.Spacing.sm)
-            actionTrigger(action: action, title: triggerTitle ?? title, isEnabled: isEnabled)
+            actionTrigger(action: action, title: triggerTitle ?? title, isEnabled: isEnabled, disabledReason: disabledReason)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .help(disabledReason ?? "")
@@ -274,7 +275,7 @@ struct AIEditTab: View {
     }
 
     @ViewBuilder
-    private func actionTrigger(action: EditAction, title: String, isEnabled: Bool) -> some View {
+    private func actionTrigger(action: EditAction, title: String, isEnabled: Bool, disabledReason: String?) -> some View {
         switch action {
         case .upscale:
             Menu(title) {
@@ -290,7 +291,7 @@ struct AIEditTab: View {
             .fixedSize()
             .controlSize(.small)
             .disabled(!isEnabled || !account.aiAllowed)
-            .help(account.aiAllowed ? "" : "Sign in to upscale")
+            .help(disabledReason ?? (account.aiAllowed ? "" : "Sign in to upscale"))
         case .createVideo:
             Menu(title) {
                 Button("Set as first frame") { sendToVideo(asReference: false) }
@@ -300,6 +301,7 @@ struct AIEditTab: View {
             .fixedSize()
             .controlSize(.small)
             .disabled(!isEnabled)
+            .help(disabledReason ?? "")
         case .edit, .generateMusic, .generateSFX, .rerun:
             Button(title) {
                 present(action)
@@ -307,6 +309,7 @@ struct AIEditTab: View {
             .buttonStyle(.capsule(.secondary))
             .controlSize(.small)
             .disabled(!isEnabled)
+            .help(disabledReason ?? "")
         }
     }
 

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -178,7 +178,9 @@ struct InspectorView: View {
         if isSingleText { tabs.append(.text) }
         if !nonText.isEmpty { tabs.append(.video) }
         if !audios.isEmpty { tabs.append(.audio) }
-        if aiEditEligible && !AccountService.shared.isMisconfigured { tabs.append(.ai) }
+        if aiEditEligible && (!AccountService.shared.isMisconfigured || FeatureGate.isExperimentalIntelEditorOnly) {
+            tabs.append(.ai)
+        }
         return tabs
     }
 
@@ -866,7 +868,7 @@ struct InspectorView: View {
 
     @ViewBuilder
     private func mediaAssetInspectorContent(_ asset: MediaAsset) -> some View {
-        if asset.type.isVisual && !AccountService.shared.isMisconfigured {
+        if asset.type.isVisual && (!AccountService.shared.isMisconfigured || FeatureGate.isExperimentalIntelEditorOnly) {
             VStack(spacing: 0) {
                 assetTabBar([.details, .ai])
                 if preferredAssetTab == .ai {

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -38,6 +38,9 @@ struct CaptionTab: View {
     private var captionTrackIndices: [Int] {
         editor.timeline.tracks.indices.filter { !editor.captionTargets(trackIds: [editor.timeline.tracks[$0].id]).isEmpty }
     }
+    private var transcriptionUnavailableReason: String? {
+        FeatureGate.transcription.unavailableReason
+    }
 
     private static let translateLanguages = [
         "Spanish", "French", "German", "Italian", "Portuguese",
@@ -354,7 +357,7 @@ struct CaptionTab: View {
 
     private var generateBar: some View {
         VStack(spacing: AppTheme.Spacing.sm) {
-            if let note {
+            if let note = note ?? transcriptionUnavailableReason {
                 Text(note)
                     .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
                     .foregroundStyle(AppTheme.Status.errorColor)
@@ -370,10 +373,11 @@ struct CaptionTab: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, AppTheme.Spacing.smMd)
                         .background(RoundedRectangle(cornerRadius: AppTheme.Radius.sm).fill(AppTheme.Accent.primary))
-                        .opacity(effectiveCount == 0 ? AppTheme.Opacity.medium : AppTheme.Opacity.opaque)
+                        .opacity((effectiveCount == 0 || transcriptionUnavailableReason != nil) ? AppTheme.Opacity.medium : AppTheme.Opacity.opaque)
                 }
                 .buttonStyle(.plain).focusable(false)
-                .disabled(effectiveCount == 0 || isGenerating)
+                .disabled(effectiveCount == 0 || isGenerating || transcriptionUnavailableReason != nil)
+                .help(transcriptionUnavailableReason ?? "")
 
                 agentMenu
             }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -264,7 +264,7 @@ struct MediaTab: View {
     }
 
     private var actionsRow: some View {
-        let showGenerate = !AccountService.shared.isMisconfigured
+        let showGenerate = !AccountService.shared.isMisconfigured || FeatureGate.isExperimentalIntelEditorOnly
         return HStack(spacing: AppTheme.Spacing.xs) {
             toolbarButton(title: "Import", systemImage: "plus", action: importMedia)
                 .tourAnchor(.importButton)

--- a/Sources/PalmierPro/MediaPanel/MusicTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MusicTab.swift
@@ -57,6 +57,9 @@ struct MusicTab: View {
     }
 
     private var validationNote: String? {
+        if let reason = FeatureGate.hostedAIGeneration.unavailableReason {
+            return reason
+        }
         guard let model else { return "No music models available." }
         if isTextMode {
             if trimmedPrompt.isEmpty { return "Describe the music to generate." }
@@ -227,7 +230,7 @@ struct MusicTab: View {
                 }
                 .buttonStyle(.plain).focusable(false)
                 .disabled(!canGenerate || !account.aiAllowed)
-                .help(account.aiAllowed ? "" : "Sign in to generate")
+                .help(FeatureGate.hostedAIGeneration.unavailableReason ?? (account.aiAllowed ? "" : "Sign in to generate"))
 
                 agentMenu
             }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -403,16 +403,16 @@ enum CompositionBuilder {
         }
 
         let layerInstructions: [AVVideoCompositionLayerInstruction] = trackMappings.filter { $0.isVideo }.map { mapping in
-            var liConfig = AVVideoCompositionLayerInstruction.Configuration(trackID: mapping.compositionTrack.trackID)
-            emitOpacitySet(config: &liConfig, value: 0, at: .zero)
+            let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: mapping.compositionTrack)
+            emitOpacitySet(config: layerInstruction, value: 0, at: .zero)
 
             switch mapping.kind {
             case .blackBackground(let range):
-                emitOpacitySet(config: &liConfig, value: 1, at: range.start)
+                emitOpacitySet(config: layerInstruction, value: 1, at: range.start)
                 if range.end < compositionDuration {
-                    emitOpacitySet(config: &liConfig, value: 0, at: range.end)
+                    emitOpacitySet(config: layerInstruction, value: 0, at: range.end)
                 }
-                return AVVideoCompositionLayerInstruction(configuration: liConfig)
+                return layerInstruction
             case .timeline(let trackIndex, let clipIds):
                 let track = timeline.tracks.indices.contains(trackIndex)
                     ? timeline.tracks[trackIndex] : nil
@@ -427,37 +427,36 @@ enum CompositionBuilder {
                         let natSize = clipNaturalSizes[clip.id] ?? mapping.naturalSize
                         let preferredTransform = clipTransforms[clip.id] ?? .identity
 
-                        emitOpacity(config: &liConfig, clip: clip, start: start, end: end, timescale: timescale)
-                        emitOpacitySet(config: &liConfig, value: 0, at: end)
-                        emitTransform(config: &liConfig, clip: clip, start: start, end: end,
+                        emitOpacity(config: layerInstruction, clip: clip, start: start, end: end, timescale: timescale)
+                        emitOpacitySet(config: layerInstruction, value: 0, at: end)
+                        emitTransform(config: layerInstruction, clip: clip, start: start, end: end,
                                       natSize: natSize, preferredTransform: preferredTransform,
                                       renderSize: renderSize, timescale: timescale)
-                        emitCrop(config: &liConfig, clip: clip, start: start, end: end,
+                        emitCrop(config: layerInstruction, clip: clip, start: start, end: end,
                                  natSize: natSize, preferredTransform: preferredTransform, timescale: timescale)
                         prevEndFrame = clip.endFrame
                     }
                 }
                 if mapping.endTime < compositionDuration {
-                    emitOpacitySet(config: &liConfig, value: 0, at: mapping.endTime)
+                    emitOpacitySet(config: layerInstruction, value: 0, at: mapping.endTime)
                 }
-                return AVVideoCompositionLayerInstruction(configuration: liConfig)
+                return layerInstruction
             }
         }
 
-        var instrConfig = AVVideoCompositionInstruction.Configuration()
-        instrConfig.timeRange = CMTimeRange(start: .zero, duration: compositionDuration)
-        instrConfig.layerInstructions = layerInstructions
-        let instruction = AVVideoCompositionInstruction(configuration: instrConfig)
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(start: .zero, duration: compositionDuration)
+        instruction.layerInstructions = layerInstructions
 
-        var vcConfig = AVVideoComposition.Configuration()
-        vcConfig.renderSize = renderSize
-        vcConfig.frameDuration = CMTime(value: 1, timescale: timescale)
-        vcConfig.instructions = [instruction]
-        vcConfig.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
-        vcConfig.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
-        vcConfig.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        let videoComposition = AVMutableVideoComposition()
+        videoComposition.renderSize = renderSize
+        videoComposition.frameDuration = CMTime(value: 1, timescale: timescale)
+        videoComposition.instructions = [instruction]
+        videoComposition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+        videoComposition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+        videoComposition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
 
-        return (audioMix, AVVideoComposition(configuration: vcConfig))
+        return (audioMix, videoComposition)
     }
 
     /// Smooth-curve subdivision count for non-linear keyframe segments.
@@ -563,7 +562,7 @@ enum CompositionBuilder {
     }
 
     private static func emitOpacitySet(
-        config: inout AVVideoCompositionLayerInstruction.Configuration,
+        config: AVMutableVideoCompositionLayerInstruction,
         value: Float,
         at time: CMTime
     ) {
@@ -572,7 +571,7 @@ enum CompositionBuilder {
     }
 
     private static func emitOpacityRamp(
-        config: inout AVVideoCompositionLayerInstruction.Configuration,
+        config: AVMutableVideoCompositionLayerInstruction,
         start: Float,
         end: Float,
         timeRange: CMTimeRange
@@ -582,7 +581,7 @@ enum CompositionBuilder {
               isUsableInstructionTime(timeRange.start),
               isUsableInstructionTime(timeRange.end),
               timeRange.duration > .zero else { return }
-        config.addOpacityRamp(.init(timeRange: timeRange, start: start, end: end))
+        config.setOpacityRamp(fromStartOpacity: start, toEndOpacity: end, timeRange: timeRange)
     }
 
     private static func normalizedOpacity(_ value: Float) -> Float? {
@@ -615,7 +614,7 @@ enum CompositionBuilder {
 
     /// Emit the transform instructions from a clip's keyframes
     private static func emitTransform(
-        config: inout AVVideoCompositionLayerInstruction.Configuration,
+        config: AVMutableVideoCompositionLayerInstruction,
         clip: Clip,
         start: CMTime,
         end: CMTime,
@@ -677,11 +676,11 @@ enum CompositionBuilder {
                 let offsetAtT = aOff + Int((Double(bOff - aOff) * t).rounded())
                 let nextTransform = clip.transformAt(frame: clip.startFrame + offsetAtT)
                 if nextT > prevT {
-                    config.addTransformRamp(.init(
-                        timeRange: CMTimeRange(start: prevT, end: nextT),
-                        start: affine(prevTransform),
-                        end: affine(nextTransform)
-                    ))
+                    config.setTransformRamp(
+                        fromStart: affine(prevTransform),
+                        toEnd: affine(nextTransform),
+                        timeRange: CMTimeRange(start: prevT, end: nextT)
+                    )
                 }
                 prevT = nextT
                 prevTransform = nextTransform
@@ -698,7 +697,7 @@ enum CompositionBuilder {
 
     /// Emit the crop instructions from a clip's keyframes
     private static func emitCrop(
-        config: inout AVVideoCompositionLayerInstruction.Configuration,
+        config: AVMutableVideoCompositionLayerInstruction,
         clip: Clip,
         start: CMTime,
         end: CMTime,
@@ -722,14 +721,14 @@ enum CompositionBuilder {
             case .setStatic(let v, let t):
                 config.setCropRectangle(rect(v), at: t)
             case .ramp(let a, let b, let range):
-                config.addCropRectangleRamp(.init(timeRange: range, start: rect(a), end: rect(b)))
+                config.setCropRectangleRamp(fromStartCropRectangle: rect(a), toEndCropRectangle: rect(b), timeRange: range)
             }
         }
     }
 
     /// Opacity instructions for a clip's keyframes + fade envelope.
     private static func emitOpacity(
-        config: inout AVVideoCompositionLayerInstruction.Configuration,
+        config: AVMutableVideoCompositionLayerInstruction,
         clip: Clip,
         start: CMTime,
         end: CMTime,
@@ -743,9 +742,9 @@ enum CompositionBuilder {
             for op in ops {
                 switch op {
                 case .setStatic(let v, let t):
-                    emitOpacitySet(config: &config, value: Float(v), at: t)
+                    emitOpacitySet(config: config, value: Float(v), at: t)
                 case .ramp(let a, let b, let range):
-                    emitOpacityRamp(config: &config, start: Float(a), end: Float(b), timeRange: range)
+                    emitOpacityRamp(config: config, start: Float(a), end: Float(b), timeRange: range)
                 }
             }
             return
@@ -756,7 +755,7 @@ enum CompositionBuilder {
             : []
 
         if clip.durationFrames <= 0 {
-            emitOpacitySet(config: &config, value: Float(clip.opacityAt(frame: clip.startFrame)), at: start)
+            emitOpacitySet(config: config, value: Float(clip.opacityAt(frame: clip.startFrame)), at: start)
         }
         emitEnvelopeRamps(
             clip: clip,
@@ -764,7 +763,7 @@ enum CompositionBuilder {
             timescale: timescale,
             sampleAt: { Float(clip.opacityAt(frame: clip.startFrame + $0)) },
             emit: { aVal, bVal, range in
-                emitOpacityRamp(config: &config, start: aVal, end: bVal, timeRange: range)
+                emitOpacityRamp(config: config, start: aVal, end: bVal, timeRange: range)
             }
         )
     }

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -85,7 +85,7 @@ struct HomeView: View {
             .padding(.horizontal, AppTheme.Spacing.xlXxl)
             .padding(.bottom, AppTheme.Spacing.xlXxl)
         }
-        .scrollEdgeEffectStyle(.soft, for: .top)
+        .palmierTopScrollEdgeEffect()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/PalmierPro/Project/ProjectCard.swift
+++ b/Sources/PalmierPro/Project/ProjectCard.swift
@@ -78,7 +78,7 @@ struct ProjectCard: View {
                         .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
                         .foregroundStyle(.red)
                         .frame(width: AppTheme.IconSize.lgXl, height: AppTheme.IconSize.lgXl)
-                        .glassEffect(.regular, in: .circle)
+                        .palmierGlassEffect(.regular, in: Circle())
                 }
                 .buttonStyle(.plain)
                 .padding(AppTheme.Spacing.smMd)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -450,7 +450,12 @@ extension NSWindow {
         wrapper.frame = NSRect(x: 0, y: 0, width: width, height: 28)
         wrapper.addSubview(host.view)
 
-        let safeArea = wrapper.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+        let safeArea: NSLayoutGuide
+        if #available(macOS 26.0, *) {
+            safeArea = wrapper.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+        } else {
+            safeArea = wrapper.safeAreaLayoutGuide
+        }
         var constraints = [
             host.view.topAnchor.constraint(equalTo: wrapper.topAnchor),
             host.view.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),

--- a/Sources/PalmierPro/Search/Indexing/EmbeddingStore.swift
+++ b/Sources/PalmierPro/Search/Indexing/EmbeddingStore.swift
@@ -85,8 +85,8 @@ struct EmbeddingStore {
                     shotEnd: raw.loadUnaligned(fromByteOffset: base + 16, as: Double.self)
                 ))
                 for d in 0..<header.dim {
-                    let half = raw.loadUnaligned(fromByteOffset: base + 24 + d * 2, as: Float16.self)
-                    vectors[i * header.dim + d] = Float(half)
+                    let half = raw.loadUnaligned(fromByteOffset: base + 24 + d * 2, as: UInt16.self)
+                    vectors[i * header.dim + d] = float32(fromBinary16: half)
                 }
             }
         }
@@ -106,7 +106,7 @@ struct EmbeddingStore {
                 data.append(Data(bytes: &v, count: 8))
             }
             for d in 0..<header.dim {
-                var half = Float16(vectors[i * header.dim + d])
+                var half = binary16(fromFloat32: vectors[i * header.dim + d])
                 data.append(Data(bytes: &half, count: 2))
             }
         }
@@ -116,6 +116,57 @@ struct EmbeddingStore {
 
     static func clearAll() {
         try? FileManager.default.removeItem(at: directory)
+    }
+
+    private static func float32(fromBinary16 bits: UInt16) -> Float {
+        let sign: Float = (bits & 0x8000) == 0 ? 1 : -1
+        let exponent = Int((bits >> 10) & 0x1f)
+        let fraction = Int(bits & 0x03ff)
+
+        switch exponent {
+        case 0:
+            guard fraction != 0 else { return (bits & 0x8000) == 0 ? 0 : -0.0 }
+            return sign * Float(fraction) * Float(pow(2.0, -24.0))
+        case 0x1f:
+            return fraction == 0 ? sign * Float.infinity : Float.nan
+        default:
+            let significand = 1 + Float(fraction) / 1024
+            return sign * significand * Float(pow(2.0, Double(exponent - 15)))
+        }
+    }
+
+    private static func binary16(fromFloat32 value: Float) -> UInt16 {
+        let bits = value.bitPattern
+        let sign = UInt16((bits >> 16) & 0x8000)
+        let exponent = Int((bits >> 23) & 0xff)
+        let fraction = bits & 0x7fffff
+
+        if exponent == 0xff {
+            return sign | (fraction == 0 ? 0x7c00 : 0x7e00)
+        }
+
+        let adjustedExponent = exponent - 127 + 15
+        if adjustedExponent >= 0x1f {
+            return sign | 0x7c00
+        }
+        if adjustedExponent <= 0 {
+            if adjustedExponent < -10 {
+                return sign
+            }
+            let mantissa = fraction | 0x800000
+            let shift = UInt32(14 - adjustedExponent)
+            var halfFraction = UInt16(mantissa >> shift)
+            if ((mantissa >> (shift - 1)) & 1) != 0 {
+                halfFraction &+= 1
+            }
+            return sign | halfFraction
+        }
+
+        var half = sign | UInt16(adjustedExponent << 10) | UInt16(fraction >> 13)
+        if (fraction & 0x00001000) != 0 {
+            half &+= 1
+        }
+        return half
     }
 
 }

--- a/Sources/PalmierPro/Settings/AccountPane.swift
+++ b/Sources/PalmierPro/Settings/AccountPane.swift
@@ -6,7 +6,9 @@ struct AccountPane: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            if account.isLoading {
+            if let reason = FeatureGate.palmierBackendAuth.unavailableReason {
+                unavailableBody(reason: reason)
+            } else if account.isLoading {
                 Text("Loading…")
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
@@ -16,7 +18,7 @@ struct AccountPane: View {
                 signedOutBody
             }
 
-            if let error = account.lastError {
+            if let error = account.lastError, FeatureGate.palmierBackendAuth.isAvailable {
                 Text(error)
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(.red)
@@ -37,6 +39,36 @@ struct AccountPane: View {
             Task { await account.signOut() }
         }
         .buttonStyle(.capsule(.secondary, size: .regular))
+    }
+
+    @ViewBuilder
+    private func unavailableBody(reason: String) -> some View {
+        UnavailableFeatureNotice(
+            title: "Account unavailable",
+            message: BuildMode.editorOnlyUnavailableMessage,
+            detail: "Account/login, subscriptions, billing, credits, cloud sync, and hosted AI generation require Palmier backend support."
+        )
+
+        section(title: "Account") {
+            Button("Sign in with Google") {}
+                .buttonStyle(.capsule(.secondary, size: .regular))
+                .disabled(true)
+                .help(reason)
+        }
+
+        section(title: "Billing and Credits") {
+            Text("Plans, credit balance, top-offs, and subscription management are unavailable in this build.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        section(title: "Cloud Sync") {
+            Text("Local project files continue to work. Cloud sync requires Convex and Clerk support.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/Settings/ModelsPane.swift
+++ b/Sources/PalmierPro/Settings/ModelsPane.swift
@@ -34,14 +34,23 @@ struct ModelsPane: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            searchBar
+            if let reason = FeatureGate.hostedModelCatalog.unavailableReason {
+                UnavailableFeatureNotice(
+                    title: "Hosted model catalog unavailable",
+                    message: BuildMode.editorOnlyUnavailableMessage,
+                    detail: "Image, video, audio, and upscale model settings require Palmier backend support."
+                )
+                .help(reason)
+            } else if sections.isEmpty {
+                searchBar
 
-            if sections.isEmpty {
                 Text(catalog.isLoaded ? "No models match \"\(query)\"." : "Loading models…")
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .padding(.top, AppTheme.Spacing.lg)
             } else {
+                searchBar
+
                 ForEach(sections) { section in
                     sectionView(section)
                 }

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
 
     private var visibleTabs: [SettingsTab] {
         SettingsTab.allCases.filter { tab in
-            !(tab == .account && account.isMisconfigured)
+            !(tab == .account && account.isMisconfigured && !FeatureGate.isExperimentalIntelEditorOnly)
         }
     }
 
@@ -71,7 +71,7 @@ private struct SettingsSidebar: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if !account.isMisconfigured {
+            if !account.isMisconfigured || FeatureGate.isExperimentalIntelEditorOnly {
                 IdentityStrip()
             }
             tabList

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -131,7 +131,7 @@ private struct SettingsDetail: View {
                 .padding(.horizontal, AppTheme.Spacing.xlXxl)
                 .padding(.bottom, AppTheme.Spacing.xlXxl)
             }
-            .scrollEdgeEffectStyle(.soft, for: .top)
+            .palmierTopScrollEdgeEffect()
         }
     }
 }

--- a/Sources/PalmierPro/Transcription/Transcription.swift
+++ b/Sources/PalmierPro/Transcription/Transcription.swift
@@ -1,6 +1,8 @@
 import AVFoundation
 import Foundation
+#if !PALMIER_EDITOR_ONLY
 import Speech
+#endif
 
 struct TranscriptionWord: Sendable, Codable {
     let text: String
@@ -39,6 +41,7 @@ struct TranscriptionResult: Sendable, Codable {
 }
 
 enum TranscriptionError: LocalizedError {
+    case editorOnlyUnavailable
     case unsupportedLocale(String)
     case modelInstallFailed(String)
     case decodeFailed
@@ -47,6 +50,8 @@ enum TranscriptionError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .editorOnlyUnavailable:
+            return "Transcription is unavailable in the experimental Intel editor-only build."
         case .unsupportedLocale(let id):
             return "On-device transcription is not available for \(id)."
         case .modelInstallFailed(let reason):
@@ -62,17 +67,6 @@ enum TranscriptionError: LocalizedError {
 }
 
 enum Transcription {
-    static func transcribeVideoAudio(videoURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
-        let tempAudioURL = try await extractAudioTrack(from: videoURL, range: sourceRange)
-        defer { try? FileManager.default.removeItem(at: tempAudioURL) }
-        let result = try await transcribe(fileURL: tempAudioURL, censorProfanity: censorProfanity, preferredLocale: preferredLocale)
-        return result.offsetting(by: sourceRange?.lowerBound ?? 0)
-    }
-
-    static func supportedLocales() async -> [Locale] {
-        await SpeechTranscriber.supportedLocales
-    }
-
     static func bestSupportedLocale(from supported: [Locale]) -> Locale? {
         let candidates = Locale.preferredLanguages.map(Locale.init(identifier:)) + [Locale.current]
         return matchLocale(candidates: candidates, supported: supported)
@@ -87,6 +81,30 @@ enum Transcription {
             return sameLang.first { $0.region?.identifier == region } ?? sameLang.first
         }
         return nil
+    }
+
+#if PALMIER_EDITOR_ONLY
+    static func transcribeVideoAudio(videoURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
+        throw TranscriptionError.editorOnlyUnavailable
+    }
+
+    static func supportedLocales() async -> [Locale] {
+        []
+    }
+
+    static func transcribe(fileURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
+        throw TranscriptionError.editorOnlyUnavailable
+    }
+#else
+    static func transcribeVideoAudio(videoURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
+        let tempAudioURL = try await extractAudioTrack(from: videoURL, range: sourceRange)
+        defer { try? FileManager.default.removeItem(at: tempAudioURL) }
+        let result = try await transcribe(fileURL: tempAudioURL, censorProfanity: censorProfanity, preferredLocale: preferredLocale)
+        return result.offsetting(by: sourceRange?.lowerBound ?? 0)
+    }
+
+    static func supportedLocales() async -> [Locale] {
+        await SpeechTranscriber.supportedLocales
     }
 
     static func transcribe(fileURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
@@ -320,4 +338,5 @@ enum Transcription {
             segments: segments,
         )
     }
+#endif
 }

--- a/Sources/PalmierPro/Transcription/Transcription.swift
+++ b/Sources/PalmierPro/Transcription/Transcription.swift
@@ -51,7 +51,7 @@ enum TranscriptionError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .editorOnlyUnavailable:
-            return "Transcription is unavailable in the experimental Intel editor-only build."
+            return "This feature is unavailable in the experimental Intel editor-only build."
         case .unsupportedLocale(let id):
             return "On-device transcription is not available for \(id)."
         case .modelInstallFailed(let reason):

--- a/Sources/PalmierPro/UI/CompatibilityViewModifiers.swift
+++ b/Sources/PalmierPro/UI/CompatibilityViewModifiers.swift
@@ -70,7 +70,7 @@ extension View {
     }
 
     @ViewBuilder
-    func palmierGlassEffectID<ID: Hashable>(_ id: ID, in namespace: Namespace.ID) -> some View {
+    func palmierGlassEffectID<ID: Hashable & Sendable>(_ id: ID, in namespace: Namespace.ID) -> some View {
         if #available(macOS 26.0, *) {
             self.glassEffectID(id, in: namespace)
         } else {

--- a/Sources/PalmierPro/UI/CompatibilityViewModifiers.swift
+++ b/Sources/PalmierPro/UI/CompatibilityViewModifiers.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+enum PalmierGlassEffectStyle {
+    case clear
+    case regular
+}
+
+struct PalmierGlassEffectContainer<Content: View>: View {
+    private let spacing: CGFloat?
+    private let content: Content
+
+    init(spacing: CGFloat? = nil, @ViewBuilder content: () -> Content) {
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            if let spacing {
+                GlassEffectContainer(spacing: spacing) {
+                    content
+                }
+            } else {
+                GlassEffectContainer {
+                    content
+                }
+            }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func palmierGlassEffect<S: Shape>(
+        _ style: PalmierGlassEffectStyle,
+        in shape: S
+    ) -> some View {
+        if #available(macOS 26.0, *) {
+            switch style {
+            case .clear:
+                self.glassEffect(.clear, in: shape)
+            case .regular:
+                self.glassEffect(.regular, in: shape)
+            }
+        } else {
+            self
+                .background(shape.fill(fallbackGlassFill(for: style)))
+                .overlay(shape.stroke(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.hairline))
+        }
+    }
+
+    @ViewBuilder
+    func palmierGlassButtonStyle() -> some View {
+        if #available(macOS 26.0, *) {
+            self.buttonStyle(.glass)
+        } else {
+            self.buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    func palmierGlassProminentButtonStyle() -> some View {
+        if #available(macOS 26.0, *) {
+            self.buttonStyle(.glassProminent)
+        } else {
+            self.buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    func palmierGlassEffectID<ID: Hashable>(_ id: ID, in namespace: Namespace.ID) -> some View {
+        if #available(macOS 26.0, *) {
+            self.glassEffectID(id, in: namespace)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func palmierTopScrollEdgeEffect() -> some View {
+        if #available(macOS 26.0, *) {
+            self.scrollEdgeEffectStyle(.soft, for: .top)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func palmierBottomScrollTracking(isScrolledFromBottom: Binding<Bool>) -> some View {
+        if #available(macOS 26.0, *) {
+            self
+                .scrollEdgeEffectStyle(.soft, for: .bottom)
+                .onScrollGeometryChange(for: Bool.self) { geo in
+                    let distance = geo.contentSize.height - geo.contentOffset.y - geo.containerSize.height
+                    return distance > 80
+                } action: { _, newValue in
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        isScrolledFromBottom.wrappedValue = newValue
+                    }
+                }
+        } else {
+            self.onAppear {
+                isScrolledFromBottom.wrappedValue = false
+            }
+        }
+    }
+
+    private func fallbackGlassFill(for style: PalmierGlassEffectStyle) -> Color {
+        switch style {
+        case .clear:
+            Color.white.opacity(AppTheme.Opacity.subtle)
+        case .regular:
+            Color.white.opacity(AppTheme.Opacity.faint)
+        }
+    }
+}

--- a/Sources/PalmierPro/UI/UnavailableFeatureNotice.swift
+++ b/Sources/PalmierPro/UI/UnavailableFeatureNotice.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct UnavailableFeatureNotice: View {
+    let title: String
+    let message: String
+    let detail: String?
+
+    init(title: String, message: String, detail: String? = nil) {
+        self.title = title
+        self.message = message
+        self.detail = detail
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Image(systemName: "lock.slash")
+                    .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                Text(title)
+                    .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+            }
+
+            Text(message)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let detail {
+                Text(detail)
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(AppTheme.Spacing.mdLg)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+        )
+    }
+}

--- a/Sources/PalmierPro/Utilities/BuildMode.swift
+++ b/Sources/PalmierPro/Utilities/BuildMode.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum BuildMode {
+    #if PALMIER_EDITOR_ONLY
+    static let isEditorOnly = true
+    #else
+    static let isEditorOnly = false
+    #endif
+
+    static let editorOnlyUnavailableMessage = "Unavailable in Intel editor-only build."
+}

--- a/Sources/PalmierPro/Utilities/BuildMode.swift
+++ b/Sources/PalmierPro/Utilities/BuildMode.swift
@@ -7,5 +7,5 @@ enum BuildMode {
     static let isEditorOnly = false
     #endif
 
-    static let editorOnlyUnavailableMessage = "Unavailable in Intel editor-only build."
+    static let editorOnlyUnavailableMessage = "This feature is unavailable in the experimental Intel editor-only build."
 }

--- a/Sources/PalmierPro/Utilities/FeatureGate.swift
+++ b/Sources/PalmierPro/Utilities/FeatureGate.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum FeatureAvailability: Equatable {
+    case available
+    case unavailable(reason: String)
+
+    var isAvailable: Bool {
+        if case .available = self { return true }
+        return false
+    }
+
+    var unavailableReason: String? {
+        if case .unavailable(let reason) = self { return reason }
+        return nil
+    }
+}
+
+enum FeatureGate {
+    static var isOfficialFullBuild: Bool { !BuildMode.isEditorOnly }
+    static var isExperimentalIntelEditorOnly: Bool { BuildMode.isEditorOnly }
+
+    static var isAppleSilicon: Bool {
+        #if arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var isIntel: Bool {
+        #if arch(x86_64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var isMacOS26OrNewer: Bool {
+        if #available(macOS 26.0, *) { return true }
+        return false
+    }
+
+    static var palmierBackendAuth: FeatureAvailability {
+        editorOnlyUnavailable(reason: "Account/login requires Palmier backend support.")
+    }
+
+    static var cloudSync: FeatureAvailability {
+        editorOnlyUnavailable(reason: "Cloud sync requires Convex and Clerk support.")
+    }
+
+    static var hostedAIGeneration: FeatureAvailability {
+        editorOnlyUnavailable(reason: "Hosted AI generation requires Palmier auth, credits, and the hosted model catalog.")
+    }
+
+    static var hostedModelCatalog: FeatureAvailability {
+        editorOnlyUnavailable(reason: "The hosted model catalog requires Convex backend support.")
+    }
+
+    static var transcription: FeatureAvailability {
+        #if PALMIER_EDITOR_ONLY
+        return editorOnlyUnavailable(reason: "Advanced transcription requires macOS 26 Speech APIs or a configured fallback provider.")
+        #else
+        if #available(macOS 26.0, *) { return .available }
+        return .unavailable(reason: "Advanced transcription requires macOS 26 Speech APIs.")
+        #endif
+    }
+
+    static var feedbackSubmission: FeatureAvailability {
+        editorOnlyUnavailable(reason: "Feedback submission requires Palmier backend support.")
+    }
+
+    static var officialUpdateChecks: FeatureAvailability {
+        editorOnlyUnavailable(reason: "Experimental Intel artifacts are not connected to the official Palmier update feed.")
+    }
+
+    private static func editorOnlyUnavailable(reason: String) -> FeatureAvailability {
+        #if PALMIER_EDITOR_ONLY
+        return .unavailable(reason: "\(BuildMode.editorOnlyUnavailableMessage) \(reason)")
+        #else
+        return .available
+        #endif
+    }
+}

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -419,11 +419,16 @@ struct ToolExecutorReadOnlyTests {
     }
 
     @Test func listModelsReportsCatalogNotLoadedInTestEnvironment() async throws {
-        // No Convex connection → catalog stays unloaded. Agents must use this to disambiguate
-        // empty results from "catalog not synced yet".
+        // Normal tests have no Convex connection, so the catalog stays unloaded.
+        // Editor-only reports an intentional disabled state instead of a pending sync.
         let h = ToolHarness()
         let body = try await h.runOK("list_models") as? [String: Any]
-        #expect(body?["loaded"] as? Bool == false)
+        if BuildMode.isEditorOnly {
+            #expect(body?["loaded"] as? Bool == true)
+            #expect(body?["disabled"] as? String == BuildMode.editorOnlyUnavailableMessage)
+        } else {
+            #expect(body?["loaded"] as? Bool == false)
+        }
     }
 
     @Test func listModelsFilterIsRespectedForAllEntries() async throws {

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -21,6 +21,11 @@ done
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+EXTRA_SWIFT_BUILD_ARGS=()
+if [ -n "${SWIFT_BUILD_ARGS:-}" ]; then
+  read -r -a EXTRA_SWIFT_BUILD_ARGS <<< "$SWIFT_BUILD_ARGS"
+fi
+
 ENV_FILE=".env"
 if [ "$CONFIG" = "release" ] && [ -f "$ROOT/.env.prod" ]; then
   ENV_FILE=".env.prod"
@@ -45,8 +50,8 @@ ZIP="$ROOT/.build/PalmierPro.zip"
 DMG="$ROOT/.build/PalmierPro.dmg"
 
 echo "==> Building ($CONFIG)"
-swift build -c "$CONFIG"
-BIN="$(swift build -c "$CONFIG" --show-bin-path)/PalmierPro"
+swift build -c "$CONFIG" "${EXTRA_SWIFT_BUILD_ARGS[@]}"
+BIN="$(swift build -c "$CONFIG" "${EXTRA_SWIFT_BUILD_ARGS[@]}" --show-bin-path)/PalmierPro"
 SPARKLE_FW="$ROOT/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 
 echo "==> Assembling $APP"

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -63,6 +63,8 @@ cp "$RESOURCES/Info.plist" "$APP/Contents/Info.plist"
 if [ "${PALMIER_EDITOR_ONLY:-}" = "1" ]; then
   echo "==> Configuring Intel editor-only app metadata"
   /usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion 15.0" "$APP/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set :SUEnableAutomaticChecks false" "$APP/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP/Contents/Info.plist" 2>/dev/null || true
 fi
 
 if [ -n "$SENTRY_DSN" ]; then

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -55,6 +55,11 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Framewor
 cp "$BIN" "$APP/Contents/MacOS/PalmierPro"
 cp "$RESOURCES/Info.plist" "$APP/Contents/Info.plist"
 
+if [ "${PALMIER_EDITOR_ONLY:-}" = "1" ]; then
+  echo "==> Configuring Intel editor-only app metadata"
+  /usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion 15.0" "$APP/Contents/Info.plist"
+fi
+
 if [ -n "$SENTRY_DSN" ]; then
   echo "==> Injecting SentryDSN into Info.plist"
   /usr/libexec/PlistBuddy -c "Delete :SentryDSN" "$APP/Contents/Info.plist" 2>/dev/null || true
@@ -74,9 +79,13 @@ inject_plist() {
 }
 
 echo "==> Injecting backend config into Info.plist"
-inject_plist PalmierClerkPublishableKey "${CLERK_PUBLISHABLE_KEY:-}"
-inject_plist PalmierConvexDeploymentURL "${CONVEX_DEPLOYMENT_URL:-}"
-inject_plist PalmierConvexHttpURL "${CONVEX_HTTP_URL:-}"
+if [ "${PALMIER_EDITOR_ONLY:-}" = "1" ]; then
+  echo "==> PALMIER_EDITOR_ONLY=1 — skipping Clerk/Convex backend config"
+else
+  inject_plist PalmierClerkPublishableKey "${CLERK_PUBLISHABLE_KEY:-}"
+  inject_plist PalmierConvexDeploymentURL "${CONVEX_DEPLOYMENT_URL:-}"
+  inject_plist PalmierConvexHttpURL "${CONVEX_HTTP_URL:-}"
+fi
 cp "$RESOURCES/AppIcon.icns" "$APP/Contents/Resources/AppIcon.icns"
 cp -R "$SPARKLE_FW" "$APP/Contents/Frameworks/Sparkle.framework"
 


### PR DESCRIPTION
Summary

This PR adds experimental Intel Mac editor-only build support for Palmier Pro using PALMIER_EDITOR_ONLY=1.

This is not full official Intel support yet. It keeps the normal Apple Silicon/macOS 26 build path intact while adding a reduced Intel/macOS 15 editor-only build that can compile, pass tests, package an app artifact, and run basic editor workflows.

CI Status

GitHub Actions passed for the Intel editor-only workflow:

Package resolve: passed
Intel editor-only x86_64 build: passed
Tests: passed
App assembly: passed
App artifact upload: passed

Artifact name:

palmier-pro-intel-editor-only-app

Runtime Test

Tested on:

Intel iMac 2019
macOS 15.7.7

Runtime smoke test results:

App launch: passed
Media import: passed
Timeline playback: passed
Audio playback: passed
Basic editing: passed
Save/reopen project: passed
Export: passed
Exported video opened in QuickTime: passed
Crashes observed: none
What Works In Intel Editor-Only Mode
App launch
Local media import
Timeline playback
Audio playback
Basic editing
Project save/reopen
Export
Local editor workflow
Disabled But Visible In Intel Editor-Only Mode

The following features are visible but clearly marked unavailable in the experimental Intel editor-only build:

Account/login
Billing/credits
Feedback submission
Hosted model catalog
Hosted AI generation
Image/video/audio generation
Music generation
Captions/autocaptions
AI Edit
Official update checks

The disabled-state message used is:

This feature is unavailable in the experimental Intel editor-only build.

Why These Features Are Disabled

This branch avoids backend/account/hosted feature paths that currently depend on production Palmier services or APIs that are not safe to enable in this experimental Intel editor-only build.

Known unavailable areas include:

Clerk/account session path
Convex/ConvexMobile backend path
Hosted model catalog
Hosted AI generation
Billing/credits
Cloud sync
Automatic transcription/captions
Official Sparkle update feed
Transcription Notes

The current Palmier transcription path uses newer macOS 26 APIs such as SpeechTranscriber and SpeechAnalyzer.

For Intel/macOS 15 support, a future fallback could be added using older Apple Speech APIs such as:

SFSpeechRecognizer
SFSpeechURLRecognitionRequest
SFSpeechAudioBufferRecognitionRequest

Other future options could include optional external or local transcription providers, but those should require explicit user consent and should not hardcode API keys or require paid third-party services by default.

Maintainer Path To Restore More Features

If maintainers want to turn this into fuller Intel support later, suggested next steps are:

Validate or replace the Intel-compatible auth path
Validate or abstract Convex/ConvexMobile usage
Restore account/login once backend support is safe
Restore cloud sync after backend compatibility is confirmed
Restore hosted AI generation once auth, billing, credits, and model catalog work
Add a transcription provider abstraction with macOS 26 and macOS 15 paths
Decide between separate Apple Silicon and Intel downloads, or a universal release
Add official signing/notarization for Intel artifacts
Add a separate Intel update feed if official Intel releases are supported
Release Strategy Suggestion

Recommended download strategy:

Official Apple Silicon/macOS 26 Palmier Pro download
Separate experimental Intel editor-only download

The Intel artifact should not be connected to the official update feed until maintainers decide the support scope, signing, notarization, and update strategy.

Important Note

This PR should be reviewed as an experimental compatibility starting point, not a claim of complete Intel support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large conditional compile surface across auth, generation, and AVFoundation export paths; default builds should be unchanged but regressions in shared code or export behavior warrant careful review.
> 
> **Overview**
> Introduces an **experimental Intel editor-only** product slice via `PALMIER_EDITOR_ONLY=1`, without changing the default macOS 26 / Apple Silicon full app when that env var is unset.
> 
> **Build & packaging:** `Package.swift` switches to macOS 15, defines `PALMIER_EDITOR_ONLY`, and drops Clerk/Convex from the dependency graph. `scripts/bundle.sh` supports `SWIFT_BUILD_ARGS`, lowers minimum OS to 15.0 for editor-only bundles, disables Sparkle auto-updates, and skips Clerk/Convex plist injection. A new **GitHub Actions** workflow builds/tests x86_64, bundles a debug app, and uploads `palmier-pro-intel-editor-only-app`.
> 
> **Runtime gating:** `BuildMode` and `FeatureGate` centralize what is available; backend services (`AccountService`, `GenerationBackend`, `ModelCatalog`, `PalmierClient`, transcription) compile to stubs or throw in editor-only mode. Agent generate/upscale tools and hosted streaming paths fail with a shared unavailable message. UI keeps entry points visible via `UnavailableFeatureNotice` (account, models, feedback, generation, music, captions, AI inspector, updates menu).
> 
> **macOS 15 / Intel compatibility:** `CompatibilityViewModifiers` wraps macOS 26 glass/scroll APIs with fallbacks; export composition moves from newer `AVVideoComposition` configuration APIs to `AVMutable*` types; embedding index I/O avoids `Float16`; window titlebar uses a safe-area fallback on older macOS.
> 
> Docs (`README`, `CONTRIBUTING`, `AGENTS`, status/checklist markdown) describe the experiment, limitations, and QA expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1196449d489d50fdfa5f916fc43558f0959bce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->