### PR TITLE
Fix insert_clips clip durations sized at stale FPS

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -280,16 +280,13 @@ extension ToolExecutor {
         guard input.atFrame >= 0 else { throw ToolError("atFrame must be >= 0 (got \(input.atFrame))") }
         let targetType = editor.timeline.tracks[input.trackIndex].type
 
-        var specs: [EditorViewModel.RippleInsertSpec] = []
-        specs.reserveCapacity(input.entries.count)
+        // Apply settings before deriving durations: it may change FPS, which clipDurationFrames depends on.
+        var resolvedAssets: [MediaAsset] = []
+        resolvedAssets.reserveCapacity(input.entries.count)
         for (idx, entry) in input.entries.enumerated() {
             let asset = try asset(entry.mediaRef, editor: editor)
             guard asset.type.isCompatible(with: targetType) else {
                 throw ToolError("entries[\(idx)]: asset type \(asset.type.rawValue) is not compatible with \(targetType.rawValue) track at index \(input.trackIndex)")
-            }
-            let duration = entry.durationFrames ?? editor.clipDurationFrames(for: asset, segment: nil)
-            guard duration >= 1 else {
-                throw ToolError("entries[\(idx)]: durationFrames must be >= 1 (got \(duration))")
             }
             if let t = entry.trimStartFrame, t < 0 {
                 throw ToolError("entries[\(idx)]: trimStartFrame must be >= 0 (got \(t))")
@@ -297,10 +294,21 @@ extension ToolExecutor {
             if let t = entry.trimEndFrame, t < 0 {
                 throw ToolError("entries[\(idx)]: trimEndFrame must be >= 0 (got \(t))")
             }
-            specs.append(.init(asset: asset, durationFrames: duration, trimStartFrame: entry.trimStartFrame, trimEndFrame: entry.trimEndFrame))
+            resolvedAssets.append(asset)
         }
 
-        let settingsNote = applySettingsIfNeededForAgent(editor, assets: specs.map(\.asset))
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: resolvedAssets)
+
+        var specs: [EditorViewModel.RippleInsertSpec] = []
+        specs.reserveCapacity(input.entries.count)
+        for (idx, entry) in input.entries.enumerated() {
+            let asset = resolvedAssets[idx]
+            let duration = entry.durationFrames ?? editor.clipDurationFrames(for: asset, segment: nil)
+            guard duration >= 1 else {
+                throw ToolError("entries[\(idx)]: durationFrames must be >= 1 (got \(duration))")
+            }
+            specs.append(.init(asset: asset, durationFrames: duration, trimStartFrame: entry.trimStartFrame, trimEndFrame: entry.trimEndFrame))
+        }
 
         let totalPush = specs.reduce(0) { $0 + $1.durationFrames }
         let tracksBefore = editor.timeline.tracks.count


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `insertClips` (`Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift`), the default `durationFrames` for each entry (and the `totalPush` derived from the specs) was computed via `editor.clipDurationFrames(for:segment:)`, which converts seconds to frames using the *current* `timeline.fps`.

Only afterward was `applySettingsIfNeededForAgent` called, which can change the timeline FPS (and resolution) to match the inserted clips. As a result, when the project FPS changed on insert, the clips and the ripple push were sized at the old frame rate while the timeline ran at the new one — producing wrong clip lengths and broken downstream sync.

## Fix

Reorder the logic so settings are applied before durations are derived:

1. First pass resolves and validates assets (type compatibility, trim bounds).
2. `applySettingsIfNeededForAgent` runs, potentially updating the timeline FPS.
3. Second pass derives default `durationFrames` (via `clipDurationFrames`) and `totalPush` at the final frame rate.

Explicit `entry.durationFrames` values are unaffected; only the FPS-derived defaults change behavior.

## Notes

This is a macOS-only target (SwiftUI/AppKit/AVFoundation, macOS 26 / arm64), so it cannot be compiled in the Linux cloud environment. The change is a pure reordering with no new APIs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-270a9139-aaca-4abe-83ce-9a216c04ba3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-270a9139-aaca-4abe-83ce-9a216c04ba3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

