### PR TITLE
Run agent read_image decode off the main actor

### DIFF
--- a/Sources/PalmierPro/Agent/AgentMentionContext.swift
+++ b/Sources/PalmierPro/Agent/AgentMentionContext.swift
@@ -11,26 +11,32 @@ enum AgentMentionContext {
         mentions.filter { text.contains("@\($0.displayName)") }
     }
 
+    /// Frozen at send time so the cached prompt prefix stays byte-stable
     @MainActor
-    static func hint(
-        _ mentions: [AgentMention],
-        editor: EditorViewModel?,
-        inlined: InlinedMentions = InlinedMentions()
-    ) -> String {
-        let entries = mentionEntries(mentions, editor: editor, inlined: inlined)
+    static func hint(_ mentions: [AgentMention], editor: EditorViewModel?) -> String {
+        let entries = mentionEntries(mentions, editor: editor)
         let data = (try? JSONSerialization.data(withJSONObject: entries, options: [.sortedKeys])) ?? Data()
         let json = String(data: data, encoding: .utf8) ?? "[]"
-        let notes = mentionNotes(mentions, inlined: inlined)
+        let notes = mentionNotes(mentions)
         let suffix = notes.isEmpty ? "" : " " + notes.joined(separator: " ")
         return "Referenced assets and timeline context in this message: \(json).\(suffix)"
     }
 
+    /// Which mentioned images were actually attached this request
+    static func inlineNote(for inlined: InlinedMentions) -> String? {
+        var parts: [String] = []
+        if !inlined.inlinedIds.isEmpty {
+            parts.append("These mentioned images are attached inline as image blocks — do not call inspect_media for them: \(inlined.inlinedIds.sorted().joined(separator: ", ")).")
+        }
+        if !inlined.failures.isEmpty {
+            let list = inlined.failures.sorted { $0.key < $1.key }.map { "\($0.key) (\($0.value))" }.joined(separator: ", ")
+            parts.append("These images could not be attached; tell the user the image could not be read rather than describing it: \(list).")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+
     @MainActor
-    static func mentionEntries(
-        _ mentions: [AgentMention],
-        editor: EditorViewModel?,
-        inlined: InlinedMentions
-    ) -> [[String: Any]] {
+    static func mentionEntries(_ mentions: [AgentMention], editor: EditorViewModel?) -> [[String: Any]] {
         mentions.map { mention in
             var entry: [String: Any] = [
                 "mention": "@\(mention.displayName)",
@@ -44,8 +50,6 @@ enum AgentMentionContext {
             entry["kind"] = mention.clipId == nil ? "mediaAsset" : "timelineClip"
             if let mediaRef = mention.mediaRef {
                 entry["mediaRef"] = mediaRef
-                if inlined.inlinedIds.contains(mediaRef) { entry["inlined"] = true }
-                if let reason = inlined.failures[mediaRef] { entry["inlineError"] = reason }
             }
             if let type = mention.type { entry["type"] = type.rawValue }
             if let clipId = mention.clipId {
@@ -56,14 +60,8 @@ enum AgentMentionContext {
         }
     }
 
-    private static func mentionNotes(_ mentions: [AgentMention], inlined: InlinedMentions) -> [String] {
+    private static func mentionNotes(_ mentions: [AgentMention]) -> [String] {
         var notes: [String] = []
-        if !inlined.inlinedIds.isEmpty {
-            notes.append("Assets marked \"inlined\": true are attached as image blocks in this message — do not call inspect_media for them.")
-        }
-        if !inlined.failures.isEmpty {
-            notes.append("Assets with \"inlineError\" could not be attached; tell the user the image could not be read rather than describing it.")
-        }
         if mentions.contains(where: { $0.referencesTimelineClips }) {
             notes.append("Entries with \"clipId\" refer to timeline clips; use clipId for timeline edits and pass it to inspect_media when inspecting visible source media.")
         }

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -294,7 +294,7 @@ final class AgentService {
         onSessionsChanged?()
     }
 
-    func send(text: String, mentions: [AgentMention]) {
+    func send(text: String, mentions: [AgentMention]) async {
         guard canStream else {
             streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
             return
@@ -303,12 +303,11 @@ final class AgentService {
         guard !trimmed.isEmpty else { return }
         let referencedMentions = AgentMentionContext.referencedMentions(mentions, in: trimmed)
         // Snapshot the mention/timeline context
-        let contextHint = referencedMentions.isEmpty
-            ? nil
-            : AgentMentionContext.hint(
-                referencedMentions, editor: editor,
-                inlined: inlineImageBlocks(for: referencedMentions)
-            )
+        var contextHint: String?
+        if !referencedMentions.isEmpty {
+            let inlined = await inlineImageBlocks(for: referencedMentions)
+            contextHint = AgentMentionContext.hint(referencedMentions, editor: editor, inlined: inlined)
+        }
 
         resolveOrphanToolUses()
         messages.append(AgentMessage(
@@ -349,7 +348,7 @@ final class AgentService {
 
         loop: while !Task.isCancelled {
             resolveOrphanToolUses()
-            let apiMsgs = apiMessages()
+            let apiMsgs = await apiMessages()
             let assistant = AgentMessage(role: .assistant, blocks: [])
             messages.append(assistant)
             let assistantID = assistant.id
@@ -511,22 +510,24 @@ final class AgentService {
         }
     }
 
-    private func apiMessages() -> [AnthropicMessage] {
-        messages.compactMap { msg in
+    private func apiMessages() async -> [AnthropicMessage] {
+        var result: [AnthropicMessage] = []
+        for msg in messages {
             var content = msg.blocks.compactMap(Self.contentBlockJSON)
             if msg.role == .user, !msg.mentions.isEmpty {
-                let inlined = inlineImageBlocks(for: msg.mentions)
+                let inlined = await inlineImageBlocks(for: msg.mentions)
                 let hint = msg.contextHint
                     ?? AgentMentionContext.hint(msg.mentions, editor: editor, inlined: inlined)
                 content.insert(contentsOf: inlined.blocks, at: 0)
                 content.insert(["type": "text", "text": hint], at: 0)
             }
-            guard !content.isEmpty else { return nil }
-            return AnthropicMessage(role: msg.role == .user ? .user : .assistant, content: content)
+            guard !content.isEmpty else { continue }
+            result.append(AnthropicMessage(role: msg.role == .user ? .user : .assistant, content: content))
         }
+        return result
     }
 
-    private func inlineImageBlocks(for mentions: [AgentMention]) -> AgentMentionContext.InlinedMentions {
+    private func inlineImageBlocks(for mentions: [AgentMention]) async -> AgentMentionContext.InlinedMentions {
         var out = AgentMentionContext.InlinedMentions()
         guard let editor else {
             for mention in mentions where mention.type == .image {
@@ -534,19 +535,30 @@ final class AgentService {
             }
             return out
         }
+        // Resolve mention -> URL on the main actor, then encode off it.
+        var pending: [(mediaRef: String, url: URL)] = []
         for mention in mentions where mention.type == .image {
             guard let mediaRef = mention.mediaRef else { continue }
             guard let asset = editor.mediaAssets.first(where: { $0.id == mediaRef }) else {
                 out.failures[mediaRef] = "asset not in media library"
                 continue
             }
-            guard let encoded = ImageEncoder.encode(url: asset.url) else {
+            pending.append((mediaRef, asset.url))
+        }
+        let jobs = pending
+        let encoded = await Task.detached(priority: .userInitiated) {
+            jobs.map { job in
+                (job.mediaRef, ImageEncoder.encode(url: job.url).map { ($0.mime, $0.data.base64EncodedString()) })
+            }
+        }.value
+        for (mediaRef, result) in encoded {
+            guard let (mime, base64) = result else {
                 out.failures[mediaRef] = "could not read or decode image file"
                 continue
             }
             out.blocks.append([
                 "type": "image",
-                "source": ["type": "base64", "media_type": encoded.mime, "data": encoded.data.base64EncodedString()],
+                "source": ["type": "base64", "media_type": mime, "data": base64],
             ])
             out.inlinedIds.insert(mediaRef)
         }

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -294,7 +294,7 @@ final class AgentService {
         onSessionsChanged?()
     }
 
-    func send(text: String, mentions: [AgentMention]) async {
+    func send(text: String, mentions: [AgentMention]) {
         guard canStream else {
             streamError = .upstream("Sign in to a paid plan or add an Anthropic API key to start.")
             return
@@ -302,12 +302,12 @@ final class AgentService {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let referencedMentions = AgentMentionContext.referencedMentions(mentions, in: trimmed)
-        // Snapshot the mention/timeline context
-        var contextHint: String?
-        if !referencedMentions.isEmpty {
-            let inlined = await inlineImageBlocks(for: referencedMentions)
-            contextHint = AgentMentionContext.hint(referencedMentions, editor: editor, inlined: inlined)
-        }
+        let contextHint = referencedMentions.isEmpty
+            ? nil
+            : AgentMentionContext.hint(
+                referencedMentions, editor: editor,
+                inlined: plannedInlines(for: referencedMentions)
+            )
 
         resolveOrphanToolUses()
         messages.append(AgentMessage(
@@ -525,6 +525,20 @@ final class AgentService {
             result.append(AnthropicMessage(role: msg.role == .user ? .user : .assistant, content: content))
         }
         return result
+    }
+
+    /// Which image mentions will inline
+    private func plannedInlines(for mentions: [AgentMention]) -> AgentMentionContext.InlinedMentions {
+        var out = AgentMentionContext.InlinedMentions()
+        for mention in mentions where mention.type == .image {
+            guard let mediaRef = mention.mediaRef else { continue }
+            if editor?.mediaAssets.contains(where: { $0.id == mediaRef }) ?? false {
+                out.inlinedIds.insert(mediaRef)
+            } else {
+                out.failures[mediaRef] = editor == nil ? "editor unavailable" : "asset not in media library"
+            }
+        }
+        return out
     }
 
     private func inlineImageBlocks(for mentions: [AgentMention]) async -> AgentMentionContext.InlinedMentions {

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -304,10 +304,7 @@ final class AgentService {
         let referencedMentions = AgentMentionContext.referencedMentions(mentions, in: trimmed)
         let contextHint = referencedMentions.isEmpty
             ? nil
-            : AgentMentionContext.hint(
-                referencedMentions, editor: editor,
-                inlined: plannedInlines(for: referencedMentions)
-            )
+            : AgentMentionContext.hint(referencedMentions, editor: editor)
 
         resolveOrphanToolUses()
         messages.append(AgentMessage(
@@ -516,8 +513,8 @@ final class AgentService {
             var content = msg.blocks.compactMap(Self.contentBlockJSON)
             if msg.role == .user, !msg.mentions.isEmpty {
                 let inlined = await inlineImageBlocks(for: msg.mentions)
-                let hint = msg.contextHint
-                    ?? AgentMentionContext.hint(msg.mentions, editor: editor, inlined: inlined)
+                var hint = msg.contextHint ?? AgentMentionContext.hint(msg.mentions, editor: editor)
+                if let note = AgentMentionContext.inlineNote(for: inlined) { hint += " " + note }
                 content.insert(contentsOf: inlined.blocks, at: 0)
                 content.insert(["type": "text", "text": hint], at: 0)
             }
@@ -525,20 +522,6 @@ final class AgentService {
             result.append(AnthropicMessage(role: msg.role == .user ? .user : .assistant, content: content))
         }
         return result
-    }
-
-    /// Which image mentions will inline
-    private func plannedInlines(for mentions: [AgentMention]) -> AgentMentionContext.InlinedMentions {
-        var out = AgentMentionContext.InlinedMentions()
-        for mention in mentions where mention.type == .image {
-            guard let mediaRef = mention.mediaRef else { continue }
-            if editor?.mediaAssets.contains(where: { $0.id == mediaRef }) ?? false {
-                out.inlinedIds.insert(mediaRef)
-            } else {
-                out.failures[mediaRef] = editor == nil ? "editor unavailable" : "asset not in media library"
-            }
-        }
-        return out
     }
 
     private func inlineImageBlocks(for mentions: [AgentMention]) async -> AgentMentionContext.InlinedMentions {

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -383,9 +383,11 @@ struct AgentPanelView: View {
 
     private func submit() {
         guard canSend else { return }
-        service.send(text: service.draft, mentions: service.mentions)
+        let text = service.draft
+        let mentions = service.mentions
         service.draft = ""
         service.mentions.removeAll()
+        Task { await service.send(text: text, mentions: mentions) }
     }
 
     private func populatePrompt(_ prompt: String) {

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -383,11 +383,9 @@ struct AgentPanelView: View {
 
     private func submit() {
         guard canSend else { return }
-        let text = service.draft
-        let mentions = service.mentions
+        service.send(text: service.draft, mentions: service.mentions)
         service.draft = ""
         service.mentions.removeAll()
-        Task { await service.send(text: text, mentions: mentions) }
     }
 
     private func populatePrompt(_ prompt: String) {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
@@ -50,17 +50,30 @@ extension ToolExecutor {
         return ToolResult(content: content, isError: result.isError)
     }
 
-    /// Maps each id to its shortest prefix (≥ 8 chars) that no other id shares.
+    /// Maps each id to its shortest prefix (≥ idPrefixFloor) that no other id shares. O(n log n)
     static func shortIdMap(_ ids: Set<String>) -> [String: String] {
+        let sorted = ids.sorted()
         var out: [String: String] = [:]
-        for id in ids {
-            var len = idPrefixFloor
-            while len < id.count, ids.contains(where: { $0 != id && $0.hasPrefix(id.prefix(len)) }) {
-                len += 1
-            }
+        for (i, id) in sorted.enumerated() {
+            var sharedLen = 0
+            if i > 0 { sharedLen = max(sharedLen, commonPrefixLength(id, sorted[i - 1])) }
+            if i < sorted.count - 1 { sharedLen = max(sharedLen, commonPrefixLength(id, sorted[i + 1])) }
+            let len = min(id.count, max(idPrefixFloor, sharedLen + 1))
             out[id] = String(id.prefix(len))
         }
         return out
+    }
+
+    private static func commonPrefixLength(_ a: String, _ b: String) -> Int {
+        var count = 0
+        var i = a.startIndex
+        var j = b.startIndex
+        while i < a.endIndex, j < b.endIndex, a[i] == b[j] {
+            count += 1
+            i = a.index(after: i)
+            j = b.index(after: j)
+        }
+        return count
     }
 
     /// Expands id-prefix arguments back to full ids before a tool runs. Throws on an ambiguous prefix;

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -288,7 +288,7 @@ extension ToolExecutor {
         }
 
         switch asset.type {
-        case .image: return try readImage(asset: asset, args: args)
+        case .image: return try await readImage(asset: asset, args: args)
         case .video: return try await readVideo(editor: editor, asset: asset, args: args, mapping: mapping)
         case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping)
         case .lottie: return try await readLottie(asset: asset, args: args)
@@ -318,17 +318,22 @@ extension ToolExecutor {
         ]
     }
 
-    private func readImage(asset: MediaAsset, args: [String: Any]) throws -> ToolResult {
+    private func readImage(asset: MediaAsset, args: [String: Any]) async throws -> ToolResult {
         let url = asset.url
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.uint64Value ?? 0
-        guard let encoded = ImageEncoder.encode(url: url) else {
+        let encoded = await Task.detached(priority: .userInitiated) {
+            ImageEncoder.encode(url: url).map {
+                (base64: $0.data.base64EncodedString(), mime: $0.mime, encodedByteSize: $0.data.count)
+            }
+        }.value
+        guard let encoded else {
             throw ToolError("Failed to read or decode image file")
         }
 
+        let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.uint64Value ?? 0
         var meta = Self.baseMeta(for: asset)
         meta["mimeType"] = encoded.mime
         meta["byteSize"] = fileSize
-        meta["encodedByteSize"] = encoded.data.count
+        meta["encodedByteSize"] = encoded.encodedByteSize
         if let props = Self.imagePropertiesSummary(at: url) {
             meta["imageProperties"] = props
         }
@@ -337,7 +342,7 @@ extension ToolExecutor {
             throw ToolError("Failed to encode metadata")
         }
         return ToolResult(
-            content: [.image(base64: encoded.data.base64EncodedString(), mediaType: encoded.mime), .text(metaJSON)],
+            content: [.image(base64: encoded.base64, mediaType: encoded.mime), .text(metaJSON)],
             isError: false
         )
     }

--- a/Sources/PalmierPro/Utilities/ImageEncoder.swift
+++ b/Sources/PalmierPro/Utilities/ImageEncoder.swift
@@ -4,14 +4,13 @@ import UniformTypeIdentifiers
 
 /// Downscales images to a max longest edge and re-encodes as JPEG
 /// so its more token efficient for agent.
-@MainActor
 enum ImageEncoder {
     /// Target 3.5 MB
     static let maxBytes = 3_500_000
     /// Internal downsample target.
     static let maxLongestEdge = 1568
 
-    struct Output {
+    struct Output: Sendable {
         let data: Data
         let mime: String
     }
@@ -24,12 +23,9 @@ enum ImageEncoder {
 
     static func encode(url: URL) -> Output? {
         let stamp = fileStamp(url: url)
-        if let stamp, let hit = cache[stamp] { return hit }
+        if let stamp, let hit = cachedOutput(stamp) { return hit }
         let output = passthrough(url: url, stamp: stamp) ?? downscaled(url: url)
-        if let output, let stamp {
-            if cache.count >= maxCacheEntries { cache.removeAll() }
-            cache[stamp] = output
-        }
+        if let output, let stamp { store(output, for: stamp) }
         return output
     }
 
@@ -97,8 +93,20 @@ enum ImageEncoder {
         let size: Int
         let mtime: Date
     }
-    private static var cache: [FileStamp: Output] = [:]
+    private nonisolated(unsafe) static var cache: [FileStamp: Output] = [:]
+    private static let cacheLock = NSLock()
     private static let maxCacheEntries = 32
+
+    private static func cachedOutput(_ stamp: FileStamp) -> Output? {
+        cacheLock.withLock { cache[stamp] }
+    }
+
+    private static func store(_ output: Output, for stamp: FileStamp) {
+        cacheLock.withLock {
+            if cache.count >= maxCacheEntries { cache.removeAll() }
+            cache[stamp] = output
+        }
+    }
 
     private static func fileStamp(url: URL) -> FileStamp? {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),

--- a/Tests/PalmierProTests/Agent/AgentMentionTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentMentionTests.swift
@@ -124,8 +124,7 @@ struct AgentMentionTests {
 
         let entries = AgentMentionContext.mentionEntries(
             editor.agentService.mentions,
-            editor: editor,
-            inlined: AgentMentionContext.InlinedMentions()
+            editor: editor
         )
 
         #expect(entries.count == 1)
@@ -165,8 +164,7 @@ struct AgentMentionTests {
 
         let entries = AgentMentionContext.mentionEntries(
             editor.agentService.mentions,
-            editor: editor,
-            inlined: AgentMentionContext.InlinedMentions()
+            editor: editor
         )
         let kinds = entries.compactMap { $0["kind"] as? String }
         #expect(kinds == ["mediaAsset", "timelineClip", "timelineRange"])


### PR DESCRIPTION
Agent image-into-chat work decoded + JPEG re-encoded + base64'd images on the **main thread**, blocking the UI. Both entry points are addressed:

- **`read_image` tool** (`ToolExecutor.readImage`) — was synchronous `@MainActor`; Sentry App Hang span culprit `ToolExecutor.readImage` (`AppHang`).
- **message inlining** (`AgentService.inlineImageBlocks`) — encoded on the main actor when sending and on every agent loop iteration via `apiMessages`.

## Change
- Drop `@MainActor` from `ImageEncoder`; guard its memo cache with an `NSLock` so `encode()` is safe off the main actor.
- `readImage`: `async`, runs `encode` + base64 in `Task.detached`, returns a `Sendable` tuple — matches `readVideo`'s `extractVisual`.
- `inlineImageBlocks`: resolve mention→URL on the main actor, encode off it via `Task.detached`; propagate `async` through `apiMessages` and `send`.

Same compression behavior (1568px / 3.5 MB JPEG), just off the main thread.

## Test
- `swift build` — clean.
- Manual: open the agent, reference/inspect a large image, confirm the UI stays responsive during the read.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent API payload assembly and concurrent `ImageEncoder` caching; wrong locking or hint splitting could change model-facing prompts or race on cache, but compression behavior is unchanged.
> 
> **Overview**
> Moves **agent image read/encode work off the main thread** so large JPEG downscale + base64 no longer blocks the UI (Sentry `ToolExecutor.readImage` app hangs and chat mention inlining).
> 
> **`ImageEncoder`** drops `@MainActor`; `Output` is `Sendable` and the file-stamp cache is guarded with **`NSLock`** so `encode()` is safe from background work. **`readImage`** (`inspect_media`) and **`inlineImageBlocks`** resolve URLs on the main actor, then run `ImageEncoder.encode` in **`Task.detached`**; **`apiMessages()`** is **`async`** and awaits inlining on each agent loop turn.
> 
> **Mention context** is split so the JSON **`contextHint` frozen at send** no longer embeds per-request inline state: `hint` / `mentionEntries` no longer take `InlinedMentions`; **`inlineNote(for:)`** appends which images were attached or failed when building API payloads.
> 
> Also rewrites **`shortIdMap`** to an **O(n log n)** neighbor-prefix algorithm (same uniqueness semantics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b309a1f1f48f07f46d240b9dddb83bd6c27fc781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->