### PR TITLE
Add MCP timeline export tool

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -25,6 +25,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case listModels = "list_models"
     case inspectMedia = "inspect_media"
     case getTranscript = "get_transcript"
+    case exportTimeline = "export_timeline"
     case inspectTimeline = "inspect_timeline"
     case searchMedia = "search_media"
     case applyColor = "apply_color"
@@ -87,6 +88,19 @@ enum ToolDefinitions {
                     "endFrame": ["type": "integer", "description": "Optional. Only return words starting before this project frame."],
                     "clipId": ["type": "string", "description": "Scope the transcript to a single clip — returns only what that clip says, in project frames. Answers \"what's in clip X?\" without scanning the whole timeline."],
                 ]
+            )
+        ),
+        AgentTool(
+            name: .exportTimeline,
+            description: "Exports the current timeline through Palmier Pro's native export pipeline. Video formats render the full timeline with the same AVFoundation/text-overlay path as the Export dialog; xml writes Final Cut Pro 7 XMEML; palmierProject writes a self-contained .palmier project package. Returns output path and timeline metadata after the export completes.",
+            inputSchema: objectSchema(
+                properties: [
+                    "outputPath": ["type": "string", "description": "Absolute output path. Use .mp4 for h264/h265, .mov for prores, .xml for xml, and .palmier for palmierProject."],
+                    "format": ["type": "string", "enum": ["h264", "h265", "prores", "xml", "palmierProject"], "description": "Optional. Default h264."],
+                    "resolution": ["type": "string", "enum": ["720p", "1080p", "1440p", "4k", "native"], "description": "Optional for video formats. Default 1080p. Ignored for xml and palmierProject."],
+                    "overwrite": ["type": "boolean", "description": "Optional. Default false. Refuses to replace an existing file or package unless true."],
+                ],
+                required: ["outputPath"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -1,0 +1,157 @@
+import CoreGraphics
+import Foundation
+
+extension ToolExecutor {
+    private enum TimelineExportFormat: String {
+        case h264, h265, prores, xml, palmierProject
+
+        var fileExtension: String {
+            switch self {
+            case .h264, .h265: "mp4"
+            case .prores: "mov"
+            case .xml: "xml"
+            case .palmierProject: Project.fileExtension
+            }
+        }
+
+        var videoFormat: ExportFormat? {
+            switch self {
+            case .h264: .h264
+            case .h265: .h265
+            case .prores: .prores
+            case .xml: .xml
+            case .palmierProject: nil
+            }
+        }
+    }
+
+    func exportTimeline(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["outputPath", "format", "resolution", "overwrite"], path: "export_timeline")
+
+        let outputPath = try args.requireString("outputPath").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !outputPath.isEmpty else {
+            throw ToolError("Missing required argument: outputPath")
+        }
+
+        let format = try Self.parseTimelineExportFormat(args.string("format") ?? "h264")
+        let resolution = try Self.parseExportResolution(args.string("resolution") ?? "1080p")
+        let overwrite = args.bool("overwrite") ?? false
+        let outputURL = URL(fileURLWithPath: (outputPath as NSString).expandingTildeInPath)
+        let fm = FileManager.default
+
+        try Self.validateExportDestination(outputURL, format: format, overwrite: overwrite, fm: fm)
+
+        if format != .xml, format != .palmierProject, editor.timeline.totalFrames <= 0 {
+            throw ToolError("Timeline has no frames to export.")
+        }
+
+        let service = ExportService()
+        switch format {
+        case .palmierProject:
+            guard await service.exportPalmierProject(
+                timeline: editor.timeline,
+                manifest: editor.mediaManifest,
+                generationLog: editor.generationLog,
+                sourceProjectURL: editor.projectURL,
+                outputURL: outputURL
+            ) != nil else {
+                throw ToolError(service.error ?? "Export failed.")
+            }
+        case .h264, .h265, .prores, .xml:
+            guard let videoFormat = format.videoFormat else {
+                throw ToolError("Unsupported export format: \(format.rawValue)")
+            }
+            await service.export(
+                timeline: editor.timeline,
+                resolver: editor.mediaResolver,
+                format: videoFormat,
+                resolution: resolution,
+                outputURL: outputURL
+            )
+            if let error = service.error {
+                throw ToolError(error)
+            }
+        }
+
+        guard fm.fileExists(atPath: outputURL.path) else {
+            throw ToolError("Export did not create output file: \(outputURL.path)")
+        }
+
+        let canvas = CGSize(width: editor.timeline.width, height: editor.timeline.height)
+        let outputSize = format.videoFormat == nil || format == .xml ? canvas : resolution.renderSize(for: canvas)
+        var payload: [String: Any] = [
+            "outputPath": outputURL.path,
+            "format": format.rawValue,
+            "width": Int(outputSize.width.rounded()),
+            "height": Int(outputSize.height.rounded()),
+            "fps": editor.timeline.fps,
+            "totalFrames": editor.timeline.totalFrames,
+            "durationSeconds": editor.timeline.fps > 0 ? Double(editor.timeline.totalFrames) / Double(editor.timeline.fps) : 0,
+        ]
+        if format != .xml, format != .palmierProject {
+            payload["resolution"] = Self.normalizedResolutionName(resolution)
+        }
+        guard let json = Self.jsonString(roundJSONFloatingPointNumbers(payload, toPlaces: 3)) else {
+            throw ToolError("Failed to encode export metadata")
+        }
+        return .ok(json)
+    }
+
+    private static func parseTimelineExportFormat(_ raw: String) throws -> TimelineExportFormat {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch normalized.lowercased() {
+        case "h264", "h.264": return .h264
+        case "h265", "h.265", "hevc": return .h265
+        case "prores", "prores422": return .prores
+        case "xml", "xmeml": return .xml
+        case "palmierproject", "palmier_project", "palmier-project", "palmier": return .palmierProject
+        default:
+            throw ToolError("Unsupported format '\(raw)'. Expected h264, h265, prores, xml, or palmierProject.")
+        }
+    }
+
+    private static func parseExportResolution(_ raw: String) throws -> ExportResolution {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "720p": return .r720p
+        case "1080p": return .r1080p
+        case "1440p", "2k": return .r1440p
+        case "4k", "2160p": return .r4k
+        case "native", "match timeline", "matchtimeline": return .native
+        default:
+            throw ToolError("Unsupported resolution '\(raw)'. Expected 720p, 1080p, 1440p, 4k, or native.")
+        }
+    }
+
+    private static func validateExportDestination(
+        _ outputURL: URL,
+        format: TimelineExportFormat,
+        overwrite: Bool,
+        fm: FileManager
+    ) throws {
+        guard outputURL.isFileURL else {
+            throw ToolError("outputPath must be a file path.")
+        }
+        guard outputURL.pathExtension.lowercased() == format.fileExtension.lowercased() else {
+            throw ToolError("outputPath must end in .\(format.fileExtension) for \(format.rawValue) export.")
+        }
+        let parent = outputURL.deletingLastPathComponent()
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: parent.path, isDirectory: &isDir), isDir.boolValue else {
+            throw ToolError("Output directory does not exist: \(parent.path)")
+        }
+        if fm.fileExists(atPath: outputURL.path), !overwrite {
+            throw ToolError("Output already exists: \(outputURL.path). Pass overwrite=true to replace it.")
+        }
+    }
+
+    private static func normalizedResolutionName(_ resolution: ExportResolution) -> String {
+        switch resolution {
+        case .r720p: "720p"
+        case .r1080p: "1080p"
+        case .r1440p: "1440p"
+        case .r4k: "4k"
+        case .native: "native"
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -75,6 +75,7 @@ final class ToolExecutor {
         case .getMedia:      return try getMedia(editor)
         case .inspectMedia:  return try await inspectMedia(editor, args)
         case .getTranscript: return try await getTranscript(editor, args)
+        case .exportTimeline: return try await exportTimeline(editor, args)
         case .inspectTimeline: return try await inspectTimeline(editor, args)
         case .searchMedia:   return try await searchMedia(editor, args)
         case .applyColor:    return try applyColor(editor, args)

--- a/Tests/PalmierProTests/Agent/ExportTimelineToolTests.swift
+++ b/Tests/PalmierProTests/Agent/ExportTimelineToolTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("ToolExecutor — export_timeline")
+@MainActor
+struct ExportTimelineToolTests {
+
+    @Test func xmlExportWritesFileAndReturnsMetadata() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(fps: 24, tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 48)]),
+        ]))
+        h.editor.timeline.width = 1280
+        h.editor.timeline.height = 720
+        let outURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-export-\(UUID().uuidString).xml")
+        defer { try? FileManager.default.removeItem(at: outURL) }
+
+        let json = try await h.runOK("export_timeline", args: [
+            "outputPath": outURL.path,
+            "format": "xml",
+        ]) as? [String: Any]
+
+        #expect(FileManager.default.fileExists(atPath: outURL.path))
+        #expect(json?["outputPath"] as? String == outURL.path)
+        #expect(json?["format"] as? String == "xml")
+        #expect(json?["width"] as? Int == 1280)
+        #expect(json?["height"] as? Int == 720)
+        #expect(json?["fps"] as? Int == 24)
+        #expect(json?["totalFrames"] as? Int == 48)
+        #expect(json?["durationSeconds"] as? Double == 2.0)
+    }
+
+    @Test func refusesExistingOutputWithoutOverwrite() async throws {
+        let h = ToolHarness()
+        let outURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-existing-\(UUID().uuidString).xml")
+        try Data("existing".utf8).write(to: outURL)
+        defer { try? FileManager.default.removeItem(at: outURL) }
+
+        let result = await h.runRaw("export_timeline", args: [
+            "outputPath": outURL.path,
+            "format": "xml",
+        ])
+
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("Pass overwrite=true"))
+    }
+
+    @Test func rejectsUnsupportedFormatAndResolution() async {
+        let h = ToolHarness()
+
+        let badFormat = await h.runRaw("export_timeline", args: [
+            "outputPath": "/tmp/export.bad",
+            "format": "gif",
+        ])
+        #expect(badFormat.isError)
+        #expect(ToolHarness.textOf(badFormat).contains("Unsupported format"))
+
+        let badResolution = await h.runRaw("export_timeline", args: [
+            "outputPath": "/tmp/export.mp4",
+            "format": "h264",
+            "resolution": "8k",
+        ])
+        #expect(badResolution.isError)
+        #expect(ToolHarness.textOf(badResolution).contains("Unsupported resolution"))
+    }
+
+    @Test func palmierProjectExportWritesPackage() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(fps: 30, tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 30)]),
+        ]))
+        let outURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-package-\(UUID().uuidString).palmier", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outURL) }
+
+        let json = try await h.runOK("export_timeline", args: [
+            "outputPath": outURL.path,
+            "format": "palmierProject",
+        ]) as? [String: Any]
+
+        #expect(FileManager.default.fileExists(atPath: outURL.appendingPathComponent(Project.timelineFilename).path))
+        #expect(FileManager.default.fileExists(atPath: outURL.appendingPathComponent(Project.manifestFilename).path))
+        #expect(json?["outputPath"] as? String == outURL.path)
+        #expect(json?["format"] as? String == "palmierProject")
+        #expect(json?["totalFrames"] as? Int == 30)
+    }
+}


