### PR TITLE
Fix chat input losing focus when backspace clears the field

### DIFF
--- a/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
@@ -99,7 +99,11 @@ struct AgentInputBox<LeadingTools: View>: View {
                 .onChange(of: draft) { old, new in
                     updateMentionQuery(from: new)
                     if !old.isEmpty && new.isEmpty {
+                        let wasFocused = focused
                         textEditorID = UUID()
+                        if wasFocused {
+                            Task { @MainActor in focused = true }
+                        }
                     }
                 }
                 .onPasteCommand(of: [.fileURL, .image, .png, .jpeg, .tiff], perform: handlePaste)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Pressing backspace to delete the last character in the chat input box caused it to lose focus (deselect), making it impossible to keep typing without clicking the field again.

## Root cause

`AgentInputBox.textField` has an `onChange(of: draft)` handler that recreates the `TextEditor` via `textEditorID = UUID()` whenever the draft transitions from non-empty to empty. This recreation destroys the view's first-responder status without restoring it, so `@FocusState` drops to `false` and the cursor vanishes.

## Fix

Capture `focused` before the recreation. If the editor was focused, schedule `focused = true` on the next `@MainActor` tick — after SwiftUI has built the new `TextEditor` — so focus is seamlessly restored.

```swift
let wasFocused = focused
textEditorID = UUID()
if wasFocused {
    Task { @MainActor in focused = true }
}
```

The `TextEditor` recreation itself is preserved; it exists to reset internal `NSTextView` state after a full clear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b600946-f4d8-40cb-b495-a8b3f52ad578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b600946-f4d8-40cb-b495-a8b3f52ad578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

