### PR TITLE
Clearer Update Badge

### DIFF
--- a/Sources/PalmierPro/App/UpdateBadgeView.swift
+++ b/Sources/PalmierPro/App/UpdateBadgeView.swift
@@ -2,59 +2,41 @@ import SwiftUI
 
 struct UpdateSidebarCard: View {
     @Bindable private var updater = Updater.shared
+    @State private var isHovering = false
 
     var body: some View {
         if updater.updateAvailable {
-            VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
-                HStack(alignment: .center, spacing: AppTheme.Spacing.sm) {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
-                        .foregroundStyle(AppTheme.Update.accent)
-                        .frame(width: AppTheme.IconSize.lg, height: AppTheme.IconSize.lg)
-
+            Button {
+                updater.checkForUpdates(nil)
+            } label: {
+                HStack(spacing: AppTheme.Spacing.sm) {
                     VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
-                        Text("Update available")
-                            .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
+                        Text("Click to install update")
+                            .font(.system(size: AppTheme.FontSize.smMd, weight: .medium))
                             .foregroundStyle(AppTheme.Text.primaryColor)
-                        if let version = updater.updateVersion {
-                            Text("Version \(version) is ready to install.")
-                                .font(.system(size: AppTheme.FontSize.xs))
-                                .foregroundStyle(AppTheme.Text.secondaryColor)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+                        Text(updater.updateVersion.map { "Version \($0)" } ?? "New version available")
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
                     }
+                    Spacer(minLength: AppTheme.Spacing.sm)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
                 }
-                .padding(.trailing, AppTheme.IconSize.sm)
-
-                Button("Install Update") {
-                    updater.checkForUpdates(nil)
-                }
-                .buttonStyle(.capsule(.prominent, size: .small))
-                .frame(maxWidth: .infinity)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.md)
             }
-            .padding(AppTheme.Spacing.md)
+            .buttonStyle(.plain)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
-                    .fill(AppTheme.Update.fill)
+                    .fill(isHovering ? AppTheme.Background.prominentColor : AppTheme.Background.raisedColor)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
-                    .strokeBorder(AppTheme.Update.border, lineWidth: AppTheme.BorderWidth.thin)
+                    .strokeBorder(AppTheme.Border.primaryColor, lineWidth: AppTheme.BorderWidth.hairline)
             )
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    updater.dismissUpdate()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: AppTheme.FontSize.micro, weight: .bold))
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
-                        .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .help("Dismiss")
-                .padding(AppTheme.Spacing.sm)
-            }
+            .onHover { isHovering = $0 }
+            .animation(.easeOut(duration: AppTheme.Anim.hover), value: isHovering)
             .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
     }

--- a/Sources/PalmierPro/App/UpdateBadgeView.swift
+++ b/Sources/PalmierPro/App/UpdateBadgeView.swift
@@ -68,36 +68,28 @@ struct UpdateProjectBadge: View {
             Button {
                 updater.checkForUpdates(nil)
             } label: {
-                HStack(spacing: AppTheme.Spacing.xs) {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .offset(y: -1)
-                    Text(badgeLabel)
-                }
-                .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
-                .foregroundStyle(AppTheme.Update.accent)
-                .lineLimit(1)
-                .padding(.horizontal, AppTheme.Spacing.sm)
-                .frame(height: AppTheme.IconSize.lg)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(AppTheme.Update.accent.opacity(AppTheme.Opacity.muted))
-                )
-                .overlay(
-                    Capsule(style: .continuous)
-                        .strokeBorder(AppTheme.Update.accent.opacity(AppTheme.Opacity.moderate), lineWidth: AppTheme.BorderWidth.thin)
-                )
-                .help("Install update")
+                Label("Update", systemImage: "arrow.down.circle.fill")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                    .foregroundStyle(AppTheme.Update.accent)
+                    .lineLimit(1)
+                    .padding(.horizontal, AppTheme.Spacing.smMd)
+                    .frame(height: AppTheme.IconSize.lg)
+                    .background(
+                        Capsule(style: .continuous)
+                            .fill(AppTheme.Update.accent.opacity(AppTheme.Opacity.muted))
+                    )
             }
             .buttonStyle(.plain)
