### PR TITLE
Fix split clip losing keyframe interpolation on right half

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -178,7 +178,8 @@ extension EditorViewModel {
             .filter { $0.frame >= splitOffset }
             .map { Keyframe(frame: $0.frame - splitOffset, value: $0.value, interpolationOut: $0.interpolationOut) }
         if rightKfs.first?.frame != 0 {
-            rightKfs.insert(Keyframe(frame: 0, value: boundary), at: 0)
+            let precedingInterp = track.keyframes.last(where: { $0.frame < splitOffset })?.interpolationOut ?? .smooth
+            rightKfs.insert(Keyframe(frame: 0, value: boundary, interpolationOut: precedingInterp), at: 0)
         }
         return (
             leftKfs.isEmpty ? nil : KeyframeTrack(keyframes: leftKfs),

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -144,6 +144,41 @@ struct SplitClipTests {
         #expect(halves[1].fadeInFrames == 0)
         #expect(halves[1].fadeOutFrames == 20)
     }
+
+    @Test func splitClipPreservesHoldInterpolationOnRightHalf() {
+        // Clip with opacity: kf at frame 0 (value 1.0, .hold) → kf at frame 30 (value 0.5).
+        // .hold means the value stays at 1.0 until frame 30. After splitting at frame 15,
+        // the right half should still hold 1.0 from frame 0 to frame 15, then jump to 0.5.
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 1.0, interpolationOut: .hold),
+            Keyframe(frame: 30, value: 0.5),
+        ])
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let rightIds = e.splitClip(clipId: "c1", atFrame: 15)
+        let right = e.timeline.tracks[0].clips.first { $0.id == rightIds[0] }!
+        // Frame 7 on the right half is inside the hold segment; value must remain 1.0.
+        #expect(right.opacityTrack?.sample(at: 7, fallback: 1.0) == 1.0)
+        // Frame 15 on the right half is at the rebased kf (30 - 15 = 15); value should be 0.5.
+        #expect(right.opacityTrack?.sample(at: 15, fallback: 0.0) == 0.5)
+    }
+
+    @Test func splitClipPreservesLinearInterpolationOnRightHalf() {
+        // Clip with rotation: kf at frame 0 (0°, .linear) → kf at frame 20 (20°).
+        // Linear means exactly 1° per frame. After splitting at frame 10, the right half
+        // should continue linearly from 10° to 20° — i.e. value at frame 5 = 15°.
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 40)
+        clip.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0.0, interpolationOut: .linear),
+            Keyframe(frame: 20, value: 20.0),
+        ])
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let rightIds = e.splitClip(clipId: "c1", atFrame: 10)
+        let right = e.timeline.tracks[0].clips.first { $0.id == rightIds[0] }!
+        // Right half: boundary kf at frame 0 (value 10.0), original kf at frame 10 (value 20.0).
+        // At frame 5 (halfway), linear interpolation gives exactly 15.0.
+        #expect(right.rotationTrack?.sample(at: 5, fallback: 0.0) == 15.0)
+    }
 }
 
 @Suite("EditorViewModel — applyTimelineSettings")


### PR DESCRIPTION
When splitting a clip between two keyframes, `splitKeyframeTrack` inserts a boundary keyframe at offset 0 of the right half. That keyframe defaulted to `.smooth` interpolation regardless of the preceding segment. A `.hold` segment incorrectly animates on the right half; a `.linear` segment incorrectly eases instead of continuing linearly. Fix looks up the preceding keyframe's `interpolationOut` and passes it to the inserted boundary keyframe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to split keyframe logic with new unit tests; no auth, persistence, or API surface changes.
> 
> **Overview**
> Fixes incorrect animation on the **right half** of a split when the cut falls between keyframes. `splitKeyframeTrack` still inserts a boundary keyframe at frame 0 on the right track, but that keyframe now uses the **`interpolationOut` of the last keyframe before the split** (falling back to `.smooth`) instead of always defaulting to smooth easing.
> 
> That keeps **hold** segments flat until the next keyframe and **linear** ramps continuing at a constant rate after the cut. Regression tests cover opacity (hold) and rotation (linear) via `splitClip` + `sample(at:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5007d2139ca603977d4e851fc441506572f63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->