### PR TITLE
[export] fix fcpxml and supports v1.10 - v.1.14

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -461,6 +461,11 @@ final class EditorViewModel {
         fitTransform(for: asset, canvasWidth: timeline.width, canvasHeight: timeline.height)
     }
 
+    func fitTransform(for clip: Clip) -> Transform {
+        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { return Transform() }
+        return fitTransform(for: asset)
+    }
+
     func fitTransform(for asset: MediaAsset, canvasWidth: Int, canvasHeight: Int) -> Transform {
         guard let sw = asset.sourceWidth, let sh = asset.sourceHeight,
               sw > 0, sh > 0, canvasWidth > 0, canvasHeight > 0 else {

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -34,6 +34,7 @@ final class ExportService {
         resolver: MediaResolver,
         format: ExportFormat,
         resolution: ExportResolution,
+        fcpxmlVersion: FCPXMLVersion = .default,
         missingMediaRefs: Set<String> = [],
         outputURL: URL,
         acquireSlot: Bool = true
@@ -55,7 +56,7 @@ final class ExportService {
                 if format == .xml {
                     try await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
                 } else {
-                    try FCPXMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
+                    try FCPXMLExporter.export(timeline: timeline, resolver: resolver, version: fcpxmlVersion, outputURL: outputURL)
                 }
                 progress = 1.0
                 Log.export.notice("export ok format=\(name)", telemetry: "Export finished", data: ["format": name])

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -32,7 +32,7 @@ enum TimelineExportFormat: String, CaseIterable, Identifiable {
     var versionLabel: String {
         switch self {
         case .xmeml: "v4"
-        case .fcpxml: "v\(FCPXMLExporter.version)"
+        case .fcpxml: ""   // user-selectable; shown via the version picker
         }
     }
 
@@ -56,6 +56,7 @@ struct ExportView: View {
     @State private var service = ExportService()
     @State private var destination: ExportDestination = .video
     @State private var timelineFormat: TimelineExportFormat = .fcpxml
+    @State private var fcpxmlVersion: FCPXMLVersion = .default
     @State private var codec: VideoCodec = .h264
     @State private var resolution: ExportResolution = .matchTimeline
     @State private var palmierResult: String?
@@ -211,6 +212,31 @@ struct ExportView: View {
         .padding(.vertical, AppTheme.Spacing.xs)
     }
 
+    @ViewBuilder
+    private var fcpxmlVersionRow: some View {
+        Divider().opacity(AppTheme.Opacity.moderate)
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Text("Version")
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+            Picker("", selection: $fcpxmlVersion) {
+                ForEach(FCPXMLVersion.allCases) { version in
+                    Text(version.rawValue).tag(version)
+                }
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .font(.system(size: AppTheme.FontSize.xs))
+            .fixedSize()
+            Text(fcpxmlVersion.compatibilityNote)
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, AppTheme.IconSize.sm + AppTheme.Spacing.md)
+    }
+
     private var palmierProjectSettings: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
             Text("Saves a copy of this project with all media bundled inside, so it opens on any machine.")
@@ -325,9 +351,7 @@ struct ExportView: View {
 
     private func timelineFormatButton(_ format: TimelineExportFormat) -> some View {
         let selected = timelineFormat == format
-        return Button {
-            timelineFormat = format
-        } label: {
+        return VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             HStack(alignment: .top, spacing: AppTheme.Spacing.md) {
                 Image(systemName: selected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.medium))
@@ -342,9 +366,11 @@ struct ExportView: View {
                         Text(format.extensionLabel)
                             .font(.system(size: AppTheme.FontSize.xs))
                             .foregroundStyle(AppTheme.Text.tertiaryColor)
-                        Text(format.versionLabel)
-                            .font(.system(size: AppTheme.FontSize.xs))
-                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        if !format.versionLabel.isEmpty {
+                            Text(format.versionLabel)
+                                .font(.system(size: AppTheme.FontSize.xs))
+                                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        }
                     }
 
                     Text(format.summary)
@@ -359,17 +385,22 @@ struct ExportView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(AppTheme.Spacing.md)
-            .background {
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
-                    .fill(selected ? AppTheme.Background.prominentColor : AppTheme.Background.raisedColor)
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
-                    .strokeBorder(selected ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+            .contentShape(Rectangle())
+            .onTapGesture { timelineFormat = format }
+
+            if selected && format == .fcpxml {
+                fcpxmlVersionRow
             }
         }
-        .buttonStyle(.plain)
+        .padding(AppTheme.Spacing.md)
+        .background {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
+                .fill(selected ? AppTheme.Background.prominentColor : AppTheme.Background.raisedColor)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
+                .strokeBorder(selected ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+        }
     }
 
     private var estimatedFileSize: String {
@@ -435,6 +466,7 @@ struct ExportView: View {
                     resolver: editor.mediaResolver,
                     format: format,
                     resolution: resolution,
+                    fcpxmlVersion: fcpxmlVersion,
                     missingMediaRefs: editor.missingMediaRefs,
                     outputURL: url
                 )

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -1,20 +1,46 @@
 import AppKit
 import Foundation
 
-/// Exports a Timeline as FCPXML 1.14 (for DaVinci Resolve / Final Cut Pro). Companion to
-/// XMLExporter (XMEML, for Premiere). The document is an `FCPXMLNode` tree (defined at the
-/// bottom); `renderFCPXML` owns indentation and escaping. Read `build()` top-down:
-/// `<fcpxml>` → `<resources>` (formats + assets) → `<library>/<event>/<project>/<sequence>`.
-/// The whole timeline is one `<gap>` with every clip connected on a lane.
+/// The `version` attribute Resolve/FCP gate import on (a literal allow-list), so it's the only thing
+/// the user picks. Every element we emit has existed since FCPXML 1.1 — the body is version-identical.
+enum FCPXMLVersion: String, CaseIterable, Identifiable, Sendable {
+    case v1_10 = "1.10"
+    case v1_11 = "1.11"
+    case v1_12 = "1.12"
+    case v1_13 = "1.13"
+    case v1_14 = "1.14"
+
+    var id: String { rawValue }
+    /// 1.10 is the broadest: every Resolve from 18 up accepts it. Higher versions need Resolve 21+.
+    static let `default`: FCPXMLVersion = .v1_10
+
+    var compatibilityNote: String {
+        switch self {
+        case .v1_10: "DaVinci Resolve 18+, Final Cut Pro 10.6+"
+        case .v1_11: "DaVinci Resolve 21+, Final Cut Pro 10.7+"
+        case .v1_12: "DaVinci Resolve 21+, Final Cut Pro 10.8+"
+        case .v1_13: "DaVinci Resolve 21+, Final Cut Pro 11+"
+        case .v1_14: "DaVinci Resolve 21+, Final Cut Pro 12+"
+        }
+    }
+}
+
+/// Exports a Timeline as FCPXML (for DaVinci Resolve / Final Cut Pro). Companion to XMLExporter
+/// (XMEML, for Premiere). The document is an `FCPXMLNode` tree (defined at the bottom); `renderFCPXML`
+/// owns indentation and escaping. Read `build()` top-down: `<fcpxml>` → `<resources>` (formats +
+/// assets + per-clip compound clips) → `<library>/<event>/<project>/<sequence>`. The timeline is one
+/// `<gap>` with every clip connected on a lane.
 ///
 /// Encoding facts (reverse-engineered from Resolve round-trips):
 /// - Position: unit = 1% of frame height, square, origin at center, +Y up.
 /// - Scale: multiplier on the conform-fit size, so we divide the aspect-fit out of width/height.
 /// - Rotation: degrees, negated (FCP is counter-clockwise-positive). Flip: negative scale.
 /// - Crop: `<adjust-crop>/<trim-rect>`, a percentage of the source per edge.
-/// - Retime: `start` holds the in-point; the `<timeMap>` is relative (0 → source span).
-/// - Volume: `<adjust-volume amount>` in dB. Keyframes: child `<param>/<keyframeAnimation>`,
-///   `time` in clip-relative seconds, `value` in the param's own unit.
+/// - Retime: a visual clip is a `<ref-clip>` over a compound clip holding the full media; the
+///   `<timeMap>` ramps the whole media (output[0, media/speed] → source[0, media]) and `start` windows
+///   in along the output axis (= source in-point ÷ speed). A clip-local ramp blacks the tail.
+/// - Keyframes: child `<param>/<keyframeAnimation>`; `time` is offset by `start` (the output axis),
+///   `value` in the param's own unit. Volume: `<adjust-volume amount>` in dB.
 ///
 /// What transports: clip placement/trims, speed, lane order, enabled state; text + font/face/
 /// size/color/alignment; position/scale/rotation/flip (+ position/scale/rotation keyframes);
@@ -26,10 +52,9 @@ import Foundation
 ///
 /// Reference: https://developer.apple.com/documentation/professional-video-applications/fcpxml-reference
 enum FCPXMLExporter {
-    static let version = "1.14"
-
-    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) throws {
-        let xml = Builder(timeline: timeline, resolver: resolver).build()
+    static func export(timeline: Timeline, resolver: MediaResolver,
+                       version: FCPXMLVersion = .default, outputURL: URL) throws {
+        let xml = Builder(timeline: timeline, resolver: resolver, version: version).build()
         guard let data = xml.data(using: .utf8) else { throw ExportError.xmlEncodingFailed }
         try data.write(to: outputURL)
     }
@@ -37,6 +62,7 @@ enum FCPXMLExporter {
     private final class Builder {
         private let timeline: Timeline
         private let resolver: MediaResolver
+        private let version: FCPXMLVersion
         private let fps: Int
         private let seqWidth: Int
         private let seqHeight: Int
@@ -66,6 +92,8 @@ enum FCPXMLExporter {
             let key: MediaResourceKey
             let assetId: String
             let formatId: String?
+            // Visual clips ref a compound clip (retime needs it; see `timeMapNode`); nil for audio.
+            let compoundId: String?
             let entry: MediaManifestEntry
             let url: URL
             var durationFrames: Int
@@ -73,9 +101,10 @@ enum FCPXMLExporter {
             var needsAudio: Bool { key.kind == .audio }
         }
 
-        init(timeline: Timeline, resolver: MediaResolver) {
+        init(timeline: Timeline, resolver: MediaResolver, version: FCPXMLVersion) {
             self.timeline = timeline
             self.resolver = resolver
+            self.version = version
             self.fps = max(1, timeline.fps)
             self.seqWidth = timeline.width
             self.seqHeight = timeline.height
@@ -85,7 +114,7 @@ enum FCPXMLExporter {
             let clips = emittableClips()
             collectResources(from: clips)
             let hasTitles = clips.contains { $0.clip.mediaType == .text }
-            let root = FCPXMLNode(name: "fcpxml", attributes: [("version", FCPXMLExporter.version)], children: [
+            let root = FCPXMLNode(name: "fcpxml", attributes: [("version", version.rawValue)], children: [
                 resourcesNode(hasTitles: hasTitles),
                 libraryNode(clips: clips),
             ])
@@ -113,7 +142,36 @@ enum FCPXMLExporter {
 
             children += resources.compactMap(formatNode)
             children += resources.map(assetNode)
+            children += resources.compactMap(compoundClipNode)
             return FCPXMLNode(name: "resources", children: children)
+        }
+
+        private func compoundClipNode(for resource: MediaResource) -> FCPXMLNode? {
+            guard let compoundId = resource.compoundId else { return nil }
+            let dur = time(frames: resource.durationFrames)
+            let video = FCPXMLNode(name: "video", attributes: [
+                ("ref", resource.assetId),
+                ("duration", dur),
+                ("start", "0s"),
+                ("offset", "0s"),
+            ])
+            let innerClip = FCPXMLNode(name: "clip", attributes: [
+                ("name", resource.entry.name),
+                ("duration", dur),
+                ("start", "0s"),
+                ("offset", "0s"),
+                ("format", resource.formatId ?? sequenceFormatId),
+            ], children: [video])
+            let sequence = FCPXMLNode(name: "sequence", attributes: [
+                ("format", resource.formatId ?? sequenceFormatId),
+                ("duration", dur),
+                ("tcStart", "0s"),
+                ("tcFormat", "NDF"),
+            ], children: [FCPXMLNode(name: "spine", children: [innerClip])])
+            return FCPXMLNode(name: "media", attributes: [
+                ("id", compoundId),
+                ("name", resource.entry.name),
+            ], children: [sequence])
         }
 
         private func libraryNode(clips: [EmittableClip]) -> FCPXMLNode {
@@ -171,13 +229,34 @@ enum FCPXMLExporter {
             let clip = item.clip
             guard let i = resourceIndex[resourceKey(for: clip)] else { return nil }
             let resource = resources[i]
-            let timeMap = timeMapNode(for: clip)
+
+            // Visual → <ref-clip> over the compound clip; audio → plain <asset-clip>.
+            if let compoundId = resource.compoundId {
+                let attrs: [(String, String)] = [
+                    ("ref", compoundId),
+                    ("name", resolver.displayName(for: clip.mediaRef)),
+                    ("lane", "\(item.lane)"),
+                    ("offset", time(frames: clip.startFrame)),
+                    ("start", clipStart(for: clip)),
+                    ("duration", time(frames: clip.durationFrames)),
+                    ("enabled", item.enabled ? "1" : "0"),
+                    ("srcEnable", "video"),
+                ]
+                return FCPXMLNode(name: "ref-clip", attributes: attrs, children: [
+                    timeMapNode(for: clip, mediaFrames: resource.durationFrames),
+                    FCPXMLNode(name: "adjust-conform", attributes: [("type", "fit")]),
+                    cropNode(for: clip),
+                    transformNode(for: clip),
+                    blendNode(for: clip),
+                ].compactMap { $0 })
+            }
+
             let attrs: [(String, String)] = [
                 ("ref", resource.assetId),
                 ("name", resolver.displayName(for: clip.mediaRef)),
                 ("lane", "\(item.lane)"),
                 ("offset", time(frames: clip.startFrame)),
-                ("start", time(frames: clip.trimStartFrame)),
+                ("start", clipStart(for: clip)),
                 ("duration", time(frames: clip.durationFrames)),
                 ("enabled", item.enabled ? "1" : "0"),
             ]
@@ -185,10 +264,7 @@ enum FCPXMLExporter {
                 name: "asset-clip",
                 attributes: attrs,
                 children: [
-                    timeMap,
-                    cropNode(for: clip),
-                    transformNode(for: clip),
-                    blendNode(for: clip),
+                    timeMapNode(for: clip, mediaFrames: resource.durationFrames),
                     volumeNode(for: clip),
                 ].compactMap { $0 }
             )
@@ -293,11 +369,11 @@ enum FCPXMLExporter {
             return "\(formatNumber(sx)) \(formatNumber(sy))"
         }
 
-        /// A keyframed `<param>`: time is clip-relative seconds, value uses the param's own unit.
+        /// A keyframed `<param>`: time is in the clip's output axis, value uses the param's own unit.
         private func keyframeParam(name: String, base: String, clip: Clip, property: AnimatableProperty,
                                    frames: [Int], value: (Int) -> String) -> FCPXMLNode {
             let keyframes = frames.sorted().map { f -> FCPXMLNode in
-                var attrs: [(String, String)] = [("time", time(frames: f - clip.startFrame))]
+                var attrs: [(String, String)] = [("time", keyframeTime(f, clip: clip))]
                 if clip.interpolation(for: property, atFrame: f) == .linear { attrs.append(("curve", "linear")) }
                 attrs.append(("value", value(f)))
                 return FCPXMLNode(name: "keyframe", attributes: attrs)
@@ -305,6 +381,16 @@ enum FCPXMLExporter {
             return FCPXMLNode(name: "param", attributes: [("name", name), ("value", base)], children: [
                 FCPXMLNode(name: "keyframeAnimation", children: keyframes),
             ])
+        }
+
+        /// A retimed clip's keyframes live in the timeMap's output axis, so `time` is offset by the clip's
+        /// `start` (= clipStart): `start + (f − startFrame)/fps`. Without it the animation lands before the
+        /// content and plays compressed. Unspeeded clips have no timeMap origin, so they stay clip-relative.
+        private func keyframeTime(_ f: Int, clip: Clip) -> String {
+            guard abs(clip.speed - 1.0) > 0.001 else { return time(frames: f - clip.startFrame) }
+            let (p, q) = rationalSpeed(clip.speed)
+            let num = clip.trimStartFrame * q + (f - clip.startFrame) * p
+            return rationalTime(num: num, den: fps * p)
         }
 
         private func cropNode(for clip: Clip) -> FCPXMLNode? {
@@ -331,22 +417,47 @@ enum FCPXMLExporter {
             linear > 0 ? 20.0 * log10(linear) : -96.0
         }
 
-        private func timeMapNode(for clip: Clip) -> FCPXMLNode? {
-            guard abs(clip.speed - 1.0) > 0.001 else { return nil }
-            // `start` already positions the in-point; the timeMap describes the retime span relative to it.
-            let sourceSpan = Int((Double(clip.durationFrames) * clip.speed).rounded())
+        /// Source in-point in the post-retime output axis Resolve expects (source ÷ speed); the raw
+        /// source frame when unspeeded.
+        private func clipStart(for clip: Clip) -> String {
+            guard abs(clip.speed - 1.0) > 0.001 else { return time(frames: clip.trimStartFrame) }
+            let (p, q) = rationalSpeed(clip.speed)
+            return rationalTime(num: clip.trimStartFrame * q, den: fps * p)
+        }
+
+        /// Resolve ramps the WHOLE media (`output[0, media/speed] → source[0, media]`) and windows in via
+        /// `start`/`duration`. A ramp that stops at the clip edge leaves no tail mapping → black last frames.
+        private func timeMapNode(for clip: Clip, mediaFrames: Int) -> FCPXMLNode? {
+            guard abs(clip.speed - 1.0) > 0.001, mediaFrames > 0 else { return nil }
+            let (p, q) = rationalSpeed(clip.speed)
             return FCPXMLNode(name: "timeMap", attributes: [("frameSampling", "floor")], children: [
+                FCPXMLNode(name: "timept", attributes: [("time", "0s"), ("value", "0s"), ("interp", "linear")]),
                 FCPXMLNode(name: "timept", attributes: [
-                    ("time", "0s"),
-                    ("value", "0s"),
-                    ("interp", "linear"),
-                ]),
-                FCPXMLNode(name: "timept", attributes: [
-                    ("time", time(frames: clip.durationFrames)),
-                    ("value", time(frames: sourceSpan)),
+                    ("time", rationalTime(num: mediaFrames * q, den: fps * p)),  // media / speed
+                    ("value", time(frames: mediaFrames)),                        // full media
                     ("interp", "linear"),
                 ]),
             ])
+        }
+
+        /// Speed as a small-denominator fraction, so the timeMap slope is exact and `start` maps back to
+        /// the original source frame. Speeds are user values (1.25, 1.24, 2.0, 0.5…).
+        private func rationalSpeed(_ speed: Double) -> (p: Int, q: Int) {
+            var best = (p: 1, q: 1), bestErr = Double.infinity
+            for q in 1...1000 {
+                let p = Int((speed * Double(q)).rounded())
+                guard p > 0 else { continue }
+                let err = abs(speed - Double(p) / Double(q))
+                if err < bestErr { best = (p, q); bestErr = err; if err == 0 { break } }
+            }
+            return best
+        }
+
+        private func rationalTime(num: Int, den: Int) -> String {
+            guard num != 0 else { return "0s" }
+            let g = gcd(abs(num), abs(den))
+            let n = num / g, d = den / g
+            return d == 1 ? "\(n)s" : "\(n)/\(d)s"
         }
 
         private func collectResources(from clips: [EmittableClip]) {
@@ -369,6 +480,7 @@ enum FCPXMLExporter {
                     key: key,
                     assetId: "asset\(id)",
                     formatId: key.kind == .visual ? "format\(id)" : nil,
+                    compoundId: key.kind == .visual ? "media\(id)" : nil,
                     entry: entry,
                     url: url,
                     durationFrames: duration

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -565,7 +565,7 @@ struct InspectorView: View {
             onReset: transformExpanded ? {
                 commitToClips(clips, actionName: "Reset Transform") { c in
                     editor.commitClipProperty(clipId: c.id) {
-                        $0.transform = Transform()
+                        $0.transform = editor.fitTransform(for: c)
                         $0.opacity = 1
                         $0.opacityTrack = nil
                         $0.positionTrack = nil

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -65,7 +65,7 @@ struct FCPXMLExporterTests {
 
         #expect(xml.hasPrefix("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
         #expect(xml.contains("<!DOCTYPE fcpxml>"))
-        #expect(xml.contains("<fcpxml version=\"1.14\">"))
+        #expect(xml.contains("<fcpxml version=\"1.10\">"))
         #expect(xml.contains("<resources>"))
         #expect(xml.contains("<format id=\"r1\""))
         #expect(xml.contains("<library>"))
@@ -75,6 +75,16 @@ struct FCPXMLExporterTests {
         #expect(xml.contains("<spine/>"))
     }
 
+    @Test func explicitVersionIsHonoredInHeader() throws {
+        let timeline = Fixtures.timeline()
+        let (resolver, tmpDir) = try makeResolver(entries: [])
+        let outURL = tmpDir.appendingPathComponent("v14.fcpxml")
+
+        try FCPXMLExporter.export(timeline: timeline, resolver: resolver, version: .v1_14, outputURL: outURL)
+
+        #expect(try readXML(at: outURL).contains("<fcpxml version=\"1.14\">"))
+    }
+
     @Test func clipsReferencingUnresolvableMediaAreSkipped() throws {
         let (resolver, tmpDir) = try makeResolver(entries: [])
         let clip = Fixtures.clip(id: "ghost", mediaRef: "missing", start: 0, duration: 30)
@@ -82,7 +92,8 @@ struct FCPXMLExporterTests {
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
-        #expect(!xml.contains("<asset-clip"))
+        #expect(!xml.contains("<ref-clip"))     // visual clips emit ref-clips now
+        #expect(!xml.contains("<media id="))    // and their compound clip
         #expect(!xml.contains("ghost"))
     }
 
@@ -95,9 +106,29 @@ struct FCPXMLExporterTests {
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
         let assetCount = xml.components(separatedBy: "<asset id=\"asset").count - 1
-        let clipCount = xml.components(separatedBy: "<asset-clip ref=\"asset1\"").count - 1
-        #expect(assetCount == 1)
-        #expect(clipCount == 2)
+        let compoundCount = xml.components(separatedBy: "<media id=\"media").count - 1
+        let clipCount = xml.components(separatedBy: "<ref-clip ref=\"media1\"").count - 1
+        #expect(assetCount == 1)       // one shared asset
+        #expect(compoundCount == 1)    // one shared compound clip
+        #expect(clipCount == 2)        // two ref-clips reference it
+    }
+
+    @Test func visualClipWrapsAssetInFullMediaCompoundClip() throws {
+        // The compound clip must hold the FULL media (here 5s @30fps = 150 frames), independent of the
+        // clip's trim/duration — that runway is what stops Resolve blacking a retimed tail. The ref-clip
+        // also carries adjust-conform=fit to match Resolve.
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        let clip = Fixtures.clip(id: "c", mediaRef: "media-v", start: 0, duration: 30, trimStart: 20)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+        let compound = xml.components(separatedBy: "<media id=\"media1\"").dropFirst().first?
+            .components(separatedBy: "</media>").first ?? ""
+
+        #expect(compound.contains("<sequence format=\"format1\" duration=\"5s\""))
+        #expect(compound.contains("<clip name=\"media-v\" duration=\"5s\" start=\"0s\" offset=\"0s\" format=\"format1\">"))
+        #expect(compound.contains("<video ref=\"asset1\" duration=\"5s\" start=\"0s\" offset=\"0s\"/>"))
+        #expect(xml.contains("<adjust-conform type=\"fit\"/>"))
     }
 
     @Test func sameMediaRefVideoAndAudioUseSeparateAssets() throws {
@@ -118,9 +149,10 @@ struct FCPXMLExporterTests {
         #expect(!videoAsset.contains("hasAudio"))
         #expect(audioAsset.contains("hasAudio=\"1\""))
         #expect(!audioAsset.contains("hasVideo"))
-        #expect(xml.contains("<asset-clip ref=\"asset1\" name=\"media-v\" lane=\"1\""))
+        // Video routes through a compound clip via <ref-clip>; audio stays a plain <asset-clip>.
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
+        #expect(xml.contains("srcEnable=\"video\""))
         #expect(xml.contains("<asset-clip ref=\"asset2\" name=\"media-v\" lane=\"-1\""))
-        #expect(!xml.contains("srcEnable"))
     }
 
     @Test func visualTrackLanesPreserveTopOverBottom() throws {
@@ -140,32 +172,86 @@ struct FCPXMLExporterTests {
 
     // MARK: - Timing & speed
 
-    @Test func videoClipEmitsAssetClipWithOffsetStartAndDuration() throws {
+    @Test func videoClipEmitsRefClipWithOffsetStartAndDuration() throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "clip-1", mediaRef: "media-v", start: 30, duration: 60, trimStart: 10)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
-        #expect(xml.contains("<asset-clip ref=\"asset1\" name=\"media-v\" lane=\"1\""))
+        // Unspeeded: start is the raw source in-point (trimStart 10 / 30fps = 1/3s), no timeMap.
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
         #expect(xml.contains("offset=\"1s\""))
         #expect(xml.contains("start=\"1/3s\""))
         #expect(xml.contains("duration=\"2s\""))
-        #expect(!xml.contains("srcEnable"))
+        #expect(!xml.contains("<timeMap"))
     }
 
-    @Test func speedChangeEmitsRelativeTimeMap() throws {
+    @Test func speedChangeEmitsWholeMediaTimeMap() throws {
+        // 5s media @ 30fps = 150 source frames; 2× speed-up, trimStart 10, 60-frame output.
         let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
         let clip = Fixtures.clip(id: "fast", mediaRef: "media-v", start: 0, duration: 60, trimStart: 10, speed: 2.0)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
-        // start positions the in-point (trimStart 10 / 30fps); the timeMap is relative to it (0 → span).
-        #expect(xml.contains("offset=\"0s\" start=\"1/3s\" duration=\"2s\""))
+        // start is in the OUTPUT axis (source-in 10 ÷ speed 2 = 5 frames = 1/6s); the timeMap describes
+        // the WHOLE media retimed (output 150/2=75f=5/2s → source 150f=5s), windowed by start/duration.
+        #expect(xml.contains("offset=\"0s\" start=\"1/6s\" duration=\"2s\""))
         #expect(xml.contains("<timeMap frameSampling=\"floor\">"))
         #expect(xml.contains("<timept time=\"0s\" value=\"0s\" interp=\"linear\"/>"))
-        #expect(xml.contains("<timept time=\"2s\" value=\"4s\" interp=\"linear\"/>"))
+        #expect(xml.contains("<timept time=\"5/2s\" value=\"5s\" interp=\"linear\"/>"))
+    }
+
+    @Test func slowMotionEmitsWholeMediaTimeMap() throws {
+        // 0.5× slow-mo: source plays at half rate, so the whole-media ramp's output axis is LONGER than
+        // the source (150 source frames = 5s → output 10s). Exercises the speed < 1 (p<q) path.
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        let clip = Fixtures.clip(id: "slow", mediaRef: "media-v", start: 0, duration: 60, trimStart: 30, speed: 0.5)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        // start = 30 ÷ 0.5 = 60 output frames = 2s; ramp output 150/0.5=300f=10s → source 150f=5s.
+        #expect(xml.contains("start=\"2s\""))
+        #expect(xml.contains("<timept time=\"10s\" value=\"5s\" interp=\"linear\"/>"))
+    }
+
+    @Test func retimedKeyframeTimeIsOffsetByStart() throws {
+        // Resolve measures param keyframe time from the timeMap origin, so it's offset by the clip's
+        // output-axis start (trimStart ÷ speed), not zero-based. 5s media @30fps, 2× speed, trimStart 10.
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        var clip = Fixtures.clip(id: "z", mediaRef: "media-v", start: 0, duration: 60, trimStart: 10, speed: 2.0)
+        clip.scaleTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: AnimPair(a: 0.5, b: 0.5), interpolationOut: .linear),
+            Keyframe(frame: 15, value: AnimPair(a: 1, b: 1), interpolationOut: .linear),
+        ])
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        // start = 10/(2×30) = 1/6s; first keyframe sits AT start, second 15 output frames later (1/6+1/2=2/3s).
+        #expect(xml.contains("start=\"1/6s\""))
+        #expect(xml.contains("<keyframe time=\"1/6s\""))
+        #expect(xml.contains("<keyframe time=\"2/3s\""))
+    }
+
+    @Test func unspeededTrimmedKeyframeStaysClipRelative() throws {
+        // With no timeMap there's no output-axis origin, so keyframe time is plain clip-relative — NOT
+        // offset by trimStart. (Guards against over-applying the retimed-clip offset.)
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        var clip = Fixtures.clip(id: "t", mediaRef: "media-v", start: 0, duration: 60, trimStart: 10)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0.0, interpolationOut: .linear),
+            Keyframe(frame: 30, value: 1.0, interpolationOut: .linear),
+        ])
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        #expect(!xml.contains("<timeMap"))
+        #expect(xml.contains("<keyframe time=\"0s\" curve=\"linear\" value=\"0\"/>"))   // not 1/3s
+        #expect(xml.contains("<keyframe time=\"1s\" curve=\"linear\" value=\"1\"/>"))
     }
 
     // MARK: - Transform, scale, flip


### PR DESCRIPTION
Speed-changed clips rendered black on their last few frames when imported into DaVinci Resolve. Our timeMap used a per-clip ramp on a flat <asset-clip>, which ends exactly at the clip edge. Resolve floor-samples past it and blacks the tail.

Reworked the retime to match Resolve's own native representation:
- Every visual clip is now a <ref-clip> over a per-media compound clip that holds the full source.
- The timeMap is the whole-media ramp (output[0, media/speed] → source[0, media]), windowed by start in the output axis (source in-point ÷ speed), using an exact small-denominator speed fraction.
- Keyframe time is offset by start for retimed clips (stays clip-relative when unspeeded).

Also:
- FCPXML version picker (1.10–1.14, default 1.10) in the export sheet.
- Reset transform now restores the aspect-fit instead of a 1×1 stretch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to FCPXML interchange (speed, keyframes, clip structure) affect Resolve/FCP imports; coverage is expanded in tests but round-trip behavior in real NLEs is the main validation surface.
> 
> **Overview**
> Fixes **DaVinci Resolve** imports where speed-changed clips showed **black tails** by aligning retime with Resolve’s model instead of a per-clip `<asset-clip>` timeMap.
> 
> **FCPXML exporter:** Visual clips are now **`<ref-clip>`** over a per-media **compound clip** that holds the **full source**; the **timeMap** spans the whole media (`output[0, media/speed] → source[0, media]`), with **`start`** on the output axis (source in-point ÷ speed) and rational speed fractions. **Retimed keyframes** offset `time` by that `start`; unspeeded clips stay clip-relative. Audio remains plain `<asset-clip>`.
> 
> **Version selection:** New **`FCPXMLVersion`** (1.10–1.14, default **1.10**) drives only the root `version` attribute; the export sheet gets a version picker with compatibility notes, and **`export_project`** accepts **`fcpxmlVersion`** (fcpxml mode only) and echoes it in the result.
> 
> **Inspector:** **Reset transform** restores the clip’s **aspect-fit** transform instead of a neutral 1×1 box.
> 
> Tests cover compound clips, ref-clips, whole-media timeMaps, and retimed vs unspeeded keyframe timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25ecd99380fd621240636c0f31f724fc8503a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->