### PR TITLE
Add duplicate_clips agent tool

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -28,6 +28,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case insertClips = "insert_clips"
     case moveClips = "move_clips"
     case removeClips = "remove_clips"
+    case duplicateClips = "duplicate_clips"
     case splitClips = "split_clips"
     case rippleDeleteRanges = "ripple_delete_ranges"
     case setClipProperties = "set_clip_properties"
@@ -464,6 +465,28 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: ["ranges"]
+            )
+        ),
+        AgentTool(
+            name: .duplicateClips,
+            description: "Creates exact copies of one or more clips at new positions. All properties are preserved: keyframes, effects, fades, speed, opacity, volume, transform, crop, and text styling. Single undoable action. Each entry specifies the source clip ID and a destination toFrame; toTrack is optional (defaults to the source clip's track). Overlap on the destination is resolved by overwriting (existing clips are trimmed/split/removed). Linked partners are duplicated automatically so A/V stays in sync — only name the lead clip.",
+            inputSchema: objectSchema(
+                properties: [
+                    "entries": [
+                        "type": "array",
+                        "description": "Per-clip duplication requests.",
+                        "items": [
+                            "type": "object",
+                            "properties": [
+                                "clipId": ["type": "string", "description": "The source clip ID to duplicate."],
+                                "toTrack": ["type": "integer", "description": "Destination track index (0-based). Omit to duplicate onto the source clip's track."],
+                                "toFrame": ["type": "integer", "description": "Destination start frame for the copy."],
+                            ],
+                            "required": ["clipId", "toFrame"],
+                        ],
+                    ],
+                ],
+                required: ["entries"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -55,6 +55,18 @@ fileprivate struct SplitClipsInput: DecodableToolArgs {
     }
 }
 
+fileprivate struct DuplicateClipsInput: DecodableToolArgs {
+    let entries: [Entry]
+    static let allowedKeys: Set<String> = ["entries"]
+
+    struct Entry: DecodableToolArgs {
+        let clipId: String
+        let toTrack: Int?
+        let toFrame: Int
+        static let allowedKeys: Set<String> = ["clipId", "toTrack", "toFrame"]
+    }
+}
+
 fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let clipIds: [String]?
     let durationFrames: Int?
@@ -470,6 +482,61 @@ extension ToolExecutor {
         }
 
         return mutationResult(editor, since: snapshot, touched: allMoves.map(\.clipId))
+    }
+
+    // MARK: duplicate_clips
+
+    func duplicateClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: DuplicateClipsInput = try decodeToolArgs(args, path: "duplicate_clips")
+        guard !input.entries.isEmpty else { throw ToolError("Missing or empty 'entries' array") }
+        if let raws = args["entries"] as? [Any] {
+            for (idx, raw) in raws.enumerated() {
+                if let d = raw as? [String: Any] {
+                    try validateUnknownKeys(d, allowed: DuplicateClipsInput.Entry.allowedKeys, path: "entries[\(idx)]")
+                }
+            }
+        }
+
+        var moves: [(clipId: String, toTrack: Int, toFrame: Int)] = []
+        var seen: Set<String> = Set(input.entries.map(\.clipId))
+        for (idx, entry) in input.entries.enumerated() {
+            let path = "entries[\(idx)]"
+            guard let loc = editor.findClip(id: entry.clipId) else {
+                throw ToolError("\(path): clip not found: \(entry.clipId)")
+            }
+            guard entry.toFrame >= 0 else {
+                throw ToolError("\(path): toFrame must be >= 0 (got \(entry.toFrame))")
+            }
+            let toTrack: Int
+            if let ti = entry.toTrack {
+                guard editor.timeline.tracks.indices.contains(ti) else {
+                    throw ToolError("\(path): toTrack \(ti) out of range (0..\(editor.timeline.tracks.count - 1))")
+                }
+                let srcType = editor.timeline.tracks[loc.trackIndex].type
+                let destType = editor.timeline.tracks[ti].type
+                guard destType.isCompatible(with: srcType) else {
+                    throw ToolError("\(path): toTrack \(ti) (\(destType.rawValue)) is incompatible with clip's \(srcType.rawValue) source track")
+                }
+                toTrack = ti
+            } else {
+                toTrack = loc.trackIndex
+            }
+            moves.append((clipId: entry.clipId, toTrack: toTrack, toFrame: entry.toFrame))
+            seen.insert(entry.clipId)
+
+            for pm in editor.partnerMoves(forMoveOf: entry.clipId, toFrame: entry.toFrame) where !seen.contains(pm.clipId) {
+                guard let pLoc = editor.findClip(id: pm.clipId) else { continue }
+                moves.append((clipId: pm.clipId, toTrack: pLoc.trackIndex, toFrame: max(0, pm.toFrame)))
+                seen.insert(pm.clipId)
+            }
+        }
+
+        let snapshot = timelineSnapshot(editor)
+        let actionName = input.entries.count == 1 ? "Duplicate Clip (Agent)" : "Duplicate Clips (Agent)"
+        editor.undo.perform(actionName) {
+            editor.duplicateClipsToPositions(moves)
+        }
+        return mutationResult(editor, since: snapshot)
     }
 
     // MARK: set_clip_properties

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -239,6 +239,7 @@ final class ToolExecutor {
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
         case .applyLayout:      return try applyLayout(editor, args)
+        case .duplicateClips:   return try duplicateClips(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -954,6 +954,92 @@ struct ToolExecutorClipTests {
         #expect(musicTrack.element.clips.contains { $0.mediaRef == music.id && $0.linkGroupId == nil })
     }
 
+    // MARK: - duplicate_clips
+
+    @Test func duplicateClipsCreatesExactCopyAtNewPosition() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let asset = h.addAsset(type: .video)
+        _ = h.editor.placeClip(asset: asset, trackIndex: 0, startFrame: 0, durationFrames: 60)
+        let srcClip = h.editor.timeline.tracks[0].clips[0]
+        h.editor.commitClipProperty(clipId: srcClip.id) { $0.speed = 1.5; $0.opacity = 0.7 }
+
+        let result = await h.runRaw("duplicate_clips", args: [
+            "entries": [["clipId": srcClip.id, "toFrame": 100]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+
+        let clips = h.editor.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(clips.count == 2)
+        let copy = clips[1]
+        #expect(copy.startFrame == 100)
+        #expect(copy.id != srcClip.id)
+        #expect(copy.speed == 1.5)
+        #expect(copy.opacity == 0.7)
+        #expect(copy.mediaRef == srcClip.mediaRef)
+    }
+
+    @Test func duplicateClipsPreservesKeyframesAndEffects() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let asset = h.addAsset(type: .video)
+        _ = h.editor.placeClip(asset: asset, trackIndex: 0, startFrame: 0, durationFrames: 60)
+        let srcId = h.editor.timeline.tracks[0].clips[0].id
+        h.editor.commitClipProperty(clipId: srcId) {
+            $0.opacityTrack = KeyframeTrack(keyframes: [
+                Keyframe(frame: 0, value: 1.0),
+                Keyframe(frame: 30, value: 0.5),
+            ])
+            $0.effects = [Effect.make("blur", ["radius": 10.0])]
+            $0.fadeInFrames = 5
+        }
+
+        let result = await h.runRaw("duplicate_clips", args: [
+            "entries": [["clipId": srcId, "toFrame": 100]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+
+        let copy = h.editor.timeline.tracks[0].clips.first { $0.startFrame == 100 }!
+        #expect(copy.opacityTrack?.keyframes.count == 2)
+        #expect(copy.opacityTrack?.keyframes[1].value == 0.5)
+        #expect(copy.effects?.count == 1)
+        #expect(copy.effects?[0].type == "blur")
+        #expect(copy.fadeInFrames == 5)
+    }
+
+    @Test func duplicateClipsExpandsLinkedPartners() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let asset = h.addAsset(type: .video, hasAudio: true)
+        _ = h.editor.placeClip(asset: asset, trackIndex: 0, startFrame: 0, durationFrames: 60)
+        #expect(h.editor.timeline.tracks.count == 2)
+        let videoClip = h.editor.timeline.tracks[0].clips[0]
+
+        let result = await h.runRaw("duplicate_clips", args: [
+            "entries": [["clipId": videoClip.id, "toFrame": 100]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+
+        let videoClips = h.editor.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        let audioClips = h.editor.timeline.tracks[1].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(videoClips.count == 2)
+        #expect(audioClips.count == 2)
+        #expect(videoClips[1].startFrame == 100)
+        #expect(audioClips[1].startFrame == 100)
+    }
+
+    @Test func duplicateClipsRejectsInvalidTrack() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = h.editor.placeClip(asset: asset, trackIndex: 0, startFrame: 0, durationFrames: 30)
+        let clipId = h.editor.timeline.tracks[0].clips[0].id
+
+        let result = await h.runRaw("duplicate_clips", args: [
+            "entries": [["clipId": clipId, "toTrack": 99, "toFrame": 0]]
+        ])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("out of range"))
+    }
+
     // MARK: - remove_clips
 
     @Test func removeClipsDropsClipsByIds() async throws {


### PR DESCRIPTION
The AI agent has no way to duplicate clips with full fidelity. The only workaround is `add_clips` + `set_clip_properties` + multiple `set_keyframes` calls — which takes 3–5 round trips and permanently loses fades, effects, and link group membership.

`duplicate_clips` takes a source clip ID and destination frame, calls the existing `duplicateClipsToPositions` path (Swift struct copy), and preserves every property in a single call: keyframes, effects, fades, speed, transform, crop, and text styling. Linked A/V partners expand automatically so video and audio stay in sync. Input shape mirrors `move_clips`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New timeline mutation path that can overwrite clips on the destination track; behavior is delegated to existing editor duplication logic with validation mirroring `move_clips`.
> 
> **Overview**
> Adds a **`duplicate_clips`** agent tool so the model can copy timeline clips in one undoable step instead of chaining `add_clips` with property/keyframe tools.
> 
> Each request is an **`entries`** array (`clipId`, required **`toFrame`**, optional **`toTrack`**) aligned with **`move_clips`**. The handler validates clips and track compatibility, auto-includes linked A/V partners via **`partnerMoves`**, and runs the existing **`duplicateClipsToPositions`** editor path inside undo. Destination overlap is handled like other clip placement (overwrite/trim). Tool registration and **`ToolExecutor`** dispatch are wired; tests cover property/effect preservation, linked duplication, and bad track indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a067dd3884c1a23748e470586a3bf2d3a3d309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->