### PR TITLE
[fix] main-thread hang when capturing project thumbnail on save

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -357,46 +357,68 @@ final class VideoProject: NSDocument {
     // MARK: - Thumbnail
 
     private var cachedThumbnail: Data?
+    private var thumbnailInFlight = false
+    private nonisolated static let thumbnailMaxPixelSize = 640
 
     private func captureThumbnail() -> Data? {
         if let cached = cachedThumbnail { return cached }
-        Log.project.debug("captureThumbnail begin")
-
-        for track in editorViewModel.timeline.tracks where track.type == .video {
-            for clip in track.clips {
-                guard let url = editorViewModel.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
-                if clip.mediaType == .image,
-                   let image = ImageEncoder.thumbnail(url: url, maxPixelSize: 640),
-                   let data = ImageEncoder.encodeJPEG(image, quality: 0.7) {
-                    cachedThumbnail = data
-                    return data
-                }
-                guard clip.mediaType == .video else { continue }
-
-                let asset = AVURLAsset(url: url)
-                guard !asset.tracks(withMediaType: .video).isEmpty else { continue }
-                let generator = AVAssetImageGenerator(asset: asset)
-                generator.maximumSize = CGSize(width: 320, height: 180)
-                generator.appliesPreferredTrackTransform = true
-                let time = CMTime(value: CMTimeValue(clip.trimStartFrame), timescale: CMTimeScale(editorViewModel.timeline.fps))
-                nonisolated(unsafe) var result: CGImage?
-                let semaphore = DispatchSemaphore(value: 0)
-                generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) { _, image, _, _, _ in
-                    result = image
-                    semaphore.signal()
-                }
-                guard semaphore.wait(timeout: .now() + .seconds(5)) == .success else {
-                    generator.cancelAllCGImageGeneration()
-                    continue
-                }
-                if let cgImage = result {
-                    let rep = NSBitmapImageRep(cgImage: cgImage)
-                    cachedThumbnail = rep.representation(using: .jpeg, properties: [.compressionFactor: 0.7])
-                    return cachedThumbnail
-                }
-            }
+        guard !thumbnailInFlight else { return nil }
+        thumbnailInFlight = true
+        Task { [weak self] in
+            await self?.generateThumbnail()
         }
         return nil
+    }
+
+    /// Picks the first usable video-track clip and generates a jpeg
+    private func generateThumbnail() async {
+        defer { thumbnailInFlight = false }
+
+        struct Candidate { let url: URL; let isVideo: Bool; let trimStartFrame: Int }
+        var candidates: [Candidate] = []
+        for track in editorViewModel.timeline.tracks where track.type == .video {
+            for clip in track.clips {
+                guard clip.mediaType == .image || clip.mediaType == .video,
+                      let url = editorViewModel.mediaResolver.expectedURL(for: clip.mediaRef) else { continue }
+                candidates.append(Candidate(
+                    url: url,
+                    isVideo: clip.mediaType == .video,
+                    trimStartFrame: clip.trimStartFrame
+                ))
+            }
+        }
+        let fps = editorViewModel.timeline.fps
+        guard !candidates.isEmpty else { return }
+
+        let maxPixelSize = Self.thumbnailMaxPixelSize
+        let data: Data? = await Task.detached(priority: .utility) {
+            for candidate in candidates {
+                if candidate.isVideo {
+                    // Async `loadTracks` / `image(at:)` — no blocking semaphore wait.
+                    let asset = AVURLAsset(url: candidate.url)
+                    guard (try? await asset.loadTracks(withMediaType: .video).first) != nil else { continue }
+                    let generator = AVAssetImageGenerator(asset: asset)
+                    // Aspect-preserving box; frame is ~640px on the long edge.
+                    generator.maximumSize = CGSize(width: maxPixelSize, height: maxPixelSize)
+                    generator.appliesPreferredTrackTransform = true
+                    let time = CMTime(value: CMTimeValue(candidate.trimStartFrame), timescale: CMTimeScale(max(fps, 1)))
+                    guard let cgImage = try? await generator.image(at: time).image else { continue }
+                    return NSBitmapImageRep(cgImage: cgImage).representation(using: .jpeg, properties: [.compressionFactor: 0.7])
+                } else if let image = ImageEncoder.thumbnail(url: candidate.url, maxPixelSize: maxPixelSize),
+                          let data = ImageEncoder.encodeJPEG(image, quality: 0.7) {
+                    return data
+                }
+            }
+            return nil
+        }.value
+
+        guard let data else { return }
+        cachedThumbnail = data
+        guard let packageURL = fileURL else { return }
+        let thumbURL = packageURL.appendingPathComponent(Project.thumbnailFilename, isDirectory: false)
+        try? await Task.detached(priority: .utility) {
+            try data.write(to: thumbURL, options: .atomic)
+        }.value
     }
 
     // MARK: - Media restore


### PR DESCRIPTION
VideoProject.captureThumbnail() ran synchronous AVAsset track loading and a 5s semaphore wait on the main thread during every save/autosave, blocking the UI

Generate the thumbnail off the main thread instead:
- captureThumbnail() returns the cached value or nil immediately and kicks off a one-time background generation (no per-edit scheduling) so save never blocks.
- Candidate clips are gathered on the main actor using the pure expectedURL (no filesystem stat), then the 640px frame decode/encode runs in a detached task via async loadTracks / image(at:).
- On completion the thumbnail is written into the saved package so the home screen shows it after the first save; the next coordinated save re-embeds it from cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to thumbnail capture/save snapshot behavior with no auth or data-model changes; first save may still omit an embedded thumbnail until cache is populated, which is preserved by existing copy-on-write fallback.
> 
> **Overview**
> Fixes **main-thread UI hangs** during save/autosave by making project thumbnail capture **non-blocking**.
> 
> **`captureThumbnail()`** now returns only a **cached** JPEG or **`nil` immediately**, starts **one** background generation via `thumbnailInFlight`, and no longer runs AVFoundation work on the main thread during `captureSaveSnapshot()`.
> 
> Thumbnail generation moves to **`generateThumbnail()`**: video/image candidates are collected on the main actor using **`expectedURL`** (no filesystem stat), then **640px** JPEG encoding runs in a **`Task.detached`** path using async **`loadTracks`** / **`image(at:)`** instead of synchronous track checks and a **5s semaphore wait**. When generation finishes, the result is **cached** and **written** into the project package’s thumbnail file so the home screen can show it after the first successful generation; later saves embed from cache via the existing snapshot/write flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77335dba44c5c08f8b6d3ee3284c0808993712ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->