### PR TITLE
[agents] split_clips can do batch operation

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -57,7 +57,9 @@ enum AgentInstructions {
             existing keyframes on that property.
           • set_keyframes: replace the keyframe track for one (clipId, property) pair. Empty \
             array clears. Frames are clip-relative.
-          • split_clip: atFrame must be strictly inside the clip.
+          • split_clips: pass one or more cut points (each atFrame strictly inside its clip) in \
+            one call — multiple cuts on the same clip are fine. Splits only insert boundaries; \
+            nothing shifts. Use ripple_delete_ranges instead when you need to remove a span.
           • sync_audio: align one or more clips to a reference (usually the camera) clip by \
             waveform — referenceClipId stays, the target(s) move. Use for dual-system sound \
             or multicam (pass targetClipIds); it returns per-clip confidence and refuses \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -11,7 +11,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case moveClips = "move_clips"
     case setClipProperties = "set_clip_properties"
     case setKeyframes = "set_keyframes"
-    case splitClip = "split_clip"
+    case splitClips = "split_clips"
     case rippleDeleteRanges = "ripple_delete_ranges"
     case removeWords = "remove_words"
     case syncAudio = "sync_audio"
@@ -275,19 +275,34 @@ enum ToolDefinitions {
             )
         ),
         AgentTool(
-            name: .splitClip,
-            description: "Splits a clip into two at atFrame. The frame must be strictly between the clip's start and end — use get_timeline to confirm the range.",
+            name: .splitClips,
+            description: "Splits clips into two at one or more cut points, all in a single undoable action. A split only inserts a boundary — it never trims media or moves clips, so unlike ripple_delete_ranges nothing shifts and there's no gap to close.\n\nTwo modes — pass exactly one:\n• splits: an array of {clipId, atFrame} (project frames). Use when you know the clip IDs.\n• trackIndex + frames: cut one track at the given project frames; each frame is matched to whichever clip on that track contains it. Pairs naturally with get_transcript / get_timeline project frames.\n\nEvery frame must fall strictly between a clip's start and end. Multiple cuts on the SAME clip are allowed — pass all the frames at once and each is resolved against the current sub-clips. Duplicate cut points are ignored. Linked audio/video partners are split at the same frame so A/V stays in sync, and the right halves are regrouped into their own link pair. One bad cut point rejects the whole call with no partial state.",
             inputSchema: objectSchema(
                 properties: [
-                    "clipId": ["type": "string", "description": "The clip ID to split"],
-                    "atFrame": ["type": "integer", "description": "Frame position to split at (must be between clip start and end)"],
+                    "splits": [
+                        "type": "array",
+                        "description": "Explicit cuts. Each item is {clipId, atFrame}.",
+                        "items": objectSchema(
+                            properties: [
+                                "clipId": ["type": "string", "description": "The clip ID to split"],
+                                "atFrame": ["type": "integer", "description": "Project frame to split at (strictly between clip start and end)"],
+                            ],
+                            required: ["clipId", "atFrame"]
+                        ),
+                    ],
+                    "trackIndex": ["type": "integer", "description": "Track to cut (use with 'frames')"],
+                    "frames": [
+                        "type": "array",
+                        "description": "Project frames to cut on trackIndex; each is matched to the clip containing it.",
+                        "items": ["type": "integer"],
+                    ],
                 ],
-                required: ["clipId", "atFrame"]
+                required: []
             )
         ),
         AgentTool(
             name: .rippleDeleteRanges,
-            description: "Cuts one or more ranges out and closes the gaps in one undoable action — the fast path for filler-word/dead-air removal. Replaces hand-cranked split_clip → split_clip → remove_clips → move_clips loops: pass every range at once.\n\nTwo modes — pass exactly one of clipId or trackIndex:\n• trackIndex (preferred for transcript-driven cuts): ranges are PROJECT frames and may span any number of clips on that track. get_transcript returns a clips array with nested words in project frames — collect every cut across the whole timeline and pass them in ONE call, no per-clip splitting and no re-reading the timeline between cuts. units must be 'frames'.\n• clipId: ranges are cut within that single clip only, clamped to its visible span. Allows units 'seconds' (source-media seconds, e.g. inspect_media WITHOUT a clipId or search_media hits); 'frames' = project frames. Use when you already have one clip's per-word timestamps.\n\nOverlapping ranges merge. Linked audio/video partners of every touched clip are cut on the same span so A/V stays in sync. Remaining clips shift left to close every gap; sync-locked tracks shift along to preserve alignment (their content isn't cut). Refuses without changing anything if a sync-locked track can't absorb the shift (e.g. it would move past frame 0). Returns the anchor track's post-cut layout (clip ids/frames) so you don't need to re-read.",
+            description: "Cuts one or more ranges out and closes the gaps in one undoable action — the fast path for filler-word/dead-air removal. Replaces hand-cranked split_clips → remove_clips → move_clips loops: pass every range at once.\n\nTwo modes — pass exactly one of clipId or trackIndex:\n• trackIndex (preferred for transcript-driven cuts): ranges are PROJECT frames and may span any number of clips on that track. get_transcript returns a clips array with nested words in project frames — collect every cut across the whole timeline and pass them in ONE call, no per-clip splitting and no re-reading the timeline between cuts. units must be 'frames'.\n• clipId: ranges are cut within that single clip only, clamped to its visible span. Allows units 'seconds' (source-media seconds, e.g. inspect_media WITHOUT a clipId or search_media hits); 'frames' = project frames. Use when you already have one clip's per-word timestamps.\n\nOverlapping ranges merge. Linked audio/video partners of every touched clip are cut on the same span so A/V stays in sync. Remaining clips shift left to close every gap; sync-locked tracks shift along to preserve alignment (their content isn't cut). Refuses without changing anything if a sync-locked track can't absorb the shift (e.g. it would move past frame 0). Returns the anchor track's post-cut layout (clip ids/frames) so you don't need to re-read.",
             inputSchema: objectSchema(
                 properties: [
                     "trackIndex": ["type": "integer", "description": "Cut project-frame ranges spanning every clip they cross on this track, in one call. From get_transcript's clips array. Mutually exclusive with clipId; requires units 'frames'."],

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -44,6 +44,19 @@ fileprivate struct MoveClipsInput: DecodableToolArgs {
     }
 }
 
+fileprivate struct SplitClipsInput: DecodableToolArgs {
+    let splits: [Split]?
+    let trackIndex: Int?
+    let frames: [Int]?
+    static let allowedKeys: Set<String> = ["splits", "trackIndex", "frames"]
+
+    struct Split: DecodableToolArgs {
+        let clipId: String
+        let atFrame: Int
+        static let allowedKeys: Set<String> = ["clipId", "atFrame"]
+    }
+}
+
 fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let clipIds: [String]
     let durationFrames: Int?
@@ -644,24 +657,60 @@ extension ToolExecutor {
         return .ok("\(action) keyframes on \(input.property) for \(input.clipId)")
     }
 
-    // MARK: split_clip
+    // MARK: split_clips
 
-    func splitClip(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
-        let clipId = try args.requireString("clipId")
-        let atFrame = try args.requireInt("atFrame")
-        guard let loc = editor.findClip(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
-        let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        guard atFrame > clip.startFrame && atFrame < clip.endFrame else {
-            throw ToolError("Frame \(atFrame) is outside clip range (\(clip.startFrame)..\(clip.endFrame))")
+    func splitClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: SplitClipsInput = try decodeToolArgs(args, path: "split_clips")
+        let hasSplits = !(input.splits ?? []).isEmpty
+        let hasTrack = input.trackIndex != nil || !(input.frames ?? []).isEmpty
+        guard hasSplits != hasTrack else {
+            throw ToolError("Provide exactly one of 'splits' (an array of {clipId, atFrame}) or 'trackIndex'+'frames' (project frames to cut on one track).")
         }
-        let rightIds = editor.splitClip(clipId: clipId, atFrame: atFrame)
-        let rightEndFrame = clip.endFrame
-        let leftSummary = "\(clipId) (frames \(clip.startFrame)..\(atFrame))"
-        let rightList = rightIds
-            .map { "\($0) (frames \(atFrame)..\(rightEndFrame))" }
+
+        // Resolve every cut to a (trackIndex, atFrame) pair against the CURRENT timeline
+        var points: [(trackIndex: Int, atFrame: Int)] = []
+        var seen: Set<String> = []
+
+        func addCut(trackIndex: Int, atFrame: Int, clip: Clip) throws {
+            guard atFrame > clip.startFrame && atFrame < clip.endFrame else {
+                throw ToolError("Frame \(atFrame) is outside clip \(clip.id) range (\(clip.startFrame)..\(clip.endFrame))")
+            }
+            let key = "\(trackIndex):\(atFrame)"
+            guard seen.insert(key).inserted else { return }
+            points.append((trackIndex, atFrame))
+        }
+
+        if let splits = input.splits {
+            for s in splits {
+                guard let loc = editor.findClip(id: s.clipId) else { throw ToolError("Clip not found: \(s.clipId)") }
+                let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                try addCut(trackIndex: loc.trackIndex, atFrame: s.atFrame, clip: clip)
+            }
+        } else {
+            guard let trackIndex = input.trackIndex,
+                  trackIndex >= 0, trackIndex < editor.timeline.tracks.count else {
+                throw ToolError("trackIndex is required and must be in 0..\(editor.timeline.tracks.count - 1)")
+            }
+            guard let frames = input.frames, !frames.isEmpty else {
+                throw ToolError("'frames' must be a non-empty array of project frames")
+            }
+            let track = editor.timeline.tracks[trackIndex]
+            for f in frames {
+                guard let clip = track.clips.first(where: { f > $0.startFrame && f < $0.endFrame }) else {
+                    throw ToolError("Frame \(f) is not strictly inside any clip on track \(trackIndex)")
+                }
+                try addCut(trackIndex: trackIndex, atFrame: f, clip: clip)
+            }
+        }
+
+        guard !points.isEmpty else { throw ToolError("No valid split points") }
+        let rightIds = editor.splitClips(at: points)
+        let cutList = points
+            .sorted { $0.trackIndex == $1.trackIndex ? $0.atFrame < $1.atFrame : $0.trackIndex < $1.trackIndex }
+            .map { "track \($0.trackIndex)@\($0.atFrame)" }
             .joined(separator: ", ")
-        let rightNote = rightIds.isEmpty ? "" : " → new right clip(s): \(rightList)"
-        return .ok("Split clip \(clipId) at frame \(atFrame). Left: \(leftSummary)\(rightNote)")
+        let newNote = rightIds.isEmpty ? "" : " New right-half clip(s): \(rightIds.joined(separator: ", "))."
+        return .ok("Split \(points.count) point(s) [\(cutList)].\(newNote) Re-read with get_timeline for updated ranges.")
     }
 
     // MARK: ripple_delete_ranges

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -680,8 +680,8 @@ extension ToolExecutor {
             points.append((trackIndex, atFrame))
         }
 
-        if let splits = input.splits {
-            for s in splits {
+        if hasSplits {
+            for s in input.splits ?? [] {
                 guard let loc = editor.findClip(id: s.clipId) else { throw ToolError("Clip not found: \(s.clipId)") }
                 let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
                 try addCut(trackIndex: loc.trackIndex, atFrame: s.atFrame, clip: clip)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -89,7 +89,7 @@ final class ToolExecutor {
         case .moveClips:        return try moveClips(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
-        case .splitClip:        return try splitClip(editor, args)
+        case .splitClips:       return try splitClips(editor, args)
         case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)
         case .removeWords:   return try await removeWords(editor, args)
         case .syncAudio:     return try await syncAudio(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -93,25 +93,34 @@ extension EditorViewModel {
     @discardableResult
     func splitClip(clipId: String, atFrame: Int) -> [String] {
         guard let loc = findClip(id: clipId) else { return [] }
-        let clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        let groupIds: Set<String> = clip.linkGroupId != nil
-            ? Set([clipId] + linkedPartnerIds(of: clipId))
-            : [clipId]
+        return splitClips(at: [(loc.trackIndex, atFrame)])
+    }
 
+    /// Splits at one or more project frames in a single undoable action
+    func splitClips(at points: [(trackIndex: Int, atFrame: Int)]) -> [String] {
         undoManager?.beginUndoGrouping()
+        defer {
+            undoManager?.endUndoGrouping()
+            undoManager?.setActionName(points.count > 1 ? "Split Clips" : "Split Clip")
+        }
         var rightIds: [String] = []
-        for id in groupIds {
-            if let rightId = splitSingleClip(clipId: id, atFrame: atFrame) {
-                rightIds.append(rightId)
+        for p in points {
+            guard p.trackIndex >= 0, p.trackIndex < timeline.tracks.count,
+                  let clip = timeline.tracks[p.trackIndex].clips.first(where: {
+                      p.atFrame > $0.startFrame && p.atFrame < $0.endFrame
+                  })
+            else { continue }
+            let groupIds: Set<String> = clip.linkGroupId != nil
+                ? Set([clip.id] + linkedPartnerIds(of: clip.id))
+                : [clip.id]
+            let rights = groupIds.compactMap { splitSingleClip(clipId: $0, atFrame: p.atFrame) }
+            // Regroup the right halves so each side is its own linked pair.
+            if groupIds.count > 1 && !rights.isEmpty {
+                let newGroup = UUID().uuidString
+                mutateClips(ids: Set(rights), actionName: "Split Clip") { $0.linkGroupId = newGroup }
             }
+            rightIds.append(contentsOf: rights)
         }
-        // Regroup the right halves so each side is its own linked pair.
-        if groupIds.count > 1 && !rightIds.isEmpty {
-            let newGroup = UUID().uuidString
-            mutateClips(ids: Set(rightIds), actionName: "Split Clip") { $0.linkGroupId = newGroup }
-        }
-        undoManager?.endUndoGrouping()
-        undoManager?.setActionName(groupIds.count > 1 ? "Split Clips" : "Split Clip")
         return rightIds
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -187,7 +187,8 @@ extension EditorViewModel {
             .filter { $0.frame >= splitOffset }
             .map { Keyframe(frame: $0.frame - splitOffset, value: $0.value, interpolationOut: $0.interpolationOut) }
         if rightKfs.first?.frame != 0 {
-            rightKfs.insert(Keyframe(frame: 0, value: boundary), at: 0)
+            let interp = track.keyframes.last { $0.frame < splitOffset }?.interpolationOut ?? .smooth
+            rightKfs.insert(Keyframe(frame: 0, value: boundary, interpolationOut: interp), at: 0)
         }
         return (
             leftKfs.isEmpty ? nil : KeyframeTrack(keyframes: leftKfs),

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -93,6 +93,8 @@ extension EditorViewModel {
     @discardableResult
     func splitClip(clipId: String, atFrame: Int) -> [String] {
         guard let loc = findClip(id: clipId) else { return [] }
+        let clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard atFrame > clip.startFrame && atFrame < clip.endFrame else { return [] }
         return splitClips(at: [(loc.trackIndex, atFrame)])
     }
 

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -846,6 +846,17 @@ struct ToolExecutorClipTests {
         #expect(neither.isError)
     }
 
+    @Test func splitClipsEmptySplitsFallsThroughToTrackMode() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = await h.runRaw("add_clips", args: [
+            "entries": [["mediaRef": asset.id, "trackIndex": 0, "startFrame": 0, "durationFrames": 90]]
+        ])
+        // Empty splits + valid trackIndex/frames must apply the track cuts, not error out.
+        let result = await h.runRaw("split_clips", args: ["splits": [], "trackIndex": 0, "frames": [30]])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        #expect(h.editor.timeline.tracks[0].clips.count == 2)
+    }
+
     // MARK: - move_clips
 
     /// Add a video clip and return its id, for tests that need an existing clip.

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -766,27 +766,7 @@ struct ToolExecutorClipTests {
         #expect(result.isError)
     }
 
-    // MARK: - split_clip
-
-    @Test func splitClipDividesAtFrame() async throws {
-        let (h, asset) = await setupWithVideoTrack()
-        _ = await h.runRaw("add_clips", args: [
-            "entries": [[
-                "mediaRef": asset.id,
-                "trackIndex": 0,
-                "startFrame": 0,
-                "durationFrames": 60,
-            ]]
-        ])
-        let clipId = h.editor.timeline.tracks[0].clips[0].id
-
-        let result = await h.runRaw("split_clip", args: ["clipId": clipId, "atFrame": 30])
-        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
-        let clips = h.editor.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
-        #expect(clips.count == 2)
-        #expect(clips[0].startFrame == 0 && clips[0].durationFrames == 30)
-        #expect(clips[1].startFrame == 30 && clips[1].durationFrames == 30)
-    }
+    // MARK: - split_clips
 
     @Test func splitClipRejectsFrameOutsideClipRange() async throws {
         let (h, asset) = await setupWithVideoTrack()
@@ -801,9 +781,69 @@ struct ToolExecutorClipTests {
         let clipId = h.editor.timeline.tracks[0].clips[0].id
 
         // Split at endFrame should fail (must be strictly inside).
-        let result = await h.runRaw("split_clip", args: ["clipId": clipId, "atFrame": 60])
+        let result = await h.runRaw("split_clips", args: ["splits": [["clipId": clipId, "atFrame": 60]]])
         #expect(result.isError)
         #expect(ToolHarness.textOf(result).contains("outside"))
+    }
+
+    @Test func splitClipsMultipleFramesOnSameClip() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = await h.runRaw("add_clips", args: [
+            "entries": [[
+                "mediaRef": asset.id,
+                "trackIndex": 0,
+                "startFrame": 0,
+                "durationFrames": 90,
+            ]]
+        ])
+
+        // Two cuts on one clip via the trackIndex+frames mode → three segments.
+        let result = await h.runRaw("split_clips", args: ["trackIndex": 0, "frames": [30, 60]])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let clips = h.editor.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(clips.count == 3)
+        #expect(clips[0].startFrame == 0 && clips[0].durationFrames == 30)
+        #expect(clips[1].startFrame == 30 && clips[1].durationFrames == 30)
+        #expect(clips[2].startFrame == 60 && clips[2].durationFrames == 30)
+    }
+
+    @Test func splitClipsDedupsDuplicateFrames() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = await h.runRaw("add_clips", args: [
+            "entries": [["mediaRef": asset.id, "trackIndex": 0, "startFrame": 0, "durationFrames": 90]]
+        ])
+        let result = await h.runRaw("split_clips", args: ["trackIndex": 0, "frames": [30, 30]])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        #expect(h.editor.timeline.tracks[0].clips.count == 2)
+        #expect(ToolHarness.textOf(result).contains("1 point"))
+    }
+
+    @Test func splitClipsRejectsSeamFrame() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = await h.runRaw("add_clips", args: [
+            "entries": [["mediaRef": asset.id, "trackIndex": 0, "startFrame": 0, "durationFrames": 90]]
+        ])
+        _ = await h.runRaw("split_clips", args: ["trackIndex": 0, "frames": [30]])
+        // Frame 30 is now a seam between two clips — strictly inside neither.
+        let result = await h.runRaw("split_clips", args: ["trackIndex": 0, "frames": [30]])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("not strictly inside"))
+    }
+
+    @Test func splitClipsRejectsBothAndNeitherMode() async throws {
+        let (h, asset) = await setupWithVideoTrack()
+        _ = await h.runRaw("add_clips", args: [
+            "entries": [["mediaRef": asset.id, "trackIndex": 0, "startFrame": 0, "durationFrames": 90]]
+        ])
+        let clipId = h.editor.timeline.tracks[0].clips[0].id
+
+        let both = await h.runRaw("split_clips", args: [
+            "splits": [["clipId": clipId, "atFrame": 30]], "trackIndex": 0, "frames": [60],
+        ])
+        #expect(both.isError)
+
+        let neither = await h.runRaw("split_clips", args: [:])
+        #expect(neither.isError)
     }
 
     // MARK: - move_clips

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -131,6 +131,17 @@ struct SplitClipTests {
         #expect(leftGroups == ["g1"])
     }
 
+    @Test func splitClipsAtMultiplePointsCutsEachAndSkipsBoundaries() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 90)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        // Two real cuts plus a repeat of the first: the repeat lands on a boundary and is a no-op.
+        let rightIds = e.splitClips(at: [(0, 30), (0, 60), (0, 30)])
+        let clips = e.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(clips.map(\.startFrame) == [0, 30, 60])
+        #expect(clips.map(\.durationFrames) == [30, 30, 30])
+        #expect(rightIds.count == 2)
+    }
+
     @Test func splitClipZerosOpacityFadesAcrossCut() {
         var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
         clip.fadeInFrames = 15

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -142,6 +142,25 @@ struct SplitClipTests {
         #expect(rightIds.count == 2)
     }
 
+    @Test func splitClipKeepsSegmentInterpolationOnRightHalf() {
+        // hold opacity (0→1.0) and linear rotation (0°→20°). Splitting mid-segment must not
+        // turn the right half's opening keyframe smooth: hold stays flat, linear stays straight.
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 1.0, interpolationOut: .hold),
+            Keyframe(frame: 30, value: 0.5),
+        ])
+        clip.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0.0, interpolationOut: .linear),
+            Keyframe(frame: 20, value: 20.0),
+        ])
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let rightId = e.splitClip(clipId: "c1", atFrame: 10)[0]
+        let right = e.timeline.tracks[0].clips.first { $0.id == rightId }!
+        #expect(right.opacityTrack?.sample(at: 5, fallback: 0.0) == 1.0)   // hold: still flat
+        #expect(right.rotationTrack?.sample(at: 5, fallback: 0.0) == 15.0) // linear: 10°→20° at halfway
+    }
+
     @Test func splitClipZerosOpacityFadesAcrossCut() {
         var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
         clip.fadeInFrames = 15

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -104,6 +104,17 @@ struct SplitClipTests {
         #expect(e.timeline.tracks[0].clips.count == 1)
     }
 
+    @Test func splitClipDoesNotCutAnotherClipOnSameTrack() {
+        // c1 = 0..30, c2 = 30..60. Splitting c1 at frame 45 (inside c2, outside c1) must
+        // do nothing — not resolve to c2 and cut it.
+        let e = editor([Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 30),
+            Fixtures.clip(id: "c2", start: 30, duration: 30),
+        ])])
+        #expect(e.splitClip(clipId: "c1", atFrame: 45).isEmpty)
+        #expect(e.timeline.tracks[0].clips.count == 2)
+    }
+
     @Test func splitWithLinkedPartnerSplitsBothAndRegroupsRightHalves() {
         // video + audio sharing g1. After split at 30, the right halves should share a
         // *new* group id (not the original g1).


### PR DESCRIPTION
before: agent split_clip calls multiple times, each time singular op.

now: agent split_clips can do batch in one call, either split by clip or split by track

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline split behavior for the agent and editor, but scope is limited to split validation and batching with expanded tests.
> 
> **Overview**
> Replaces the agent **`split_clip`** tool with **`split_clips`**, so multiple cuts land in **one undoable step** instead of repeated single-split calls.
> 
> Callers use either a **`splits`** list of `{clipId, atFrame}` or **`trackIndex` + `frames`** (project frames resolved to whichever clip contains each frame). Duplicate cut points are ignored; any invalid cut fails the whole call. Agent instructions and **`ripple_delete_ranges`** docs now reference **`split_clips`**.
> 
> **`EditorViewModel`** adds **`splitClips(at:)`** (linked partners split and right halves regrouped); **`splitClip`** delegates there and only cuts when the frame is strictly inside the named clip’s range—not another clip on the same track. Keyframe splitting keeps the **right segment’s opening interpolation** from the segment before the cut.
> 
> Tests cover multi-cut on one clip, deduping, seam rejection, mode validation, and the wrong-clip / interpolation fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df783c345ff3d36a02165dca3cdf4e6dc6725e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->