### PR TITLE
[agents] Add language param to get_transcript and inspect_media

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -79,7 +79,9 @@ enum AgentInstructions {
           (or differs from the user's system locale), always pass language as a BCP-47 tag \
           (e.g. language='es', language='fr', language='ja') to get_transcript and inspect_media. \
           Without it, the wrong model is used and the output will be garbled or empty. If the user \
-          says transcription looks wrong, ask for the spoken language and retry with language set.
+          says transcription looks wrong, ask for the spoken language and retry with language set. \
+          When you then cut with remove_words, pass the SAME language — the indices are only valid \
+          against the transcription that produced them, so a mismatch cuts the wrong words.
 
         # Export
         - When the user asks to export/render/save, call export_project. It matches the Export \

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -75,6 +75,11 @@ enum AgentInstructions {
           remove_words. The transcript summary is lossy — it hides reworded retakes ("in one state" \
           vs "in one place") and sub-frame seam fragments (a word whose start == end rounds to zero \
           frames); verify a suspected dangling fragment against the words, not the summary.
+        - On-device transcription is language-specific. When the spoken language is not English \
+          (or differs from the user's system locale), always pass language as a BCP-47 tag \
+          (e.g. language='es', language='fr', language='ja') to get_transcript and inspect_media. \
+          Without it, the wrong model is used and the output will be garbled or empty. If the user \
+          says transcription looks wrong, ask for the spoken language and retry with language set.
 
         # Export
         - When the user asks to export/render/save, call export_project. It matches the Export \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -77,6 +77,7 @@ enum ToolDefinitions {
                     "endSeconds": ["type": "number", "description": "Video/audio. Window end (default: asset duration)."],
                     "wordTimestamps": ["type": "boolean", "description": "Video/audio. Add word-level [text, start, end] tuples (capped at 10000 — most clips return all words at once; narrow with startSeconds/endSeconds only for very long media). Use for word-boundary edits like filler-word removal."],
                     "overview": ["type": "boolean", "description": "Video only. One storyboard grid of visually distinct, timestamped moments instead of frames — far more coverage per token; few tiles means static footage. maxFrames ignored."],
+                    "language": ["type": "string", "description": "Optional BCP-47 language tag of the spoken audio (e.g. 'es', 'fr', 'ja', 'zh-Hans'). Defaults to the system language. Specify when the spoken language differs from the system locale — on-device models are language-specific and will produce garbled output if the wrong language is used."],
                 ],
                 required: ["mediaRef"]
             )
@@ -89,6 +90,7 @@ enum ToolDefinitions {
                     "startFrame": ["type": "integer", "description": "Optional. Only return words ending after this project frame. Use with the returned nextStartFrame to page a long timeline."],
                     "endFrame": ["type": "integer", "description": "Optional. Only return words starting before this project frame."],
                     "clipId": ["type": "string", "description": "Scope the transcript to a single clip — returns only what that clip says, in project frames. Answers \"what's in clip X?\" without scanning the whole timeline."],
+                    "language": ["type": "string", "description": "Optional BCP-47 language tag of the spoken audio (e.g. 'es', 'fr', 'ja', 'zh-Hans'). Defaults to the system language. Specify when the spoken language differs from the system locale — on-device models are language-specific and will produce garbled output if the wrong language is used."],
                 ]
             )
         ),

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -318,6 +318,7 @@ enum ToolDefinitions {
                         "enum": ["tight", "balanced", "loose"],
                         "description": "How much silence to leave between the words on either side of a cut. 'tight' butts them close (snappy, can feel clipped), 'balanced' (default) keeps a natural beat, 'loose' leaves more breathing room. The removed words' own frames always go regardless.",
                     ],
+                    "language": ["type": "string", "description": "BCP-47 language tag of the spoken audio. Must match the language passed to the get_transcript call the indices came from — word indices are only valid against the same transcription, so a localed transcript requires the same tag here or the wrong words are cut."],
                 ],
                 required: ["words"]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -16,14 +16,7 @@ extension ToolExecutor {
         if let s = args.double("fontSize") { style.fontSize = s }
         if let c = try parseColorHex(args.string("color"), path: "add_captions") { style.color = c }
 
-        var locale: Locale?
-        if let lang = args.string("language") {
-            let candidate = Locale(identifier: lang)
-            guard let match = Transcription.matchLocale(candidates: [candidate], supported: await Transcription.supportedLocales()) else {
-                throw ToolError("add_captions: on-device transcription does not support language '\(lang)'.")
-            }
-            locale = match
-        }
+        let locale = try await Self.parseLocale(args, path: "add_captions")
 
         var center = AppTheme.Caption.defaultCenter
         if let x = args.double("centerX") { center.x = CGFloat(x) }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -262,8 +262,17 @@ extension ToolExecutor {
         return .ok(json)
     }
 
+    private static func parseLocale(_ args: [String: Any], path: String) async throws -> Locale? {
+        guard let lang = args.string("language") else { return nil }
+        let candidate = Locale(identifier: lang)
+        guard let match = Transcription.matchLocale(candidates: [candidate], supported: await Transcription.supportedLocales()) else {
+            throw ToolError("\(path): on-device transcription does not support language '\(lang)'.")
+        }
+        return match
+    }
+
     private static let inspectMediaAllowedKeys: Set<String> = [
-        "mediaRef", "clipId", "maxFrames", "startSeconds", "endSeconds", "wordTimestamps", "overview",
+        "mediaRef", "clipId", "maxFrames", "startSeconds", "endSeconds", "wordTimestamps", "overview", "language",
     ]
 
     func inspectMedia(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -298,10 +307,12 @@ extension ToolExecutor {
             mapping = (clip, editor.timeline.fps)
         }
 
+        let preferredLocale = try await Self.parseLocale(args, path: "inspect_media")
+
         switch asset.type {
         case .image: return try await readImage(asset: asset, args: args)
-        case .video: return try await readVideo(editor: editor, asset: asset, args: args, mapping: mapping)
-        case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping)
+        case .video: return try await readVideo(editor: editor, asset: asset, args: args, mapping: mapping, preferredLocale: preferredLocale)
+        case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping, preferredLocale: preferredLocale)
         case .lottie: return try await readLottie(asset: asset, args: args)
         case .text: throw ToolError("Text clips are not stored as media assets.")
         }
