### PR TITLE
[telemetry] link user id

### DIFF
--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -206,6 +206,7 @@ final class AccountService {
         guard let convex else { return }
 
         let user = Clerk.shared.user
+        Telemetry.setUser(id: user?.id)
         let name = [user?.firstName, user?.lastName]
             .compactMap { $0 }
             .joined(separator: " ")
@@ -289,6 +290,7 @@ final class AccountService {
     }
 
     private func clearAccount() {
+        Telemetry.setUser(id: nil)
         accountSubscription?.cancel()
         accountSubscription = nil
         buyCreditsTask?.cancel()

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -64,6 +64,16 @@ enum Telemetry {
         String(id.prefix(8))
     }
 
+    static func setUser(id: String?) {
+        guard didStart else { return }
+        SentrySDK.configureScope { scope in
+            guard let id else { scope.setUser(nil); return }
+            let user = User()
+            user.userId = id
+            scope.setUser(user)
+        }
+    }
+
     static func setExtra(value: Any?, key: String) {
         guard didStart else { return }
         SentrySDK.configureScope { scope in


### PR DESCRIPTION
Set the Sentry scope user to the Clerk user id on auth, clear it on sign-out. Id only — no email or name — consistent with `sendDefaultPii = false`.

## Test
- `swift build` — clean.