### PR TITLE
Make timeline zoom buttons clickable

### DIFF
--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -43,9 +43,12 @@ struct ToolbarView: View {
 
             // Zoom
             HStack(spacing: AppTheme.Spacing.xs) {
-                Image(systemName: "minus.magnifyingglass")
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .font(.system(size: AppTheme.FontSize.sm))
+                zoomButton(
+                    "minus.magnifyingglass",
+                    help: "Zoom Out",
+                    isDisabled: editor.zoomScale <= editor.minZoomScale,
+                    action: zoomOut
+                )
                 // Log-mapped so slider travel is uniform per zoom factor
                 let zoomBinding = Binding(
                     get: { log(editor.zoomScale) },
@@ -55,9 +58,12 @@ struct ToolbarView: View {
                     .controlSize(.mini)
                     .tint(AppTheme.Accent.primary)
                     .frame(width: 100)
-                Image(systemName: "plus.magnifyingglass")
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .font(.system(size: AppTheme.FontSize.sm))
+                zoomButton(
+                    "plus.magnifyingglass",
+                    help: "Zoom In",
+                    isDisabled: editor.zoomScale >= Zoom.max,
+                    action: zoomIn
+                )
             }
         }
         .padding(.horizontal, AppTheme.Spacing.md)
@@ -74,6 +80,36 @@ struct ToolbarView: View {
         }
         .buttonStyle(.plain)
         .help(help)
+    }
+
+    private func zoomButton(
+        _ systemName: String,
+        help: String,
+        isDisabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(isDisabled ? AppTheme.Text.mutedColor : AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
+                .hoverHighlight()
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .help(help)
+    }
+
+    private func zoomOut() {
+        setZoomScale(editor.zoomScale / Zoom.toolbarStepFactor)
+    }
+
+    private func zoomIn() {
+        setZoomScale(editor.zoomScale * Zoom.toolbarStepFactor)
+    }
+
+    private func setZoomScale(_ zoomScale: Double) {
+        editor.zoomScale = min(Zoom.max, max(editor.minZoomScale, zoomScale))
     }
 
     private func undo() {

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -82,6 +82,7 @@ enum Zoom {
     static let min: Double = 0.05
     static let floor: Double = 0.0001
     static let max: Double = 40.0
+    static let toolbarStepFactor: Double = 1.25
     static let scrollSensitivity: Double = 0.04
     static let magnifySensitivity: Double = 1.5 
     static let panSpeed: Double = 5.0


### PR DESCRIPTION
<img width="1170" height="864" alt="image" src="https://github.com/user-attachments/assets/6d7f96e7-4bc3-48d5-9e12-355d84fbc25e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolbar-only UI that updates existing `editor.zoomScale` with the same bounds used elsewhere; no auth, persistence, or timeline input changes.
> 
> **Overview**
> The toolbar **minus/plus magnifying glass** icons next to the zoom slider are now **buttons** that step timeline zoom in and out, instead of static decoration.
> 
> Each click multiplies or divides `editor.zoomScale` by **`Zoom.toolbarStepFactor` (1.25)**, with **`setZoomScale`** clamping between **`editor.minZoomScale`** and **`Zoom.max`**. Buttons use **help text**, **hover highlight**, and **disabled** state (muted styling) at the min/max limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2e5d75136bd41eabf7a5590bbeab3de0fc8419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->