### PR TITLE
[fix] main-thread hang from per-clip stat() on the timeline draw path

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -197,6 +197,7 @@ extension EditorViewModel {
         }
         undoManager?.setActionName(actionName)
         videoEngine?.activateTab(activePreviewTab)
+        refreshMissingMediaCache()
         notifyTimelineChanged()
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -353,12 +353,32 @@ extension EditorViewModel {
     func isMediaOffline(_ mediaRef: String) -> Bool {
         offlineMediaRefs.contains(mediaRef)
             || unprocessableMediaRefs.contains(mediaRef)
-            || mediaResolver.isMissing(for: mediaRef)
+            || missingMediaRefs.contains(mediaRef)
     }
 
     /// Present-but-unpreparable (e.g. failed to encode)
     func isMediaUnprocessable(_ mediaRef: String) -> Bool {
-        unprocessableMediaRefs.contains(mediaRef) && !mediaResolver.isMissing(for: mediaRef)
+        unprocessableMediaRefs.contains(mediaRef) && !missingMediaRefs.contains(mediaRef)
+    }
+
+    /// Recompute `missingMediaRefs` off the main thread, then publish on the main actor.
+    func refreshMissingMediaCache() {
+        let entries = mediaManifest.entries
+        let projectPath = projectURL?.path
+        missingMediaRefreshTask?.cancel()
+        missingMediaRefreshTask = Task { [weak self] in
+            let missing = await Task.detached(priority: .utility) {
+                MediaResolver.missingAssetIds(entries: entries, projectPath: projectPath)
+            }.value
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self else { return }
+                if self.missingMediaRefs != missing {
+                    self.missingMediaRefs = missing
+                }
+                self.missingMediaRefreshTask = nil
+            }
+        }
     }
 
     func isClipMediaOffline(_ clip: Clip) -> Bool {
@@ -569,6 +589,7 @@ extension EditorViewModel {
         )
         await asset.loadMetadata()
         updateManifestMetadata(for: asset)
+        refreshMissingMediaCache()
         searchIndex.schedule(asset)
         switch asset.type {
         case .video:

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -110,6 +110,8 @@ final class EditorViewModel {
     var mediaAssets: [MediaAsset] = []
     var offlineMediaRefs: Set<String> = []
     var unprocessableMediaRefs: Set<String> = []
+    var missingMediaRefs: Set<String> = []
+    @ObservationIgnored var missingMediaRefreshTask: Task<Void, Never>?
     let mediaVisualCache = MediaVisualCache()
     let searchIndex = SearchIndexCoordinator()
     var projectURL: URL? {
@@ -170,7 +172,12 @@ final class EditorViewModel {
     @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Never>?
     @ObservationIgnored var mediaImportSequence: Int = 0
 
-    func showMediaPanelMediaTab() { mediaPanelShowMediaTabTick += 1 }
+    func showMediaPanelMediaTab() {
+        mediaPanelShowMediaTabTick += 1
+        // Refresh offline status when the user opens the media tab, so missing
+        // files show as offline even for assets not on the timeline.
+        refreshMissingMediaCache()
+    }
 
     init() {
         mediaResolver = MediaResolver(
@@ -179,6 +186,23 @@ final class EditorViewModel {
         )
         agentService.editor = self
         searchIndex.assetsProvider = { [weak self] in self?.mediaAssets ?? [] }
+
+        // Re-check media presence when the app regains focus: a user may have
+        // deleted/moved backing files in Finder (or ejected a volume) while we
+        // were inactive. `refreshMissingMediaCache` stats off the main thread.
+        didBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshMissingMediaCache() }
+        }
+    }
+
+    @ObservationIgnored private nonisolated(unsafe) var didBecomeActiveObserver: NSObjectProtocol?
+
+    deinit {
+        if let didBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+        }
     }
 
     // MARK: - Document bridge

--- a/Sources/PalmierPro/Models/MediaResolver.swift
+++ b/Sources/PalmierPro/Models/MediaResolver.swift
@@ -31,6 +31,26 @@ final class MediaResolver: @unchecked Sendable {
         return !FileManager.default.fileExists(atPath: url.path)
     }
 
+    /// Compute the set of asset IDs whose backing file is missing on disk, from a
+    /// snapshot of manifest entries + the project base path
+    static func missingAssetIds(entries: [MediaManifestEntry], projectPath: String?) -> Set<String> {
+        var missing: Set<String> = []
+        for entry in entries {
+            let path: String?
+            switch entry.source {
+            case .external(let absolutePath):
+                path = absolutePath
+            case .project(let relativePath):
+                path = projectPath.map { ($0 as NSString).appendingPathComponent(relativePath) }
+            }
+            guard let path, FileManager.default.fileExists(atPath: path) else {
+                missing.insert(entry.id)
+                continue
+            }
+        }
+        return missing
+    }
+
     func displayName(for assetId: String) -> String {
         entry(for: assetId)?.name ?? "Offline"
     }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -406,10 +406,12 @@ final class VideoProject: NSDocument {
         let resolver = editorViewModel.mediaResolver
         var restored = 0
         var missing = 0
+        var missingRefs: Set<String> = []
         for entry in editorViewModel.mediaManifest.entries {
             guard let url = resolver.expectedURL(for: entry.id) else {
                 Log.project.warning("restore: could not resolve URL for entry id=\(entry.id) name=\(entry.name)")
                 missing += 1
+                missingRefs.insert(entry.id)
                 continue
             }
             let asset = MediaAsset(entry: entry, resolvedURL: url)
@@ -417,6 +419,7 @@ final class VideoProject: NSDocument {
             guard FileManager.default.fileExists(atPath: url.path) else {
                 Log.project.warning("restore: media file missing id=\(entry.id) name=\(entry.name) path=\(url.path)")
                 missing += 1
+                missingRefs.insert(entry.id)
                 continue
             }
             restored += 1
@@ -431,6 +434,7 @@ final class VideoProject: NSDocument {
             }
             Task { await asset.loadMetadata() }
         }
+        editorViewModel.missingMediaRefs = missingRefs
         Log.project.notice(
             "restore ok restored=\(restored) missing=\(missing)",
             telemetry: "Media restored",

--- a/Tests/PalmierProTests/Media/MediaResolverTests.swift
+++ b/Tests/PalmierProTests/Media/MediaResolverTests.swift
@@ -104,6 +104,34 @@ struct MediaResolverTests {
 
     // MARK: - Cache behavior
 
+    // MARK: - missingAssetIds (off-main-thread offline computation)
+
+    @Test func missingAssetIdsFlagsExternalMissingAndKeepsPresent() throws {
+        let present = try makeTempFile()
+        defer { try? FileManager.default.removeItem(at: present) }
+
+        let entries = [
+            entry(id: "present", source: .external(absolutePath: present.path)),
+            entry(id: "gone", source: .external(absolutePath: "/tmp/missing-\(UUID().uuidString)"))
+        ]
+        let missing = MediaResolver.missingAssetIds(entries: entries, projectPath: nil)
+        #expect(missing == ["gone"])
+    }
+
+    @Test func missingAssetIdsResolvesProjectRelativePaths() throws {
+        let projectDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("proj-\(UUID().uuidString)")
+        let inner = projectDir.appendingPathComponent("media/asset.mp4")
+        try FileManager.default.createDirectory(at: inner.deletingLastPathComponent(), withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: inner.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: projectDir) }
+
+        let entries = [entry(id: "a", source: .project(relativePath: "media/asset.mp4"))]
+        #expect(MediaResolver.missingAssetIds(entries: entries, projectPath: projectDir.path).isEmpty)
+        // No project base path -> project-relative entry cannot resolve -> missing.
+        #expect(MediaResolver.missingAssetIds(entries: entries, projectPath: nil) == ["a"])
+    }
+
     @Test func entryCacheRebuildsWhenEntryCountChanges() {
         var entries = [entry(id: "a", source: .external(absolutePath: "/tmp/a"))]
         var manifest = MediaManifest()


### PR DESCRIPTION
we are reading `stat()` from file manager on main thread to check if clips are missing, which causes a lot of app hangs for slow volumes.

fix: replace per-draw stat() with in-memory cache. cache is refreshed on project open/restore, import, relink, undo/redo, app activation, and opening the media tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Offline/unprocessable UI now depends on cache freshness between refresh triggers; stale offline state is possible briefly until the next refresh, but behavior is unchanged aside from moving disk I/O off the hot path.
> 
> **Overview**
> Fixes main-thread hangs from **per-clip `fileExists` checks** on the timeline draw path by routing offline detection through a cached `missingMediaRefs` set instead of `mediaResolver.isMissing(for:)` on every read.
> 
> **`MediaResolver.missingAssetIds`** bulk-scans manifest entries (external and project-relative paths) on a background task; **`refreshMissingMediaCache()`** cancels in-flight work, runs that scan at utility priority, and updates the cache on the main actor only when the set changes. Project restore seeds `missingMediaRefs` synchronously during manifest restore.
> 
> The cache is refreshed on **media library undo/redo**, **import finalize**, **opening the media tab**, and **`NSApplication.didBecomeActive`** (Finder moves/deletes while inactive). Tests cover `missingAssetIds` for present/missing external files and project-relative resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0d26023ec5c6884f437500da119a41e10c9a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->