### PR TITLE
Fix fatal crash: load Metal kernels without Bundle.module

### DIFF
--- a/Sources/PalmierPro/Compositing/Kernels/CIKernelLoader.swift
+++ b/Sources/PalmierPro/Compositing/Kernels/CIKernelLoader.swift
@@ -1,11 +1,19 @@
 import CoreImage
 import Foundation
 
-/// Loads Core Image kernels from a plugin-compiled `.metallib` in `Bundle.module`.
-/// Centralizes the load + the silent-failure path the per-effect kernels all shared.
+/// Loads Core Image kernels from the plugin-compiled `.metallib` resources.
 enum CIKernelLoader {
+    private static func metallibURL(_ lib: String) -> URL? {
+        guard let resourceURL = Bundle.main.resourceURL else { return nil }
+        let candidates = [
+            resourceURL.appendingPathComponent("\(lib).metallib"),
+            resourceURL.appendingPathComponent("PalmierPro_PalmierPro.bundle/\(lib).metallib"),
+        ]
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
     private static func data(_ lib: String) -> Data? {
-        Bundle.module.url(forResource: lib, withExtension: "metallib").flatMap { try? Data(contentsOf: $0) }
+        metallibURL(lib).flatMap { try? Data(contentsOf: $0) }
     }
 
     static func kernel(_ lib: String, _ function: String) -> CIKernel? {

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -108,7 +108,7 @@ if ! ls "$RES_BUNDLE"/*.metallib >/dev/null 2>&1; then
   echo "!! no .metallib in SwiftPM resource bundle at $RES_BUNDLE — Metal effects would be missing" >&2
   exit 1
 fi
-cp -R "$RES_BUNDLE" "$APP/Contents/Resources/"
+cp "$RES_BUNDLE"/*.metallib "$APP/Contents/Resources/"
 
 install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/PalmierPro"
 touch "$APP"


### PR DESCRIPTION
## Problem

`PALMIER-PRO-EN` (fatal, shipped builds): the app `fatalError`s the first time any Metal-backed color effect renders.

`CIKernelLoader` loaded its `.metallib`s via `Bundle.module`, whose SwiftPM-generated accessor only checks two paths — the **build-machine path baked in at compile time** (`/Users/.../.build/.../release/...`) and the **`.app` root** (never `Contents/Resources`) — then `fatalError`s. So it works on the build machine (the baked path exists) and crashes every shipped install.

```
resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle:
from /Applications/PalmierPro.app/PalmierPro_PalmierPro.bundle
  or /Users/harrison/.../.build/arm64-apple-macosx/release/PalmierPro_PalmierPro.bundle
```

## Fix

Mirror the existing `BundledFonts` pattern, which already avoids `Bundle.module` for this exact reason:

- `CIKernelLoader` locates each `.metallib` via `Bundle.main.resourceURL` — `Contents/Resources/<lib>.metallib` (packaged) or `…/PalmierPro_PalmierPro.bundle/<lib>.metallib` (`swift run`) — and degrades to `nil` (effect no-ops) instead of crashing.
- `bundle.sh` flattens the `.metallib` files into `Contents/Resources`, exactly as it already does for `Fonts/`.

This was the only remaining `Bundle.module` user, so it closes the whole crash class.

## Test
- `swift build` clean against `main`.
- Recommend `scripts/bundle.sh release --sign` + apply a grade in the resulting `.app` to confirm Metal effects render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)