### PR TITLE
Harden Google sign-in flow

### DIFF
--- a/Sources/PalmierPro/Account/AccountPopoverCard.swift
+++ b/Sources/PalmierPro/Account/AccountPopoverCard.swift
@@ -22,7 +22,7 @@ struct AccountPopoverCard: View {
             if let error = account.lastError {
                 Text(error)
                     .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(.red)
+                    .foregroundStyle(AppTheme.Status.errorColor)
             }
         }
         .padding(AppTheme.Spacing.md)
@@ -205,10 +205,11 @@ struct AccountPopoverCard: View {
                     dismiss()
                 }
             } else {
-                footerButton(label: "Sign in", systemImage: "person.crop.circle") {
+                footerButton(label: account.isSigningIn ? "Opening Google…" : "Sign in", systemImage: "person.crop.circle") {
                     Task { await account.signInWithGoogle() }
                     dismiss()
                 }
+                .disabled(account.isSigningIn)
             }
         }
     }

--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -103,6 +103,7 @@ final class AccountService {
     private(set) var account: AccountResponse?
     private(set) var availablePlans: [AvailablePlan] = []
     private(set) var lastError: String?
+    private(set) var isSigningIn: Bool = false
     private(set) var isBuyingCredits: Bool = false
     private(set) var authState: AuthState<String> = .loading
 
@@ -301,8 +302,19 @@ final class AccountService {
 
     func signInWithGoogle() async {
         guard !isMisconfigured else { return }
+        guard !isSigningIn else {
+            lastError = "Sign-in is already in progress."
+            Log.account.notice(
+                "sign in ignored provider=google reason=in_progress",
+                telemetry: "Sign in ignored",
+                data: ["provider": "google", "reason": "in_progress"]
+            )
+            return
+        }
+        isSigningIn = true
         lastError = nil
         Log.account.notice("sign in requested provider=google", telemetry: "Sign in requested", data: ["provider": "google"])
+        defer { isSigningIn = false }
         do {
             _ = try await Clerk.shared.auth.signInWithOAuth(provider: .google)
         } catch {

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ClerkKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -28,6 +29,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             AppState.shared.showHome()
         }
         return true
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            Task { @MainActor in
+                do {
+                    let handled = try await Clerk.shared.handle(url)
+                    Log.account.notice(
+                        "auth callback \(handled ? "handled" : "ignored") url=\(Self.safeURLDescription(url))",
+                        telemetry: "Auth callback received",
+                        data: ["handled": handled, "url": Self.safeURLDescription(url)]
+                    )
+                } catch {
+                    Log.account.warning(
+                        "auth callback failed url=\(Self.safeURLDescription(url)) error=\(Log.detail(error))",
+                        telemetry: "Auth callback failed",
+                        data: ["error": error.localizedDescription, "url": Self.safeURLDescription(url)]
+                    )
+                }
+            }
+        }
+    }
+
+    private static func safeURLDescription(_ url: URL) -> String {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.path = url.path
+        return components.string ?? url.scheme ?? "unknown"
     }
 
     @MainActor

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -1307,9 +1307,9 @@ struct GenerationView: View {
         .buttonBorderShape(.circle)
         .controlSize(.regular)
         .tint(AppTheme.Accent.primary)
-        .disabled(aiAllowed ? !canSubmit : account.isMisconfigured)
-        .opacity((aiAllowed ? canSubmit : !account.isMisconfigured) ? 1 : AppTheme.Opacity.strong)
-        .help(aiAllowed ? "" : (account.isMisconfigured ? "AI is unavailable" : "Sign in to generate"))
+        .disabled(aiAllowed ? !canSubmit : account.isMisconfigured || account.isSigningIn)
+        .opacity((aiAllowed ? canSubmit : !account.isMisconfigured && !account.isSigningIn) ? AppTheme.Opacity.opaque : AppTheme.Opacity.strong)
+        .help(aiAllowed ? "" : (account.isMisconfigured ? "AI is unavailable" : account.isSigningIn ? "Opening Google" : "Sign in to generate"))
     }
 
     // MARK: - Type picker

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -174,10 +174,11 @@ private struct HomeSidebar: View {
             VStack(alignment: .leading, spacing: 2) {
                 if !account.isSignedIn && !account.isMisconfigured {
                     SidebarRowButton(
-                        label: "Sign in with Google",
+                        label: account.isSigningIn ? "Opening Google…" : "Sign in with Google",
                         systemImage: "person.crop.circle",
                         action: { Task { await account.signInWithGoogle() } }
                     )
+                    .disabled(account.isSigningIn)
                 }
                 SidebarRowButton(
                     label: "New Project",

--- a/Sources/PalmierPro/Project/WelcomeOverlay.swift
+++ b/Sources/PalmierPro/Project/WelcomeOverlay.swift
@@ -72,9 +72,12 @@ struct WelcomeOverlay: View {
                 .buttonStyle(.capsule(.prominent, size: .regular))
                 .keyboardShortcut(.defaultAction)
         } else {
-            Button("Sign In") { Task { await account.signInWithGoogle() } }
+            Button(account.isSigningIn ? "Opening Google…" : "Sign In") {
+                Task { await account.signInWithGoogle() }
+            }
                 .buttonStyle(.capsule(.prominent, size: .regular))
                 .keyboardShortcut(.defaultAction)
+                .disabled(account.isSigningIn)
         }
     }
 

--- a/Sources/PalmierPro/Settings/AccountPane.swift
+++ b/Sources/PalmierPro/Settings/AccountPane.swift
@@ -19,7 +19,7 @@ struct AccountPane: View {
             if let error = account.lastError {
                 Text(error)
                     .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(.red)
+                    .foregroundStyle(AppTheme.Status.errorColor)
             }
         }
     }
@@ -249,10 +249,11 @@ struct AccountPane: View {
             .foregroundStyle(AppTheme.Text.tertiaryColor)
             .fixedSize(horizontal: false, vertical: true)
 
-        Button("Sign in with Google") {
+        Button(account.isSigningIn ? "Opening Google…" : "Sign in with Google") {
             Task { await account.signInWithGoogle() }
         }
         .buttonStyle(.capsule(.secondary, size: .regular))
+        .disabled(account.isSigningIn)
         .padding(.top, AppTheme.Spacing.xs)
     }
 }


### PR DESCRIPTION
avoid racing, disable buttons while signing in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication entry points and OAuth URL handling; mistakes could break sign-in completion or leave users stuck, but changes are narrowly scoped with guards and logging.
> 
> **Overview**
> **Hardens Google OAuth** by tracking **`isSigningIn`** in `AccountService`, ignoring duplicate `signInWithGoogle()` calls (with user-visible error and telemetry), and clearing the flag when the flow finishes.
> 
> **Routes `palmier://` callbacks** through `AppDelegate.application(_:open:)` so **`Clerk.shared.handle(url)`** can complete sign-in, with sanitized URL logging on success or failure.
> 
> **Sign-in entry points** (home sidebar, welcome overlay, account popover/settings, generation panel) now show **"Opening Google…"**, **disable** while in progress, and the generate submit control stays inactive with updated tooltip/opacity. Account error labels use **`AppTheme.Status.errorColor`** instead of raw red.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6796f1d45f01f341e52cf65c950915fc0ce2e4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->