### PR TITLE
Fix accuracy for waveform in audio

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9cea4e06af93ec4e9468a1239c6feb73249f1373664f3daf6aa8fec20701023b",
+  "originHash" : "806aa29ab163d9ddd0a263c12468e03f6dc0cc679d156fc54fb46aeab0640103",
   "pins" : [
     {
       "identity" : "clerk-convex-swift",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "125b71b2f8725931a5b0e8252f0799ef2adad120",
         "version" : "0.8.1"
-      }
-    },
-    {
-      "identity" : "dswaveformimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dmrschmidt/DSWaveformImage",
-      "state" : {
-        "revision" : "a7a96cf4478c6fa084e76c175bcf7f4c9a38f80a",
-        "version" : "14.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
         .executable(name: "PalmierPro", targets: ["PalmierPro"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/dmrschmidt/DSWaveformImage", from: "14.2.2"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.40.0"),
@@ -23,7 +22,6 @@ let package = Package(
         .executableTarget(
             name: "PalmierPro",
             dependencies: [
-                .product(name: "DSWaveformImage", package: "DSWaveformImage"),
                 .product(name: "MCP", package: "swift-sdk"),
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Sentry", package: "sentry-cocoa"),

--- a/Sources/PalmierPro/Audio/WaveformExtractor.swift
+++ b/Sources/PalmierPro/Audio/WaveformExtractor.swift
@@ -1,0 +1,69 @@
+import Accelerate
+import AVFoundation
+import Foundation
+
+/// Extracts a peak amplitude envelope for timeline waveform display.
+///
+/// Unlike an averaged envelope, each bucket stores the loudest sample it spans, so
+/// transients (drum hits, consonants) keep their height instead of being smoothed
+/// toward the noise floor. Output matches the draw convention: 0 = full scale, 1 =
+/// at/below the noise floor.
+enum WaveformExtractor {
+    static let samplesPerSecond: Double = 200
+    static let noiseFloorDb: Float = -50
+    /// Resolution ceiling. Below ~20 min this never binds; longer assets taper so a
+    /// 2-hour file stays ~240k samples instead of growing without bound.
+    static let maxSamples = 240_000
+
+    static func peakEnvelope(from url: URL, range: ClosedRange<Double>? = nil) async throws -> [Float] {
+        let asset = AVURLAsset(url: url)
+        let duration = (try? await asset.load(.duration).seconds) ?? 0
+        let span = range.map { $0.upperBound - $0.lowerBound } ?? duration
+        let rate = span > 0 ? min(samplesPerSecond, Double(maxSamples) / span) : samplesPerSecond
+
+        var out: [Float] = []
+        var carryPeak: Float = 0
+        var carryCount = 0
+        var hopSize = 0
+
+        try await AudioTrackReader.read(from: url, outputSettings: [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ], range: range) { pcm in
+            if hopSize == 0 {
+                hopSize = max(1, Int((pcm.format.sampleRate / rate).rounded()))
+            }
+            guard let channel = pcm.floatChannelData else { return }
+            let ptr = channel[0]
+            let count = Int(pcm.frameLength)
+            var i = 0
+            while i < count {
+                let take = min(hopSize - carryCount, count - i)
+                var localMax: Float = 0
+                vDSP_maxmgv(ptr + i, 1, &localMax, vDSP_Length(take))
+                if localMax > carryPeak { carryPeak = localMax }
+                carryCount += take
+                i += take
+                if carryCount == hopSize {
+                    out.append(normalized(peak: carryPeak))
+                    carryPeak = 0
+                    carryCount = 0
+                }
+            }
+        }
+        if carryCount > 0 { out.append(normalized(peak: carryPeak)) }
+        return out
+    }
+
+    /// Linear peak → normalized dB position. 0 dBFS → 0, ≤ noise floor → 1.
+    private static func normalized(peak: Float) -> Float {
+        guard peak > 0 else { return 1 }
+        let db = 20 * log10(peak)
+        let clamped = min(0, max(noiseFloorDb, db))
+        return clamped / noiseFloorDb
+    }
+}

--- a/Sources/PalmierPro/Audio/WaveformExtractor.swift
+++ b/Sources/PalmierPro/Audio/WaveformExtractor.swift
@@ -11,7 +11,9 @@ enum WaveformExtractor {
         let asset = AVURLAsset(url: url)
         let duration = (try? await asset.load(.duration).seconds) ?? 0
         let span = range.map { $0.upperBound - $0.lowerBound } ?? duration
-        let rate = span > 0 ? min(samplesPerSecond, Double(maxSamples) / span) : samplesPerSecond
+        let rate = span.isFinite && span > 0
+            ? min(samplesPerSecond, Double(maxSamples) / span)
+            : samplesPerSecond
 
         var out: [Float] = []
         var carryPeak: Float = 0

--- a/Sources/PalmierPro/Audio/WaveformExtractor.swift
+++ b/Sources/PalmierPro/Audio/WaveformExtractor.swift
@@ -2,17 +2,9 @@ import Accelerate
 import AVFoundation
 import Foundation
 
-/// Extracts a peak amplitude envelope for timeline waveform display.
-///
-/// Unlike an averaged envelope, each bucket stores the loudest sample it spans, so
-/// transients (drum hits, consonants) keep their height instead of being smoothed
-/// toward the noise floor. Output matches the draw convention: 0 = full scale, 1 =
-/// at/below the noise floor.
 enum WaveformExtractor {
     static let samplesPerSecond: Double = 200
     static let noiseFloorDb: Float = -50
-    /// Resolution ceiling. Below ~20 min this never binds; longer assets taper so a
-    /// 2-hour file stays ~240k samples instead of growing without bound.
     static let maxSamples = 240_000
 
     static func peakEnvelope(from url: URL, range: ClosedRange<Double>? = nil) async throws -> [Float] {
@@ -59,7 +51,6 @@ enum WaveformExtractor {
         return out
     }
 
-    /// Linear peak → normalized dB position. 0 dBFS → 0, ≤ noise floor → 1.
     private static func normalized(peak: Float) -> Float {
         guard peak > 0 else { return 1 }
         let db = 20 * log10(peak)

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -1,7 +1,6 @@
 import AppKit
 import AVFoundation
 import CryptoKit
-import DSWaveformImage
 import ImageIO
 import UniformTypeIdentifiers
 
@@ -176,17 +175,9 @@ final class MediaVisualCache {
         let asset = AVURLAsset(url: url)
         guard (try? await asset.loadTracks(withMediaType: .audio).first) != nil else { return nil }
 
-        let duration = (try? await asset.load(.duration).seconds) ?? 0
-        let count = waveformSampleCount(duration: duration)
-        guard let samples = try? await WaveformAnalyzer().samples(fromAudioAt: url, count: count) else { return nil }
+        guard let samples = try? await WaveformExtractor.peakEnvelope(from: url), !samples.isEmpty else { return nil }
         if let cacheKey { saveWaveform(samples, key: cacheKey) }
         return samples
-    }
-
-    private nonisolated static func waveformSampleCount(duration: Double) -> Int {
-        guard duration.isFinite, duration > 0 else { return 4000 }
-        if duration >= Double(20_000) / 150 { return 20_000 }
-        return max(4000, Int(duration * 150))
     }
 
     private nonisolated static func videoThumbnailTimes(duration: Double) -> [CMTime] {
@@ -215,14 +206,15 @@ final class MediaVisualCache {
         return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
     }
 
+    // ".waveform2" supersedes the old averaged-envelope cache so stale shapes regenerate.
     private nonisolated static func loadWaveform(key: String) -> [Float]? {
-        let url = diskCache.directory.appendingPathComponent(key + ".waveform")
+        let url = diskCache.directory.appendingPathComponent(key + ".waveform2")
         guard let data = try? Data(contentsOf: url), !data.isEmpty, data.count % 4 == 0 else { return nil }
         return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
     }
 
     private nonisolated static func saveWaveform(_ samples: [Float], key: String) {
-        let url = diskCache.directory.appendingPathComponent(key + ".waveform")
+        let url = diskCache.directory.appendingPathComponent(key + ".waveform2")
         samples.withUnsafeBytes { try? Data($0).write(to: url) }
     }
 

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -206,7 +206,6 @@ final class MediaVisualCache {
         return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
     }
 
-    // ".waveform2" supersedes the old averaged-envelope cache so stale shapes regenerate.
     private nonisolated static func loadWaveform(key: String) -> [Float]? {
         let url = diskCache.directory.appendingPathComponent(key + ".waveform2")
         guard let data = try? Data(contentsOf: url), !data.isEmpty, data.count % 4 == 0 else { return nil }


### PR DESCRIPTION

Top fix, buttom is the error (each text is a word spoken. bottom shows a couiple peaks which isn't accurate)
<img width="1325" height="743" alt="Screenshot 2026-06-25 at 11 58 14 AM" src="https://github.com/user-attachments/assets/82109de5-c12f-4602-9522-4b6e55a356a6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to waveform visualization and dependency removal; no auth, playback, or transcription pipeline changes beyond shared AudioTrackReader usage.
> 
> **Overview**
> Timeline waveforms are generated with a new **`WaveformExtractor`** instead of **DSWaveformImage**, addressing peaks that did not line up with spoken words. PCM is streamed via **`AudioTrackReader`**, peak levels are computed per time bucket with **Accelerate** (`vDSP_maxmgv`), and values are normalized on a dB scale with a noise floor so silence reads correctly.
> 
> **`MediaVisualCache`** now calls **`WaveformExtractor.peakEnvelope`** and drops the old duration-based sample-count logic. On-disk waveform cache files use the **`.waveform2`** extension so stale **`.waveform`** entries from the previous analyzer are not reused. The **DSWaveformImage** package is removed from **`Package.swift`** and **`Package.resolved`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26fccc3d71fa4b66debc2b07398d0f336e4c75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->