### PR TITLE
[fix] XMEML source timecode for tmcd tracks at their own rate (failed to import to davinci)

### DIFF
--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -42,6 +42,37 @@ enum XMLExporter {
         try? xml.data(using: .utf8)?.write(to: outputURL)
     }
 
+    // MARK: - Source timecode
+
+    /// A source's start timecode: frame number in the timecode track's own `quanta` rate, plus its drop-frame flag.
+    struct SourceTimecode: Equatable { let frame: Int; let quanta: Int; let dropFrame: Bool }
+
+    /// The `<timecode>` values to emit for a file. A `tmcd` timecode runs at its own rate (often 30 DF
+    /// even on 60p footage), so when present it — not the video rate — drives the rate/format. When absent,
+    /// fall back to the video rate and emit a dummy 00:00:00:00.
+    static func timecodeTags(source: SourceTimecode?, videoTimebase: Int, videoNtsc: Bool)
+        -> (base: Int, ntsc: Bool, frame: Int, dropFrame: Bool, string: String) {
+        let base = source?.quanta ?? videoTimebase
+        let dropFrame = source?.dropFrame ?? (videoNtsc && videoTimebase % 30 == 0)
+        let ntsc = dropFrame ? true : videoNtsc
+        let frame = source?.frame ?? 0
+        return (base, ntsc, frame, dropFrame, formatTimecode(frame: frame, fps: base, dropFrame: dropFrame))
+    }
+
+    /// Frame count → SMPTE string; drop-frame (29.97/59.94) uses `;` separators and skips dropped frames.
+    static func formatTimecode(frame: Int, fps: Int, dropFrame: Bool) -> String {
+        guard fps > 0 else { return "00:00:00:00" }
+        var f = frame
+        if dropFrame {
+            let drop = Int((Double(fps) * 0.066666).rounded())   // 2 @ 30, 4 @ 60
+            let d = f / (fps * 600), m = f % (fps * 600)
+            f += drop * 9 * d + (m > drop ? drop * ((m - drop) / (fps * 60)) : 0)
+        }
+        let sep = dropFrame ? ";" : ":"
+        let ff = f % fps, ss = (f / fps) % 60, mm = (f / (fps * 60)) % 60, hh = f / (fps * 3600)
+        return String(format: "%02d\(sep)%02d\(sep)%02d\(sep)%02d", hh, mm, ss, ff)
+    }
+
     // MARK: - Builder
 
     private final class Builder {
@@ -56,8 +87,8 @@ enum XMLExporter {
         /// Clip id → position within its media type, used to emit `<link>` cross-references.
         private var clipAddresses: [String: ClipAddress] = [:]
         private var clipsByLinkGroup: [String: [Clip]] = [:]
-        /// Source start timecode (frames) per media ref; nil = no timecode track. Avoids re-reading per file.
-        private var startFrameCache: [String: Int?] = [:]
+        /// Source start timecode per media ref; nil = no timecode track. Avoids re-reading per file.
+        private var startFrameCache: [String: SourceTimecode?] = [:]
 
         private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
         private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
@@ -215,14 +246,13 @@ enum XMLExporter {
                     rate(timebase, ntsc: ntsc),
                   ])])])
 