### PR DESCRIPTION
## Summary
- adds an `export_timeline` MCP tool definition and executor wiring
- calls Palmier Pro's native `ExportService` pipeline for h264/h265/prores/xml exports
- supports self-contained `.palmier` project export through the existing project exporter
- returns output path plus timeline/export metadata
- adds focused tests for XML export, destination overwrite validation, unsupported args, and `.palmier` package export

## Notes
This intentionally bridges MCP to the existing app export pipeline instead of reconstructing timeline rendering externally.

## Verification
- `git diff --check` passed
- attempted `swift test --filter ExportTimelineToolTests` and `swift test --skip-update --filter ExportTimelineToolTests`; local SwiftPM repeatedly stalled while downloading/building binary artifacts (`Sentry` and `Sparkle`), so focused tests did not complete in this environment.

## Follow-up
Please run the focused test target in an environment with SwiftPM binary artifacts available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Agents can write large files to arbitrary paths the user specifies; validation limits accidental overwrites but export is still heavy I/O and uses the same production export pipeline as the UI.
> 
> **Overview**
> Introduces **`export_timeline`** so the assistant can export the open project without reimplementing rendering.
> 
> The tool is registered in **`ToolDefinitions`** and dispatched from **`ToolExecutor`**. A new **`ToolExecutor+Export`** implementation parses `outputPath`, optional `format` (h264/h265/prores/xml/palmierProject), `resolution`, and `overwrite`, validates the parent directory, extension match, and existing files, then calls the same **`ExportService`** paths as the in-app Export UI (AVFoundation video, XMEML, or self-contained **`.palmier`** via `exportPalmierProject`). Success returns JSON with the output path plus width, height, fps, frame count, and duration.
> 
> **`ExportTimelineToolTests`** cover XML output metadata, overwrite refusal, bad format/resolution errors, and palmier package creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2652d56f46decb9998d66d16dcaed40dfdc21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->