### PR TITLE
[fix] serialize imported-asset finalization to fix batch-generation crash

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -191,7 +191,7 @@ extension ToolExecutor {
             try FileManager.default.moveItem(at: tempURL, to: asset.url)
             asset.generationStatus = .none
             editor.importMediaAsset(asset, skipAppend: true)
-            await editor.finalizeImportedAsset(asset)
+            await editor.finalizeImportedAssetSerially(asset).value
         } catch {
             let message = (error as? ToolError)?.message ?? error.localizedDescription
             Log.project.error("import_media download failed url=\(remoteURL.absoluteString) error=\(message)")

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -561,6 +561,20 @@ extension EditorViewModel {
         return context.makeImage()
     }
 
+    /// Serializes finalization so a batch of imports/generations completing at once
+    /// can't interleave their `mediaManifest.entries` / `mediaAssets` mutations across
+    /// `loadMetadata()`'s AVFoundation `await`s, which corrupts the @Observable arrays.
+    @discardableResult
+    func finalizeImportedAssetSerially(_ asset: MediaAsset) -> Task<Void, Never> {
+        let prior = importFinalizeTail
+        let task = Task { @MainActor [weak self] in
+            await prior?.value
+            await self?.finalizeImportedAsset(asset)
+        }
+        importFinalizeTail = task
+        return task
+    }
+
     func finalizeImportedAsset(_ asset: MediaAsset) async {
         Log.project.notice(
             "media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -108,6 +108,7 @@ final class EditorViewModel {
     // MARK: - Media library (in-memory, rebuilt on project open)
 
     var mediaAssets: [MediaAsset] = []
+    @ObservationIgnored var importFinalizeTail: Task<Void, Never>?
     var offlineMediaRefs: Set<String> = []
     var unprocessableMediaRefs: Set<String> = []
     let mediaVisualCache = MediaVisualCache()

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -206,7 +206,7 @@ final class GenerationService {
             asset.generationStatus = .none
             editor.importMediaAsset(asset, skipAppend: true)
             editor.appendGenerationLog(for: asset)
-            await editor.finalizeImportedAsset(asset)
+            await editor.finalizeImportedAssetSerially(asset).value
             return true
         } catch {
             let message = error.localizedDescription


### PR DESCRIPTION
When several asset finalizations complete near-simultaneously, each spawns an independent task. `finalizeImportedAsset` awaits `MediaAsset.loadMetadata()` (many AVFoundation suspension points) and then mutates the shared Observable `mediaManifest.entries` / `mediaAssets`. Concurrent tasks interleave across those awaits and reentrantly mutate the same arrays, corrupting the copy-on-write buffer (SIGABRT). Does not reproduce for a single import.

Route finalization through a serial `Task` chain (`finalizeImportedAssetSerially`) so only one runs at a time; the array mutations can no longer interleave.

## Test
- `swift build` — clean.