+            .help(helpText)
             .fixedSize(horizontal: true, vertical: false)
             .transition(.opacity.combined(with: .scale))
         }
     }
 
-    private var badgeLabel: String {
+    private var helpText: String {
         if let version = updater.updateVersion {
-            return "Update v\(version)"
+            return "Install update v\(version)"
         }
-        return "Update available"
+        return "Install update"
     }
 }

--- a/Sources/PalmierPro/App/UpdateBadgeView.swift
+++ b/Sources/PalmierPro/App/UpdateBadgeView.swift
@@ -1,50 +1,102 @@
 import SwiftUI
 
-struct UpdateBadgeView: View {
+struct UpdateSidebarCard: View {
     @Bindable private var updater = Updater.shared
 
     var body: some View {
         if updater.updateAvailable {
-            HStack(spacing: 0) {
-                Button {
-                    updater.checkForUpdates(nil)
-                } label: {
-                    Text(badgeLabel)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
-                        .foregroundStyle(AppTheme.Text.primaryColor)
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .padding(.leading, AppTheme.Spacing.sm)
-                        .padding(.trailing, AppTheme.Spacing.xxs)
-                        .padding(.vertical, AppTheme.Spacing.xxs)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .help("Install update")
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+                HStack(alignment: .center, spacing: AppTheme.Spacing.sm) {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
+                        .foregroundStyle(AppTheme.Update.accent)
+                        .frame(width: AppTheme.IconSize.lg, height: AppTheme.IconSize.lg)
 
+                    VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                        Text("Update available")
+                            .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
+                            .foregroundStyle(AppTheme.Text.primaryColor)
+                        if let version = updater.updateVersion {
+                            Text("Version \(version) is ready to install.")
+                                .font(.system(size: AppTheme.FontSize.xs))
+                                .foregroundStyle(AppTheme.Text.secondaryColor)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.trailing, AppTheme.IconSize.sm)
+
+                Button("Install Update") {
+                    updater.checkForUpdates(nil)
+                }
+                .buttonStyle(.capsule(.prominent, size: .small))
+                .frame(maxWidth: .infinity)
+            }
+            .padding(AppTheme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
+                    .fill(AppTheme.Update.fill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
+                    .strokeBorder(AppTheme.Update.border, lineWidth: AppTheme.BorderWidth.thin)
+            )
+            .overlay(alignment: .topTrailing) {
                 Button {
                     updater.dismissUpdate()
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: AppTheme.FontSize.micro, weight: .bold))
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
-                        .padding(.leading, AppTheme.Spacing.xxs)
-                        .padding(.trailing, AppTheme.Spacing.xs)
-                        .padding(.vertical, AppTheme.Spacing.xxs)
+                        .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help("Dismiss")
+                .padding(AppTheme.Spacing.sm)
             }
-            .glassEffect(.regular, in: .capsule)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+}
+
+struct UpdateProjectBadge: View {
+    @Bindable private var updater = Updater.shared
+
+    var body: some View {
+        if updater.updateAvailable {
+            Button {
+                updater.checkForUpdates(nil)
+            } label: {
+                HStack(spacing: AppTheme.Spacing.xs) {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .offset(y: -1)
+                    Text(badgeLabel)
+                }
+                .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                .foregroundStyle(AppTheme.Update.accent)
+                .lineLimit(1)
+                .padding(.horizontal, AppTheme.Spacing.sm)
+                .frame(height: AppTheme.IconSize.lg)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(AppTheme.Update.accent.opacity(AppTheme.Opacity.muted))
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .strokeBorder(AppTheme.Update.accent.opacity(AppTheme.Opacity.moderate), lineWidth: AppTheme.BorderWidth.thin)
+                )
+                .help("Install update")
+            }
+            .buttonStyle(.plain)
             .fixedSize(horizontal: true, vertical: false)
             .transition(.opacity.combined(with: .scale))
         }
     }
 
     private var badgeLabel: String {
-        if let v = updater.updateVersion {
-            return "Update v\(v)"
+        if let version = updater.updateVersion {
+            return "Update v\(version)"
         }
         return "Update available"
     }

--- a/Sources/PalmierPro/App/Updater.swift
+++ b/Sources/PalmierPro/App/Updater.swift
@@ -31,10 +31,6 @@ final class Updater: NSObject {
         controller?.checkForUpdates(sender)
     }
 
-    func dismissUpdate() {
-        clearUpdateAvailability()
-    }
-
     private func checkForUpdateInformation() {
         lastBackgroundCheck = Date()
         controller?.updater.checkForUpdateInformation()

--- a/Sources/PalmierPro/App/Updater.swift
+++ b/Sources/PalmierPro/App/Updater.swift
@@ -9,6 +9,8 @@ final class Updater: NSObject {
     private(set) var updateVersion: String?
 
     private var controller: SPUStandardUpdaterController?
+    private var lastBackgroundCheck: Date?
+    private var notificationObservers: [NSObjectProtocol] = []
 
     private override init() {
         super.init()
@@ -21,7 +23,8 @@ final class Updater: NSObject {
             userDriverDelegate: nil
         )
         self.controller = controller
-        controller.updater.checkForUpdateInformation()
+        installObservers(updater: controller.updater)
+        checkForUpdateInformation()
     }
 
     @objc func checkForUpdates(_ sender: Any?) {
@@ -30,6 +33,49 @@ final class Updater: NSObject {
 
     func dismissUpdate() {
         clearUpdateAvailability()
+    }
+
+    private func checkForUpdateInformation() {
+        lastBackgroundCheck = Date()
+        controller?.updater.checkForUpdateInformation()
+    }
+
+    private func checkForUpdateIfStale() {
+        guard controller != nil else { return }
+        let now = Date()
+        if let lastBackgroundCheck, now.timeIntervalSince(lastBackgroundCheck) < 3600 { return }
+        checkForUpdateInformation()
+    }
+
+    private func installObservers(updater: SPUUpdater) {
+        let center = NotificationCenter.default
+
+        notificationObservers.append(
+            center.addObserver(
+                forName: .SUUpdaterDidFindValidUpdate,
+                object: updater,
+                queue: .main
+            ) { [weak self] notification in
+                guard let item = notification.userInfo?[SUUpdaterAppcastItemNotificationKey] as? SUAppcastItem else {
+                    return
+                }
+                Task { @MainActor in
+                    self?.markUpdateAvailable(item)
+                }
+            }
+        )
+
+        notificationObservers.append(
+            center.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.checkForUpdateIfStale()
+                }
+            }
+        )
     }
 
     private func markUpdateAvailable(_ item: SUAppcastItem) {
@@ -41,6 +87,17 @@ final class Updater: NSObject {
         updateAvailable = false
         updateVersion = nil
     }
+
+    private func shouldClearAfterNoUpdateFound(_ error: NSError) -> Bool {
+        let reasonRaw = (error.userInfo[SPUNoUpdateFoundReasonKey] as? NSNumber)?.intValue
+            ?? Int(SPUNoUpdateFoundReason.unknown.rawValue)
+        switch SPUNoUpdateFoundReason(rawValue: Int32(reasonRaw)) {
+        case .onLatestVersion, .onNewerThanLatestVersion:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 extension Updater: SPUUpdaterDelegate {
@@ -48,7 +105,10 @@ extension Updater: SPUUpdaterDelegate {
         markUpdateAvailable(item)
     }
 
-    @objc func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+    @objc func updaterDidNotFindUpdate(_ updater: SPUUpdater) {}
+
+    @objc func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
+        guard let error = error as NSError?, shouldClearAfterNoUpdateFound(error) else { return }
         clearUpdateAvailability()
     }
 }

--- a/Sources/PalmierPro/Editor/TitleBarView.swift
+++ b/Sources/PalmierPro/Editor/TitleBarView.swift
@@ -26,7 +26,7 @@ struct TitleBarTrailingView: View {
         HStack(spacing: AppTheme.Spacing.sm) {
             Spacer(minLength: 0)
 
-            UpdateBadgeView()
+            UpdateProjectBadge()
 
             Button(action: { editor.showExportDialog = true }) {
                 HStack(spacing: AppTheme.Spacing.xs) {

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -57,8 +57,6 @@ struct HomeView: View {
         HStack(spacing: AppTheme.Spacing.md) {
             WelcomeTitle()
 
-            UpdateBadgeView()
-
             Spacer()
         }
         .padding(.horizontal, AppTheme.Spacing.xlXxl)
@@ -164,6 +162,7 @@ private struct WelcomeTitle: View {
 
 private struct HomeSidebar: View {
     @Bindable private var account = AccountService.shared
+    @Bindable private var updater = Updater.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -195,13 +194,18 @@ private struct HomeSidebar: View {
 
             Spacer(minLength: 0)
 
+            UpdateSidebarCard()
+                .padding(.horizontal, AppTheme.Spacing.smMd)
+                .padding(.bottom, AppTheme.Spacing.sm)
+                .animation(.easeInOut(duration: AppTheme.Anim.transition), value: updater.updateAvailable)
+
             SidebarRowButton(
                 label: "Settings",
                 systemImage: "gearshape",
                 action: { SettingsWindowController.shared.show() }
             )
-            .padding(.horizontal, 8)
-            .padding(.bottom, 10)
+            .padding(.horizontal, AppTheme.Spacing.smMd)
+            .padding(.bottom, AppTheme.Spacing.md)
         }
         .frame(maxHeight: .infinity, alignment: .top)
     }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -66,8 +66,6 @@ enum AppTheme {
 
     enum Update {
         static let accent = Accent.timecodeColor
-        static let fill = Accent.timecodeColor.opacity(Opacity.moderate)
-        static let border = Accent.timecodeColor.opacity(Opacity.prominent)
     }
 
     // MARK: - Adjust sliders

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -64,6 +64,12 @@ enum AppTheme {
         )
     }
 
+    enum Update {
+        static let accent = Accent.timecodeColor
+        static let fill = Accent.timecodeColor.opacity(Opacity.moderate)
+        static let border = Accent.timecodeColor.opacity(Opacity.prominent)
+    }
+
     // MARK: - Adjust sliders
 
     enum Slider {


### PR DESCRIPTION
Check when app refocuses (throttled once every hour) instead of on app open.
Make it more visible.

Reaosn: direct users to update the app for the best experience.

<img width="1037" height="624" alt="Screenshot 2026-06-30 at 11 59 00 PM" src="https://github.com/user-attachments/assets/8595b3a9-174b-4a7a-be9d-2c75b35966e4" />

<img width="1280" height="830" alt="Screenshot 2026-06-26 at 11 18 15 AM" src="https://github.com/user-attachments/assets/e4015fd7-c853-43c4-922d-afef1e8655b5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sparkle integration and UI-only changes; no auth, data, or export paths touched. Slightly more background update checks on refocus (hourly cap).
> 
> **Overview**
> Makes in-app update discovery more visible and keeps availability state fresher without hammering Sparkle on every launch.
> 
> **Updater** now re-checks for update information when the app becomes active, throttled to once per hour, and listens for Sparkle’s “valid update found” notification in addition to delegate callbacks. It **removes** user dismiss of the badge; availability clears only when Sparkle reports the app is on the latest or newer than the feed. The old `dismissUpdate` path is gone.
> 
> **UI** splits the single compact badge into **`UpdateSidebarCard`** (home sidebar: “Click to install update” + version, hover card) and **`UpdateProjectBadge`** (editor title bar capsule with accent styling). The home header no longer shows an update chip; **`AppTheme.Update.accent`** centralizes badge color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb6855402def73f80a63ba12b1b84b3cc78a751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->