### PR TITLE
Fix segment-drop trim: store trimEndFrame as a tail amount, not an out-point

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -367,12 +367,17 @@ final class EditorViewModel {
         let shouldLink = addLinkedAudio && targetIsVideo && asset.type == .video && asset.hasAudio
         let linkGroupId: String? = shouldLink ? UUID().uuidString : nil
         let trimStart = sourceSegment.map { secondsToFrame(seconds: $0.lowerBound, fps: timeline.fps) } ?? 0
+        let totalSourceFrames = secondsToFrame(seconds: asset.duration, fps: timeline.fps)
 
         // sourceSegment (source seconds) and explicit trim frames are mutually exclusive; callers pass one.
         let applyTrim: (inout Clip) -> Void = { clip in
             if sourceSegment != nil {
+                // trimStartFrame/trimEndFrame are amounts trimmed off the head/tail
+                // (sourceDurationFrames = consumed + trimStart + trimEnd), so the tail
+                // trim is whatever source remains after the head trim and visible span.
+                let consumed = Int((Double(durationFrames) * clip.speed).rounded())
                 clip.trimStartFrame = trimStart
-                clip.trimEndFrame = trimStart + durationFrames
+                clip.trimEndFrame = max(0, totalSourceFrames - trimStart - consumed)
             } else {
                 if let t = trimStartFrame { clip.trimStartFrame = t }
                 if let t = trimEndFrame { clip.trimEndFrame = t }

--- a/Tests/PalmierProTests/Search/SegmentTrimInvariantTests.swift
+++ b/Tests/PalmierProTests/Search/SegmentTrimInvariantTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// Smoke test for the segment-drop trim bug.
+///
+/// `trimEndFrame` is a TAIL-trim amount (frames cut off the end of the source),
+/// per `Clip.sourceDurationFrames = sourceFramesConsumed + trimStartFrame + trimEndFrame`.
+/// Therefore a clip created from a dropped source segment must satisfy the
+/// invariant: trimStart + consumed + trimEnd == the asset's real frame count.
+/// It can never reference more (or fewer) frames than the source actually has.
+@MainActor
+@Suite("Segment trim source-length invariant")
+struct SegmentTrimInvariantTests {
+    private func editor(fps: Int = 30) -> EditorViewModel {
+        let e = EditorViewModel()
+        e.timeline = Fixtures.timeline(fps: fps, tracks: [Fixtures.videoTrack()])
+        return e
+    }
+
+    /// 100s asset @ 30fps = 3000 source frames.
+    private func asset() -> MediaAsset {
+        MediaAsset(url: URL(fileURLWithPath: "/tmp/a.mov"), type: .video, name: "a", duration: 100)
+    }
+
+    @Test func midSegmentSourceLengthMatchesAsset() {
+        let e = editor()
+        let a = asset()
+        e.createClips(from: [a], trackIndex: 0, startFrame: 0, segments: [a.id: 10...14])
+        let clip = e.timeline.tracks[0].clips.first
+        #expect(clip != nil)
+        // Must equal the asset's true frame count (3000), not an inflated/deflated value.
+        #expect(clip?.sourceDurationFrames == 3000)
+    }
+
+    @Test func endSegmentDoesNotExceedAsset() {
+        let e = editor()
+        let a = asset()
+        e.createClips(from: [a], trackIndex: 0, startFrame: 0, segments: [a.id: 96...100])
+        let clip = e.timeline.tracks[0].clips.first
+        // Segment runs to the asset end → nothing trimmed off the tail.
+        #expect(clip?.trimEndFrame == 0)
+        #expect(clip?.sourceDurationFrames == 3000)
+    }
+}

--- a/Tests/PalmierProTests/Search/SegmentTrimTests.swift
+++ b/Tests/PalmierProTests/Search/SegmentTrimTests.swift
@@ -27,8 +27,8 @@ struct SegmentTrimTests {
         let a = asset()
         e.createClips(from: [a], trackIndex: 0, startFrame: 0, segments: [a.id: 10...14])
         let clip = e.timeline.tracks[0].clips.first
-        #expect(clip?.trimStartFrame == 300)   // 10s × 30
-        #expect(clip?.trimEndFrame == 420)     // trimStart + 120
+        #expect(clip?.trimStartFrame == 300)   // 10s × 30, head trim
+        #expect(clip?.trimEndFrame == 2580)    // tail trim: 3000 total − 300 head − 120 visible
         #expect(clip?.durationFrames == 120)
     }
 
@@ -41,13 +41,14 @@ struct SegmentTrimTests {
         #expect(clip?.durationFrames == 3000)
     }
 
-    /// Fence-post: a segment ending exactly at the asset end yields an exclusive
-    /// trimEnd equal to the asset's frame count — valid, not an overrun.
+    /// Fence-post: a segment ending exactly at the asset end trims nothing off
+    /// the tail, so trimEndFrame is 0 (and the clip references the full source).
     @Test func segmentAtAssetEndStaysInBounds() {
         let e = editor()
         let a = asset()
         e.createClips(from: [a], trackIndex: 0, startFrame: 0, segments: [a.id: 96...100])
         let clip = e.timeline.tracks[0].clips.first
-        #expect(clip?.trimEndFrame == 3000)    // 100s × 30, exclusive end
+        #expect(clip?.trimEndFrame == 0)            // ends at asset end → no tail trim
+        #expect(clip?.sourceDurationFrames == 3000) // references the whole 100s × 30 source
     }
 }


### PR DESCRIPTION
Fixes #162.

### Problem
`placeClip`'s `sourceSegment` path set `clip.trimEndFrame = trimStart + durationFrames`, treating `trimEndFrame` as an absolute end position. But `trimEndFrame` is a tail-trim amount (`sourceDurationFrames = sourceFramesConsumed + trimStartFrame + trimEndFrame`). The result was an invalid `sourceDurationFrames` (e.g. a 3000-frame asset reporting 6000 frames), which mis-sampled the timeline waveform/thumbnail and produced wrong FCPXML `outPoint`/`sourceDuration`. Playback was unaffected because the render path ignores `trimEndFrame`.

### Fix
Compute the tail trim as the source remaining after the head trim and visible span:
```swift
let totalSourceFrames = secondsToFrame(seconds: asset.duration, fps: timeline.fps)
...
let consumed = Int((Double(durationFrames) * clip.speed).rounded())
clip.trimStartFrame = trimStart
clip.trimEndFrame = max(0, totalSourceFrames - trimStart - consumed)
```

### Tests
- Added `SegmentTrimInvariantTests` asserting the source-length invariant (`trimStart + consumed + trimEnd == asset frame count`) for a mid-clip and an end-of-clip segment. Fails on the old code (`6000 != 3000`), passes after the fix.
- Corrected `SegmentTrimTests` expectations and comments, which had encoded the buggy out-point values (`trimEnd` 10–14s: `420 → 2580`; 96–100s: `3000 → 0`).

### Results
- Full suite: **735 tests, 122 suites, all passing**, no regressions.
- One behavioral line changed in `placeClip` plus test updates. No public API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path fix in placeClip for sourceSegment placement plus test updates; no API changes and playback was already unaffected.
> 
> **Overview**
> Fixes incorrect **trim** values when placing clips from a **source segment** (e.g. search moment drops). `placeClip` no longer sets `trimEndFrame` to `trimStart + durationFrames` (treating it like an absolute out-point). It now derives **tail trim** from the asset’s total source frames minus head trim and consumed visible span: `trimEndFrame = max(0, totalSourceFrames - trimStart - consumed)`, matching `Clip.sourceDurationFrames = consumed + trimStart + trimEnd`.
> 
> **Tests** were updated to expect the correct tail amounts (e.g. mid-segment `2580` instead of `420`, end-of-asset `0` instead of `3000`). New **`SegmentTrimInvariantTests`** assert `sourceDurationFrames` always equals the real asset frame count for mid and end segments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94a66891ce8c1418fd37d176c320a6c77b8ffc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->