### PR TITLE
Revert "fix: safe-cast timecode format description to avoid crash on export"

### DIFF
--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -280,7 +280,7 @@ enum XMLExporter {
             guard let track = asset.tracks(withMediaType: .timecode).first,
                   let format = track.formatDescriptions.first,
                   let reader = try? AVAssetReader(asset: asset) else { return nil }
-            guard let desc = format as? CMFormatDescription else { return nil }
+            let desc = format as! CMFormatDescription
             let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(desc))
             let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(desc) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
             guard quanta > 0 else { return nil }


### PR DESCRIPTION
Reverts palmier-io/palmier-pro#147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces a possible crash on XML export when reading `tmcd` metadata if the format description type is unexpected, instead of failing open with no source timecode.
> 
> **Overview**
> Reverts the safe-cast change in **`readSourceTimecode`** inside `XMLExporter.swift`, so the first timecode track format description is again cast with **`as! CMFormatDescription`** instead of **`as?`** with an early **`nil`** return.
> 
> That means export no longer skips source timecode when the cast fails; it will trap if AVFoundation ever supplies a non–time-code format description on that track.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156babf9b998bea03215b69525941934ab483fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->