### PR TITLE
fix: safe-cast timecode format description to avoid crash on export

### DIFF
--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -280,7 +280,7 @@ enum XMLExporter {
             guard let track = asset.tracks(withMediaType: .timecode).first,
                   let format = track.formatDescriptions.first,
                   let reader = try? AVAssetReader(asset: asset) else { return nil }
-            let desc = format as! CMFormatDescription
+            guard let desc = format as? CMFormatDescription else { return nil }
             let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(desc))
             let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(desc) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
             guard quanta > 0 else { return nil }


### PR DESCRIPTION
Fixes #146.

## What's happening

`AVAssetTrack.formatDescriptions` (synchronous API) returns `[Any]`. The previous code did an unconditional force cast:

```swift
let desc = format as! CMFormatDescription
```

If the format description is anything other than `CMFormatDescription`, Swift throws a fatal error — not a catchable exception, the app just dies mid-export with no useful message.

## How to reproduce

1. Find or create a QuickTime `.mov` with an unusual timecode track — e.g. a file muxed by FFmpeg using a non-standard `tmcd` box, or a file whose timecode track format description was written by a third-party camera that doesn't emit a standard `CMTimeCodeFormatDescription`.
2. Import it into Palmier Pro.
3. Export → XMEML.
4. App crashes with `EXC_BAD_INSTRUCTION` / `Fatal error: Could not cast value of type '...' to 'CMFormatDescription'` in `XMLExporter.readSourceTimecode`.

Well-formed camera footage (Sony, Fuji, Canon, DJI) won't hit this because their `tmcd` tracks always carry a proper `CMTimeCodeFormatDescription`. The crash surface is edge-case files — FFmpeg output, third-party NLEs, or anything with a non-standard timecode box.

## Fix

```swift
// before
let desc = format as! CMFormatDescription

// after
guard let desc = format as? CMFormatDescription else { return nil }
```

Returns `nil` on an unexpected format, same as every other early-exit in `readSourceTimecode`. Export continues without source timecode, identical behaviour to a clip with no timecode track at all.

The rest of the codebase that reads format descriptions uses the async `track.load(.formatDescriptions)` API (e.g. `AlphaVideoNormalizer.swift:35`), which returns `[CMFormatDescription]` directly. This was the one remaining spot on the synchronous path.

`swift build` passes. No new unit test — `readSourceTimecode` needs a real MOV file on disk, and the existing timecode suite covers the formatting logic downstream of this call.