### PR TITLE
Rescale keyframes when clip speed changes

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -257,10 +257,13 @@ extension EditorViewModel {
         let basis = dragBefore[clip.id] ?? clip
         let sourceFrames = Double(basis.durationFrames) * basis.speed
         let newDuration = max(1, Int((sourceFrames / newSpeed).rounded()))
+        let oldDuration = clip.durationFrames
         let oldEnd = clip.endFrame
 
         timeline.tracks[ti].clips[loc.clipIndex].speed = newSpeed
         timeline.tracks[ti].clips[loc.clipIndex].durationFrames = newDuration
+        // Keyframe offsets are clip-relative, so retime them before the clamp drops them.
+        timeline.tracks[ti].clips[loc.clipIndex].rescaleKeyframes(by: Double(newDuration) / Double(oldDuration))
         timeline.tracks[ti].clips[loc.clipIndex].clampKeyframesToDuration()
         timeline.tracks[ti].clips[loc.clipIndex].clampFadesToDuration()
 

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -52,6 +52,25 @@ struct ApplyClipSpeedTests {
         let updated = e.timeline.tracks[0].clips.first { $0.id == "c2" }!
         #expect(updated.startFrame == 100)
     }
+
+    @Test func applyClipSpeedRescalesKeyframesInsteadOfDroppingThem() {
+        // 2x speed halves a 60-frame clip; keyframes must rescale, not get clamped away.
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 1.0),
+            Keyframe(frame: 30, value: 0.5),
+            Keyframe(frame: 60, value: 0.0),
+        ])
+        clip.scaleTrack = KeyframeTrack(keyframes: [Keyframe(frame: 60, value: AnimPair(a: 2.0, b: 2.0))])
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+
+        e.applyClipSpeed(clipId: "c1", newSpeed: 2.0)
+        let updated = e.timeline.tracks[0].clips[0]
+
+        #expect(updated.durationFrames == 30)
+        #expect(updated.opacityTrack?.keyframes.map(\.frame) == [0, 15, 30])
+        #expect(updated.scaleTrack?.keyframes.map(\.frame) == [30])
+    }
 }
 
 @Suite("EditorViewModel — splitClip")


### PR DESCRIPTION
Fixes #128.

### Problem
`EditorViewModel.setClipSpeed` recomputes `durationFrames` for the new speed and then calls only `clampKeyframesToDuration()`, which drops every keyframe whose clip-relative offset is past the new (shorter) duration. The survivors keep their old offsets, so any animation is silently destroyed when a clip is retimed.

The frame-rate path (`applyTimelineSettings`) already handles this correctly by calling `rescaleKeyframes(by:)` before clamping. This makes `setClipSpeed` consistent with it.

### Fix
Retime the keyframes by the duration ratio before the clamp (one line):

```swift
let oldDuration = clip.durationFrames
...
timeline.tracks[ti].clips[loc.clipIndex].durationFrames = newDuration
// Keyframe offsets are clip-relative, so retime them before the clamp drops them.
timeline.tracks[ti].clips[loc.clipIndex].rescaleKeyframes(by: Double(newDuration) / Double(oldDuration))
timeline.tracks[ti].clips[loc.clipIndex].clampKeyframesToDuration()
```

`rescaleKeyframes`/`rescaledKeyframeTrack` already guard a non-finite/≤0 scale, and `durationFrames` is always ≥ 1, so no extra guard is needed.

### Test
Adds `applyClipSpeedRescalesKeyframesInsteadOfDroppingThem`: a 60-frame clip with opacity keyframes at `[0, 30, 60]` and a scale keyframe at `60`, sped up 2×.
- Without the fix: `opacity -> [0, 30]` (offset-60 dropped), `scale -> nil` (track wiped).
- With the fix: `opacity -> [0, 15, 30]`, `scale -> [30]`.

`swift test` is green (662/662).

### Scope
UI speed path only. The agent/MCP speed path (`ToolExecutor+Clips.applyPropertyChanges`) has the same omission; happy to follow up separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to clip speed mutation using an existing rescale helper; covered by a new unit test.
> 
> **Overview**
> **Clip speed changes** now **rescale clip-relative keyframe times** by the new duration ratio **before** `clampKeyframesToDuration()`, instead of only clamping and silently dropping keyframes past the shorter timeline duration.
> 
> This aligns the UI speed path in `setClipSpeed` with the FPS retime path that already calls `rescaleKeyframes(by:)`.
> 
> Adds a regression test: 2× speed on a 60-frame clip expects opacity keyframes at `[0, 15, 30]` and a scale keyframe at frame 30.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ffb952abf05b5eb8cf2469eb87fe103bffd15e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->