### PR TITLE
[fix] restore media manifest before window mounts on project open

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -301,6 +301,12 @@ final class VideoProject: NSDocument {
             self?.updateChangeCount(.changeDone)
         }
 
+        if let manifest = loadedManifest {
+            editorViewModel.mediaManifest = manifest
+            loadedManifest = nil
+            restoreAssetsFromManifest()
+        }
+
         let editorView = EditorView()
             .environment(editorViewModel)
             .focusEffectDisabled()
@@ -340,11 +346,6 @@ final class VideoProject: NSDocument {
 
         AppState.shared.showEditor(for: self)
 
-        if let manifest = loadedManifest {
-            editorViewModel.mediaManifest = manifest
-            loadedManifest = nil
-            restoreAssetsFromManifest()
-        }
         if let log = loadedGenerationLog {
             editorViewModel.generationLog = log
             loadedGenerationLog = nil


### PR DESCRIPTION
PreviewView.makeNSView triggers rebuild() during window setup, which resolves every clip against the media manifest. The manifest was being restored after the window was created, so clips resolved as offline until the next rebuild (triggered by the first user action). Move the manifest restore ahead of EditorView creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reorders existing open-project setup with no new persistence or API surface; risk is limited to startup ordering regressions.
> 
> **Overview**
> Fixes a **project open** race where timeline clips briefly appeared **offline** until the user triggered another preview rebuild.
> 
> **`makeWindowControllers`** now applies the loaded **`mediaManifest`** and runs **`restoreAssetsFromManifest()`** immediately after timeline/agent setup and **before** **`EditorView()`** is created. That way the first **`PreviewView.makeNSView`** / **`VideoEngine`** rebuild during window setup can resolve clip media refs against a populated manifest and restored **`mediaAssets`**, instead of rebuilding against an empty library.
> 
> Generation log loading, search index, and telemetry stay **after** the window is shown; only manifest restore moved earlier in the sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309dbc512f7dc1b8572d5854350eaccf54f715c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->