### PR TITLE
[agent] Opt-in TwelveLabs video understanding (analyze_video tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Generate videos and images with SOTA models like Seedance, Kling, Nano Banana Pr
 
 Connects your Claude/Codex/Cursor via MCP, or use the in-app agent to work on the same project together.
 
+### Video understanding (optional)
+
+Add a [TwelveLabs](https://twelvelabs.io) API key in **Settings → Agent** to unlock the `analyze_video` tool. The in-app agent can then ask TwelveLabs Pegasus about a whole clip — "summarize this", "what is the speaker demonstrating", "find the moment the goal is scored" — reasoning over motion and audio together, beyond on-device frame sampling. Off by default; with no key set, everything works exactly as before.
+
 ## MCP server
 
 When the app is open, it exposes an MCP server at `http://127.0.0.1:19789/mcp` via HTTP. To connect:

--- a/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+extension Notification.Name {
+    static let twelveLabsAPIKeyChanged = Notification.Name("twelveLabsAPIKeyChanged")
+}
+
+enum TwelveLabsKeychain {
+    private static let account = "twelvelabs-api-key"
+
+    static func save(_ key: String) {
+        KeychainStore.save(key, account: account)
+        NotificationCenter.default.post(name: .twelveLabsAPIKeyChanged, object: nil)
+    }
+
+    static func load() -> String? {
+        #if DEBUG
+        if let env = ProcessInfo.processInfo.environment["TWELVELABS_API_KEY"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !env.isEmpty {
+            return env
+        }
+        #endif
+        return KeychainStore.load(account: account)
+    }
+
+    static func delete() {
+        KeychainStore.delete(account: account)
+        NotificationCenter.default.post(name: .twelveLabsAPIKeyChanged, object: nil)
+    }
+}
+
+enum TwelveLabsClientError: LocalizedError {
+    case missingAPIKey
+    case httpError(status: Int, body: String)
+    case decoding(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey: "No TwelveLabs API key is set. Add one in Settings → Agent."
+        case .httpError(let status, let body): "TwelveLabs API error (\(status)): \(body.prefix(500))"
+        case .decoding(let msg): "TwelveLabs response error: \(msg)"
+        }
+    }
+}
+
+/// TwelveLabs Pegasus video understanding over the v1.3 REST API (no official Swift SDK).
+struct TwelveLabsClient: Sendable {
+    let apiKey: String
+
+    private static let baseURL = URL(string: "https://api.twelvelabs.io/v1.3")!
+    private static let pegasusModel = "pegasus1.5"
+
+    /// Uploads a local video file as a TwelveLabs asset, then asks Pegasus the prompt about it.
+    func understand(videoURL: URL, prompt: String) async throws -> String {
+        let assetID = try await uploadAsset(fileURL: videoURL)
+        return try await analyze(assetID: assetID, prompt: prompt)
+    }
+
+    private func uploadAsset(fileURL: URL) async throws -> String {
+        guard !apiKey.isEmpty else { throw TwelveLabsClientError.missingAPIKey }
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: Self.baseURL.appendingPathComponent("assets"))
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let fileData = try await Task.detached(priority: .userInitiated) {
+            try Data(contentsOf: fileURL)
+        }.value
+        var body = Data()
+        body.appendFormField("method", value: "direct", boundary: boundary)
+        body.appendFileField(
+            "file", filename: fileURL.lastPathComponent,
+            mimeType: Self.mimeType(for: fileURL), data: fileData, boundary: boundary
+        )
+        body.appendBoundaryTerminator(boundary)
+        request.httpBody = body
+
+        let json = try await send(request)
+        guard let id = (json["_id"] ?? json["id"]) as? String, !id.isEmpty else {
+            throw TwelveLabsClientError.decoding("asset response missing _id")
+        }
+        return id
+    }
+
+    private func analyze(assetID: String, prompt: String) async throws -> String {
+        guard !apiKey.isEmpty else { throw TwelveLabsClientError.missingAPIKey }
+
+        var request = URLRequest(url: Self.baseURL.appendingPathComponent("analyze"))
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "video": ["type": "asset_id", "asset_id": assetID],
+            "prompt": prompt,
+            "model_name": Self.pegasusModel,
+            "stream": false,
+        ])
+
+        let json = try await send(request)
+        guard let text = json["data"] as? String else {
+            throw TwelveLabsClientError.decoding("analyze response missing data")
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func send(_ request: URLRequest) async throws -> [String: Any] {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            throw TwelveLabsClientError.httpError(
+                status: http.statusCode,
+                body: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw TwelveLabsClientError.decoding("response was not a JSON object")
+        }
+        return json
+    }
+
+    private static func mimeType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "mov": "video/quicktime"
+        case "m4v": "video/x-m4v"
+        case "webm": "video/webm"
+        default: "video/mp4"
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendFormField(_ name: String, value: String, boundary: String) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        append("\(value)\r\n".data(using: .utf8)!)
+    }
+
+    mutating func appendFileField(
+        _ name: String, filename: String, mimeType: String, data: Data, boundary: String
+    ) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+        append(data)
+        append("\r\n".data(using: .utf8)!)
+    }
+
+    mutating func appendBoundaryTerminator(_ boundary: String) {
+        append("--\(boundary)--\r\n".data(using: .utf8)!)
+    }
+}

