### PR TITLE
fix(export): surface XML/FCPXML write failures instead of silently succeeding

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -102,7 +102,11 @@ extension ToolExecutor {
                 throw ToolError("export_project: \(error.localizedDescription)")
             }
         }
-        XMLExporter.export(timeline: editor.timeline, resolver: editor.mediaResolver, outputURL: outputURL)
+        do {
+            try XMLExporter.export(timeline: editor.timeline, resolver: editor.mediaResolver, outputURL: outputURL)
+        } catch {
+            throw ToolError("export_project: XML export failed: \(error.localizedDescription)")
+        }
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: XML export failed")
         }

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -4,11 +4,13 @@ import AppKit
 enum ExportError: LocalizedError {
     case unsupportedPreset
     case invalidFormat
+    case xmlEncodingFailed
 
     var errorDescription: String? {
         switch self {
         case .unsupportedPreset: "Export preset not supported on this system"
         case .invalidFormat: "Invalid export format"
+        case .xmlEncodingFailed: "Couldn't encode the timeline as XML"
         }
     }
 }
@@ -47,9 +49,18 @@ final class ExportService {
                 telemetry: "Export started",
                 data: ["format": "xml", "tracks": timeline.tracks.count, "clips": timeline.tracks.reduce(0) { $0 + $1.clips.count }]
             )
-            XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
-            progress = 1.0
-            Log.export.notice("export ok format=xml", telemetry: "Export finished", data: ["format": "xml"])
+            do {
+                try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
+                progress = 1.0
+                Log.export.notice("export ok format=xml", telemetry: "Export finished", data: ["format": "xml"])
+            } catch {
+                self.error = Log.detail(error)
+                Log.export.error(
+                    "export failed format=xml: \(Log.detail(error))",
+                    telemetry: "Export failed",
+                    data: ["format": "xml", "error": Log.detail(error)]
+                )
+            }
             return
         }
 

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -38,9 +38,10 @@ import Foundation
 
 enum XMLExporter {
 
-    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) {
+    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) throws {
         let xml = Builder(timeline: timeline, resolver: resolver).build()
-        try? xml.data(using: .utf8)?.write(to: outputURL)
+        guard let data = xml.data(using: .utf8) else { throw ExportError.xmlEncodingFailed }
+        try data.write(to: outputURL)
     }
 
     // MARK: - Source timecode

--- a/Tests/PalmierProTests/Export/XMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/XMLExporterTests.swift
@@ -55,7 +55,7 @@ struct XMLExporterTests {
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.hasPrefix("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
@@ -67,6 +67,21 @@ struct XMLExporterTests {
         #expect(xml.contains("</xmeml>"))
     }
 
+    @Test func exportThrowsWhenDestinationIsUnwritable() throws {
+        // A path inside a directory that does not exist can't be written.
+        // The exporter must surface that failure instead of silently "succeeding".
+        let timeline = Fixtures.timeline()
+        let (resolver, tmpDir) = try makeResolver(entries: [])
+        let unwritable = tmpDir
+            .appendingPathComponent("does-not-exist", isDirectory: true)
+            .appendingPathComponent("out.xml")
+
+        #expect(throws: (any Error).self) {
+            try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: unwritable)
+        }
+        #expect(!FileManager.default.fileExists(atPath: unwritable.path))
+    }
+
     @Test func headerReportsTimelineFpsAndCanvasDimensions() throws {
         var timeline = Fixtures.timeline(fps: 24)
         timeline.width = 1280
@@ -74,7 +89,7 @@ struct XMLExporterTests {
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<timebase>24</timebase>"))
@@ -87,7 +102,7 @@ struct XMLExporterTests {
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let outURL = tmpDir.appendingPathComponent("out.xml")
 
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<duration>0</duration>"))
@@ -118,7 +133,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<clipitem id=\"clipitem-clip-1\">"))
@@ -137,7 +152,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("ghost-clip"))
@@ -171,7 +186,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // The full <file> element appears exactly once; the second reference is a self-closing tag.
@@ -191,7 +206,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let audioSec = xml.range(of: "<audio>"), let videoSec = xml.range(of: "<video>") else {
@@ -238,7 +253,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<linkclipref>clipitem-vc</linkclipref>"))
@@ -254,7 +269,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("<link>"))
@@ -269,7 +284,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>timeremap</effectid>"))
@@ -283,7 +298,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("timeremap"))
@@ -295,7 +310,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>audiolevels</effectid>"))
@@ -308,7 +323,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("audiolevels"))
@@ -321,7 +336,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // FCP7 keeps opacity in its own Opacity effect, not inside Basic Motion.
@@ -339,7 +354,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("<effectid>basic</effectid>"))
@@ -358,7 +373,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Defaults (centerX/Y=0.5, width=height=1, rotation=0, opacity=1) → no filter at all.
@@ -378,7 +393,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(!xml.contains("clipitem-tc"))
@@ -396,7 +411,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Find the <track> block in the <audio> section and verify its enabled flag.
@@ -415,7 +430,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let videoStart = xml.range(of: "<video>") else { Issue.record("no <video>"); return }
@@ -448,7 +463,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         #expect(xml.contains("A &amp; B &lt; C &gt; &quot;D&quot; &apos;E&apos;"))
@@ -464,7 +479,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // in = trimStart, out = trimStart + sourceFramesConsumed (= durationFrames * speed = 60 at speed=1).
@@ -481,7 +496,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clipA, clipB])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         // Sequence <duration> appears before the first <media> block; clip <duration> entries
@@ -500,7 +515,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [later, earlier])])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         guard let earlyRange = xml.range(of: "earlier"), let laterRange = xml.range(of: "later") else {
@@ -553,7 +568,7 @@ struct XMLExporterTests {
         ])
 
         let outURL = tmpDir.appendingPathComponent("out.xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
+        try XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outURL)
 
         let xml = try readXML(at: outURL)
         let bottomRange = xml.range(of: "bottom-clip")
