### PR TITLE
[settings] skills

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -341,7 +341,8 @@ final class AgentService {
             streamError = .upstream("No backend available.")
             return
         }
-        let tools = ToolDefinitions.all.map {
+        SkillStore.shared.reload()
+        let tools = ToolDefinitions.inAppAgent.map {
             AnthropicToolSchema(name: $0.name.rawValue, description: $0.description, inputSchema: $0.inputSchema)
         }
 
@@ -354,7 +355,7 @@ final class AgentService {
 
             do {
                 let stream = client.stream(
-                    system: AgentInstructions.serverInstructions,
+                    system: AgentInstructions.serverInstructions + SkillStore.shared.promptIndex,
                     tools: tools,
                     messages: apiMsgs
                 )

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -341,7 +341,7 @@ final class AgentService {
             streamError = .upstream("No backend available.")
             return
         }
-        SkillStore.shared.reload()
+        await SkillStore.shared.reloadInBackground()
         let tools = ToolDefinitions.inAppAgent.map {
             AnthropicToolSchema(name: $0.name.rawValue, description: $0.description, inputSchema: $0.inputSchema)
         }

--- a/Sources/PalmierPro/Agent/Panel/MarkdownText.swift
+++ b/Sources/PalmierPro/Agent/Panel/MarkdownText.swift
@@ -4,14 +4,16 @@ import SwiftUI
 /// AttributedString rendered by one Text view to minimize hosted-text count under LazyVStack.
 struct MarkdownText: View {
     let text: String
+    var proseFont: Font = .body
+    var blockSpacing: CGFloat = AppTheme.Spacing.md
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+        VStack(alignment: .leading, spacing: blockSpacing) {
             ForEach(Array(Self.cachedParse(text).enumerated()), id: \.offset) { _, block in
                 switch block {
                 case .prose(let attr):
                     Text(attr)
-                        .font(.body)
+                        .font(proseFont)
                         .foregroundStyle(AppTheme.Text.primaryColor)
                         .lineSpacing(AppTheme.Spacing.xs)
                         .textSelection(.enabled)

--- a/Sources/PalmierPro/Agent/Skills/Skill.swift
+++ b/Sources/PalmierPro/Agent/Skills/Skill.swift
@@ -34,4 +34,26 @@ enum SkillFrontmatter {
             : ""
         return (fields, body)
     }
+
+    static func replacingName(_ text: String, name: String) -> String {
+        let lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+            return "---\nname: \(name)\n---\n\n" + text
+        }
+        var front: [String] = []
+        var replaced = false
+        var i = 1
+        while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "---" {
+            if let colon = lines[i].firstIndex(of: ":"),
+               lines[i][..<colon].trimmingCharacters(in: .whitespaces) == "name" {
+                front.append("name: \(name)"); replaced = true
+            } else {
+                front.append(lines[i])
+            }
+            i += 1
+        }
+        if !replaced { front.insert("name: \(name)", at: 0) }
+        let rest = i < lines.count ? lines[i...].joined(separator: "\n") : "---"
+        return "---\n" + front.joined(separator: "\n") + "\n" + rest
+    }
 }

--- a/Sources/PalmierPro/Agent/Skills/Skill.swift
+++ b/Sources/PalmierPro/Agent/Skills/Skill.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A skill is a folder under `~/.palmier/skills/<id>/` with a `SKILL.md` file
+struct Skill: Identifiable, Sendable {
+    let id: String  // folder name
+    let name: String
+    let description: String
+    let path: URL  // the SKILL.md file
+}
+
+enum SkillFrontmatter {
+    /// Splits a SKILL.md into its frontmatter fields and body
+    static func parse(_ text: String) -> (fields: [String: String], body: String) {
+        var fields: [String: String] = [:]
+        let lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+            return (fields, text)
+        }
+        var i = 1
+        while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "---" {
+            let line = lines[i]
+            if let colon = line.firstIndex(of: ":") {
+                let key = line[..<colon].trimmingCharacters(in: .whitespaces)
+                var value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+                if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                    value = String(value.dropFirst().dropLast())
+                }
+                if !key.isEmpty { fields[key] = value }
+            }
+            i += 1
+        }
+        let body = i + 1 < lines.count
+            ? lines[(i + 1)...].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            : ""
+        return (fields, body)
+    }
+}

--- a/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
@@ -28,8 +28,7 @@ final class SkillCatalog {
     private(set) var lastError: String?
 
     private static var cacheURL: URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("PalmierPro/skills-catalog.json")
+        DiskCache.rootDirectory.appendingPathComponent("skills-catalog.json")
     }
 
     private init() { loadCache() }

--- a/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One entry in the published catalog.json. `sha` is a content hash of the SKILL.md
+/// and is the version anchor: a changed sha means an update is available.
+struct SkillCatalogEntry: Codable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let description: String
+    let sha: String
+    let path: String
+}
+
+/// Fetches the community skill catalog from the palmier-skills repo (raw GitHub CDN)
+@Observable
+@MainActor
+final class SkillCatalog {
+    static let shared = SkillCatalog()
+
+    /// Catalog source. Override with the PALMIER_SKILLS_BASE env var to test against a
+    /// local clone, e.g. file:///path/to/palmier-skills.
+    static var base: String {
+        ProcessInfo.processInfo.environment["PALMIER_SKILLS_BASE"]
+            ?? "https://raw.githubusercontent.com/palmier-io/palmier-skills/main"
+    }
+
+    private(set) var entries: [SkillCatalogEntry] = []
+    private(set) var isLoading = false
+    private(set) var lastError: String?
+
+    private static var cacheURL: URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("PalmierPro/skills-catalog.json")
+    }
+
+    private init() { loadCache() }
+
+    func entry(id: String) -> SkillCatalogEntry? { entries.first { $0.id == id } }
+
+    static func bodyURL(path: String) -> URL? { URL(string: "\(base)/\(path)") }
+
+    private func loadCache() {
+        guard let data = try? Data(contentsOf: Self.cacheURL),
+              let decoded = try? JSONDecoder().decode([SkillCatalogEntry].self, from: data)
+        else { return }
+        entries = decoded
+    }
+
+    func refresh() async {
+        guard !isLoading, let url = URL(string: "\(Self.base)/catalog.json") else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let data = try await Self.fetch(url)
+            entries = try JSONDecoder().decode([SkillCatalogEntry].self, from: data)
+            lastError = nil
+            try? FileManager.default.createDirectory(
+                at: Self.cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try? data.write(to: Self.cacheURL)
+            Log.agent.notice("skill catalog loaded \(self.entries.count) entries from \(Self.base)")
+        } catch {
+            lastError = error.localizedDescription
+            Log.agent.error("skill catalog refresh failed (\(Self.base)): \(error.localizedDescription)")
+        }
+    }
+
+    /// Reads a catalog/body URL. File URLs are read directly
+    static func fetch(_ url: URL) async throws -> Data {
+        if url.isFileURL { return try Data(contentsOf: url) }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -24,7 +24,14 @@ enum SkillExternalAgent: String, CaseIterable, Sendable {
     }
 }
 
-/// Reads skills from `~/.palmier/skills/` (the single source of truth)
+/// Result of scanning the skills folder, computed off the main actor.
+struct SkillScan: Sendable {
+    let skills: [Skill]
+    let bodies: [String: String]
+    let shas: [String: String]
+}
+
+/// Reads skills from `~/.palmier/skills/` — the single source of truth.
 @Observable
 @MainActor
 final class SkillStore {
@@ -32,30 +39,43 @@ final class SkillStore {
 
     private(set) var skills: [Skill] = []
 
-    /// Ledger of catalog-installed skills: id → the sha installed
+    /// Catalog-installed skills: id → the sha installed. A skill here is "community"; one
+    /// in the folder but not here is the user's own.
     private(set) var installed: [String: String] = [:]
 
-    // Caches populated by reload() from the file text it already reads, so the body and
-    // content hash don't trigger a fresh disk read on every view render.
+    // Filled by a scan so body and content hash are cache lookups, not per-render disk reads.
     private var bodyCache: [String: String] = [:]
     private var shaCache: [String: String] = [:]
 
-    static var directory: URL {
+    nonisolated static var directory: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".palmier/skills", isDirectory: true)
     }
 
     private static var ledgerURL: URL { directory.appendingPathComponent(".installed.json") }
 
-    private init() { reload() }
+    private init() { Task { await reloadInBackground() } }
 
-    /// Rescans the skills folder and the install ledger, caching each body and content hash.
-    func reload() {
+    func reload() { apply(Self.scan()) }
+
+    func reloadInBackground() async {
+        let scan = await Task.detached(priority: .utility) { Self.scan() }.value
+        apply(scan)
+    }
+
+    private func apply(_ scan: SkillScan) {
+        skills = scan.skills
+        bodyCache = scan.bodies
+        shaCache = scan.shas
+        installed = Self.loadLedger()
+    }
+
+    nonisolated static func scan() -> SkillScan {
         let fm = FileManager.default
         var found: [Skill] = []
         var bodies: [String: String] = [:]
         var shas: [String: String] = [:]
-        if let entries = try? fm.contentsOfDirectory(at: Self.directory, includingPropertiesForKeys: nil) {
+        if let entries = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) {
             for dir in entries {
                 let md = dir.appendingPathComponent("SKILL.md")
                 guard let text = try? String(contentsOf: md, encoding: .utf8) else { continue }
@@ -64,21 +84,17 @@ final class SkillStore {
                 let id = dir.lastPathComponent
                 found.append(Skill(id: id, name: name, description: description, path: md))
                 bodies[id] = body
-                shas[id] = Self.sha12(Data(text.utf8))
+                shas[id] = sha12(Data(text.utf8))
             }
         }
-        skills = found.sorted { $0.id < $1.id }
-        bodyCache = bodies
-        shaCache = shas
-        installed = Self.loadLedger()
+        return SkillScan(skills: found.sorted { $0.id < $1.id }, bodies: bodies, shas: shas)
     }
 
     // MARK: Catalog install / ledger
 
-    /// Content hash of the skill's SKILL.md
     func localSha(_ skill: Skill) -> String? { shaCache[skill.id] }
 
-    /// Downloads a catalog skill into the folder
+    /// Downloads a catalog skill into the folder; also used to apply an update.
     func install(_ entry: SkillCatalogEntry) async {
         guard let url = SkillCatalog.bodyURL(path: entry.path) else { return }
         do {
@@ -94,7 +110,7 @@ final class SkillStore {
         }
     }
 
-    private static func sha12(_ data: Data) -> String {
+    nonisolated private static func sha12(_ data: Data) -> String {
         String(SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined().prefix(12))
     }
 
@@ -143,9 +159,8 @@ final class SkillStore {
         reload()
     }
 
-    /// Copies the skill's folder into an external agent's skills directory under a
-    /// `palmier-` prefix, so we only ever overwrite our own prior copy — never a
-    /// skill the user authored there.
+    /// Copies under a `palmier-` prefix so we only overwrite our own prior copy, never a
+    /// skill the user authored in the target agent's folder.
     func copy(_ skill: Skill, to agent: SkillExternalAgent) {
         let source = skill.path.deletingLastPathComponent()
         let dest = agent.skillsDirectory.appendingPathComponent("palmier-\(skill.id)", isDirectory: true)
@@ -160,7 +175,6 @@ final class SkillStore {
         }
     }
 
-    /// Removes a skill's folder from `~/.palmier/skills/`.
     func delete(_ skill: Skill) {
         try? FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
         installed[skill.id] = nil
@@ -168,7 +182,6 @@ final class SkillStore {
         reload()
     }
 
-    /// Scaffolds a new skill folder with a template SKILL.md
     @discardableResult
     func newSkill() -> String? {
         let fm = FileManager.default

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -80,6 +80,23 @@ final class SkillStore {
         shaCache = scan.shas
     }
 
+    /// Parsed contents of one SKILL.md when it passes the same checks as `scan`.
+    private struct ParsedSkill: Sendable {
+        let skill: Skill
+        let body: String
+        let sha: String
+    }
+
+    nonisolated private static func parseSkill(id: String, path: URL, text: String) -> ParsedSkill? {
+        let (fields, body) = SkillFrontmatter.parse(text)
+        guard let name = fields["name"], let description = fields["description"] else { return nil }
+        return ParsedSkill(
+            skill: Skill(id: id, name: name, description: description, path: path),
+            body: body,
+            sha: sha12(Data(text.utf8))
+        )
+    }
+
     nonisolated static func scan() -> SkillScan {
         let fm = FileManager.default
         var found: [Skill] = []
@@ -89,12 +106,11 @@ final class SkillStore {
             for dir in entries {
                 let md = dir.appendingPathComponent("SKILL.md")
                 guard let text = try? String(contentsOf: md, encoding: .utf8) else { continue }
-                let (fields, body) = SkillFrontmatter.parse(text)
-                guard let name = fields["name"], let description = fields["description"] else { continue }
                 let id = dir.lastPathComponent
-                found.append(Skill(id: id, name: name, description: description, path: md))
-                bodies[id] = body
-                shas[id] = sha12(Data(text.utf8))
+                guard let parsed = parseSkill(id: id, path: md, text: text) else { continue }
+                found.append(parsed.skill)
+                bodies[id] = parsed.body
+                shas[id] = parsed.sha
             }
         }
         return SkillScan(skills: found.sorted { $0.id < $1.id }, bodies: bodies, shas: shas)
@@ -107,19 +123,56 @@ final class SkillStore {
     @discardableResult
     func install(_ entry: SkillCatalogEntry) async -> Bool {
         guard let url = SkillCatalog.bodyURL(path: entry.path) else { return false }
+        guard let dir = Self.skillDirectory(for: entry.id) else {
+            Log.agent.error("install skill \(entry.id) rejected: invalid id")
+            return false
+        }
         do {
             let data = try await SkillCatalog.fetch(url)
-            let dir = Self.directory.appendingPathComponent(entry.id, isDirectory: true)
+            guard let text = String(data: data, encoding: .utf8) else {
+                Log.agent.error("install skill \(entry.id) rejected: invalid UTF-8")
+                return false
+            }
+            let md = dir.appendingPathComponent("SKILL.md")
+            guard Self.parseSkill(id: entry.id, path: md, text: text) != nil else {
+                Log.agent.error("install skill \(entry.id) rejected: missing name or description frontmatter")
+                return false
+            }
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try data.write(to: dir.appendingPathComponent("SKILL.md"))
+            try data.write(to: md)
+            reload()
+            guard skills.contains(where: { $0.id == entry.id }) else {
+                try? FileManager.default.removeItem(at: dir)
+                Log.agent.error("install skill \(entry.id) rejected: SKILL.md not recognized after install")
+                return false
+            }
             installed[entry.id] = entry.sha
             writeLedger()
-            reload()
             return true
         } catch {
             Log.agent.error("install skill \(entry.id) failed: \(error.localizedDescription)")
             return false
         }
+    }
+
+    /// Resolves `~/.palmier/skills/<id>/` only when `id` is a single safe path component.
+    nonisolated static func skillDirectory(for id: String) -> URL? {
+        guard isValidSkillId(id) else { return nil }
+        let dir = directory.appendingPathComponent(id, isDirectory: true).standardizedFileURL
+        guard isUnderSkillsRoot(dir) else { return nil }
+        return dir
+    }
+
+    nonisolated private static func isValidSkillId(_ id: String) -> Bool {
+        guard !id.isEmpty, id != ".", id != ".." else { return false }
+        guard !id.contains("/"), !id.contains("\\") else { return false }
+        return true
+    }
+
+    nonisolated private static func isUnderSkillsRoot(_ url: URL) -> Bool {
+        let root = directory.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        return path == root || path.hasPrefix(root + "/")
     }
 
     nonisolated private static func sha12(_ data: Data) -> String {

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -1,0 +1,141 @@
+import Foundation
+import AppKit
+
+/// External coding agents that read the same SKILL.md format from their own folders.
+enum SkillExternalAgent: String, CaseIterable, Sendable {
+    case claude, codex, cursor
+
+    var label: String {
+        switch self {
+        case .claude: "Claude Code"
+        case .codex: "Codex"
+        case .cursor: "Cursor"
+        }
+    }
+
+    var skillsDirectory: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        switch self {
+        case .claude: return home.appendingPathComponent(".claude/skills", isDirectory: true)
+        case .codex: return home.appendingPathComponent(".codex/skills", isDirectory: true)
+        case .cursor: return home.appendingPathComponent(".cursor/skills", isDirectory: true)
+        }
+    }
+}
+
+/// Reads skills from `~/.palmier/skills/` (the single source of truth)
+@Observable
+@MainActor
+final class SkillStore {
+    static let shared = SkillStore()
+
+    private(set) var skills: [Skill] = []
+
+    static var directory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".palmier/skills", isDirectory: true)
+    }
+
+    private init() { reload() }
+
+    /// Rescans the skills folder
+    func reload() {
+        let fm = FileManager.default
+        var found: [Skill] = []
+        if let entries = try? fm.contentsOfDirectory(at: Self.directory, includingPropertiesForKeys: nil) {
+            for dir in entries {
+                let md = dir.appendingPathComponent("SKILL.md")
+                guard let text = try? String(contentsOf: md, encoding: .utf8) else { continue }
+                let (fields, _) = SkillFrontmatter.parse(text)
+                guard let name = fields["name"], let description = fields["description"] else { continue }
+                found.append(Skill(id: dir.lastPathComponent, name: name, description: description, path: md))
+            }
+        }
+        skills = found.sorted { $0.id < $1.id }
+    }
+
+    func body(for id: String) -> String? {
+        guard let skill = skills.first(where: { $0.id == id }),
+              let text = try? String(contentsOf: skill.path, encoding: .utf8)
+        else { return nil }
+        return SkillFrontmatter.parse(text).body
+    }
+
+    /// The always-on index appended to the in-app assistant's system prompt: one line
+    /// per skill so the model knows what's available; full bodies load via read_skill.
+    var promptIndex: String {
+        guard !skills.isEmpty else { return "" }
+        let lines = skills.map { "- \($0.id): \($0.description)" }.joined(separator: "\n")
+        return """
+
+
+            # Skills
+            Playbooks for specific tasks. Before a task that matches one, call read_skill(id) \
+            to load its full procedure, then follow it.
+            \(lines)
+            """
+    }
+
+    func openFolder() {
+        try? FileManager.default.createDirectory(
+            at: Self.directory, withIntermediateDirectories: true
+        )
+        NSWorkspace.shared.open(Self.directory)
+    }
+
+    func reveal(_ url: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func save(_ skill: Skill, raw: String) {
+        try? raw.write(to: skill.path, atomically: true, encoding: .utf8)
+        reload()
+    }
+
+    /// Copies the skill's folder into an external agent's skills directory
+    func copy(_ skill: Skill, to agent: SkillExternalAgent) {
+        let source = skill.path.deletingLastPathComponent()
+        let dest = agent.skillsDirectory.appendingPathComponent(skill.id, isDirectory: true)
+        let fm = FileManager.default
+        do {
+            try fm.createDirectory(at: agent.skillsDirectory, withIntermediateDirectories: true)
+            if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
+            try fm.copyItem(at: source, to: dest)
+            reveal(dest)
+        } catch {
+            Log.agent.error("copy skill to \(agent.rawValue) failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Scaffolds a new skill folder with a template SKILL.md
+    @discardableResult
+    func newSkill() -> String? {
+        let fm = FileManager.default
+        var id = "new-skill"
+        var n = 2
+        while fm.fileExists(atPath: Self.directory.appendingPathComponent(id).path) {
+            id = "new-skill-\(n)"; n += 1
+        }
+        let dir = Self.directory.appendingPathComponent(id, isDirectory: true)
+        let md = dir.appendingPathComponent("SKILL.md")
+        let template = """
+            ---
+            name: New skill
+            description: Describe in one line when the assistant should use this skill.
+            ---
+
+            ## Workflow
+            1. First step.
+            2. Second step.
+            """
+        do {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            try template.write(to: md, atomically: true, encoding: .utf8)
+        } catch {
+            return nil
+        }
+        reload()
+        reveal(md)
+        return id
+    }
+}

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import CryptoKit
 
 /// External coding agents that read the same SKILL.md format from their own folders.
 enum SkillExternalAgent: String, CaseIterable, Sendable {
@@ -31,35 +32,85 @@ final class SkillStore {
 
     private(set) var skills: [Skill] = []
 
+    /// Ledger of catalog-installed skills: id → the sha installed
+    private(set) var installed: [String: String] = [:]
+
+    // Caches populated by reload() from the file text it already reads, so the body and
+    // content hash don't trigger a fresh disk read on every view render.
+    private var bodyCache: [String: String] = [:]
+    private var shaCache: [String: String] = [:]
+
     static var directory: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".palmier/skills", isDirectory: true)
     }
 
+    private static var ledgerURL: URL { directory.appendingPathComponent(".installed.json") }
+
     private init() { reload() }
 
-    /// Rescans the skills folder
+    /// Rescans the skills folder and the install ledger, caching each body and content hash.
     func reload() {
         let fm = FileManager.default
         var found: [Skill] = []
+        var bodies: [String: String] = [:]
+        var shas: [String: String] = [:]
         if let entries = try? fm.contentsOfDirectory(at: Self.directory, includingPropertiesForKeys: nil) {
             for dir in entries {
                 let md = dir.appendingPathComponent("SKILL.md")
                 guard let text = try? String(contentsOf: md, encoding: .utf8) else { continue }
-                let (fields, _) = SkillFrontmatter.parse(text)
+                let (fields, body) = SkillFrontmatter.parse(text)
                 guard let name = fields["name"], let description = fields["description"] else { continue }
-                found.append(Skill(id: dir.lastPathComponent, name: name, description: description, path: md))
+                let id = dir.lastPathComponent
+                found.append(Skill(id: id, name: name, description: description, path: md))
+                bodies[id] = body
+                shas[id] = Self.sha12(Data(text.utf8))
             }
         }
         skills = found.sorted { $0.id < $1.id }
+        bodyCache = bodies
+        shaCache = shas
+        installed = Self.loadLedger()
     }
 
-    func body(for id: String) -> String? {
-        guard let skill = skills.first(where: { $0.id == id }),
-              let text = try? String(contentsOf: skill.path, encoding: .utf8)
-        else { return nil }
-        return SkillFrontmatter.parse(text).body
+    // MARK: Catalog install / ledger
+
+    /// Content hash of the skill's SKILL.md
+    func localSha(_ skill: Skill) -> String? { shaCache[skill.id] }
+
+    /// Downloads a catalog skill into the folder
+    func install(_ entry: SkillCatalogEntry) async {
+        guard let url = SkillCatalog.bodyURL(path: entry.path) else { return }
+        do {
+            let data = try await SkillCatalog.fetch(url)
+            let dir = Self.directory.appendingPathComponent(entry.id, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try data.write(to: dir.appendingPathComponent("SKILL.md"))
+            installed[entry.id] = entry.sha
+            writeLedger()
+            reload()
+        } catch {
+            Log.agent.error("install skill \(entry.id) failed: \(error.localizedDescription)")
+        }
     }
+
+    private static func sha12(_ data: Data) -> String {
+        String(SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined().prefix(12))
+    }
+
+    private static func loadLedger() -> [String: String] {
+        guard let data = try? Data(contentsOf: ledgerURL),
+              let map = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return map
+    }
+
+    private func writeLedger() {
+        try? FileManager.default.createDirectory(at: Self.directory, withIntermediateDirectories: true)
+        if let data = try? JSONEncoder().encode(installed) { try? data.write(to: Self.ledgerURL) }
+    }
+
+    func body(for id: String) -> String? { bodyCache[id] }
 
     /// The always-on index appended to the in-app assistant's system prompt: one line
     /// per skill so the model knows what's available; full bodies load via read_skill.
@@ -112,6 +163,8 @@ final class SkillStore {
     /// Removes a skill's folder from `~/.palmier/skills/`.
     func delete(_ skill: Skill) {
         try? FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
+        installed[skill.id] = nil
+        writeLedger()
         reload()
     }
 
@@ -143,7 +196,16 @@ final class SkillStore {
             return nil
         }
         reload()
-        reveal(md)
         return id
+    }
+
+    /// Updates only the `name` frontmatter field, leaving the rest of the SKILL.md intact.
+    func rename(_ skill: Skill, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != skill.name,
+              let text = try? String(contentsOf: skill.path, encoding: .utf8) else { return }
+        let updated = SkillFrontmatter.replacingName(text, name: trimmed)
+        try? updated.write(to: skill.path, atomically: true, encoding: .utf8)
+        reload()
     }
 }

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -56,7 +56,10 @@ final class SkillStore {
 
     private var reloadGeneration = 0
 
-    private init() { Task { await reloadInBackground() } }
+    private init() {
+        installed = Self.loadLedger()
+        Task { await reloadInBackground() }
+    }
 
     func reload() {
         reloadGeneration += 1
@@ -75,7 +78,6 @@ final class SkillStore {
         skills = scan.skills
         bodyCache = scan.bodies
         shaCache = scan.shas
-        installed = Self.loadLedger()
     }
 
     nonisolated static func scan() -> SkillScan {
@@ -102,9 +104,9 @@ final class SkillStore {
 
     func localSha(_ skill: Skill) -> String? { shaCache[skill.id] }
 
-    /// Downloads a catalog skill into the folder; also used to apply an update.
-    func install(_ entry: SkillCatalogEntry) async {
-        guard let url = SkillCatalog.bodyURL(path: entry.path) else { return }
+    @discardableResult
+    func install(_ entry: SkillCatalogEntry) async -> Bool {
+        guard let url = SkillCatalog.bodyURL(path: entry.path) else { return false }
         do {
             let data = try await SkillCatalog.fetch(url)
             let dir = Self.directory.appendingPathComponent(entry.id, isDirectory: true)
@@ -113,8 +115,10 @@ final class SkillStore {
             installed[entry.id] = entry.sha
             writeLedger()
             reload()
+            return true
         } catch {
             Log.agent.error("install skill \(entry.id) failed: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -224,9 +224,9 @@ final class SkillStore {
         reload()
     }
 
-    /// Copies under a `palmier-` prefix so we only overwrite our own prior copy, never a
-    /// skill the user authored in the target agent's folder.
-    func copy(_ skill: Skill, to agent: SkillExternalAgent) {
+    /// Copies under a `palmier-` prefix so we only overwrite our own prior copy
+    @discardableResult
+    func copy(_ skill: Skill, to agent: SkillExternalAgent) -> URL? {
         let source = skill.path.deletingLastPathComponent()
         let dest = agent.skillsDirectory.appendingPathComponent("palmier-\(skill.id)", isDirectory: true)
         let fm = FileManager.default
@@ -234,9 +234,10 @@ final class SkillStore {
             try fm.createDirectory(at: agent.skillsDirectory, withIntermediateDirectories: true)
             if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
             try fm.copyItem(at: source, to: dest)
-            reveal(dest)
+            return dest
         } catch {
             Log.agent.error("copy skill to \(agent.rawValue) failed: \(error.localizedDescription)")
+            return nil
         }
     }
 

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -54,12 +54,20 @@ final class SkillStore {
 
     private static var ledgerURL: URL { directory.appendingPathComponent(".installed.json") }
 
+    private var reloadGeneration = 0
+
     private init() { Task { await reloadInBackground() } }
 
-    func reload() { apply(Self.scan()) }
+    func reload() {
+        reloadGeneration += 1
+        apply(Self.scan())
+    }
 
     func reloadInBackground() async {
+        reloadGeneration += 1
+        let generation = reloadGeneration
         let scan = await Task.detached(priority: .utility) { Self.scan() }.value
+        guard generation == reloadGeneration else { return }
         apply(scan)
     }
 

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -7,7 +7,7 @@ enum SkillExternalAgent: String, CaseIterable, Sendable {
 
     var label: String {
         switch self {
-        case .claude: "Claude Code"
+        case .claude: "Claude"
         case .codex: "Codex"
         case .cursor: "Cursor"
         }
@@ -92,10 +92,12 @@ final class SkillStore {
         reload()
     }
 
-    /// Copies the skill's folder into an external agent's skills directory
+    /// Copies the skill's folder into an external agent's skills directory under a
+    /// `palmier-` prefix, so we only ever overwrite our own prior copy — never a
+    /// skill the user authored there.
     func copy(_ skill: Skill, to agent: SkillExternalAgent) {
         let source = skill.path.deletingLastPathComponent()
-        let dest = agent.skillsDirectory.appendingPathComponent(skill.id, isDirectory: true)
+        let dest = agent.skillsDirectory.appendingPathComponent("palmier-\(skill.id)", isDirectory: true)
         let fm = FileManager.default
         do {
             try fm.createDirectory(at: agent.skillsDirectory, withIntermediateDirectories: true)
@@ -105,6 +107,12 @@ final class SkillStore {
         } catch {
             Log.agent.error("copy skill to \(agent.rawValue) failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Removes a skill's folder from `~/.palmier/skills/`.
+    func delete(_ skill: Skill) {
+        try? FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
+        reload()
     }
 
     /// Scaffolds a new skill folder with a template SKILL.md

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -41,6 +41,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case deleteFolder = "delete_folder"
     case sendFeedback = "send_feedback"
     case setProjectSettings = "set_project_settings"
+    case readSkill = "read_skill"
 }
 
 struct AgentTool: @unchecked Sendable {
@@ -808,6 +809,21 @@ enum ToolDefinitions {
             }
             .joined(separator: "\n")
     }
+
+    /// In-app assistant only. Not registered with the MCP server
+    static let readSkill = AgentTool(
+        name: .readSkill,
+        description: "Load the full instructions for one of the skills listed under # Skills in your system prompt. Call this before starting a task that matches a skill's description, then follow the returned procedure. Pass the id exactly as listed.",
+        inputSchema: objectSchema(
+            properties: [
+                "id": ["type": "string", "description": "The skill id, exactly as listed under # Skills."],
+            ],
+            required: ["id"]
+        )
+    )
+
+    /// Tools for the in-app agent: every MCP tool plus read_skill.
+    static var inAppAgent: [AgentTool] { all + [readSkill] }
 
     private static func objectSchema(
         properties: [String: [String: Any]] = [:],

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -112,7 +112,18 @@ final class ToolExecutor {
         case .deleteFolder:  return try deleteFolder(editor, args)
         case .sendFeedback:  return try await sendFeedback(editor, args)
         case .setProjectSettings: return try setProjectSettings(editor, args)
+        case .readSkill:     return readSkill(args)
         }
+    }
+
+    func readSkill(_ args: [String: Any]) -> ToolResult {
+        guard let id = args.string("id") else {
+            return .error("read_skill requires an 'id'.")
+        }
+        guard let body = SkillStore.shared.body(for: id) else {
+            return .error("Unknown skill: \(id)")
+        }
+        return .ok(body)
     }
 
     /// Reverts the assistant's most recent timeline edit. Refuses to undo the user's own edits.

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case models
     case agent
+    case skills
     case storage
 
     var id: String { rawValue }
@@ -15,6 +16,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .models: return "Models"
         case .agent: return "Agent"
+        case .skills: return "Skills"
         case .storage: return "Storage"
         }
     }
@@ -25,6 +27,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "gearshape"
         case .models: return "square.stack.3d.up"
         case .agent: return "paperplane"
+        case .skills: return "book.closed"
         case .storage: return "internaldrive"
         }
     }
@@ -53,7 +56,12 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.black.opacity(AppTheme.Opacity.medium))
         }
-        .frame(minWidth: 760, idealWidth: 980, minHeight: 480, idealHeight: 640)
+        .frame(
+            minWidth: AppTheme.Window.settingsMin.width,
+            idealWidth: AppTheme.Window.settingsDefault.width,
+            minHeight: AppTheme.Window.settingsMin.height,
+            idealHeight: AppTheme.Window.settingsDefault.height
+        )
         .background(.ultraThinMaterial)
         .focusEffectDisabled()
         .onAppear {
@@ -124,6 +132,8 @@ private struct SettingsDetail: View {
                         ModelsPane()
                     case .agent:
                         AgentPane()
+                    case .skills:
+                        SkillsPane()
                     case .storage:
                         StoragePane()
                     }
@@ -174,10 +184,10 @@ final class SettingsWindowController: NSWindowController {
         let initialView = SettingsView().tint(AppTheme.Accent.primary)
         let hosting = NSHostingController(rootView: AnyView(initialView))
         let window = NSWindow(contentViewController: hosting)
-        window.setContentSize(NSSize(width: 980, height: 640))
-        window.minSize = NSSize(width: 760, height: 480)
+        window.setContentSize(AppTheme.Window.settingsDefault)
+        window.minSize = AppTheme.Window.settingsMin
         window.title = "Settings"
-        window.setFrameAutosaveName("PalmierProSettings-v2")
+        window.setFrameAutosaveName("PalmierProSettings-v3")
         window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -217,9 +217,9 @@ struct SkillsPane: View {
                     SkillAvailableRow(entry: entry, installing: installing.contains(entry.id)) {
                         installing.insert(entry.id)
                         Task {
-                            await store.install(entry)
+                            let ok = await store.install(entry)
                             installing.remove(entry.id)
-                            selection = entry.id
+                            if ok { selection = entry.id }
                         }
                     }
                 }
@@ -271,7 +271,6 @@ struct SkillsPane: View {
     private func commitTitle() {
         guard editingTitle else { return }
         editingTitle = false
-        // Rename the skill the edit started on (titleSkillId), not the now-selected one.
         if let skill = store.skills.first(where: { $0.id == titleSkillId }) {
             store.rename(skill, to: draftTitle)
         }

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct SkillsPane: View {
-    @State private var store = SkillStore.shared
-    @State private var catalog = SkillCatalog.shared
+    @Bindable private var store = SkillStore.shared
+    @Bindable private var catalog = SkillCatalog.shared
     @State private var selection: String?
     @State private var query = ""
     @State private var editing = false
@@ -18,7 +18,44 @@ struct SkillsPane: View {
     @State private var titleSkillId: String?
     @FocusState private var titleFocused: Bool
 
-    enum CommunityState { case upToDate, update, modified }
+    private enum CommunityState {
+        case upToDate, update, modified
+
+        var badge: SkillRowBadge? {
+            switch self {
+            case .update: .update
+            case .modified: .modified
+            case .upToDate: nil
+            }
+        }
+
+        func provenance(sha: String) -> String {
+            switch self {
+            case .modified: "Community · modified locally"
+            case .update: "Community · update available"
+            case .upToDate: "Community · v\(sha)"
+            }
+        }
+    }
+
+    private enum CommunityItem: Identifiable {
+        case installed(Skill)
+        case available(SkillCatalogEntry)
+
+        var id: String {
+            switch self {
+            case .installed(let s): s.id
+            case .available(let e): e.id
+            }
+        }
+
+        var sortName: String {
+            switch self {
+            case .installed(let s): s.name.lowercased()
+            case .available(let e): e.name.lowercased()
+            }
+        }
+    }
 
     private func matches(_ name: String, _ description: String) -> Bool {
         let q = query.trimmingCharacters(in: .whitespaces).lowercased()
@@ -35,28 +72,7 @@ struct SkillsPane: View {
 
     private var availableEntries: [SkillCatalogEntry] {
         let local = Set(store.skills.map(\.id))
-        return catalog.entries
-            .filter { !local.contains($0.id) }
-            .filter { matches($0.name, $0.description) }
-    }
-
-    /// Community section: installed-from-catalog skills plus not-yet-installed catalog
-    /// entries, merged and sorted by name. (The id sets are disjoint by construction.)
-    enum CommunityItem: Identifiable {
-        case installed(Skill)
-        case available(SkillCatalogEntry)
-        var id: String {
-            switch self {
-            case .installed(let s): s.id
-            case .available(let e): e.id
-            }
-        }
-        var sortName: String {
-            switch self {
-            case .installed(let s): s.name.lowercased()
-            case .available(let e): e.name.lowercased()
-            }
-        }
+        return catalog.entries.filter { !local.contains($0.id) && matches($0.name, $0.description) }
     }
 
     private var communityItems: [CommunityItem] {
@@ -73,12 +89,6 @@ struct SkillsPane: View {
         if store.localSha(skill) != ledger { return .modified }
         if let entry = catalog.entry(id: skill.id), entry.sha != ledger { return .update }
         return .upToDate
-    }
-
-    /// The catalog entry to install when an update is available for a community skill.
-    private func updateEntry(_ skill: Skill) -> SkillCatalogEntry? {
-        guard store.installed[skill.id] != nil, communityState(skill) == .update else { return nil }
-        return catalog.entry(id: skill.id)
     }
 
     var body: some View {
@@ -174,7 +184,7 @@ struct SkillsPane: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: AppTheme.BorderWidth.hairline) {
                     sectionHeader("My Skills", count: mySkills.count, expanded: $showMy)
-                    if showMy { skillRows(mySkills) }
+                    if showMy { skillListRows(mySkills) }
                     sectionHeader("Community", count: communityItems.count, expanded: $showCommunity)
                     if showCommunity { communityRows }
                     if let error = catalog.lastError, catalog.entries.isEmpty {
@@ -191,28 +201,18 @@ struct SkillsPane: View {
         }
     }
 
-    @ViewBuilder private func skillRows(_ items: [Skill]) -> some View {
-        if items.isEmpty {
-            emptyRow
-        } else {
-            ForEach(items) { skill in
-                SkillRow(skill: skill, isSelected: selected?.id == skill.id, badge: badge(for: skill)) {
-                    selection = skill.id
-                }
-            }
-        }
+    @ViewBuilder private func skillListRows(_ items: [Skill]) -> some View {
+        if items.isEmpty { emptyRow }
+        else { ForEach(items) { selectSkillRow($0) } }
     }
 
     @ViewBuilder private var communityRows: some View {
-        if communityItems.isEmpty {
-            emptyRow
-        } else {
+        if communityItems.isEmpty { emptyRow }
+        else {
             ForEach(communityItems) { item in
                 switch item {
                 case .installed(let skill):
-                    SkillRow(skill: skill, isSelected: selected?.id == skill.id, badge: badge(for: skill)) {
-                        selection = skill.id
-                    }
+                    selectSkillRow(skill)
                 case .available(let entry):
                     SkillAvailableRow(entry: entry, installing: installing.contains(entry.id)) {
                         installing.insert(entry.id)
@@ -224,6 +224,13 @@ struct SkillsPane: View {
                     }
                 }
             }
+        }
+    }
+
+    @ViewBuilder private func selectSkillRow(_ skill: Skill) -> some View {
+        let badge = store.installed[skill.id] != nil ? communityState(skill).badge : nil
+        SkillRow(skill: skill, isSelected: selected?.id == skill.id, badge: badge) {
+            selection = skill.id
         }
     }
 
@@ -259,29 +266,11 @@ struct SkillsPane: View {
         .buttonStyle(.plain)
     }
 
-    private func badge(for skill: Skill) -> SkillRowBadge? {
-        guard store.installed[skill.id] != nil else { return nil }
-        switch communityState(skill) {
-        case .update: return .update
-        case .modified: return .modified
-        case .upToDate: return nil
-        }
-    }
-
     private func commitTitle() {
         guard editingTitle else { return }
         editingTitle = false
         if let skill = store.skills.first(where: { $0.id == titleSkillId }) {
             store.rename(skill, to: draftTitle)
-        }
-    }
-
-    private func provenance(_ skill: Skill) -> String {
-        guard let sha = store.installed[skill.id] else { return "Local skill" }
-        switch communityState(skill) {
-        case .modified: return "Community · modified locally"
-        case .update: return "Community · update available"
-        case .upToDate: return "Community · v\(sha)"
         }
     }
 
@@ -312,6 +301,7 @@ struct SkillsPane: View {
 
     private func toolbar(_ skill: Skill) -> some View {
         let dirty = editing && draft != originalDraft
+        let state = communityState(skill)
         return HStack(spacing: AppTheme.Spacing.md) {
             if editingTitle {
                 TextField("Name", text: $draftTitle)
@@ -354,12 +344,16 @@ struct SkillsPane: View {
                     .foregroundStyle(AppTheme.Text.mutedColor)
             }
             if editing {
-                SkillSaveButton(dirty: dirty) {
-                    store.save(skill, raw: draft)
-                    originalDraft = draft
+                Button { store.save(skill, raw: draft); originalDraft = draft } label: {
+                    Text("Save")
+                        .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                        .foregroundStyle(dirty ? AppTheme.Accent.primary : AppTheme.Text.mutedColor)
                 }
+                .buttonStyle(.plain)
+                .keyboardShortcut("s", modifiers: .command)
+                .disabled(!dirty)
             }
-            if !editing, let entry = updateEntry(skill) {
+            if !editing, state == .update, let entry = catalog.entry(id: skill.id) {
                 Button("Update") { Task { await store.install(entry) } }
                     .buttonStyle(.plain)
                     .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
@@ -401,9 +395,15 @@ struct SkillsPane: View {
 
     private func viewContent(_ skill: Skill) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
-            Text(provenance(skill))
-                .font(.system(size: AppTheme.FontSize.xxs))
-                .foregroundStyle(AppTheme.Text.mutedColor)
+            if let sha = store.installed[skill.id] {
+                Text(communityState(skill).provenance(sha: sha))
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+            } else {
+                Text("Local skill")
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+            }
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
                 Text("DESCRIPTION")
                     .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
@@ -442,6 +442,24 @@ struct SkillsPane: View {
 
 // MARK: - Hover-aware controls
 
+private struct SkillSegmentButton: View {
+    let systemName: String
+    let active: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
+                .padding(.horizontal, AppTheme.Spacing.sm)
+                .padding(.vertical, AppTheme.Spacing.xs)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs, isActive: active)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 private struct SkillIconButton: View {
     let systemName: String
     let help: String
@@ -462,59 +480,15 @@ private struct SkillIconButton: View {
     }
 }
 
-private struct SkillSegmentButton: View {
-    let systemName: String
-    let active: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
-                .padding(.horizontal, AppTheme.Spacing.sm)
-                .padding(.vertical, AppTheme.Spacing.xs)
-                .hoverHighlight(cornerRadius: AppTheme.Radius.xs, isActive: active)
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-private struct SkillSaveButton: View {
-    let dirty: Bool
-    let action: () -> Void
-    @State private var hovering = false
-
-    var body: some View {
-        Button(action: action) {
-            Text("Save")
-                .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
-                .foregroundStyle(dirty ? AppTheme.Accent.primary : AppTheme.Text.mutedColor)
-                .opacity(hovering && dirty ? 0.75 : 1)
-        }
-        .buttonStyle(.plain)
-        .keyboardShortcut("s", modifiers: .command)
-        .disabled(!dirty)
-        .onHover { hovering = $0 }
-    }
-}
-
 private struct SkillCopyMenu: View {
     let skill: Skill
     let store: SkillStore
     @State private var showing = false
 
     var body: some View {
-        Button { showing.toggle() } label: {
-            Image(systemName: "square.and.arrow.up")
-                .font(.system(size: AppTheme.FontSize.md))
-                .foregroundStyle(AppTheme.Accent.primary)
-                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
-                .padding(AppTheme.Spacing.xs)
-                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
+        SkillIconButton(systemName: "square.and.arrow.up", help: "Copy to agent", tint: AppTheme.Accent.primary) {
+            showing.toggle()
         }
-        .buttonStyle(.plain)
-        .help("Copy to agent")
         .popover(isPresented: $showing, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
                 Text("COPY TO")
@@ -525,10 +499,19 @@ private struct SkillCopyMenu: View {
                     .padding(.top, AppTheme.Spacing.smMd)
                     .padding(.bottom, AppTheme.Spacing.xs)
                 ForEach(SkillExternalAgent.allCases, id: \.self) { agent in
-                    SkillPopoverRow(label: agent.label) {
+                    Button {
                         store.copy(skill, to: agent)
                         showing = false
+                    } label: {
+                        Text(agent.label)
+                            .font(.system(size: AppTheme.FontSize.sm))
+                            .foregroundStyle(AppTheme.Text.primaryColor)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, AppTheme.Spacing.md)
+                            .padding(.vertical, AppTheme.Spacing.sm)
+                            .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
                     }
+                    .buttonStyle(.plain)
                 }
             }
             .padding(.bottom, AppTheme.Spacing.xs)
@@ -537,25 +520,7 @@ private struct SkillCopyMenu: View {
     }
 }
 
-private struct SkillPopoverRow: View {
-    let label: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.primaryColor)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, AppTheme.Spacing.md)
-                .padding(.vertical, AppTheme.Spacing.sm)
-                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-enum SkillRowBadge { case update, modified }
+private enum SkillRowBadge { case update, modified }
 
 private struct SkillRow: View {
     let skill: Skill
@@ -573,28 +538,24 @@ private struct SkillRow: View {
                 .foregroundStyle(AppTheme.Text.primaryColor)
                 .lineLimit(1)
             Spacer(minLength: AppTheme.Spacing.xs)
-            badgeView
+            switch badge {
+            case .update:
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Accent.primary)
+            case .modified:
+                Text("Modified")
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+            case nil:
+                EmptyView()
+            }
         }
         .padding(.horizontal, AppTheme.Spacing.sm)
         .padding(.vertical, AppTheme.Spacing.smMd)
         .frame(maxWidth: .infinity, alignment: .leading)
         .hoverHighlight(cornerRadius: AppTheme.Radius.sm, isActive: isSelected)
         .onTapGesture(perform: action)
-    }
-
-    @ViewBuilder private var badgeView: some View {
-        switch badge {
-        case .update:
-            Image(systemName: "arrow.down.circle.fill")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Accent.primary)
-        case .modified:
-            Text("Modified")
-                .font(.system(size: AppTheme.FontSize.xxs))
-                .foregroundStyle(AppTheme.Text.mutedColor)
-        case nil:
-            EmptyView()
-        }
     }
 }
 

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -8,6 +8,7 @@ struct SkillsPane: View {
     @State private var draft = ""
     @State private var originalDraft = ""
     @State private var editSkillId: String?
+    @State private var confirmingDelete = false
 
     private var filtered: [Skill] {
         let q = query.trimmingCharacters(in: .whitespaces).lowercased()
@@ -54,6 +55,21 @@ struct SkillsPane: View {
         .onChange(of: selection) {
             editing = false
             editSkillId = nil
+        }
+        .confirmationDialog(
+            "Delete this skill?",
+            isPresented: $confirmingDelete,
+            titleVisibility: .visible,
+            presenting: selected
+        ) { skill in
+            Button("Delete \u{201C}\(skill.name)\u{201D}", role: .destructive) {
+                store.delete(skill)
+                selection = store.skills.first?.id
+                editing = false
+                editSkillId = nil
+            }
+        } message: { _ in
+            Text("This removes the folder from ~/.palmier/skills.")
         }
     }
 
@@ -147,6 +163,7 @@ struct SkillsPane: View {
             SkillIconButton(systemName: "arrow.up.forward.app", help: "Reveal in Finder", tint: AppTheme.Accent.primary) {
                 store.reveal(skill.path)
             }
+            SkillIconButton(systemName: "trash", help: "Delete skill") { confirmingDelete = true }
         }
         .padding(.horizontal, AppTheme.Spacing.xlXxl)
         .padding(.top, AppTheme.Spacing.md)

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -1,0 +1,385 @@
+import SwiftUI
+
+struct SkillsPane: View {
+    @State private var store = SkillStore.shared
+    @State private var selection: String?
+    @State private var query = ""
+    @State private var editing = false
+    @State private var draft = ""
+    @State private var originalDraft = ""
+    @State private var editSkillId: String?
+
+    private var filtered: [Skill] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return store.skills }
+        return store.skills.filter {
+            $0.name.lowercased().contains(q) || $0.description.lowercased().contains(q)
+        }
+    }
+
+    private var selected: Skill? {
+        store.skills.first { $0.id == selection } ?? store.skills.first
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+            Text("These skills are available to the in-app agent. For Claude/Codex/Cursor, use the copy button.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 0) {
+                leftColumn
+                    .frame(width: 220)
+                Divider().overlay(AppTheme.Border.subtleColor)
+                rightColumn
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            .frame(height: 600)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                    .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                    .strokeBorder(AppTheme.Border.primaryColor, lineWidth: AppTheme.BorderWidth.thin)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
+        }
+        .onAppear {
+            store.reload()
+            if selection == nil { selection = store.skills.first?.id }
+        }
+        .onChange(of: selection) {
+            editing = false
+            editSkillId = nil
+        }
+    }
+
+    // MARK: Left column (search + list)
+
+    private var leftColumn: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+                TextField("Search skills", text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                SkillIconButton(systemName: "plus", help: "New skill") { store.newSkill().map { selection = $0 } }
+                SkillIconButton(systemName: "folder", help: "Open skills folder") { store.openFolder() }
+            }
+            .padding(.horizontal, AppTheme.Spacing.md)
+            .padding(.vertical, AppTheme.Spacing.smMd)
+
+            Divider().overlay(AppTheme.Border.subtleColor)
+
+            if filtered.isEmpty {
+                Text(store.skills.isEmpty ? "No skills yet." : "No matches.")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(spacing: AppTheme.BorderWidth.hairline) {
+                        ForEach(filtered) { skill in
+                            SkillRow(skill: skill, isSelected: selected?.id == skill.id) {
+                                selection = skill.id
+                            }
+                        }
+                    }
+                    .padding(AppTheme.Spacing.xs)
+                }
+                .frame(maxHeight: .infinity)
+            }
+        }
+    }
+
+    // MARK: Right column
+
+    @ViewBuilder private var rightColumn: some View {
+        if let skill = selected {
+            VStack(alignment: .leading, spacing: 0) {
+                toolbar(skill)
+                if editing {
+                    editContent
+                } else {
+                    ScrollView {
+                        viewContent(skill)
+                            .padding(.horizontal, AppTheme.Spacing.xlXxl)
+                            .padding(.top, AppTheme.Spacing.md)
+                            .padding(.bottom, AppTheme.Spacing.xlXxl)
+                    }
+                }
+            }
+        } else {
+            Text("Select a skill.")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func toolbar(_ skill: Skill) -> some View {
+        let dirty = editing && draft != originalDraft
+        return HStack(spacing: AppTheme.Spacing.md) {
+            Text(skill.name)
+                .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .lineLimit(1)
+            Spacer(minLength: AppTheme.Spacing.md)
+            if editing, dirty {
+                Text("Edited")
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+            }
+            if editing {
+                SkillSaveButton(dirty: dirty) {
+                    store.save(skill, raw: draft)
+                    originalDraft = draft
+                }
+            }
+            viewEditToggle(skill)
+            SkillCopyMenu(skill: skill, store: store)
+            SkillIconButton(systemName: "arrow.up.forward.app", help: "Reveal in Finder", tint: AppTheme.Accent.primary) {
+                store.reveal(skill.path)
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.xlXxl)
+        .padding(.top, AppTheme.Spacing.md)
+        .padding(.bottom, AppTheme.Spacing.md)
+    }
+
+    private func viewEditToggle(_ skill: Skill) -> some View {
+        HStack(spacing: AppTheme.BorderWidth.hairline) {
+            SkillSegmentButton(systemName: "eye", active: !editing) { editing = false }
+            SkillSegmentButton(systemName: "chevron.left.forwardslash.chevron.right", active: editing) {
+                if editSkillId != skill.id {
+                    draft = (try? String(contentsOf: skill.path, encoding: .utf8)) ?? ""
+                    originalDraft = draft
+                    editSkillId = skill.id
+                }
+                editing = true
+            }
+        }
+        .padding(AppTheme.BorderWidth.thin)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+        )
+    }
+
+    // MARK: View / edit content
+
+    private func viewContent(_ skill: Skill) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+                Text("DESCRIPTION")
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                    .tracking(AppTheme.Tracking.tight)
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                Text(skill.description)
+                    .font(.system(size: AppTheme.FontSize.md))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            MarkdownText(text: store.body(for: skill.id) ?? "")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var editContent: some View {
+        TextEditor(text: $draft)
+            .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+            .foregroundStyle(AppTheme.Text.primaryColor)
+            .scrollContentBackground(.hidden)
+            .padding(AppTheme.Spacing.md)
+            .background(Color.white.opacity(AppTheme.Opacity.subtle))
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
+            .padding(.horizontal, AppTheme.Spacing.xlXxl)
+            .padding(.top, AppTheme.Spacing.md)
+            .padding(.bottom, AppTheme.Spacing.xlXxl)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Hover-aware controls
+
+private struct SkillIconButton: View {
+    let systemName: String
+    let help: String
+    var tint: Color = AppTheme.Text.secondaryColor
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: AppTheme.FontSize.md))
+                .foregroundStyle(tint)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+                .padding(AppTheme.Spacing.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                        .fill(hovering ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help(help)
+    }
+}
+
+private struct SkillSegmentButton: View {
+    let systemName: String
+    let active: Bool
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
+                .padding(.horizontal, AppTheme.Spacing.sm)
+                .padding(.vertical, AppTheme.Spacing.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                        .fill(fill)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+    }
+
+    private var fill: Color {
+        if active { return Color.white.opacity(AppTheme.Opacity.faint) }
+        if hovering { return Color.white.opacity(AppTheme.Opacity.subtle) }
+        return .clear
+    }
+}
+
+private struct SkillSaveButton: View {
+    let dirty: Bool
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text("Save")
+                .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                .foregroundStyle(dirty ? AppTheme.Accent.primary : AppTheme.Text.mutedColor)
+                .opacity(hovering && dirty ? 0.75 : 1)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut("s", modifiers: .command)
+        .disabled(!dirty)
+        .onHover { hovering = $0 }
+    }
+}
+
+private struct SkillCopyMenu: View {
+    let skill: Skill
+    let store: SkillStore
+    @State private var hovering = false
+    @State private var showing = false
+
+    var body: some View {
+        Button { showing.toggle() } label: {
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: AppTheme.FontSize.md))
+                .foregroundStyle(AppTheme.Accent.primary)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+                .padding(AppTheme.Spacing.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                        .fill(hovering ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help("Copy to agent")
+        .popover(isPresented: $showing, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("COPY TO")
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                    .tracking(AppTheme.Tracking.tight)
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.top, AppTheme.Spacing.smMd)
+                    .padding(.bottom, AppTheme.Spacing.xs)
+                ForEach(SkillExternalAgent.allCases, id: \.self) { agent in
+                    SkillPopoverRow(label: agent.label) {
+                        store.copy(skill, to: agent)
+                        showing = false
+                    }
+                }
+            }
+            .padding(.bottom, AppTheme.Spacing.xs)
+            .frame(minWidth: 168)
+        }
+    }
+}
+
+private struct SkillPopoverRow: View {
+    let label: String
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.sm)
+                .background(hovering ? Color.white.opacity(AppTheme.Opacity.subtle) : .clear)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+    }
+}
+
+private struct SkillRow: View {
+    let skill: Skill
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: "doc.text")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(isSelected ? AppTheme.Accent.primary : AppTheme.Text.mutedColor)
+            Text(skill.name)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(fill)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: action)
+        .onHover { hovering = $0 }
+    }
+
+    private var fill: Color {
+        if isSelected { return Color.white.opacity(AppTheme.Opacity.faint) }
+        if hovering { return Color.white.opacity(AppTheme.Opacity.subtle) }
+        return .clear
+    }
+}

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -15,6 +15,7 @@ struct SkillsPane: View {
     @State private var showCommunity = true
     @State private var editingTitle = false
     @State private var draftTitle = ""
+    @State private var titleSkillId: String?
     @FocusState private var titleFocused: Bool
 
     enum CommunityState { case upToDate, update, modified }
@@ -122,9 +123,9 @@ struct SkillsPane: View {
             if editing, draft != originalDraft, let edited = store.skills.first(where: { $0.id == editSkillId }) {
                 store.save(edited, raw: draft)
             }
+            commitTitle()
             editing = false
             editSkillId = nil
-            editingTitle = false
         }
         .confirmationDialog(
             "Delete this skill?",
@@ -267,10 +268,13 @@ struct SkillsPane: View {
         }
     }
 
-    private func commitTitle(_ skill: Skill) {
+    private func commitTitle() {
         guard editingTitle else { return }
         editingTitle = false
-        store.rename(skill, to: draftTitle)
+        // Rename the skill the edit started on (titleSkillId), not the now-selected one.
+        if let skill = store.skills.first(where: { $0.id == titleSkillId }) {
+            store.rename(skill, to: draftTitle)
+        }
     }
 
     private func provenance(_ skill: Skill) -> String {
@@ -327,9 +331,9 @@ struct SkillsPane: View {
                             .strokeBorder(AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium),
                                           lineWidth: AppTheme.BorderWidth.thin)
                     )
-                    .onSubmit { commitTitle(skill) }
+                    .onSubmit { commitTitle() }
                     .onExitCommand { editingTitle = false }
-                    .onChange(of: titleFocused) { if !titleFocused { commitTitle(skill) } }
+                    .onChange(of: titleFocused) { if !titleFocused { commitTitle() } }
             } else {
                 Text(skill.name)
                     .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
@@ -339,6 +343,7 @@ struct SkillsPane: View {
                     .onTapGesture(count: 2) {
                         guard !editing else { return }
                         draftTitle = skill.name
+                        titleSkillId = skill.id
                         editingTitle = true
                         titleFocused = true
                     }
@@ -377,7 +382,7 @@ struct SkillsPane: View {
         HStack(spacing: AppTheme.BorderWidth.hairline) {
             SkillSegmentButton(systemName: "eye", active: !editing) { editing = false }
             SkillSegmentButton(systemName: "chevron.left.forwardslash.chevron.right", active: editing) {
-                editingTitle = false
+                commitTitle()
                 if editSkillId != skill.id {
                     draft = (try? String(contentsOf: skill.path, encoding: .utf8)) ?? ""
                     originalDraft = draft

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -82,10 +82,17 @@ struct SkillsPane: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            Text("These skills are available to the in-app agent. For Claude/Codex/Cursor, use the copy button.")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text("These skills are available to the in-app agent. For Claude/Codex/Cursor, use the copy button.")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let url = URL(string: "https://github.com/palmier-io/palmier-skills") {
+                    Link("Check out community skills ↗", destination: url)
+                        .font(.system(size: AppTheme.FontSize.sm))
+                        .foregroundStyle(AppTheme.Accent.primary)
+                }
+            }
 
             HStack(spacing: 0) {
                 leftColumn

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -137,9 +137,7 @@ struct SkillsPane: View {
     }
 
     private func displayPath(_ skill: Skill) -> String {
-        let folder = skill.path.deletingLastPathComponent().path
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return folder.hasPrefix(home) ? "~" + folder.dropFirst(home.count) : folder
+        skill.path.deletingLastPathComponent().path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
     }
 
     // MARK: Left column (search + list)

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -28,13 +28,10 @@ struct SkillsPane: View {
         store.skills.filter { matches($0.name, $0.description) }
     }
 
-    /// Folder skills with no ledger entry — the user's own.
+    /// No ledger entry → the user's own; in the ledger → installed from the catalog.
     private var mySkills: [Skill] { filtered.filter { store.installed[$0.id] == nil } }
-
-    /// Folder skills installed from the catalog.
     private var communitySkills: [Skill] { filtered.filter { store.installed[$0.id] != nil } }
 
-    /// Catalog entries not present in the folder.
     private var availableEntries: [SkillCatalogEntry] {
         let local = Set(store.skills.map(\.id))
         return catalog.entries
@@ -67,7 +64,7 @@ struct SkillsPane: View {
     }
 
     private var selected: Skill? {
-        store.skills.first { $0.id == selection } ?? store.skills.first
+        filtered.first { $0.id == selection } ?? filtered.first
     }
 
     private func communityState(_ skill: Skill) -> CommunityState {
@@ -110,11 +107,14 @@ struct SkillsPane: View {
             .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
         }
         .onAppear {
-            store.reload()
             if selection == nil { selection = store.skills.first?.id }
+            Task { await store.reloadInBackground() }
             Task { await catalog.refresh() }
         }
         .onChange(of: selection) {
+            if editing, draft != originalDraft, let edited = store.skills.first(where: { $0.id == editSkillId }) {
+                store.save(edited, raw: draft)
+            }
             editing = false
             editSkillId = nil
             editingTitle = false

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SkillsPane: View {
     @State private var store = SkillStore.shared
+    @State private var catalog = SkillCatalog.shared
     @State private var selection: String?
     @State private var query = ""
     @State private var editing = false
@@ -9,17 +10,77 @@ struct SkillsPane: View {
     @State private var originalDraft = ""
     @State private var editSkillId: String?
     @State private var confirmingDelete = false
+    @State private var installing: Set<String> = []
+    @State private var showMy = true
+    @State private var showCommunity = true
+    @State private var editingTitle = false
+    @State private var draftTitle = ""
+    @FocusState private var titleFocused: Bool
+
+    enum CommunityState { case upToDate, update, modified }
+
+    private func matches(_ name: String, _ description: String) -> Bool {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        return q.isEmpty || name.lowercased().contains(q) || description.lowercased().contains(q)
+    }
 
     private var filtered: [Skill] {
-        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !q.isEmpty else { return store.skills }
-        return store.skills.filter {
-            $0.name.lowercased().contains(q) || $0.description.lowercased().contains(q)
+        store.skills.filter { matches($0.name, $0.description) }
+    }
+
+    /// Folder skills with no ledger entry — the user's own.
+    private var mySkills: [Skill] { filtered.filter { store.installed[$0.id] == nil } }
+
+    /// Folder skills installed from the catalog.
+    private var communitySkills: [Skill] { filtered.filter { store.installed[$0.id] != nil } }
+
+    /// Catalog entries not present in the folder.
+    private var availableEntries: [SkillCatalogEntry] {
+        let local = Set(store.skills.map(\.id))
+        return catalog.entries
+            .filter { !local.contains($0.id) }
+            .filter { matches($0.name, $0.description) }
+    }
+
+    /// Community section: installed-from-catalog skills plus not-yet-installed catalog
+    /// entries, merged and sorted by name. (The id sets are disjoint by construction.)
+    enum CommunityItem: Identifiable {
+        case installed(Skill)
+        case available(SkillCatalogEntry)
+        var id: String {
+            switch self {
+            case .installed(let s): s.id
+            case .available(let e): e.id
+            }
         }
+        var sortName: String {
+            switch self {
+            case .installed(let s): s.name.lowercased()
+            case .available(let e): e.name.lowercased()
+            }
+        }
+    }
+
+    private var communityItems: [CommunityItem] {
+        (communitySkills.map { CommunityItem.installed($0) } + availableEntries.map { CommunityItem.available($0) })
+            .sorted { $0.sortName < $1.sortName }
     }
 
     private var selected: Skill? {
         store.skills.first { $0.id == selection } ?? store.skills.first
+    }
+
+    private func communityState(_ skill: Skill) -> CommunityState {
+        let ledger = store.installed[skill.id]
+        if store.localSha(skill) != ledger { return .modified }
+        if let entry = catalog.entry(id: skill.id), entry.sha != ledger { return .update }
+        return .upToDate
+    }
+
+    /// The catalog entry to install when an update is available for a community skill.
+    private func updateEntry(_ skill: Skill) -> SkillCatalogEntry? {
+        guard store.installed[skill.id] != nil, communityState(skill) == .update else { return nil }
+        return catalog.entry(id: skill.id)
     }
 
     var body: some View {
@@ -51,10 +112,12 @@ struct SkillsPane: View {
         .onAppear {
             store.reload()
             if selection == nil { selection = store.skills.first?.id }
+            Task { await catalog.refresh() }
         }
         .onChange(of: selection) {
             editing = false
             editSkillId = nil
+            editingTitle = false
         }
         .confirmationDialog(
             "Delete this skill?",
@@ -68,9 +131,15 @@ struct SkillsPane: View {
                 editing = false
                 editSkillId = nil
             }
-        } message: { _ in
-            Text("This removes the folder from ~/.palmier/skills.")
+        } message: { skill in
+            Text("This permanently removes \(displayPath(skill)).")
         }
+    }
+
+    private func displayPath(_ skill: Skill) -> String {
+        let folder = skill.path.deletingLastPathComponent().path
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return folder.hasPrefix(home) ? "~" + folder.dropFirst(home.count) : folder
     }
 
     // MARK: Left column (search + list)
@@ -87,30 +156,124 @@ struct SkillsPane: View {
                     .foregroundStyle(AppTheme.Text.primaryColor)
                 SkillIconButton(systemName: "plus", help: "New skill") { store.newSkill().map { selection = $0 } }
                 SkillIconButton(systemName: "folder", help: "Open skills folder") { store.openFolder() }
+                SkillIconButton(systemName: "arrow.clockwise", help: "Refresh catalog") {
+                    Task { await catalog.refresh() }
+                }
             }
             .padding(.horizontal, AppTheme.Spacing.md)
             .padding(.vertical, AppTheme.Spacing.smMd)
 
             Divider().overlay(AppTheme.Border.subtleColor)
 
-            if filtered.isEmpty {
-                Text(store.skills.isEmpty ? "No skills yet." : "No matches.")
-                    .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    VStack(spacing: AppTheme.BorderWidth.hairline) {
-                        ForEach(filtered) { skill in
-                            SkillRow(skill: skill, isSelected: selected?.id == skill.id) {
-                                selection = skill.id
-                            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppTheme.BorderWidth.hairline) {
+                    sectionHeader("My Skills", count: mySkills.count, expanded: $showMy)
+                    if showMy { skillRows(mySkills) }
+                    sectionHeader("Community", count: communityItems.count, expanded: $showCommunity)
+                    if showCommunity { communityRows }
+                    if let error = catalog.lastError, catalog.entries.isEmpty {
+                        Text("Catalog: \(error)")
+                            .font(.system(size: AppTheme.FontSize.xxs))
+                            .foregroundStyle(AppTheme.Text.mutedColor)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(AppTheme.Spacing.sm)
+                    }
+                }
+                .padding(AppTheme.Spacing.xs)
+            }
+            .frame(maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder private func skillRows(_ items: [Skill]) -> some View {
+        if items.isEmpty {
+            emptyRow
+        } else {
+            ForEach(items) { skill in
+                SkillRow(skill: skill, isSelected: selected?.id == skill.id, badge: badge(for: skill)) {
+                    selection = skill.id
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var communityRows: some View {
+        if communityItems.isEmpty {
+            emptyRow
+        } else {
+            ForEach(communityItems) { item in
+                switch item {
+                case .installed(let skill):
+                    SkillRow(skill: skill, isSelected: selected?.id == skill.id, badge: badge(for: skill)) {
+                        selection = skill.id
+                    }
+                case .available(let entry):
+                    SkillAvailableRow(entry: entry, installing: installing.contains(entry.id)) {
+                        installing.insert(entry.id)
+                        Task {
+                            await store.install(entry)
+                            installing.remove(entry.id)
+                            selection = entry.id
                         }
                     }
-                    .padding(AppTheme.Spacing.xs)
                 }
-                .frame(maxHeight: .infinity)
             }
+        }
+    }
+
+    private var emptyRow: some View {
+        Text("None")
+            .font(.system(size: AppTheme.FontSize.sm))
+            .foregroundStyle(AppTheme.Text.mutedColor)
+            .padding(.horizontal, AppTheme.Spacing.sm)
+            .padding(.vertical, AppTheme.Spacing.xs)
+    }
+
+    private func sectionHeader(_ title: String, count: Int, expanded: Binding<Bool>) -> some View {
+        Button { expanded.wrappedValue.toggle() } label: {
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+                    .rotationEffect(.degrees(expanded.wrappedValue ? 90 : 0))
+                Text(title.uppercased())
+                    .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
+                    .tracking(AppTheme.Tracking.tight)
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+                Text("\(count)")
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.mutedColor.opacity(AppTheme.Opacity.prominent))
+                Spacer()
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, AppTheme.Spacing.sm)
+            .padding(.top, AppTheme.Spacing.smMd)
+            .padding(.bottom, AppTheme.Spacing.xxs)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func badge(for skill: Skill) -> SkillRowBadge? {
+        guard store.installed[skill.id] != nil else { return nil }
+        switch communityState(skill) {
+        case .update: return .update
+        case .modified: return .modified
+        case .upToDate: return nil
+        }
+    }
+
+    private func commitTitle(_ skill: Skill) {
+        guard editingTitle else { return }
+        editingTitle = false
+        store.rename(skill, to: draftTitle)
+    }
+
+    private func provenance(_ skill: Skill) -> String {
+        guard let sha = store.installed[skill.id] else { return "Local skill" }
+        switch communityState(skill) {
+        case .modified: return "Community · modified locally"
+        case .update: return "Community · update available"
+        case .upToDate: return "Community · v\(sha)"
         }
     }
 
@@ -142,10 +305,39 @@ struct SkillsPane: View {
     private func toolbar(_ skill: Skill) -> some View {
         let dirty = editing && draft != originalDraft
         return HStack(spacing: AppTheme.Spacing.md) {
-            Text(skill.name)
-                .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
-                .foregroundStyle(AppTheme.Text.primaryColor)
-                .lineLimit(1)
+            if editingTitle {
+                TextField("Name", text: $draftTitle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .focused($titleFocused)
+                    .padding(.horizontal, AppTheme.Spacing.xs)
+                    .padding(.vertical, AppTheme.Spacing.xxs)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                            .fill(Color.white.opacity(AppTheme.Opacity.faint))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                            .strokeBorder(AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium),
+                                          lineWidth: AppTheme.BorderWidth.thin)
+                    )
+                    .onSubmit { commitTitle(skill) }
+                    .onExitCommand { editingTitle = false }
+                    .onChange(of: titleFocused) { if !titleFocused { commitTitle(skill) } }
+            } else {
+                Text(skill.name)
+                    .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .lineLimit(1)
+                    .help("Double-click to rename")
+                    .onTapGesture(count: 2) {
+                        guard !editing else { return }
+                        draftTitle = skill.name
+                        editingTitle = true
+                        titleFocused = true
+                    }
+            }
             Spacer(minLength: AppTheme.Spacing.md)
             if editing, dirty {
                 Text("Edited")
@@ -157,6 +349,12 @@ struct SkillsPane: View {
                     store.save(skill, raw: draft)
                     originalDraft = draft
                 }
+            }
+            if !editing, let entry = updateEntry(skill) {
+                Button("Update") { Task { await store.install(entry) } }
+                    .buttonStyle(.plain)
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                    .foregroundStyle(AppTheme.Accent.primary)
             }
             viewEditToggle(skill)
             SkillCopyMenu(skill: skill, store: store)
@@ -174,6 +372,7 @@ struct SkillsPane: View {
         HStack(spacing: AppTheme.BorderWidth.hairline) {
             SkillSegmentButton(systemName: "eye", active: !editing) { editing = false }
             SkillSegmentButton(systemName: "chevron.left.forwardslash.chevron.right", active: editing) {
+                editingTitle = false
                 if editSkillId != skill.id {
                     draft = (try? String(contentsOf: skill.path, encoding: .utf8)) ?? ""
                     originalDraft = draft
@@ -192,18 +391,27 @@ struct SkillsPane: View {
     // MARK: View / edit content
 
     private func viewContent(_ skill: Skill) -> some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            Text(provenance(skill))
+                .font(.system(size: AppTheme.FontSize.xxs))
+                .foregroundStyle(AppTheme.Text.mutedColor)
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
                 Text("DESCRIPTION")
                     .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
                     .tracking(AppTheme.Tracking.tight)
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                 Text(skill.description)
-                    .font(.system(size: AppTheme.FontSize.md))
+                    .font(.system(size: AppTheme.FontSize.smMd))
                     .foregroundStyle(AppTheme.Text.secondaryColor)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            MarkdownText(text: store.body(for: skill.id) ?? "")
+            Divider().overlay(AppTheme.Border.subtleColor)
+                .padding(.vertical, AppTheme.Spacing.xs)
+            MarkdownText(
+                text: store.body(for: skill.id) ?? "",
+                proseFont: .system(size: AppTheme.FontSize.smMd),
+                blockSpacing: AppTheme.Spacing.sm
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -230,7 +438,6 @@ private struct SkillIconButton: View {
     let help: String
     var tint: Color = AppTheme.Text.secondaryColor
     let action: () -> Void
-    @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
@@ -239,14 +446,9 @@ private struct SkillIconButton: View {
                 .foregroundStyle(tint)
                 .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
                 .padding(AppTheme.Spacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                        .fill(hovering ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
-                )
-                .contentShape(Rectangle())
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
         .help(help)
     }
 }
@@ -255,7 +457,6 @@ private struct SkillSegmentButton: View {
     let systemName: String
     let active: Bool
     let action: () -> Void
-    @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
@@ -264,20 +465,9 @@ private struct SkillSegmentButton: View {
                 .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
                 .padding(.horizontal, AppTheme.Spacing.sm)
                 .padding(.vertical, AppTheme.Spacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                        .fill(fill)
-                )
-                .contentShape(Rectangle())
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs, isActive: active)
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
-    }
-
-    private var fill: Color {
-        if active { return Color.white.opacity(AppTheme.Opacity.faint) }
-        if hovering { return Color.white.opacity(AppTheme.Opacity.subtle) }
-        return .clear
     }
 }
 
@@ -303,7 +493,6 @@ private struct SkillSaveButton: View {
 private struct SkillCopyMenu: View {
     let skill: Skill
     let store: SkillStore
-    @State private var hovering = false
     @State private var showing = false
 
     var body: some View {
@@ -313,14 +502,9 @@ private struct SkillCopyMenu: View {
                 .foregroundStyle(AppTheme.Accent.primary)
                 .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
                 .padding(AppTheme.Spacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                        .fill(hovering ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
-                )
-                .contentShape(Rectangle())
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
         .help("Copy to agent")
         .popover(isPresented: $showing, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
@@ -347,7 +531,6 @@ private struct SkillCopyMenu: View {
 private struct SkillPopoverRow: View {
     let label: String
     let action: () -> Void
-    @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
@@ -357,19 +540,19 @@ private struct SkillPopoverRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, AppTheme.Spacing.md)
                 .padding(.vertical, AppTheme.Spacing.sm)
-                .background(hovering ? Color.white.opacity(AppTheme.Opacity.subtle) : .clear)
-                .contentShape(Rectangle())
+                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
         }
         .buttonStyle(.plain)
-        .onHover { hovering = $0 }
     }
 }
+
+enum SkillRowBadge { case update, modified }
 
 private struct SkillRow: View {
     let skill: Skill
     let isSelected: Bool
+    var badge: SkillRowBadge? = nil
     let action: () -> Void
-    @State private var hovering = false
 
     var body: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
@@ -380,23 +563,60 @@ private struct SkillRow: View {
                 .font(.system(size: AppTheme.FontSize.sm))
                 .foregroundStyle(AppTheme.Text.primaryColor)
                 .lineLimit(1)
-            Spacer(minLength: 0)
+            Spacer(minLength: AppTheme.Spacing.xs)
+            badgeView
         }
         .padding(.horizontal, AppTheme.Spacing.sm)
         .padding(.vertical, AppTheme.Spacing.smMd)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                .fill(fill)
-        )
-        .contentShape(Rectangle())
+        .hoverHighlight(cornerRadius: AppTheme.Radius.sm, isActive: isSelected)
         .onTapGesture(perform: action)
-        .onHover { hovering = $0 }
     }
 
-    private var fill: Color {
-        if isSelected { return Color.white.opacity(AppTheme.Opacity.faint) }
-        if hovering { return Color.white.opacity(AppTheme.Opacity.subtle) }
-        return .clear
+    @ViewBuilder private var badgeView: some View {
+        switch badge {
+        case .update:
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Accent.primary)
+        case .modified:
+            Text("Modified")
+                .font(.system(size: AppTheme.FontSize.xxs))
+                .foregroundStyle(AppTheme.Text.mutedColor)
+        case nil:
+            EmptyView()
+        }
+    }
+}
+
+private struct SkillAvailableRow: View {
+    let entry: SkillCatalogEntry
+    let installing: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: "doc.text")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.mutedColor)
+            Text(entry.name)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .lineLimit(1)
+            Spacer(minLength: AppTheme.Spacing.xs)
+            if installing {
+                ProgressView().controlSize(.small)
+            } else {
+                Button("Install", action: action)
+                    .buttonStyle(.plain)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                    .foregroundStyle(AppTheme.Accent.primary)
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+        .help(entry.description)
     }
 }

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -16,7 +16,17 @@ struct SkillsPane: View {
     @State private var editingTitle = false
     @State private var draftTitle = ""
     @State private var titleSkillId: String?
+    @State private var copyToast: CopyToast?
     @FocusState private var titleFocused: Bool
+
+    private struct CopyToast: Equatable {
+        let agentLabel: String
+        let url: URL
+
+        var displayPath: String {
+            url.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        }
+    }
 
     private enum CommunityState {
         case upToDate, update, modified
@@ -94,7 +104,7 @@ struct SkillsPane: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
-                Text("These skills are available to the in-app agent. For Claude/Codex/Cursor, use the copy button.")
+                Text("These skills are available to the in-app agent once installed. For Claude/Codex/Cursor, add them to their respective directories.")
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .fixedSize(horizontal: false, vertical: true)
@@ -112,7 +122,7 @@ struct SkillsPane: View {
                 rightColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
-            .frame(height: 600)
+            .frame(minHeight: 480, maxHeight: .infinity)
             .frame(maxWidth: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.md)
@@ -123,7 +133,15 @@ struct SkillsPane: View {
                     .strokeBorder(AppTheme.Border.primaryColor, lineWidth: AppTheme.BorderWidth.thin)
             )
             .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
+            .overlay(alignment: .top) {
+                if let toast = copyToast {
+                    copyToastBanner(toast)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: copyToast)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
             if selection == nil { selection = store.skills.first?.id }
             Task { await store.reloadInBackground() }
@@ -156,6 +174,51 @@ struct SkillsPane: View {
 
     private func displayPath(_ skill: Skill) -> String {
         skill.path.deletingLastPathComponent().path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+    }
+
+    private func copyToastBanner(_ toast: CopyToast) -> some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
+                .foregroundStyle(AppTheme.Status.successColor)
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text("Added to \(toast.agentLabel)")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                Text(toast.displayPath)
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: AppTheme.Spacing.md)
+            Button("Open") {
+                store.reveal(toast.url)
+                copyToast = nil
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+            .foregroundStyle(AppTheme.Accent.primary)
+        }
+        .padding(.horizontal, AppTheme.Spacing.mdLg)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .frame(maxWidth: 380)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .fill(AppTheme.Background.prominentColor)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                        .strokeBorder(AppTheme.Border.primaryColor, lineWidth: AppTheme.BorderWidth.hairline)
+                )
+        )
+        .shadow(AppTheme.Shadow.lg)
+        .padding(.top, AppTheme.Spacing.lgXl)
+        .onTapGesture { copyToast = nil }
+        .task(id: toast) {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            copyToast = nil
+        }
     }
 
     // MARK: Left column (search + list)
@@ -367,8 +430,10 @@ struct SkillsPane: View {
                     .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
                     .foregroundStyle(AppTheme.Accent.primary)
             }
+            SkillCopyMenu(skill: skill, store: store) { agent, url in
+                copyToast = CopyToast(agentLabel: agent.label, url: url)
+            }
             viewEditToggle(skill)
-            SkillCopyMenu(skill: skill, store: store)
             SkillIconButton(systemName: "arrow.up.forward.app", help: "Reveal in Finder", tint: AppTheme.Accent.primary) {
                 store.reveal(skill.path)
             }
@@ -491,27 +556,42 @@ private struct SkillIconButton: View {
 private struct SkillCopyMenu: View {
     let skill: Skill
     let store: SkillStore
+    let onCopied: (SkillExternalAgent, URL) -> Void
     @State private var showing = false
 
     var body: some View {
-        SkillIconButton(systemName: "square.and.arrow.up", help: "Copy to agent", tint: AppTheme.Accent.primary) {
-            showing.toggle()
+        Button { showing.toggle() } label: {
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Text("Add to Claude")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .semibold))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+            }
+            .foregroundStyle(AppTheme.Accent.primary)
+            .padding(.horizontal, AppTheme.Spacing.mdLg)
+            .padding(.vertical, AppTheme.Spacing.xs)
+            .background(
+                Capsule()
+                    .fill(AppTheme.Accent.primary.opacity(AppTheme.Opacity.subtle))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium),
+                                          lineWidth: AppTheme.BorderWidth.thin)
+                    )
+            )
         }
+        .buttonStyle(.plain)
+        .help("Add this skill to an agent")
         .popover(isPresented: $showing, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
-                Text("COPY TO")
-                    .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
-                    .tracking(AppTheme.Tracking.tight)
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .padding(.horizontal, AppTheme.Spacing.md)
-                    .padding(.top, AppTheme.Spacing.smMd)
-                    .padding(.bottom, AppTheme.Spacing.xs)
                 ForEach(SkillExternalAgent.allCases, id: \.self) { agent in
                     Button {
-                        store.copy(skill, to: agent)
+                        if let url = store.copy(skill, to: agent) {
+                            onCopied(agent, url)
+                        }
                         showing = false
                     } label: {
-                        Text(agent.label)
+                        Text("Add to \(agent.label)")
                             .font(.system(size: AppTheme.FontSize.sm))
                             .foregroundStyle(AppTheme.Text.primaryColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -522,7 +602,7 @@ private struct SkillCopyMenu: View {
                     .buttonStyle(.plain)
                 }
             }
-            .padding(.bottom, AppTheme.Spacing.xs)
+            .padding(.vertical, AppTheme.Spacing.xs)
             .frame(minWidth: 168)
         }
     }

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -130,9 +130,7 @@ struct SkillsPane: View {
             Task { await catalog.refresh() }
         }
         .onChange(of: selection) {
-            if editing, draft != originalDraft, let edited = store.skills.first(where: { $0.id == editSkillId }) {
-                store.save(edited, raw: draft)
-            }
+            commitDraftIfDirty()
             commitTitle()
             editing = false
             editSkillId = nil
@@ -144,6 +142,8 @@ struct SkillsPane: View {
             presenting: selected
         ) { skill in
             Button("Delete \u{201C}\(skill.name)\u{201D}", role: .destructive) {
+                commitDraftIfDirty()
+                commitTitle()
                 store.delete(skill)
                 selection = store.skills.first?.id
                 editing = false
@@ -264,6 +264,14 @@ struct SkillsPane: View {
             .padding(.bottom, AppTheme.Spacing.xxs)
         }
         .buttonStyle(.plain)
+    }
+
+    private func commitDraftIfDirty() {
+        guard draft != originalDraft,
+              let id = editSkillId,
+              let skill = store.skills.first(where: { $0.id == id }) else { return }
+        store.save(skill, raw: draft)
+        originalDraft = draft
     }
 
     private func commitTitle() {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -272,6 +272,8 @@ enum AppTheme {
         static let projectDefault = NSSize(width: 1600, height: 1000)
         static let projectMin = NSSize(width: 960, height: 600)
         static let projectTitlebarTrailingWidth: CGFloat = 280
+        static let settingsDefault = NSSize(width: 1200, height: 820)
+        static let settingsMin = NSSize(width: 860, height: 560)
     }
 
     enum Caption {


### PR DESCRIPTION
Skills for in app chat + external agents.

### How it works

Created a new public repo at https://github.com/palmier-io/palmier-skills to host all the skills. Local skills for palmier stores at `~/.palmier/skills`, similar to `~/.claude/skills`, `~/.cursor/skills`, `~/.codex/skills`.

The Skills tab in settings reads and writes `~/.palmier/skills`, where user can download from the repo, or add their own. These skills can be added to claude/cursor/codex by copying the skill to their respective folders.

The in app agent will have a `read-skill` tool, while external agents use their existing skill loading tool.

<img width="1312" height="784" alt="Screenshot 2026-06-27 at 1 24 48 AM" src="https://github.com/user-attachments/assets/f6718ac9-fa5b-4231-be62-da6c527f22a8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent system prompts and adds a new tool path; remote catalog installs write under the user home with path validation, but skill bodies can steer agent behavior once loaded.
> 
> **Overview**
> Adds a **Skills** system so the in-app agent can follow user-defined playbooks stored as `SKILL.md` under `~/.palmier/skills`, with a new **Skills** settings tab to manage them.
> 
> **In-app agent:** Each agent loop reloads skills, registers **`read_skill`** (via `ToolDefinitions.inAppAgent`, not MCP), and appends a **# Skills** index to the system prompt so the model can load full procedures on demand.
> 
> **Data & catalog:** `SkillStore` scans local folders (frontmatter `name`/`description`), caches bodies, tracks catalog installs in `.installed.json`, and supports install/update from the **palmier-skills** GitHub catalog (`SkillCatalog`, disk cache, `PALMIER_SKILLS_BASE` override). Users can create, edit, rename, delete skills and **copy** folders into Claude/Codex/Cursor skill dirs (`palmier-<id>`).
> 
> **UI:** `SkillsPane` lists “My” vs community skills, search, markdown preview (`MarkdownText` typography knobs), raw editor, install/update badges by content sha, and larger settings window sizes (`AppTheme.Window.settings*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7da18f5dbba3cb84e6ebddbc41ce02a87d9034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->