--- a/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
@@ -71,7 +71,7 @@ struct TwelveLabsClient: Sendable {
     private func uploadAsset(fileURL: URL) async throws -> String {
         guard !apiKey.isEmpty else { throw TwelveLabsClientError.missingAPIKey }
 
-        if let bytes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int,
+        if let bytes = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
            bytes > Self.maxDirectUploadBytes {
             throw TwelveLabsClientError.fileTooLarge(bytes: bytes, limit: Self.maxDirectUploadBytes)
         }

--- a/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
@@ -49,6 +49,9 @@ struct TwelveLabsClient: Sendable {
 
     private static let baseURL = URL(string: "https://api.twelvelabs.io/v1.3")!
     private static let pegasusModel = "pegasus1.5"
+    /// Large uploads and whole-clip Pegasus analysis routinely run past URLSession's
+    /// default 60s request timeout, so give both a generous ceiling.
+    private static let requestTimeout: TimeInterval = 300
 
     /// Uploads a local video file as a TwelveLabs asset, then asks Pegasus the prompt about it.
     func understand(videoURL: URL, prompt: String) async throws -> String {
@@ -62,26 +65,57 @@ struct TwelveLabsClient: Sendable {
         let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: Self.baseURL.appendingPathComponent("assets"))
         request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
-        let fileData = try await Task.detached(priority: .userInitiated) {
-            try Data(contentsOf: fileURL)
-        }.value
-        var body = Data()
-        body.appendFormField("method", value: "direct", boundary: boundary)
-        body.appendFileField(
-            "file", filename: fileURL.lastPathComponent,
-            mimeType: Self.mimeType(for: fileURL), data: fileData, boundary: boundary
+        // Stream the multipart body to a temp file so a multi-GB source clip is never
+        // held in memory all at once; upload(fromFile:) then streams it from disk.
+        let bodyURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tl-upload-\(UUID().uuidString).multipart")
+        try Self.writeMultipartBody(
+            to: bodyURL, fileURL: fileURL,
+            mimeType: Self.mimeType(for: fileURL), boundary: boundary
         )
-        body.appendBoundaryTerminator(boundary)
-        request.httpBody = body
+        defer { try? FileManager.default.removeItem(at: bodyURL) }
 
-        let json = try await send(request)
+        let (data, response) = try await URLSession.shared.upload(for: request, fromFile: bodyURL)
+        let json = try Self.decodeJSON(data, response)
         guard let id = (json["_id"] ?? json["id"]) as? String, !id.isEmpty else {
             throw TwelveLabsClientError.decoding("asset response missing _id")
         }
         return id
+    }
+
+    /// Writes the `method=direct` field and the file part to `bodyURL`, streaming the
+    /// source file in 1 MiB chunks so it is never fully resident in memory.
+    private static func writeMultipartBody(
+        to bodyURL: URL, fileURL: URL, mimeType: String, boundary: String
+    ) throws {
+        FileManager.default.createFile(atPath: bodyURL.path, contents: nil)
+        let out = try FileHandle(forWritingTo: bodyURL)
+        defer { try? out.close() }
+
+        var header = Data()
+        header.appendFormField("method", value: "direct", boundary: boundary)
+        header.append("--\(boundary)\r\n".data(using: .utf8)!)
+        header.append(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"\(fileURL.lastPathComponent)\"\r\n"
+                .data(using: .utf8)!
+        )
+        header.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+        try out.write(contentsOf: header)
+
+        let input = try FileHandle(forReadingFrom: fileURL)
+        defer { try? input.close() }
+        while let chunk = try input.read(upToCount: 1 << 20), !chunk.isEmpty {
+            try out.write(contentsOf: chunk)
+        }
+
+        var footer = Data()
+        footer.append("\r\n".data(using: .utf8)!)
+        footer.appendBoundaryTerminator(boundary)
+        try out.write(contentsOf: footer)
     }
 
     private func analyze(assetID: String, prompt: String) async throws -> String {
@@ -89,6 +123,7 @@ struct TwelveLabsClient: Sendable {
 
         var request = URLRequest(url: Self.baseURL.appendingPathComponent("analyze"))
         request.httpMethod = "POST"
+        request.timeoutInterval = Self.requestTimeout
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: [
@@ -107,6 +142,10 @@ struct TwelveLabsClient: Sendable {
 
     private func send(_ request: URLRequest) async throws -> [String: Any] {
         let (data, response) = try await URLSession.shared.data(for: request)
+        return try Self.decodeJSON(data, response)
+    }
+
+    private static func decodeJSON(_ data: Data, _ response: URLResponse) throws -> [String: Any] {
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
             throw TwelveLabsClientError.httpError(
                 status: http.statusCode,
@@ -134,16 +173,6 @@ private extension Data {
         append("--\(boundary)\r\n".data(using: .utf8)!)
         append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
         append("\(value)\r\n".data(using: .utf8)!)
-    }
-
-    mutating func appendFileField(
-        _ name: String, filename: String, mimeType: String, data: Data, boundary: String
-    ) {
-        append("--\(boundary)\r\n".data(using: .utf8)!)
-        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
-        append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
-        append(data)
-        append("\r\n".data(using: .utf8)!)
     }
 
     mutating func appendBoundaryTerminator(_ boundary: String) {

--- a/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/TwelveLabsClient.swift
@@ -31,12 +31,17 @@ enum TwelveLabsKeychain {
 
 enum TwelveLabsClientError: LocalizedError {
     case missingAPIKey
+    case fileTooLarge(bytes: Int, limit: Int)
     case httpError(status: Int, body: String)
     case decoding(String)
 
     var errorDescription: String? {
         switch self {
         case .missingAPIKey: "No TwelveLabs API key is set. Add one in Settings → Agent."
+        case .fileTooLarge(let bytes, let limit):
+            let mb = { (b: Int) in String(format: "%.0f", Double(b) / 1_048_576) }
+            return "Video is \(mb(bytes)) MB, but TwelveLabs direct upload supports up to \(mb(limit)) MB. "
+                + "Export or trim a smaller clip and retry. (Larger files need TwelveLabs' multipart upload, which isn't wired up yet.)"
         case .httpError(let status, let body): "TwelveLabs API error (\(status)): \(body.prefix(500))"
         case .decoding(let msg): "TwelveLabs response error: \(msg)"
         }
@@ -52,6 +57,10 @@ struct TwelveLabsClient: Sendable {
     /// Large uploads and whole-clip Pegasus analysis routinely run past URLSession's
     /// default 60s request timeout, so give both a generous ceiling.
     private static let requestTimeout: TimeInterval = 300
+    /// TwelveLabs caps direct local-file uploads (`method=direct`) at 200 MB; larger files
+    /// require the separate multipart/chunked upload flow. Guard so callers get a clear
+    /// message instead of an opaque API failure on full-resolution source clips.
+    private static let maxDirectUploadBytes = 200 * 1_048_576
 
     /// Uploads a local video file as a TwelveLabs asset, then asks Pegasus the prompt about it.
     func understand(videoURL: URL, prompt: String) async throws -> String {
@@ -61,6 +70,11 @@ struct TwelveLabsClient: Sendable {
 
     private func uploadAsset(fileURL: URL) async throws -> String {
         guard !apiKey.isEmpty else { throw TwelveLabsClientError.missingAPIKey }
+
+        if let bytes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int,
+           bytes > Self.maxDirectUploadBytes {
+            throw TwelveLabsClientError.fileTooLarge(bytes: bytes, limit: Self.maxDirectUploadBytes)
+        }
 
         let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: Self.baseURL.appendingPathComponent("assets"))

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -40,6 +40,11 @@ enum AgentInstructions {
           startSeconds/endSeconds for full frames. Plan splits, trims, and captions from \
           segment timestamps; wordTimestamps=true on a narrow window for exact word \
           boundaries.
+        - When the question is about the whole clip's content rather than a specific frame \
+          ("summarize this video", "what's the speaker demonstrating", "find the goal") and a \
+          TwelveLabs key is set, analyze_video answers it from cloud video understanding in one \
+          call. It's opt-in — if no key is configured it returns a notice and you fall back to \
+          inspect_media.
         - To find a moment across the library ("the sunset shot", "where she mentions the \
           budget"), call search_media before inspecting files one by one — describe what's \
           on screen or quote the words said. Hits are source-second ranges ready to convert \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -26,6 +26,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case importMedia = "import_media"
     case listModels = "list_models"
     case inspectMedia = "inspect_media"
+    case analyzeVideo = "analyze_video"
     case getTranscript = "get_transcript"
     case inspectTimeline = "inspect_timeline"
     case searchMedia = "search_media"
@@ -81,6 +82,17 @@ enum ToolDefinitions {
                     "language": ["type": "string", "description": "Optional BCP-47 language tag of the spoken audio (e.g. 'es', 'fr', 'ja', 'zh-Hans'). Defaults to the system language. Specify when the spoken language differs from the system locale — on-device models are language-specific and will produce garbled output if the wrong language is used."],
                 ],
                 required: ["mediaRef"]
+            )
+        ),
+        AgentTool(
+            name: .analyzeVideo,
+            description: "Ask a question about an entire video asset and get a natural-language answer from TwelveLabs Pegasus — a cloud video-understanding model that reasons over the whole clip's visuals AND audio at once. Use this when inspect_media's sampled frames aren't enough: a one-line summary of a long clip, \"what is the speaker demonstrating?\", \"is there a logo on screen?\", \"find the moment the goal is scored and describe it\", scene/mood/quality assessment, or content checks before placing footage. Pegasus sees motion and continuity that isolated frames miss.\n\nOpt-in and off by default: it requires a TwelveLabs API key in Settings → Agent. With no key set, this tool returns a notice and nothing happens — fall back to inspect_media (on-device frames + transcription). The asset is uploaded to TwelveLabs for analysis, so only call it when the user wants cloud understanding; one call covers the whole asset, so don't loop it per frame.",
+            inputSchema: objectSchema(
+                properties: [
+                    "mediaRef": ["type": "string", "description": "Video asset ID from get_media. Images and audio are not supported — use inspect_media for those."],
+                    "prompt": ["type": "string", "description": "What to ask about the video. Free-form, e.g. 'Summarize this clip in one sentence' or 'When does the on-screen text appear and what does it say?'"],
+                ],
+                required: ["mediaRef", "prompt"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
@@ -41,7 +41,11 @@ extension ToolExecutor {
         let client = TwelveLabsClient(apiKey: apiKey)
         let answer: String
         do {
-            answer = try await client.understand(videoURL: url, prompt: prompt)
+            // Run off the main actor: building the multipart upload body streams the whole
+            // source file from disk, which would otherwise block the editor on @MainActor.
+            answer = try await Task.detached(priority: .userInitiated) {
+                try await client.understand(videoURL: url, prompt: prompt)
+            }.value
         } catch {
             Log.agent.warning("analyze_video failed: \(error.localizedDescription)")
             return .error("TwelveLabs analysis failed: \(error.localizedDescription)")

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
@@ -24,10 +24,18 @@ extension ToolExecutor {
         }
         let url = asset.url
         guard FileManager.default.fileExists(atPath: url.path) else {
-            if asset.isGenerating {
-                throw ToolError("Asset \(asset.id) isn't on disk yet. Poll get_media and retry once generationStatus becomes 'none'.")
+            switch asset.generationStatus {
+            case .downloading:
+                throw ToolError("Asset \(asset.id) is still downloading. Poll get_media and retry once generationStatus becomes 'none'.")
+            case .generating:
+                throw ToolError("Asset \(asset.id) is still generating. Poll get_media and retry once generationStatus becomes 'none'.")
+            case .rendering:
+                throw ToolError("Asset \(asset.id) is still rendering. Poll get_media and retry once generationStatus becomes 'none'.")
+            case .failed(let msg):
+                throw ToolError("Asset \(asset.id) failed: \(msg)")
+            case .none:
+                throw ToolError("Media file not on disk: \(url.lastPathComponent)")
             }
-            throw ToolError("Media file not on disk: \(url.lastPathComponent)")
         }
 
         let client = TwelveLabsClient(apiKey: apiKey)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+TwelveLabs.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+extension ToolExecutor {
+    private static let analyzeVideoAllowedKeys: Set<String> = ["mediaRef", "prompt"]
+
+    /// Pegasus video understanding. Opt-in: when no TwelveLabs key is set this returns a clear,
+    /// non-fatal error so the rest of the agent is unchanged. Uploads the source asset to
+    /// TwelveLabs and returns Pegasus's answer to the prompt.
+    func analyzeVideo(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.analyzeVideoAllowedKeys, path: "analyze_video")
+
+        let apiKey = await Task.detached(priority: .utility) { TwelveLabsKeychain.load() ?? "" }.value
+        guard !apiKey.isEmpty else {
+            return .error("TwelveLabs is not configured. Add an API key in Settings → Agent to enable video understanding, then retry. Until then, use inspect_media for on-device frame sampling and transcription.")
+        }
+
+        let mediaRef = try args.requireString("mediaRef")
+        let prompt = try args.requireString("prompt").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { throw ToolError("analyze_video: prompt is empty") }
+
+        let asset = try asset(mediaRef, editor: editor)
+        guard asset.type == .video else {
+            throw ToolError("analyze_video only handles video assets — \(asset.name) is \(asset.type.rawValue). Use inspect_media for images and audio.")
+        }
+        let url = asset.url
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            if asset.isGenerating {
+                throw ToolError("Asset \(asset.id) isn't on disk yet. Poll get_media and retry once generationStatus becomes 'none'.")
+            }
+            throw ToolError("Media file not on disk: \(url.lastPathComponent)")
+        }
+
+        let client = TwelveLabsClient(apiKey: apiKey)
+        let answer: String
+        do {
+            answer = try await client.understand(videoURL: url, prompt: prompt)
+        } catch {
+            Log.agent.warning("analyze_video failed: \(error.localizedDescription)")
+            return .error("TwelveLabs analysis failed: \(error.localizedDescription)")
+        }
+
+        let payload: [String: Any] = [
+            "mediaRef": asset.id,
+            "name": asset.name,
+            "model": "pegasus1.5",
+            "answer": answer,
+        ]
+        guard let json = Self.jsonString(payload) else {
+            throw ToolError("analyze_video: failed to encode result")
+        }
+        return .ok(json)
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -76,6 +76,7 @@ final class ToolExecutor {
         case .getTimeline:   return try getTimeline(editor, args)
         case .getMedia:      return try getMedia(editor)
         case .inspectMedia:  return try await inspectMedia(editor, args)
+        case .analyzeVideo:  return try await analyzeVideo(editor, args)
         case .getTranscript: return try await getTranscript(editor, args)
         case .inspectTimeline: return try await inspectTimeline(editor, args)
         case .searchMedia:   return try await searchMedia(editor, args)

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -8,11 +8,19 @@ struct AgentPane: View {
     @State private var draft: String = ""
     @FocusState private var isFocused: Bool
 
+    @State private var hasTLKey: Bool = false
+    @State private var maskedTLKey: String = ""
+    @State private var tlDraft: String = ""
+    @FocusState private var isTLFocused: Bool
+
     private let consoleURL = URL(string: "https://console.anthropic.com/settings/keys")!
+    private let twelveLabsURL = URL(string: "https://playground.twelvelabs.io/dashboard/api-key")!
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
             apiKeySection
+            Divider().overlay(AppTheme.Border.subtleColor)
+            twelveLabsSection
             Divider().overlay(AppTheme.Border.subtleColor)
             mcpSection
         }
@@ -111,12 +119,19 @@ struct AgentPane: View {
         Task { @MainActor in
             let key = await Self.loadKey()
             applyKey(key)
+            let tlKey = await Self.loadTLKey()
+            applyTLKey(tlKey)
         }
     }
 
     private func applyKey(_ key: String) {
         hasKey = !key.isEmpty
         maskedKey = mask(key)
+    }
+
+    private func applyTLKey(_ key: String) {
+        hasTLKey = !key.isEmpty
+        maskedTLKey = mask(key)
     }
 
     private func save() {
@@ -151,6 +166,125 @@ struct AgentPane: View {
     private func mask(_ key: String) -> String {
         guard key.count > 4 else { return String(repeating: "\u{2022}", count: 32) }
         return String(repeating: "\u{2022}", count: 36) + key.suffix(4)
+    }
+
+    // MARK: - TwelveLabs API key
+
+    private var twelveLabsSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            twelveLabsHeader
+            twelveLabsKeyField
+        }
+    }
+
+    private var twelveLabsHeader: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            Text("TwelveLabs API Key")
+                .font(.system(size: AppTheme.FontSize.md, weight: .medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+
+            HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
+                Text("Optional. Enables the analyze_video tool — ask the agent to understand a clip with TwelveLabs Pegasus. Stored in your macOS Keychain.")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button(action: { NSWorkspace.shared.open(twelveLabsURL, configuration: .init(), completionHandler: nil) }) {
+                    HStack(spacing: 2) {
+                        Text("Get TwelveLabs API key")
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                    }
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Accent.primary)
+                }
+                .buttonStyle(.plain)
+                .fixedSize()
+            }
+        }
+    }
+
+    private var twelveLabsKeyField: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            twelveLabsFieldBox
+            twelveLabsTrailingControl
+        }
+    }
+
+    private var twelveLabsFieldBox: some View {
+        SecureField(twelveLabsPlaceholder, text: $tlDraft)
+            .textFieldStyle(.plain)
+            .focused($isTLFocused)
+            .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+            .foregroundStyle(AppTheme.Text.primaryColor)
+            .onSubmit(saveTL)
+            .padding(.horizontal, AppTheme.Spacing.md)
+            .padding(.vertical, AppTheme.Spacing.smMd)
+            .background(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                    .fill(Color.black.opacity(AppTheme.Opacity.muted))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                    .strokeBorder(
+                        isTLFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
+                        lineWidth: AppTheme.BorderWidth.thin
+                    )
+            )
+            .animation(.easeOut(duration: AppTheme.Anim.hover), value: isTLFocused)
+    }
+
+    private var twelveLabsPlaceholder: String {
+        hasTLKey ? maskedTLKey : "tlk_..."
+    }
+
+    @ViewBuilder
+    private var twelveLabsTrailingControl: some View {
+        let trimmed = tlDraft.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            Button("Save", action: saveTL)
+                .buttonStyle(.capsule(.prominent, size: .regular))
+                .controlSize(.large)
+        } else if hasTLKey {
+            Button(action: removeTL) {
+                Image(systemName: "trash")
+                    .font(.system(size: AppTheme.FontSize.md))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+            }
+            .buttonStyle(.capsule(.secondary, size: .regular))
+            .controlSize(.large)
+            .help("Remove TwelveLabs API key")
+        }
+    }
+
+    private func saveTL() {
+        let key = tlDraft.trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else { return }
+        tlDraft = ""
+        isTLFocused = false
+        Task { @MainActor in
+            await Task.detached(priority: .userInitiated) {
+                TwelveLabsKeychain.save(key)
+            }.value
+            applyTLKey(key)
+        }
+    }
+
+    private func removeTL() {
+        tlDraft = ""
+        Task { @MainActor in
+            await Task.detached(priority: .userInitiated) {
+                TwelveLabsKeychain.delete()
+            }.value
+            applyTLKey("")
+        }
+    }
+
+    private static func loadTLKey() async -> String {
+        await Task.detached(priority: .utility) {
+            TwelveLabsKeychain.load() ?? ""
+        }.value
     }
 
     // MARK: - MCP server


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

Palmier Pro is "the video editor built for AI," so I added an optional bridge to TwelveLabs Pegasus — a cloud video-understanding model that reasons over a whole clip's visuals **and** audio at once. It's entirely opt-in: with no key set, nothing changes.

### What it adds
- **`TwelveLabsClient`** (`Agent/Clients/`) — Pegasus video understanding over the v1.3 REST API via `URLSession`. There's no official Swift SDK, so it talks to the API directly. It mirrors `AnthropicClient`'s auth/error shape, and the key lives in the macOS Keychain via `TwelveLabsKeychain` (mirroring `AnthropicKeychain`, including the `#if DEBUG` env override) — never hardcoded.
- **`analyze_video` agent tool** (`Agent/Tools/`, wired into `ToolExecutor`/`ToolDefinitions` exactly like the existing tools, so it's also exposed over the MCP server) — the in-app agent can ask Pegasus about a video asset: "summarize this clip," "what is the speaker demonstrating," "find the moment the goal is scored." This complements `inspect_media` (on-device sampled frames + transcription) by adding whole-clip understanding that isolated frames miss. If no TwelveLabs key is configured, the tool returns a clear notice and no-ops, so the agent simply falls back to `inspect_media`.
- **Settings → Agent** — a TwelveLabs API key field, stored identically to the Anthropic key (Keychain, with a trash button to clear it).
- Docs: a short opt-in capability note in the README and one line in the agent instructions.

### Why it fits
A video editor built for AI is the ideal home for video understanding. This keeps the existing on-device path as the default and layers cloud understanding on top only when a user provides their own key.

### How it was tested
- The TwelveLabs REST contracts the client depends on were **live-verified end to end** against `api.twelvelabs.io/v1.3`: multipart asset upload (`method=direct`, `file=`) → `_id`, then `POST /v1.3/analyze` with `{"video":{"type":"asset_id",...},"model_name":"pegasus1.5","stream":false}` returning the answer at `.data`.
- I wrote the Swift to match the repo's existing conventions closely (client/keychain/error shape, `ToolExecutor` extension pattern, `AppTheme`-only styling in the settings pane, minimal comments per AGENTS.md, async/await + off-main-actor file IO). New files pass `swiftc -parse`.
- **Honest caveat:** I couldn't run a full `swift build` to completion on my non-macOS-26 CI — the build reached the Metal-toolchain plugin step (the `MetalCIKernelPlugin`) before my toolchain blocked there, which is unrelated to these changes. CI here runs on a `macos-26` runner and will compile it properly; I'd appreciate a maintainer building it on macOS to confirm. Happy to adjust anything to fit your conventions.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uploads user video to a third-party API when enabled; key handling follows existing Anthropic patterns but adds new external dependency and long-running network I/O on agent tool calls.
> 
> **Overview**
> Adds **optional** cloud video understanding via TwelveLabs Pegasus. With no API key, behavior is unchanged.
> 
> **`TwelveLabsClient`** uploads a local video to TwelveLabs v1.3 (streaming multipart to disk, 200 MB direct-upload cap, 300s timeouts), runs Pegasus `pegasus1.5`, and returns the answer. **`TwelveLabsKeychain`** stores the key like Anthropic (Keychain + DEBUG env override).
> 
> New **`analyze_video`** agent/MCP tool (`mediaRef` + `prompt`) validates video assets on disk, runs upload/analysis off the main actor, and returns a clear notice when TwelveLabs isn’t configured so the agent falls back to **`inspect_media`**.
> 
> **Settings → Agent** gets a TwelveLabs key field (save/remove, masked display). README and agent instructions document when to use **`analyze_video`** vs on-device inspection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30bd1e38646344ceaea7d0ec66e0a5e06add3a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->