@@ -590,7 +605,7 @@ struct XMLExporterTests {
         let timeline = Fixtures.timeline(tracks: [track])
         let out = FileManager.default.temporaryDirectory
             .appendingPathComponent("export-\(UUID().uuidString).xml")
-        XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: out)
+        try? XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: out)
         return (try? String(contentsOf: out, encoding: .utf8)) ?? ""
     }
 


### PR DESCRIPTION
## Summary

The XML/FCPXML exporter swallowed every failure and the UI reported success anyway, so a failed export looked identical to a successful one: progress hit 100%, "Export finished" was logged, the dialog closed, and no file was written. Fixes #182.

Root cause, `XMLExporter.export` discarded errors and couldn't signal failure:

```swift
try? xml.data(using: .utf8)?.write(to: outputURL)   // non-throwing
```

and `ExportService`'s XML branch set `progress = 1.0` + logged "ok" unconditionally, never touching `self.error` (unlike the video/ProRes path right below it, which already has a proper `do/catch`).

## Changes

- **`XMLExporter.export` is now `throws`**: a real `try data.write(to:)`, plus a `guard let data = … else { throw ExportError.xmlEncodingFailed }` for the (unlikely) encoding failure.
- **`ExportError.xmlEncodingFailed`** added with a user-facing description.
- **`ExportService`** wraps the XML export in `do/catch`: on failure it sets `self.error` and logs "export failed" (telemetry "Export failed"); `progress` and the "ok" log now only happen on success. This makes the XML path behave exactly like the existing video/ProRes path, so the dialog correctly stays open and shows the error.
- **`ToolExecutor+Export.swift`** (agent `export_project`) now `try`s the call and surfaces the underlying error message; the existing `fileExists` guard remains as a backstop.

No behavior change on success: a writable destination still produces the same XML and the same "Export finished" log.

## Test plan

- New test `exportThrowsWhenDestinationIsUnwritable` (`Export/XMLExporterTests.swift`): exports to a path inside a non-existent directory and asserts the call throws and no file is created. Verified **red before / green after** the fix (reverting to the old `try?` makes it fail with "an error was expected but none was thrown").
- Updated the existing `XMLExporter.export` call sites in the test suite for the now-throwing API.
- `swift build` clean.
- `swift test` → **743 tests / 124 suites pass**.

## Notes / scope

- Severity is Medium: XML write failures are uncommon in normal use (the save panel usually yields a writable location), but a silent "success with no file" is a data-loss/trust bug worth fixing, and the change is small and isolated.
- Only the XML/FCPXML branch was affected; the video, ProRes, and `.palmier` bundle export paths already handled errors and are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated error-handling change on the XML export path; success behavior is unchanged and video/ProRes paths are untouched.
> 
> **Overview**
> Fixes a bug where XML/FCPXML export could **report success with no file written** because `XMLExporter.export` used `try?` on encode/write and never threw.
> 
> **`XMLExporter.export` is now `throws`**: UTF-8 encoding failures raise `ExportError.xmlEncodingFailed`, and disk writes use `try data.write(to:)`.
> 
> **Call sites propagate failures**: `ExportService`'s XML branch matches video export—`progress` and success telemetry only on success; failures set `self.error` and log "Export failed". Agent `export_project` XML mode wraps the exporter and returns a `ToolError` with the underlying message.
> 
> Tests add `exportThrowsWhenDestinationIsUnwritable` and update existing callers for the throwing API. Successful exports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2f2d8fa6bda6607eddc248ac2e1de2205e7cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->