### PR TITLE
Add caption/text background color to agent tools

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -218,7 +218,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .setClipProperties,
-            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, or — for text clips only — content, fontName, fontSize, color, alignment. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
+            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, or — for text clips only — content, fontName, fontSize, color, backgroundColor, backgroundEnabled, alignment. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": [
@@ -247,7 +247,9 @@ enum ToolDefinitions {
                     "content": ["type": "string", "description": "Text clips only. New text content."],
                     "fontName": ["type": "string", "description": "Text clips only. Font PostScript or family name."],
                     "fontSize": ["type": "number", "description": "Text clips only. Font size in canvas points."],
-                    "color": ["type": "string", "description": "Text clips only. Hex '#RRGGBB' or '#RRGGBBAA'."],
+                    "color": ["type": "string", "description": "Text clips only. Text (foreground) color, hex '#RRGGBB' or '#RRGGBBAA'."],
+                    "backgroundColor": ["type": "string", "description": "Text clips only. Background box fill color behind the text, hex '#RRGGBB' or '#RRGGBBAA' (use the AA byte for a translucent box, e.g. '#00000099'). Setting it turns the background on. Pass backgroundEnabled:false to remove the box."],
+                    "backgroundEnabled": ["type": "boolean", "description": "Text clips only. Toggle the background box on or off without changing its color."],
                     "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text clips only."],
                 ],
                 required: ["clipIds"]
@@ -366,7 +368,9 @@ enum ToolDefinitions {
                                 ],
                                 "fontName": ["type": "string", "description": "Font PostScript or family name, e.g. 'Helvetica-Bold', 'Georgia-Bold'. Default 'Helvetica-Bold'. Falls back to bold system font if not found."],
                                 "fontSize": ["type": "number", "description": "Font size in canvas points (default 96). On a 1080p canvas ~50 is a caption, ~120 is a title."],
-                                "color": ["type": "string", "description": "Hex '#RRGGBB' or '#RRGGBBAA' (default '#FFFFFF')"],
+                                "color": ["type": "string", "description": "Text (foreground) color, hex '#RRGGBB' or '#RRGGBBAA' (default '#FFFFFF')"],
+                                "backgroundColor": ["type": "string", "description": "Optional background box fill color behind the text, hex '#RRGGBB' or '#RRGGBBAA' (use the AA byte for a translucent box, e.g. '#00000099'). Off by default; setting it turns the box on."],
+                                "backgroundEnabled": ["type": "boolean", "description": "Optional. Toggle the background box on or off explicitly (defaults on when backgroundColor is set, off otherwise)."],
                                 "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text alignment (default 'center')"],
                             ],
                             "required": ["startFrame", "durationFrames", "content"],