@@ -358,7 +369,7 @@ extension ToolExecutor {
         )
     }
 
-    private func readVideo(editor: EditorViewModel, asset: MediaAsset, args: [String: Any], mapping: (clip: Clip, fps: Int)? = nil) async throws -> ToolResult {
+    private func readVideo(editor: EditorViewModel, asset: MediaAsset, args: [String: Any], mapping: (clip: Clip, fps: Int)? = nil, preferredLocale: Locale? = nil) async throws -> ToolResult {
         guard asset.duration > 0 else { throw ToolError("Video has zero duration: \(asset.name)") }
 
         let range = try Self.sourceRange(args, duration: asset.duration)
@@ -381,7 +392,7 @@ extension ToolExecutor {
         )
         async let transcriptTask: Result<TranscriptionResult, Error>? = {
             guard hasAudio else { return nil }
-            do { return .success(try await TranscriptCache.shared.transcript(for: url, isVideo: true, range: range)) }
+            do { return .success(try await TranscriptCache.shared.transcript(for: url, isVideo: true, range: range, preferredLocale: preferredLocale)) }
             catch { return .failure(error) }
         }()
 
@@ -493,11 +504,11 @@ extension ToolExecutor {
         return context.makeImage().flatMap { ImageEncoder.encodeJPEG($0, quality: quality) }
     }
 
-    private func readAudio(editor: EditorViewModel, asset: MediaAsset, args: [String: Any], mapping: (clip: Clip, fps: Int)? = nil) async throws -> ToolResult {
+    private func readAudio(editor: EditorViewModel, asset: MediaAsset, args: [String: Any], mapping: (clip: Clip, fps: Int)? = nil, preferredLocale: Locale? = nil) async throws -> ToolResult {
         let range = try Self.sourceRange(args, duration: asset.duration)
         let transcript: TranscriptionResult
         do {
-            transcript = try await TranscriptCache.shared.transcript(for: asset.url, isVideo: false, range: range)
+            transcript = try await TranscriptCache.shared.transcript(for: asset.url, isVideo: false, range: range, preferredLocale: preferredLocale)
         } catch {
             throw ToolError("Transcription failed: \(error.localizedDescription)")
         }
@@ -557,7 +568,7 @@ extension ToolExecutor {
         return out
     }
 
-    private static let getTranscriptAllowedKeys: Set<String> = ["startFrame", "endFrame", "clipId", "wordTimestamps"]
+    private static let getTranscriptAllowedKeys: Set<String> = ["startFrame", "endFrame", "clipId", "wordTimestamps", "language"]
 
     func getTranscript(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.getTranscriptAllowedKeys, path: "get_transcript")
@@ -576,8 +587,9 @@ extension ToolExecutor {
                 throw ToolError("Clip \(clipFilter) has no transcribable audio. If it's a video with linked audio, scope to the linked audio clip instead.")
             }
         }
+        let preferredLocale = try await Self.parseLocale(args, path: "get_transcript")
 
-        let (allWords, skipped) = try await timelineWords(editor)
+        let (allWords, skipped) = try await timelineWords(editor, preferredLocale: preferredLocale)
 
         var clipsOut: [[String: Any]] = []
         var totalWords = 0
@@ -619,7 +631,7 @@ extension ToolExecutor {
         return .ok(json)
     }
 
-    func timelineWords(_ editor: EditorViewModel) async throws -> (words: [TimelineWord], skipped: [[String: Any]]) {
+    func timelineWords(_ editor: EditorViewModel, preferredLocale: Locale? = nil) async throws -> (words: [TimelineWord], skipped: [[String: Any]]) {
         let fps = editor.timeline.fps
         let assetsById = Dictionary(editor.mediaAssets.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         struct Frag { let clipId: String; let trackIndex: Int; let clip: Clip; let url: URL; let isVideo: Bool }
@@ -636,7 +648,7 @@ extension ToolExecutor {
         var transcripts: [URL: TranscriptionResult] = [:]
         var skipped: [[String: Any]] = []
         for url in Set(frags.map(\.url)) {
-            do { transcripts[url] = try await TranscriptCache.shared.transcript(for: url, isVideo: isVideoByURL[url] ?? true, range: nil) }
+            do { transcripts[url] = try await TranscriptCache.shared.transcript(for: url, isVideo: isVideoByURL[url] ?? true, range: nil, preferredLocale: preferredLocale) }
             catch { skipped.append(["file": url.lastPathComponent, "reason": error.localizedDescription]) }
         }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -262,7 +262,7 @@ extension ToolExecutor {
         return .ok(json)
     }
 
-    private static func parseLocale(_ args: [String: Any], path: String) async throws -> Locale? {
+    static func parseLocale(_ args: [String: Any], path: String) async throws -> Locale? {
         guard let lang = args.string("language") else { return nil }
         let candidate = Locale(identifier: lang)
         guard let match = Transcription.matchLocale(candidates: [candidate], supported: await Transcription.supportedLocales()) else {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension ToolExecutor {
 
-    private static let removeWordsAllowedKeys: Set<String> = ["words", "cutAggressiveness"]
+    private static let removeWordsAllowedKeys: Set<String> = ["words", "cutAggressiveness", "language"]
 
     func removeWords(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.removeWordsAllowedKeys, path: "remove_words")
@@ -17,7 +17,8 @@ extension ToolExecutor {
             aggressiveness = a
         } else { aggressiveness = .balanced }
 
-        let (allWords, _) = try await timelineWords(editor)
+        let preferredLocale = try await Self.parseLocale(args, path: "remove_words")
+        let (allWords, _) = try await timelineWords(editor, preferredLocale: preferredLocale)
         guard !allWords.isEmpty else { throw ToolError("No transcribable speech on the timeline.") }
 
         var selected = Set<Int>(), ignored: [Int] = []

--- a/Sources/PalmierPro/Transcription/TranscriptCache.swift
+++ b/Sources/PalmierPro/Transcription/TranscriptCache.swift
@@ -9,7 +9,13 @@ actor TranscriptCache {
     private var memory: [String: TranscriptionResult] = [:]
     private static let memoryMax = 4
 
-    func transcript(for url: URL, isVideo: Bool, range: ClosedRange<Double>?) async throws -> TranscriptionResult {
+    func transcript(for url: URL, isVideo: Bool, range: ClosedRange<Double>?, preferredLocale: Locale? = nil) async throws -> TranscriptionResult {
+        // When a locale is forced, bypass the cache — locale variants must not overwrite the auto-detected entry.
+        if let preferredLocale {
+            return isVideo
+                ? try await Transcription.transcribeVideoAudio(videoURL: url, preferredLocale: preferredLocale, sourceRange: range)
+                : try await Transcription.transcribe(fileURL: url, preferredLocale: preferredLocale, sourceRange: range)
+        }
         let key = Self.key(for: url)
         if let key, let full = cached(key) {
             return range.map { Self.filter(full, to: $0) } ?? full


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`get_transcript` and `inspect_media` had no way to specify the spoken language. Both tools defaulted to the system locale, so footage in French, Spanish, Japanese, etc. would use the wrong on-device speech model and produce garbled or empty transcripts.

`add_captions` already accepted a `language` parameter — this brings the two read tools in line with it.

## Changes

**`TranscriptCache`** — add `preferredLocale` parameter to `transcript(for:isVideo:range:)`. When a locale is explicitly set, the cache is bypassed entirely so a language-specific transcription never clobbers the auto-detected entry for the same file.

**`ToolExecutor+Timeline`** — shared `parseLocale` helper that validates the BCP-47 tag against `SpeechTranscriber.supportedLocales` (same validation used by `add_captions`). Threaded through:
- `inspectMedia` → `readVideo` / `readAudio`
- `getTranscript` → `timelineWords`

**`ToolDefinitions`** — `language` property added to both `get_transcript` and `inspect_media` schemas with a description that explains why it matters.

**`AgentInstructions`** — explicit guidance that the agent should pass `language` whenever the spoken language differs from the system locale, and to ask the user for the language when transcription looks wrong.

## Behavior

- `language` is optional on both tools; omitting it preserves the existing auto-detect behavior.
- Passing an unsupported tag (e.g. `language: "klingon"`) returns a `ToolError` immediately rather than silently falling back.
- Auto-detected transcripts stay cached; localed transcripts are always re-run (no locale-keyed cache pollution).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fa2c2ef-7eaf-41cb-977f-b6238ff4f4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fa2c2ef-7eaf-41cb-977f-b6238ff4f4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

