### PR TITLE
Validate speed/volume/opacity/trim in set_clip_properties

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -425,6 +425,21 @@ extension ToolExecutor {
         if let df = input.durationFrames, df < 1 {
             throw ToolError("durationFrames must be >= 1 (got \(df))")
         }
+        if let s = input.speed, s <= 0 {
+            throw ToolError("speed must be > 0 (got \(s))")
+        }
+        if let v = input.volume, !(0...1).contains(v) {
+            throw ToolError("volume must be between 0 and 1 (got \(v))")
+        }
+        if let o = input.opacity, !(0...1).contains(o) {
+            throw ToolError("opacity must be between 0 and 1 (got \(o))")
+        }
+        if let t = input.trimStartFrame, t < 0 {
+            throw ToolError("trimStartFrame must be >= 0 (got \(t))")
+        }
+        if let t = input.trimEndFrame, t < 0 {
+            throw ToolError("trimEndFrame must be >= 0 (got \(t))")
+        }
         let color = try parseColorHex(input.color, path: "set_clip_properties")
         let alignment = try parseAlignment(input.alignment, path: "set_clip_properties")
 

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -980,6 +980,22 @@ struct ToolExecutorClipTests {
         #expect(result.isError)
     }
 
+    @Test func setClipPropertiesRejectsOutOfRangeValues() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        let clipId = await addedClip(in: h, asset: asset)
+        let cases: [(String, Any)] = [
+            ("speed", 0.0), ("speed", -2.0),
+            ("volume", 5.0), ("opacity", -1.0), ("trimStartFrame", -100),
+        ]
+        for (field, value) in cases {
+            var args: [String: Any] = ["clipIds": [clipId]]
+            args[field] = value
+            let result = await h.runRaw("set_clip_properties", args: args)
+            #expect(result.isError, "\(field)=\(value) should be rejected")
+            #expect(ToolHarness.textOf(result).contains(field), "error should name \(field)")
+        }
+    }
+
     @Test func setClipPropertiesDurationAndSpeedPropagateToLinkedPartner() async throws {
         let (h, videoId, audioId) = await setupLinkedPair()
         _ = await h.runRaw("set_clip_properties", args: [


### PR DESCRIPTION
Fixes #143.

### Problem
`set_clip_properties` validated only `durationFrames`, so the agent tool accepted out-of-range `speed` (<= 0), `volume`/`opacity` (outside 0...1), and negative `trimStartFrame`/`trimEndFrame` that the editor UI disallows. A non-positive `speed` is also a latent corruption: a later speed edit recomputes `durationFrames = max(1, durationFrames * oldSpeed / newSpeed)`, which with a negative old speed collapses the clip to 1 frame.

### Fix
Add the missing guards next to the existing `durationFrames` check, in the same style (`throw ToolError("... (got X)")`):

```swift
if let s = input.speed, s <= 0 { throw ToolError("speed must be > 0 (got \(s))") }
if let v = input.volume, !(0...1).contains(v) { throw ToolError("volume must be between 0 and 1 (got \(v))") }
if let o = input.opacity, !(0...1).contains(o) { throw ToolError("opacity must be between 0 and 1 (got \(o))") }
if let t = input.trimStartFrame, t < 0 { throw ToolError("trimStartFrame must be >= 0 (got \(t))") }
if let t = input.trimEndFrame, t < 0 { throw ToolError("trimEndFrame must be >= 0 (got \(t))") }
```

Scoped to `set_clip_properties`; `add_clips`/`insert_clips` already guard their own trim/duration and don't take speed/volume/opacity.

### Test
`setClipPropertiesRejectsOutOfRangeValues` asserts each of `speed: 0`, `speed: -2`, `volume: 5`, `opacity: -1`, `trimStartFrame: -100` is rejected.
- Without the fix: 5 failures (all wrongly accepted).
- With the fix: passes.

`swift test` is green (733/733). No existing test used out-of-range values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation only at the agent tool boundary; no changes to editor apply logic beyond rejecting bad args earlier.
> 
> **Overview**
> The agent **`set_clip_properties`** tool now rejects out-of-range inputs that the editor already disallows, matching the existing **`durationFrames`** guard style with **`ToolError`** messages that include the bad value.
> 
> **`speed`** must be **> 0** (blocking non-positive values that can corrupt clip duration on later speed edits). **`volume`** and **`opacity`** must stay in **0...1**. **`trimStartFrame`** and **`trimEndFrame`** must be **≥ 0**.
> 
> Adds **`setClipPropertiesRejectsOutOfRangeValues`** to assert errors for invalid **`speed`**, **`volume`**, **`opacity`**, and **`trimStartFrame`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f52ad13c14c042524e33faeec39f094c47115d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->