### PR TITLE
fix: guard timecode format description using CFTypeID before force cast

### DIFF
--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -280,7 +280,7 @@ enum XMLExporter {
             guard let track = asset.tracks(withMediaType: .timecode).first,
                   let format = track.formatDescriptions.first,
                   let reader = try? AVAssetReader(asset: asset) else { return nil }
-            let desc = format as! CMFormatDescription
+            guard let desc = format as? CMFormatDescription else { return nil }
             let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(desc))
             let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(desc) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
             guard quanta > 0 else { return nil }

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -280,7 +280,8 @@ enum XMLExporter {
             guard let track = asset.tracks(withMediaType: .timecode).first,
                   let format = track.formatDescriptions.first,
                   let reader = try? AVAssetReader(asset: asset) else { return nil }
-            guard let desc = format as? CMFormatDescription else { return nil }
+            guard CFGetTypeID(format as CFTypeRef) == CMFormatDescriptionGetTypeID() else { return nil }
+            let desc = format as! CMFormatDescription
             let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(desc))
             let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(desc) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
             guard quanta > 0 else { return nil }


### PR DESCRIPTION
Revised fix for #146, replacing the previous PR (#147) which was reverted because `as?` on a CoreFoundation type triggers a compiler warning that your CI treats as an error:

```
error: conditional downcast to CoreFoundation type 'CMFormatDescription' will always succeed
```

This is a known Swift/CF quirk — both `as!` and `as?` are opaque to the Swift type system for CF types, so the compiler warns on `as?` even though the runtime cast can fail.

**The correct approach** is an explicit `CFTypeID` guard before the force cast:

```swift
// before (v1 — triggers compiler warning → CI error)
guard let desc = format as? CMFormatDescription else { return nil }

// after (v2 — explicit CF-level type check, no warning)
guard CFGetTypeID(format as CFTypeRef) == CMFormatDescriptionGetTypeID() else { return nil }
let desc = format as! CMFormatDescription
```

`CFGetTypeID` is the canonical way to validate CF types in Swift without going through the bridging layer. If the type doesn't match we return `nil` — same early-exit behaviour as every other guard in `readSourceTimecode`. The force cast on the next line is then safe.

Verified locally:

```
$ swift build
Build complete!
```

No errors, no warnings on `XMLExporter.swift`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard on an export edge case; failure mode is unchanged (nil timecode) with no auth or data-model impact.
> 
> **Overview**
> **`readSourceTimecode`** now checks that the timecode track’s first format description is actually a **`CMFormatDescription`** before using it.
> 
> A **`CFGetTypeID`** guard runs right after the existing AVFoundation setup guards. If the type doesn’t match, the function returns **`nil`** like the other failure paths, so export falls back to dummy timecode instead of an unsafe cast. The following **`as! CMFormatDescription`** is only reached when the runtime type is confirmed.
> 
> This replaces a conditional **`as?`** approach that Swift treats as always succeeding for Core Foundation types and that CI flags as an error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d617f83facd5f3e80ddb0ed87623c9a772b339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->