@@ -385,7 +389,9 @@ enum ToolDefinitions {
                     "language": ["type": "string", "description": "Optional BCP-47 language of the speech (e.g. 'es', 'ja', 'en-GB'). Defaults to the system language — set this when the footage is in another language, or transcription will be garbage."],
                     "fontName": ["type": "string", "description": "Optional font PostScript or family name (default 'Helvetica-Bold'). Falls back to bold system font if not found."],
                     "fontSize": ["type": "number", "description": "Optional font size in canvas points (default 48)."],
-                    "color": ["type": "string", "description": "Optional hex '#RRGGBB' or '#RRGGBBAA' (default white)."],
+                    "color": ["type": "string", "description": "Optional text (foreground) color, hex '#RRGGBB' or '#RRGGBBAA' (default white)."],
+                    "backgroundColor": ["type": "string", "description": "Optional background box fill color behind each caption, hex '#RRGGBB' or '#RRGGBBAA' (use the AA byte for a translucent box, e.g. '#00000099' for a subtle scrim). Off by default; setting it turns the box on — the common request for a black caption background."],
+                    "backgroundEnabled": ["type": "boolean", "description": "Optional. Toggle the background box on or off explicitly (defaults on when backgroundColor is set, off otherwise)."],
                     "centerX": ["type": "number", "description": "Optional horizontal center 0–1 (default 0.5)."],
                     "centerY": ["type": "number", "description": "Optional vertical center 0–1 (default 0.9, near the bottom)."],
                     "textCase": ["type": "string", "enum": ["auto", "upper", "lower"], "description": "Optional letter case (default auto)."],

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -3,7 +3,8 @@ import Foundation
 
 extension ToolExecutor {
     private static let addCaptionsAllowedKeys: Set<String> = [
-        "clipIds", "fontName", "fontSize", "color", "centerX", "centerY", "textCase", "censorProfanity", "language",
+        "clipIds", "fontName", "fontSize", "color", "backgroundColor", "backgroundEnabled",
+        "centerX", "centerY", "textCase", "censorProfanity", "language",
     ]
 
     func addCaptions(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -15,6 +16,11 @@ extension ToolExecutor {
         if let f = args.string("fontName") { style.fontName = f }
         if let s = args.double("fontSize") { style.fontSize = s }
         if let c = try parseColorHex(args.string("color"), path: "add_captions") { style.color = c }
+        if let bg = try parseColorHex(args.string("backgroundColor"), path: "add_captions") {
+            style.background.color = bg
+            style.background.enabled = true
+        }
+        if let e = args.bool("backgroundEnabled") { style.background.enabled = e }
 
         var locale: Locale?
         if let lang = args.string("language") {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -57,6 +57,8 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let fontName: String?
     let fontSize: Double?
     let color: String?
+    let backgroundColor: String?
+    let backgroundEnabled: Bool?
     let alignment: String?
 
     static let allowedKeys: Set<String> = [
@@ -64,7 +66,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
         "durationFrames", "trimStartFrame", "trimEndFrame", "speed",
         "volume", "opacity",
         "transform",
-        "content", "fontName", "fontSize", "color", "alignment",
+        "content", "fontName", "fontSize", "color", "backgroundColor", "backgroundEnabled", "alignment",
     ]
 
     var hasAnyProperty: Bool {
@@ -72,7 +74,8 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
             || speed != nil || volume != nil || opacity != nil
             || transform != nil
             || content != nil || fontName != nil || fontSize != nil
-            || color != nil || alignment != nil
+            || color != nil || backgroundColor != nil || backgroundEnabled != nil
+            || alignment != nil
     }
 }
 
@@ -414,7 +417,7 @@ extension ToolExecutor {
 
     // MARK: set_clip_properties
 
-    private static let textOnlyKeys: Set<String> = ["content", "fontName", "fontSize", "color", "alignment"]
+    private static let textOnlyKeys: Set<String> = ["content", "fontName", "fontSize", "color", "backgroundColor", "backgroundEnabled", "alignment"]
 
     func setClipProperties(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: SetClipPropertiesInput = try decodeToolArgs(args, path: "set_clip_properties")
@@ -441,6 +444,7 @@ extension ToolExecutor {
             throw ToolError("trimEndFrame must be >= 0 (got \(t))")
         }
         let color = try parseColorHex(input.color, path: "set_clip_properties")
+        let backgroundColor = try parseColorHex(input.backgroundColor, path: "set_clip_properties")
         let alignment = try parseAlignment(input.alignment, path: "set_clip_properties")
 
         // Resolve clipIds + collect types so we can reject text-only fields on non-text clips.
@@ -454,6 +458,8 @@ extension ToolExecutor {
             input.fontName  != nil ? "fontName"  : nil,
             input.fontSize  != nil ? "fontSize"  : nil,
             input.color     != nil ? "color"     : nil,
+            input.backgroundColor   != nil ? "backgroundColor"   : nil,
+            input.backgroundEnabled != nil ? "backgroundEnabled" : nil,
             input.alignment != nil ? "alignment" : nil,
         ].compactMap { $0 }
         if !textOnlyUsed.isEmpty {
@@ -488,6 +494,8 @@ extension ToolExecutor {
                     fontName: isText ? input.fontName : nil,
                     fontSize: isText ? input.fontSize : nil,
                     color: isText ? color : nil,
+                    backgroundColor: isText ? backgroundColor : nil,
+                    backgroundEnabled: isText ? input.backgroundEnabled : nil,
                     alignment: isText ? alignment : nil,
                     clipId: id,
                     editor: editor
@@ -507,7 +515,8 @@ extension ToolExecutor {
                     trimEndFrame:   partnerIsText ? nil : input.trimEndFrame,
                     speed:          partnerIsText ? nil : input.speed,
                     volume: nil, opacity: nil, transform: nil,
-                    content: nil, fontName: nil, fontSize: nil, color: nil, alignment: nil,
+                    content: nil, fontName: nil, fontSize: nil, color: nil,
+                    backgroundColor: nil, backgroundEnabled: nil, alignment: nil,
                     clipId: partnerId,
                     editor: editor
                 )
@@ -531,6 +540,8 @@ extension ToolExecutor {
         fontName: String?,
         fontSize: Double?,
         color: TextStyle.RGBA?,
+        backgroundColor: TextStyle.RGBA?,
+        backgroundEnabled: Bool?,
         alignment: TextStyle.Alignment?,
         clipId: String,
         editor: EditorViewModel
@@ -572,12 +583,19 @@ extension ToolExecutor {
                 clip.transform = next
                 changed.append("transform")
             }
-            if content != nil || fontName != nil || fontSize != nil || color != nil || alignment != nil {
+            if content != nil || fontName != nil || fontSize != nil || color != nil
+                || backgroundColor != nil || backgroundEnabled != nil || alignment != nil {
                 if let c = content { clip.textContent = c; changed.append("content") }
                 var style = clip.textStyle ?? TextStyle()
                 if let f = fontName  { style.fontName = f; changed.append("fontName") }
                 if let s = fontSize  { style.fontSize = s; changed.append("fontSize") }
                 if let c = color     { style.color = c; changed.append("color") }
+                if let bc = backgroundColor {
+                    style.background.color = bc
+                    style.background.enabled = true
+                    changed.append("backgroundColor")
+                }
+                if let be = backgroundEnabled { style.background.enabled = be; changed.append("backgroundEnabled") }
                 if let a = alignment { style.alignment = a; changed.append("alignment") }
                 clip.textStyle = style
             }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -12,7 +12,7 @@ fileprivate struct PartialTextSpec {
 extension ToolExecutor {
     private static let addTextsAllowedKeys: Set<String> = [
         "trackIndex", "startFrame", "durationFrames", "content",
-        "transform", "fontName", "fontSize", "color", "alignment",
+        "transform", "fontName", "fontSize", "color", "backgroundColor", "backgroundEnabled", "alignment",
     ]
 
     private func parseAddTextTransform(
@@ -80,6 +80,11 @@ extension ToolExecutor {
             if let f = entry.string("fontName") { style.fontName = f }
             if let s = entry.double("fontSize") { style.fontSize = s }
             if let c = try parseColorHex(entry.string("color"), path: path) { style.color = c }
+            if let bg = try parseColorHex(entry.string("backgroundColor"), path: path) {
+                style.background.color = bg
+                style.background.enabled = true
+            }
+            if let e = entry.bool("backgroundEnabled") { style.background.enabled = e }
             if let a = try parseAlignment(entry.string("alignment"), path: path) { style.alignment = a }
 
             let transform = try parseAddTextTransform(

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -973,6 +973,48 @@ struct ToolExecutorClipTests {
         #expect(result.isError)
     }
 
+    @Test func setClipPropertiesSetsTextBackgroundColor() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        _ = await h.runRaw("add_texts", args: [
+            "entries": [["trackIndex": 0, "startFrame": 0, "durationFrames": 60, "content": "Hi"]]
+        ])
+        let textId = h.editor.timeline.tracks[0].clips[0].id
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [textId], "backgroundColor": "#000000",
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let style = h.editor.timeline.tracks[0].clips[0].textStyle
+        #expect(style?.background.enabled == true)
+        #expect(style?.background.color == TextStyle.RGBA(r: 0, g: 0, b: 0, a: 1))
+    }
+
+    @Test func setClipPropertiesTogglesTextBackgroundOff() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        _ = await h.runRaw("add_texts", args: [
+            "entries": [["trackIndex": 0, "startFrame": 0, "durationFrames": 60, "content": "Hi", "backgroundColor": "#FF0000"]]
+        ])
+        let textId = h.editor.timeline.tracks[0].clips[0].id
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [textId], "backgroundEnabled": false,
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let style = h.editor.timeline.tracks[0].clips[0].textStyle
+        #expect(style?.background.enabled == false)
+        #expect(style?.background.color == TextStyle.RGBA(r: 1, g: 0, b: 0, a: 1))
+    }
+
+    @Test func setClipPropertiesRejectsBackgroundColorOnVideoClip() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        let clipId = await addedClip(in: h, asset: asset)
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clipId], "backgroundColor": "#000000",
+        ])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("backgroundColor"))
+    }
+
     @Test func setClipPropertiesRejectsNoProperties() async throws {
         let (h, asset) = await setupWithVideoTrack()
         let clipId = await addedClip(in: h, asset: asset)
@@ -1218,6 +1260,43 @@ struct ToolExecutorTextFolderTests {
         let clip = h.editor.timeline.tracks[0].clips[0]
         #expect(clip.textContent == "Caption")
         #expect(clip.textStyle?.fontSize == 48)
+    }
+
+    @Test func addTextsAppliesBackgroundColor() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "durationFrames": 60,
+                "content": "Lower third",
+                "backgroundColor": "#000000",
+            ]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let style = h.editor.timeline.tracks[0].clips[0].textStyle
+        #expect(style?.background.enabled == true)
+        #expect(style?.background.color == TextStyle.RGBA(r: 0, g: 0, b: 0, a: 1))
+    }
+
+    @Test func addTextsBackgroundEnabledFalseOverridesColor() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "durationFrames": 60,
+                "content": "No box",
+                "backgroundColor": "#000000",
+                "backgroundEnabled": false,
+            ]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let style = h.editor.timeline.tracks[0].clips[0].textStyle
+        #expect(style?.background.enabled == false)
+        #expect(style?.background.color == TextStyle.RGBA(r: 0, g: 0, b: 0, a: 1))
     }
 
     @Test func addTextsRejectsAudioTargetTrack() async throws {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

A user asked for a black background behind captions, but the agent had no way to set it: `add_captions` and `set_clip_properties` only exposed text (foreground) `color`. Background fills are a common caption styling need (legibility over busy footage).

## What

The data model (`TextStyle.background: Fill`), renderer (`TextLayerController` → `CATextLayer.backgroundColor`), and editor UI (Captions tab + Text inspector) already fully support a background box. Only the agent tools lacked parameters. This PR wires those through.

New parameters (text clips only):

- **`backgroundColor`** — hex `#RRGGBB` / `#RRGGBBAA` fill behind the text. Setting it turns the background box on. The `AA` byte gives a translucent scrim (e.g. `#00000099`).
- **`backgroundEnabled`** — explicit on/off toggle, so the box can be removed (`false`) or enabled with its current/default color without changing the color.

Added to:

- `add_captions` — the headline request ("black caption background").
- `set_clip_properties` — text-only field; rejected on non-text clips like the existing text fields. Reports `backgroundColor` / `backgroundEnabled` in the change summary.
- `add_texts` — for parity with titles/lower-thirds.

Semantics: passing `backgroundColor` sets the color and enables the box; `backgroundEnabled` overrides the enabled flag (so `backgroundColor` + `backgroundEnabled:false` sets the color but keeps the box hidden). No model/renderer changes were needed — a non-default background flows through the existing caption pipeline and serializes back via `get_timeline`.

## Tests

Added executor tests covering `add_texts` and `set_clip_properties`: background color applied + enabled, `backgroundEnabled:false` override, and rejection of `backgroundColor` on a video clip.

## Note

This is a macOS-only target (AppKit/AVFoundation, Swift 6.2). The cloud VM has no Swift toolchain, so `swift build` / `swift test` could not be run here — changes were verified by inspection against the existing color-handling paths they mirror.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddc28e72-5e23-4696-b59c-227fc3a94747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddc28e72-5e23-4696-b59c-227fc3a94747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

