### PR TITLE
[ui] move project settings from preview panel to inspector panel

### DIFF
--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -76,8 +76,8 @@ struct InspectorView: View {
     private var projectMetadataContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xl) {
-                if let url = editor.projectURL {
-                    metadataSection(title: "Project") {
+                metadataSection(title: "Project") {
+                    if let url = editor.projectURL {
                         plainMetadataRow(
                             label: "Name",
                             value: url.deletingPathExtension().lastPathComponent
@@ -88,13 +88,13 @@ struct InspectorView: View {
                             truncate: .middle
                         )
                     }
+                    plainMetadataRow(label: "Duration", value: formatDuration(Double(editor.timeline.totalFrames) / Double(editor.timeline.fps)))
                 }
 
-                metadataSection(title: "Format") {
-                    plainMetadataRow(label: "Resolution", value: "\(editor.timeline.width) × \(editor.timeline.height)")
-                    plainMetadataRow(label: "Frame Rate", value: "\(editor.timeline.fps) fps")
-                    plainMetadataRow(label: "Aspect Ratio", value: formatAspectRatio(width: editor.timeline.width, height: editor.timeline.height))
-                    plainMetadataRow(label: "Duration", value: formatDuration(Double(editor.timeline.totalFrames) / Double(editor.timeline.fps)))
+                metadataSection(title: "Settings") {
+                    menuMetadataRow(label: "Resolution", value: "\(editor.timeline.width) × \(editor.timeline.height)") { qualityMenuItems }
+                    menuMetadataRow(label: "Frame Rate", value: "\(editor.timeline.fps) fps") { fpsMenuItems }
+                    menuMetadataRow(label: "Aspect Ratio", value: formatAspectRatio(width: editor.timeline.width, height: editor.timeline.height)) { aspectMenuItems }
                 }
             }
             .padding(.horizontal, AppTheme.Spacing.lg)
@@ -138,12 +138,100 @@ struct InspectorView: View {
                 .multilineTextAlignment(.trailing)
                 .textSelection(.enabled)
                 .help(valueHelp ?? value)
+                .padding(.horizontal, AppTheme.Spacing.xs)
         }
+        .frame(height: AppTheme.IconSize.md)
     }
 
     private func formatAspectRatio(width: Int, height: Int) -> String {
         let gcd = gcd(width, height)
         return "\(width / gcd):\(height / gcd)"
+    }
+
+    private func menuMetadataRow<MenuContent: View>(
+        label: String,
+        value: String,
+        @ViewBuilder menu: @escaping () -> MenuContent
+    ) -> some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Text(label)
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize()
+            Spacer()
+            Menu {
+                menu()
+            } label: {
+                HStack(spacing: AppTheme.Spacing.xxs) {
+                    Text(value)
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: AppTheme.FontSize.micro, weight: .semibold))
+                        .foregroundStyle(AppTheme.Text.mutedColor)
+                }
+                .padding(.horizontal, AppTheme.Spacing.xs)
+                .frame(height: AppTheme.IconSize.md)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+            }
+            .menuStyle(.button)
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .fixedSize()
+        }
+    }
+
+    @ViewBuilder
+    private var aspectMenuItems: some View {
+        ForEach(AspectPreset.allCases, id: \.self) { preset in
+            Button {
+                editor.applyTimelineSettings(fps: editor.timeline.fps, width: preset.width, height: preset.height)
+            } label: {
+                HStack {
+                    Text(preset.label)
+                    Spacer()
+                    if editor.timeline.width == preset.width && editor.timeline.height == preset.height {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var fpsMenuItems: some View {
+        ForEach([24, 25, 30, 50, 60], id: \.self) { fps in
+            Button {
+                editor.applyTimelineSettings(fps: fps, width: editor.timeline.width, height: editor.timeline.height)
+            } label: {
+                HStack {
+                    Text("\(fps) fps")
+                    Spacer()
+                    if editor.timeline.fps == fps {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var qualityMenuItems: some View {
+        ForEach(QualityPreset.allCases, id: \.self) { preset in
+            Button {
+                let (w, h) = preset.resolution(currentWidth: editor.timeline.width, currentHeight: editor.timeline.height)
+                editor.applyTimelineSettings(fps: editor.timeline.fps, width: w, height: h)
+            } label: {
+                HStack {
+                    Text(preset.label)
+                    Spacer()
+                    if preset.matches(width: editor.timeline.width, height: editor.timeline.height) {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Clip Inspector

--- a/Sources/PalmierPro/Inspector/ProjectSettingsPresets.swift
+++ b/Sources/PalmierPro/Inspector/ProjectSettingsPresets.swift
@@ -1,0 +1,73 @@
+// Shared presets for editable project settings (used by the inspector's Format section).
+
+enum AspectPreset: CaseIterable {
+    case sixteenNine, nineByFourteen, nineSixteen, oneOne, fourThree, twoPointFourOne
+
+    var label: String {
+        switch self {
+        case .sixteenNine: "16:9"
+        case .nineByFourteen: "9:14"
+        case .nineSixteen: "9:16"
+        case .oneOne: "1:1"
+        case .fourThree: "4:3"
+        case .twoPointFourOne: "2.4:1"
+        }
+    }
+
+    var width: Int {
+        switch self {
+        case .sixteenNine: 1920
+        case .nineByFourteen: 1080
+        case .nineSixteen: 1080
+        case .oneOne: 1080
+        case .fourThree: 1440
+        case .twoPointFourOne: 2560
+        }
+    }
+
+    var height: Int {
+        switch self {
+        case .sixteenNine: 1080
+        case .nineByFourteen: 1680
+        case .nineSixteen: 1920
+        case .oneOne: 1080
+        case .fourThree: 1080
+        case .twoPointFourOne: 1080
+        }
+    }
+}
+
+enum QualityPreset: CaseIterable {
+    case hd720, fullHD, twoK, fourK
+
+    var label: String {
+        switch self {
+        case .hd720: "720p"
+        case .fullHD: "1080p"
+        case .twoK: "2K"
+        case .fourK: "4K"
+        }
+    }
+
+    /// Scale resolution while preserving the current aspect ratio.
+    func resolution(currentWidth: Int, currentHeight: Int) -> (width: Int, height: Int) {
+        let target = shortEdge
+        if currentWidth <= currentHeight {
+            return (target, Int(Double(target) * Double(currentHeight) / Double(currentWidth)))
+        }
+        return (Int(Double(target) * Double(currentWidth) / Double(currentHeight)), target)
+    }
+
+    func matches(width: Int, height: Int) -> Bool {
+        min(width, height) == shortEdge
+    }
+
+    private var shortEdge: Int {
+        switch self {
+        case .hd720: 720
+        case .fullHD: 1080
+        case .twoK: 1440
+        case .fourK: 2160
+        }
+    }
+}

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -94,7 +94,7 @@ struct PreviewContainerView: View {
             if isTimeline || editor.activePreviewTab.clipType == .video {
                 captureFrameButton
             }
-            projectSettingsGroup
+            settingsMenuButton(label: zoomBadgeLabel, help: "Canvas Zoom") { zoomMenuItems }
         }
         .padding(.horizontal, AppTheme.Spacing.lg)
         .frame(height: 36)
@@ -128,83 +128,6 @@ struct PreviewContainerView: View {
 
     // MARK: - Project settings
 
-    private var projectSettingsGroup: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: AppTheme.Spacing.md) {
-                settingsMenuButton(label: aspectBadgeLabel, help: "Aspect Ratio") { aspectMenuItems }
-                settingsMenuButton(label: "\(editor.timeline.fps)", help: "Frame Rate") { fpsMenuItems }
-                settingsMenuButton(label: qualityBadgeLabel, help: "Resolution") { qualityMenuItems }
-                settingsMenuButton(label: zoomBadgeLabel, help: "Canvas Zoom") { zoomMenuItems }
-            }
-
-            Menu {
-                Menu("Aspect Ratio") { aspectMenuItems }
-                Menu("Frame Rate") { fpsMenuItems }
-                Menu("Quality") { qualityMenuItems }
-                Menu("Zoom") { zoomMenuItems }
-            } label: {
-                badgeIcon("slider.horizontal.3")
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .hoverHighlight()
-            .help("Project Settings")
-        }
-    }
-
-    @ViewBuilder
-    private var aspectMenuItems: some View {
-        ForEach(AspectPreset.allCases, id: \.self) { preset in
-            Button {
-                editor.applyTimelineSettings(fps: editor.timeline.fps, width: preset.width, height: preset.height)
-            } label: {
-                HStack {
-                    Text(preset.label)
-                    Spacer()
-                    if editor.timeline.width == preset.width && editor.timeline.height == preset.height {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var fpsMenuItems: some View {
-        ForEach([24, 25, 30, 50, 60], id: \.self) { fps in
-            Button {
-                editor.applyTimelineSettings(fps: fps, width: editor.timeline.width, height: editor.timeline.height)
-            } label: {
-                HStack {
-                    Text("\(fps) fps")
-                    Spacer()
-                    if editor.timeline.fps == fps {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var qualityMenuItems: some View {
-        ForEach(QualityPreset.allCases, id: \.self) { preset in
-            Button {
-                let (w, h) = preset.resolution(currentWidth: editor.timeline.width, currentHeight: editor.timeline.height)
-                editor.applyTimelineSettings(fps: editor.timeline.fps, width: w, height: h)
-            } label: {
-                HStack {
-                    Text(preset.label)
-                    Spacer()
-                    if preset.matches(width: editor.timeline.width, height: editor.timeline.height) {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        }
-    }
-
     @ViewBuilder
     private var zoomMenuItems: some View {
         ForEach(ZoomPreset.allCases, id: \.self) { preset in
@@ -235,21 +158,6 @@ struct PreviewContainerView: View {
         abs(editor.canvasZoom - preset.value) < 0.01
     }
 
-    private var aspectBadgeLabel: String {
-        let w = editor.timeline.width
-        let h = editor.timeline.height
-        let g = gcd(w, h)
-        return "\(w / g):\(h / g)"
-    }
-
-    private var qualityBadgeLabel: String {
-        let h = min(editor.timeline.width, editor.timeline.height)
-        if h <= 720 { return "HD" }
-        if h <= 1080 { return "FHD" }
-        if h <= 1440 { return "2K" }
-        return "4K"
-    }
-
     private func settingsMenuButton<MenuContent: View>(
         label: String,
         help: String,
@@ -273,13 +181,6 @@ struct PreviewContainerView: View {
             .foregroundStyle(AppTheme.Text.secondaryColor)
             .padding(.horizontal, AppTheme.Spacing.sm)
             .frame(height: AppTheme.IconSize.mdLg)
-    }
-
-    private func badgeIcon(_ systemName: String) -> some View {
-        Image(systemName: systemName)
-            .font(.system(size: AppTheme.FontSize.sm))
-            .foregroundStyle(AppTheme.Text.secondaryColor)
-            .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
     }
 
     // MARK: - Image preview
@@ -771,78 +672,6 @@ struct PreviewContainerView: View {
 }
 
 // MARK: - Settings Presets
-
-private enum AspectPreset: CaseIterable {
-    case sixteenNine, nineByFourteen, nineSixteen, oneOne, fourThree, twoPointFourOne
-
-    var label: String {
-        switch self {
-        case .sixteenNine: "16:9"
-        case .nineByFourteen: "9:14"
-        case .nineSixteen: "9:16"
-        case .oneOne: "1:1"
-        case .fourThree: "4:3"
-        case .twoPointFourOne: "2.4:1"
-        }
-    }
-
-    var width: Int {
-        switch self {
-        case .sixteenNine: 1920
-        case .nineByFourteen: 1080
-        case .nineSixteen: 1080
-        case .oneOne: 1080
-        case .fourThree: 1440
-        case .twoPointFourOne: 2560
-        }
-    }
-
-    var height: Int {
-        switch self {
-        case .sixteenNine: 1080
-        case .nineByFourteen: 1680
-        case .nineSixteen: 1920
-        case .oneOne: 1080
-        case .fourThree: 1080
-        case .twoPointFourOne: 1080
-        }
-    }
-}
-
-private enum QualityPreset: CaseIterable {
-    case hd720, fullHD, twoK, fourK
-
-    var label: String {
-        switch self {
-        case .hd720: "720p"
-        case .fullHD: "1080p"
-        case .twoK: "2K"
-        case .fourK: "4K"
-        }
-    }
-
-    /// Scale resolution while preserving the current aspect ratio.
-    func resolution(currentWidth: Int, currentHeight: Int) -> (width: Int, height: Int) {
-        let target = shortEdge
-        if currentWidth <= currentHeight {
-            return (target, Int(Double(target) * Double(currentHeight) / Double(currentWidth)))
-        }
-        return (Int(Double(target) * Double(currentWidth) / Double(currentHeight)), target)
-    }
-
-    func matches(width: Int, height: Int) -> Bool {
-        min(width, height) == shortEdge
-    }
-
-    private var shortEdge: Int {
-        switch self {
-        case .hd720: 720
-        case .fullHD: 1080
-        case .twoK: 1440
-        case .fourK: 2160
-        }
-    }
-}
 
 private enum ZoomPreset: CaseIterable {
     case twentyFivePercent, fiftyPercent, seventyFivePercent, fit, oneTwentyFivePercent, oneFiftyPercent, twoHundredPercent


### PR DESCRIPTION
users can't find where to set resolution/fps from the little button in preview. moving it to the inspector panel makes the most sense

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where users edit timeline FPS and resolution, but behavior still goes through existing `applyTimelineSettings` (FPS rescaling, etc.); scope is UI relocation plus shared presets.
> 
> **Overview**
> **Project resolution, frame rate, and aspect ratio** are no longer edited from the preview transport bar; they live in the inspector’s empty-selection **Settings** section as dropdown rows (same presets and `applyTimelineSettings` behavior as before).
> 
> The preview bar now only exposes **canvas zoom**. **Duration** moved into the **Project** metadata block. `AspectPreset` and `QualityPreset` were extracted to `ProjectSettingsPresets.swift` so the inspector and preview don’t duplicate preset definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c696cbbe0d489864ba6df10a4589ebbce080c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->