### PR TITLE
Agent: set_project_settings tool + auto-match timeline on clip add

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -40,6 +40,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case deleteMedia = "delete_media"
     case deleteFolder = "delete_folder"
     case sendFeedback = "send_feedback"
+    case setProjectSettings = "set_project_settings"
 }
 
 struct AgentTool: @unchecked Sendable {
@@ -745,6 +746,19 @@ enum ToolDefinitions {
                     "mediaRef": ["type": "string", "description": "Media asset id from get_media to measure RAW (no grade). Provide this or clipId."],
                     "atFrame": ["type": "integer", "description": "Optional project frame to sample a clip. Defaults to the clip's midpoint. Ignored for mediaRef."],
                     "reference": ["type": "string", "description": "Optional image/video asset id from get_media to compare against; returns its scopes + the subject−reference gap."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .setProjectSettings,
+            description: "Change the project's frame rate, resolution, or aspect ratio. Pass any combination of fps, explicit width+height, aspectRatio, and quality. aspectRatio and explicit width/height are mutually exclusive; quality scales the current aspect ratio (or the selected preset when combined with aspectRatio). The timeline's existing clips are re-fitted automatically: auto-fit transforms recalculate for the new canvas size, and all frame positions/durations rescale when fps changes. Undoable.",
+            inputSchema: objectSchema(
+                properties: [
+                    "fps": ["type": "integer", "description": "Frame rate in frames per second. Common values: 24, 25, 30, 48, 50, 60."],
+                    "width": ["type": "integer", "description": "Canvas width in pixels. Use with height for an exact resolution. Mutually exclusive with aspectRatio."],
+                    "height": ["type": "integer", "description": "Canvas height in pixels. Use with width for an exact resolution. Mutually exclusive with aspectRatio."],
+                    "aspectRatio": ["type": "string", "enum": ["16:9", "9:16", "1:1", "4:3", "2.4:1", "9:14"], "description": "Preset aspect ratio — sets both width and height from the preset, or combined with quality to pick a specific size. Mutually exclusive with width/height."],
+                    "quality": ["type": "string", "enum": ["720p", "1080p", "2K", "4K"], "description": "Resolution quality preset — scales the short edge to the target while preserving the current (or specified) aspect ratio."],
                 ]
             )
         ),

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -280,16 +280,13 @@ extension ToolExecutor {
         guard input.atFrame >= 0 else { throw ToolError("atFrame must be >= 0 (got \(input.atFrame))") }
         let targetType = editor.timeline.tracks[input.trackIndex].type
 
-        var specs: [EditorViewModel.RippleInsertSpec] = []
-        specs.reserveCapacity(input.entries.count)
+        // Apply settings before deriving durations: it may change FPS, which clipDurationFrames depends on.
+        var resolvedAssets: [MediaAsset] = []
+        resolvedAssets.reserveCapacity(input.entries.count)
         for (idx, entry) in input.entries.enumerated() {
             let asset = try asset(entry.mediaRef, editor: editor)
             guard asset.type.isCompatible(with: targetType) else {
                 throw ToolError("entries[\(idx)]: asset type \(asset.type.rawValue) is not compatible with \(targetType.rawValue) track at index \(input.trackIndex)")
-            }
-            let duration = entry.durationFrames ?? editor.clipDurationFrames(for: asset, segment: nil)
-            guard duration >= 1 else {
-                throw ToolError("entries[\(idx)]: durationFrames must be >= 1 (got \(duration))")
             }
             if let t = entry.trimStartFrame, t < 0 {
                 throw ToolError("entries[\(idx)]: trimStartFrame must be >= 0 (got \(t))")
@@ -297,10 +294,21 @@ extension ToolExecutor {
             if let t = entry.trimEndFrame, t < 0 {
                 throw ToolError("entries[\(idx)]: trimEndFrame must be >= 0 (got \(t))")
             }
-            specs.append(.init(asset: asset, durationFrames: duration, trimStartFrame: entry.trimStartFrame, trimEndFrame: entry.trimEndFrame))
+            resolvedAssets.append(asset)
         }
 
-        let settingsNote = applySettingsIfNeededForAgent(editor, assets: specs.map(\.asset))
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: resolvedAssets)
+
+        var specs: [EditorViewModel.RippleInsertSpec] = []
+        specs.reserveCapacity(input.entries.count)
+        for (idx, entry) in input.entries.enumerated() {
+            let asset = resolvedAssets[idx]
+            let duration = entry.durationFrames ?? editor.clipDurationFrames(for: asset, segment: nil)
+            guard duration >= 1 else {
+                throw ToolError("entries[\(idx)]: durationFrames must be >= 1 (got \(duration))")
+            }
+            specs.append(.init(asset: asset, durationFrames: duration, trimStartFrame: entry.trimStartFrame, trimEndFrame: entry.trimEndFrame))
+        }
 
         let totalPush = specs.reduce(0) { $0 + $1.durationFrames }
         let tracksBefore = editor.timeline.tracks.count

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -174,6 +174,8 @@ extension ToolExecutor {
             throw ToolError("Mixed trackIndex: \(omittedCount) of \(specs.count) entries omitted trackIndex. Either set it on every entry or omit it on every entry (to auto-create shared tracks).")
         }
 
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: specs.map(\.asset))
+
         let actionName = specs.count == 1 ? "Add Clip (Agent)" : "Add Clips (Agent)"
         let (createdTracks, summaries) = try withUndoGroup(editor, actionName: actionName) { () -> ([String], [String]) in
             var createdTracks: [String] = []
@@ -255,7 +257,8 @@ extension ToolExecutor {
         }
         editor.notifyTimelineChanged()
 
-        let prefix = createdTracks.isEmpty ? "" : "Created \(createdTracks.joined(separator: ", ")). "
+        var prefix = createdTracks.isEmpty ? "" : "Created \(createdTracks.joined(separator: ", ")). "
+        if let note = settingsNote { prefix = "\(note) \(prefix)" }
         return .ok("\(prefix)Added \(specs.count) clip\(specs.count == 1 ? "" : "s"): \(summaries.joined(separator: "; "))")
     }
 
@@ -297,6 +300,8 @@ extension ToolExecutor {
             specs.append(.init(asset: asset, durationFrames: duration, trimStartFrame: entry.trimStartFrame, trimEndFrame: entry.trimEndFrame))
         }
 
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: specs.map(\.asset))
+
         let totalPush = specs.reduce(0) { $0 + $1.durationFrames }
         let tracksBefore = editor.timeline.tracks.count
         let ids = editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
@@ -305,7 +310,8 @@ extension ToolExecutor {
         }
         let audioNote = editor.timeline.tracks.count > tracksBefore
             ? " Created an audio track (appended) for the linked audio." : ""
-        return .ok("Inserted \(specs.count) clip\(specs.count == 1 ? "" : "s") at frame \(input.atFrame) on track \(input.trackIndex), pushed later clips +\(totalPush)f: \(ids.joined(separator: ", ")).\(audioNote)")
+        let settingsPrefix = settingsNote.map { "\($0) " } ?? ""
+        return .ok("\(settingsPrefix)Inserted \(specs.count) clip\(specs.count == 1 ? "" : "s") at frame \(input.atFrame) on track \(input.trackIndex), pushed later clips +\(totalPush)f: \(ids.joined(separator: ", ")).\(audioNote)")
     }
 
     // MARK: remove_clips

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+fileprivate struct SetProjectSettingsInput: DecodableToolArgs {
+    let fps: Int?
+    let width: Int?
+    let height: Int?
+    let aspectRatio: String?
+    let quality: String?
+    static let allowedKeys: Set<String> = ["fps", "width", "height", "aspectRatio", "quality"]
+}
+
+extension ToolExecutor {
+
+    func setProjectSettings(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: SetProjectSettingsInput = try decodeToolArgs(args, path: "set_project_settings")
+
+        guard input.fps != nil || input.width != nil || input.height != nil
+                || input.aspectRatio != nil || input.quality != nil else {
+            throw ToolError("Provide at least one of: fps, width, height, aspectRatio, quality")
+        }
+        if input.aspectRatio != nil && (input.width != nil || input.height != nil) {
+            throw ToolError("'aspectRatio' and explicit 'width'/'height' are mutually exclusive")
+        }
+        if let fps = input.fps, fps < 1 || fps > 120 {
+            throw ToolError("fps must be between 1 and 120 (got \(fps))")
+        }
+
+        let aspectPreset: AspectPreset? = try input.aspectRatio.map { ar in
+            switch ar {
+            case "16:9":   return .sixteenNine
+            case "9:16":   return .nineSixteen
+            case "1:1":    return .oneOne
+            case "4:3":    return .fourThree
+            case "2.4:1":  return .twoPointFourOne
+            case "9:14":   return .nineByFourteen
+            default:
+                throw ToolError("Unknown aspectRatio '\(ar)'. Use one of: 16:9, 9:16, 1:1, 4:3, 2.4:1, 9:14")
+            }
+        }
+
+        let qualityPreset: QualityPreset? = try input.quality.map { q in
+            switch q {
+            case "720p":  return .hd720
+            case "1080p": return .fullHD
+            case "2K":    return .twoK
+            case "4K":    return .fourK
+            default:
+                throw ToolError("Unknown quality '\(q)'. Use one of: 720p, 1080p, 2K, 4K")
+            }
+        }
+
+        let newFPS = input.fps ?? editor.timeline.fps
+        let newWidth: Int
+        let newHeight: Int
+
+        if let preset = aspectPreset {
+            var baseW = preset.width
+            var baseH = preset.height
+            if let quality = qualityPreset {
+                let scaled = quality.resolution(currentWidth: baseW, currentHeight: baseH)
+                baseW = scaled.width
+                baseH = scaled.height
+            }
+            newWidth = baseW
+            newHeight = baseH
+        } else if let quality = qualityPreset {
+            let scaled = quality.resolution(currentWidth: editor.timeline.width, currentHeight: editor.timeline.height)
+            newWidth = scaled.width
+            newHeight = scaled.height
+        } else {
+            newWidth = input.width ?? editor.timeline.width
+            newHeight = input.height ?? editor.timeline.height
+        }
+
+        guard newWidth > 0 && newHeight > 0 else {
+            throw ToolError("Resolution must have positive width and height")
+        }
+
+        let prevFPS = editor.timeline.fps
+        let prevWidth = editor.timeline.width
+        let prevHeight = editor.timeline.height
+
+        editor.applyTimelineSettings(fps: newFPS, width: newWidth, height: newHeight)
+        editor.undoManager?.setActionName("Set Project Settings (Agent)")
+
+        var changes: [String] = []
+        if newFPS != prevFPS { changes.append("fps \(prevFPS) → \(newFPS)") }
+        if newWidth != prevWidth || newHeight != prevHeight {
+            changes.append("resolution \(prevWidth)×\(prevHeight) → \(newWidth)×\(newHeight)")
+        }
+
+        if changes.isEmpty {
+            return .ok("No change — settings already match: \(newWidth)×\(newHeight) @ \(newFPS)fps")
+        }
+        return .ok("Updated: \(changes.joined(separator: ", ")). Now \(newWidth)×\(newHeight) @ \(newFPS)fps.")
+    }
+
+    /// Mirrors the UI's first-clip settings check: auto-applies timeline settings to match
+    /// the first video asset when the timeline is empty or unconfigured.
+    /// Returns a note string if settings changed, nil otherwise.
+    func applySettingsIfNeededForAgent(_ editor: EditorViewModel, assets: [MediaAsset]) -> String? {
+        let prevFPS = editor.timeline.fps
+        let prevWidth = editor.timeline.width
+        let prevHeight = editor.timeline.height
+
+        switch editor.checkProjectSettings(for: assets) {
+        case .proceed:
+            // checkProjectSettings silently auto-applied on the first-ever clip when !settingsConfigured
+            guard editor.timeline.fps != prevFPS
+                    || editor.timeline.width != prevWidth
+                    || editor.timeline.height != prevHeight else { return nil }
+            return "Set timeline to \(editor.timeline.width)×\(editor.timeline.height) @ \(editor.timeline.fps)fps to match clip."
+        case .mismatch(let fps, let width, let height):
+            editor.applyTimelineSettings(fps: fps, width: width, height: height)
+            return "Matched timeline to clip: \(width)×\(height) @ \(fps)fps."
+        }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -111,6 +111,7 @@ final class ToolExecutor {
         case .deleteMedia:   return try deleteMedia(editor, args)
         case .deleteFolder:  return try deleteFolder(editor, args)
         case .sendFeedback:  return try await sendFeedback(editor, args)
+        case .setProjectSettings: return try setProjectSettings(editor, args)
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two related improvements to agent capabilities around project settings:

### 1. `set_project_settings` tool (new)

Lets the agent change the project's frame rate, resolution, and aspect ratio. Accepts any combination of:

- `fps` — integer, e.g. 24, 30, 60
- `width` + `height` — explicit pixel dimensions
- `aspectRatio` — preset: `16:9`, `9:16`, `1:1`, `4:3`, `2.4:1`, `9:14`
- `quality` — preset: `720p`, `1080p`, `2K`, `4K` (scales the short edge, preserves aspect)

`aspectRatio` and `quality` can be combined to select a specific preset+size (e.g. 9:16 @ 1080p → 1080×1920). `aspectRatio` and explicit `width`/`height` are mutually exclusive.

Under the hood this calls `applyTimelineSettings(fps:width:height:)`, so existing clips get their auto-fit transforms recalculated for the new canvas, and all frame positions/durations are rescaled on fps change. The action is undoable.

### 2. Auto-match timeline on `add_clips` / `insert_clips`

Before placing clips, both tools now run the same settings check the UI performs when dragging to the timeline:

| Condition | Behaviour |
|-----------|-----------|
| No video in the batch | Proceed, no check |
| `settingsConfigured == false` (first-ever clip) | Silently auto-match to clip FPS/resolution |
| Timeline is empty but was previously configured + mismatch | Auto-apply clip settings (agent equivalent of "Change to Match") |
| Timeline has existing clips | Proceed, no check |

When settings are changed, the tool result includes a note, e.g. `"Matched timeline to clip: 3840×2160 @ 24fps."`.

## Why

Previously the agent bypassed the mismatch check entirely, so dropping a 4K/24fps clip onto a freshly-opened 1080p/30fps project left the timeline misconfigured. This brings agent behaviour in line with the drag-to-timeline UI flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b93269ea-9415-46e5-a4db-42a7542a69dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b93269ea-9415-46e5-a4db-42a7542a69dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

