### PR TITLE
[ui] double click a clip on preview selects that clip

### DIFF
--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -41,6 +41,18 @@ struct PreviewContainerView: View {
                     }
                 }
                 .frame(width: scaledWidth, height: scaledHeight)
+                .simultaneousGesture(
+                    SpatialTapGesture(count: 2)
+                        .onEnded { value in
+                            guard isTimeline,
+                                  let id = PreviewHitTester.clipID(
+                                    at: value.location,
+                                    viewSize: CGSize(width: scaledWidth, height: scaledHeight),
+                                    editor: editor
+                                  ) else { return }
+                            editor.selectedClipIds = editor.expandToLinkGroup([id])
+                        }
+                )
                 .overlay(
                     Rectangle()
                         .stroke(Color.white.opacity(editor.canvasZoom < 1.0 ? AppTheme.Opacity.moderate : 0), lineWidth: AppTheme.BorderWidth.thin)

--- a/Sources/PalmierPro/Preview/PreviewHitTester.swift
+++ b/Sources/PalmierPro/Preview/PreviewHitTester.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+import Foundation
+
+/// Maps a point in the preview (top-left origin, view space) to the topmost visible
+/// clip drawn under it at the current playhead frame, for click-to-select.
+@MainActor
+enum PreviewHitTester {
+    static func clipID(at point: CGPoint, viewSize: CGSize, editor: EditorViewModel) -> String? {
+        let videoRect = videoContentRect(in: viewSize, timeline: editor.timeline)
+        guard videoRect.width > 0, videoRect.height > 0 else { return nil }
+        let frame = editor.playheadState.timelineFrame
+
+        // Text overlays draw above all video in the preview, so they win hit priority.
+        // Within each pass, track 0 is topmost (see CompositionBuilder).
+        for textPass in [true, false] {
+            for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
+                for clip in track.clips {
+                    guard clip.mediaType != .audio else { continue }
+                    guard (clip.mediaType == .text) == textPass else { continue }
+                    guard clip.contains(timelineFrame: frame) else { continue }
+                    guard clip.opacityAt(frame: frame) > 0.01 else { continue }
+                    if hit(clip: clip, frame: frame, point: point, videoRect: videoRect) {
+                        return clip.id
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func hit(clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
+        let t = clip.transformAt(frame: frame)
+        let rect = clipFrame(t, videoRect: videoRect)
+        guard rect.width > 0, rect.height > 0 else { return false }
+
+        // Move the point into the clip's unrotated local space (origin at clip center).
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let rad = t.rotation * .pi / 180
+        let c = cos(rad), s = sin(rad)
+        let dx = point.x - center.x, dy = point.y - center.y
+        let lx = dx * c + dy * s
+        let ly = -dx * s + dy * c
+
+        // Local rect spans ±half-extents; crop trims it (crop is source-space, so local too).
+        let crop = clip.cropAt(frame: frame)
+        let halfW = rect.width / 2, halfH = rect.height / 2
+        let left = -halfW + crop.left * rect.width
+        let right = halfW - crop.right * rect.width
+        let top = -halfH + crop.top * rect.height
+        let bottom = halfH - crop.bottom * rect.height
+        return lx >= left && lx <= right && ly >= top && ly <= bottom
+    }
+
+    private static func videoContentRect(in viewSize: CGSize, timeline: Timeline) -> CGRect {
+        guard viewSize.width > 0, viewSize.height > 0 else { return .zero }
+        let videoAspect = CGFloat(timeline.width) / CGFloat(timeline.height)
+        let viewAspect = viewSize.width / viewSize.height
+        let w: CGFloat, h: CGFloat
+        if viewAspect > videoAspect {
+            h = viewSize.height; w = h * videoAspect
+        } else {
+            w = viewSize.width; h = w / videoAspect
+        }
+        return CGRect(x: (viewSize.width - w) / 2, y: (viewSize.height - h) / 2, width: w, height: h)
+    }
+
+    private static func clipFrame(_ t: Transform, videoRect: CGRect) -> CGRect {
+        let tl = t.topLeft
+        return CGRect(
+            x: videoRect.origin.x + tl.x * videoRect.width,
+            y: videoRect.origin.y + tl.y * videoRect.height,
+            width: t.width * videoRect.width,
+            height: t.height * videoRect.height
+        )
+    }
+}

--- a/Sources/PalmierPro/Preview/PreviewHitTester.swift
+++ b/Sources/PalmierPro/Preview/PreviewHitTester.swift
@@ -10,25 +10,32 @@ enum PreviewHitTester {
         guard videoRect.width > 0, videoRect.height > 0 else { return nil }
         let frame = editor.playheadState.timelineFrame
 
-        // Text overlays draw above all video in the preview, so they win hit priority.
-        // Within each pass, track 0 is topmost (see CompositionBuilder).
-        for textPass in [true, false] {
-            for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
-                for clip in track.clips {
-                    guard clip.mediaType != .audio else { continue }
-                    guard (clip.mediaType == .text) == textPass else { continue }
-                    guard clip.contains(timelineFrame: frame) else { continue }
-                    guard clip.opacityAt(frame: frame) > 0.01 else { continue }
-                    if hit(clip: clip, frame: frame, point: point, videoRect: videoRect) {
-                        return clip.id
-                    }
-                }
+        // Text draws above all video; within text, higher track index is on top, so keep the last hit.
+        var topText: String?
+        for track in editor.timeline.tracks where !track.hidden {
+            for clip in track.clips where clip.mediaType == .text {
+                guard clip.contains(timelineFrame: frame), clip.opacityAt(frame: frame) > 0.01 else { continue }
+                if textHit(clip, point: point, videoRect: videoRect) { topText = clip.id }
+            }
+        }
+        if let topText { return topText }
+
+        // Video/image: track 0 is topmost (see CompositionBuilder), so first hit wins.
+        for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
+            for clip in track.clips where clip.mediaType != .text && clip.mediaType != .audio {
+                guard clip.contains(timelineFrame: frame), clip.opacityAt(frame: frame) > 0.01 else { continue }
+                if videoHit(clip, frame: frame, point: point, videoRect: videoRect) { return clip.id }
             }
         }
         return nil
     }
 
-    private static func hit(clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
+    /// Text renders as an axis-aligned `CATextLayer` from the static transform — no rotation/crop.
+    private static func textHit(_ clip: Clip, point: CGPoint, videoRect: CGRect) -> Bool {
+        clipFrame(clip.transform, videoRect: videoRect).contains(point)
+    }
+
+    private static func videoHit(_ clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
         let t = clip.transformAt(frame: frame)
         let rect = clipFrame(t, videoRect: videoRect)
         guard rect.width > 0, rect.height > 0 else { return false }


### PR DESCRIPTION
Add point-based hit testing in the preview canvas: a double-tap maps the click to composition geometry (aspect-fit videoRect + per-clip transform, crop, and rotation) and selects the topmost visible clip drawn under the cursor at the current playhead frame. Text overlays take hit priority over video, matching their draw order in the preview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only selection UI that reuses existing link-group expansion; no auth, persistence, or export path changes.
> 
> **Overview**
> **Double-tapping the timeline preview** now selects the visible clip under the cursor at the current playhead, using the same linked-clip expansion as timeline clicks (`expandToLinkGroup`).
> 
> A new **`PreviewHitTester`** maps tap coordinates in the scaled preview frame to the topmost hit clip: aspect-fit **video rect**, per-frame **transform** and **crop**, **rotation** for video/image, and draw order where **text** is tested above non-audio video (hidden tracks and near-zero opacity are skipped). The gesture is **`simultaneousGesture`** so it only runs on the timeline tab and does not replace transform/crop overlay handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b88742d1382fb49c24382e59e60cb5c6efe529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->