-            // timecode is required for Davinci Resolve. Either read from source or emit a dummy 00:00:00:00.
-            let dropFrame = ntsc && timebase % 30 == 0
-            let startFrame = sourceStartFrame(for: mediaRef) ?? 0
+            // timecode is required for Davinci Resolve; computed by the unit-tested timecodeTags.
+            let tc = XMLExporter.timecodeTags(source: sourceTimecode(for: mediaRef), videoTimebase: timebase, videoNtsc: ntsc)
             let timecode = el("timecode", [
-                rate(timebase, ntsc: ntsc),
-                leaf("string", formatTimecode(frame: startFrame, fps: timebase, dropFrame: dropFrame)),
-                leaf("frame", startFrame),
-                leaf("displayformat", dropFrame ? "DF" : "NDF"),
+                rate(tc.base, ntsc: tc.ntsc),
+                leaf("string", tc.string),
+                leaf("frame", tc.frame),
+                leaf("displayformat", tc.dropFrame ? "DF" : "NDF"),
             ])
             return el("file", attrs: [("id", fileId)], [
                 leaf("name", fileName),
@@ -235,18 +265,25 @@ enum XMLExporter {
         }
 
         /// Source start timecode — one read serves both the video and audio file nodes.
-        private func sourceStartFrame(for mediaRef: String) -> Int? {
+        private func sourceTimecode(for mediaRef: String) -> SourceTimecode? {
             if let cached = startFrameCache[mediaRef] { return cached }
-            let frame = resolver.resolveURL(for: mediaRef).flatMap(Builder.readStartTimecodeFrame)
-            startFrameCache[mediaRef] = frame
-            return frame
+            let tc = resolver.resolveURL(for: mediaRef).flatMap(Builder.readSourceTimecode)
+            startFrameCache[mediaRef] = tc
+            return tc
         }
 
-        /// Start frame from the QuickTime `tmcd` track; skip the leading edit-boundary buffer (no data buffer).
-        private static func readStartTimecodeFrame(url: URL) -> Int? {
+        /// Start timecode read from the QuickTime `tmcd` track: the start frame plus the timecode's
+        /// own frame quanta and drop-frame flag (often 30 DF even on 60p footage).
+        private static func readSourceTimecode(url: URL) -> SourceTimecode? {
             let asset = AVURLAsset(url: url)
             guard let track = asset.tracks(withMediaType: .timecode).first,
+                  let format = track.formatDescriptions.first,
                   let reader = try? AVAssetReader(asset: asset) else { return nil }
+            let desc = format as! CMFormatDescription
+            let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(desc))
+            let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(desc) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
+            guard quanta > 0 else { return nil }
+
             let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
             guard reader.canAdd(output) else { return nil }
             reader.add(output)
@@ -256,22 +293,9 @@ enum XMLExporter {
                 var be: UInt32 = 0
                 guard CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: 4, destination: &be) == kCMBlockBufferNoErr
                 else { return nil }
-                return Int(UInt32(bigEndian: be))
+                return SourceTimecode(frame: Int(UInt32(bigEndian: be)), quanta: quanta, dropFrame: dropFrame)
             }
             return nil
-        }
-
-        /// Frame count → SMPTE string; drop-frame (29.97/59.94) uses `;` separators and skips dropped frames.
-        private func formatTimecode(frame: Int, fps: Int, dropFrame: Bool) -> String {
-            var f = frame
-            if dropFrame {
-                let drop = Int((Double(fps) * 0.066666).rounded())   // 2 @ 30, 4 @ 60
-                let d = f / (fps * 600), m = f % (fps * 600)
-                f += drop * 9 * d + (m > drop ? drop * ((m - drop) / (fps * 60)) : 0)
-            }
-            let sep = dropFrame ? ";" : ":"
-            let ff = f % fps, ss = (f / fps) % 60, mm = (f / (fps * 60)) % 60, hh = f / (fps * 3600)
-            return String(format: "%02d\(sep)%02d\(sep)%02d\(sep)%02d", hh, mm, ss, ff)
         }
 
         // MARK: - Links

--- a/Tests/PalmierProTests/Export/XMLExporterTimecodeTests.swift
+++ b/Tests/PalmierProTests/Export/XMLExporterTimecodeTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import PalmierPro
+
+/// Regression for source-timecode export (DaVinci/Premiere relink by source timecode).
+///
+/// A QuickTime `tmcd` track carries its own frame quanta and drop-frame flag, which can differ from
+/// the video rate (e.g. 30 DF timecode on 59.94p footage). The earlier exporter formatted the start
+/// frame using the *video* rate and a drop-frame flag *guessed* from it, so the emitted timecode
+/// didn't match the file and DaVinci refused to relink. `timecodeTags` must follow the track.
+@Suite("XMLExporter timecode")
+struct XMLExporterTimecodeTests {
+    typealias Source = XMLExporter.SourceTimecode
+
+    // MARK: - timecodeTags follows the track, not the video rate
+
+    @Test func nonDropSourceEmitsNonDropTimecodeRegardlessOfVideoNtsc() {
+        // 29.97 NDF source: start 18:13:40:20 → frame 1968620 at quanta 30, drop-frame FALSE.
+        // The video is NTSC (the old code would have forced drop-frame here).
+        let tc = XMLExporter.timecodeTags(
+            source: Source(frame: 1968620, quanta: 30, dropFrame: false),
+            videoTimebase: 30, videoNtsc: true
+        )
+        #expect(tc.base == 30)
+        #expect(tc.ntsc == true)        // 29.97 NDF still rides NTSC
+        #expect(tc.dropFrame == false)
+        #expect(tc.string == "18:13:40:20")
+        #expect(!tc.string.contains(";"))
+    }
+
+    @Test func dropFrameSourceOn60pUsesTrackQuantaNotVideoRate() {
+        // Fuji 59.94p: tmcd runs at quanta 30 DF; start 00:23:53;.. → frame 42966.
+        // Formatting at the video rate (60) gave the wrong 00;11;56;.. — must use quanta 30.
+        let tc = XMLExporter.timecodeTags(
+            source: Source(frame: 42966, quanta: 30, dropFrame: true),
+            videoTimebase: 60, videoNtsc: true
+        )
+        #expect(tc.base == 30)
+        #expect(tc.dropFrame == true)
+        #expect(tc.frame == 42966)
+        #expect(tc.string == "00;23;53;18")   // 42966 @ 30 DF, matches the file's 00:23:53;36 @ 60
+    }
+
+    @Test func cleanThirtyFpsSourceStaysNonNtsc() {
+        let tc = XMLExporter.timecodeTags(
+            source: Source(frame: 0, quanta: 30, dropFrame: false),
+            videoTimebase: 30, videoNtsc: false
+        )
+        #expect(tc.ntsc == false)
+        #expect(tc.string == "00:00:00:00")
+    }
+
+    @Test func noTimecodeTrackFallsBackToVideoRateAndZero() {
+        // No tmcd → dummy 00:00:00:00 at the video rate; drop-frame guessed from the video rate.
+        let tc = XMLExporter.timecodeTags(source: nil, videoTimebase: 30, videoNtsc: true)
+        #expect(tc.frame == 0)
+        #expect(tc.base == 30)
+        #expect(tc.dropFrame == true)   // legacy guess for NTSC 30 when the source is silent
+        #expect(tc.string == "00;00;00;00")
+    }
+
+    // MARK: - formatTimecode math
+
+    @Test func nonDropFormattingRollsFieldsAtFps() {
+        #expect(XMLExporter.formatTimecode(frame: 0, fps: 25, dropFrame: false) == "00:00:00:00")
+        // 18:45:23:23 @ 25fps = 1688098.
+        #expect(XMLExporter.formatTimecode(frame: 1688098, fps: 25, dropFrame: false) == "18:45:23:23")
+        // One full hour at 24fps.
+        #expect(XMLExporter.formatTimecode(frame: 24 * 3600, fps: 24, dropFrame: false) == "01:00:00:00")
+    }
+
+    @Test func dropFrameSkipsDroppedFrameNumbers() {
+        // At 30 DF the first two frame numbers of each non-tenth minute are dropped, so the
+        // displayed value runs ahead of the raw count.
+        #expect(XMLExporter.formatTimecode(frame: 0, fps: 30, dropFrame: true) == "00;00;00;00")
+        #expect(XMLExporter.formatTimecode(frame: 42966, fps: 30, dropFrame: true) == "00;23;53;18")
+    }
+
+    @Test func zeroFpsDoesNotCrash() {
+        #expect(XMLExporter.formatTimecode(frame: 100, fps: 0, dropFrame: false) == "00:00:00:00")
+    }
+}


### PR DESCRIPTION
fixes #110 

The exporter read each source's start timecode but formatted it using the video frame rate and a drop-frame flag guessed from it. A QuickTime tmcd track runs at its own quanta/drop-frame (e.g. 30 DF on 59.94p footage), so the emitted timecode disagreed with the file and DaVinci Resolve could not relink clips by source timecode.

Read the timecode track's frame quanta and drop-frame flag from its format description and use those to interpret, format, and tag <timecode>. Also fixes non-drop 29.97/59.94 sources that were forced into drop-frame format.

Extract timecodeTags/formatTimecode as pure functions with unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 65f66063f803c137cf4bb4bd32eb0b1cdb89b55f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->