### PR TITLE
Captions: max words per caption

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -10,6 +10,8 @@ extension EditorViewModel {
         var textCase: CaptionCase = .auto
         var censorProfanity: Bool = false
         var locale: Locale? = nil
+        /// 0 = automatic (segment + width). >0 = at most this many words per caption.
+        var wordsPerCaption: Int = 0
     }
 
     enum CaptionCase: String, CaseIterable, Sendable {
@@ -166,10 +168,20 @@ extension EditorViewModel {
         for (ref, result) in results {
             let clips = targets.filter { $0.clip.mediaRef == ref }
             guard !clips.isEmpty else { continue }
-            let phrases = result.segments.flatMap { seg in
-                CaptionBuilder.phrases(
+            let phrases = result.segments.flatMap { seg -> [CaptionBuilder.Phrase] in
+                let segWords = wordsIn(seg, result.words)
+                // Fixed word count per caption (when set and we have word timings); else
+                // fall back to the automatic segment + width split.
+                if request.wordsPerCaption > 0, !segWords.isEmpty {
+                    return CaptionBuilder.phrases(
+                        words: segWords,
+                        maxWords: request.wordsPerCaption,
+                        minDuration: AppTheme.Caption.minDisplayDuration
+                    )
+                }
+                return CaptionBuilder.phrases(
                     for: seg,
-                    words: wordsIn(seg, result.words),
+                    words: segWords,
                     fits: { captionLineFits($0, style: request.style) },
                     minDuration: AppTheme.Caption.minDisplayDuration
                 )

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -170,9 +170,10 @@ extension EditorViewModel {
             guard !clips.isEmpty else { continue }
             let phrases = result.segments.flatMap { seg -> [CaptionBuilder.Phrase] in
                 let segWords = wordsIn(seg, result.words)
-                // Fixed word count per caption (when set and we have word timings); else
-                // fall back to the automatic segment + width split.
-                if request.wordsPerCaption > 0, !segWords.isEmpty {
+                // Fixed word count per caption — only when the timed words actually
+                // cover the segment's text, so we never silently drop untimed speech.
+                // Otherwise fall back to the automatic segment + width split.
+                if request.wordsPerCaption > 0, wordsCover(seg, segWords) {
                     return CaptionBuilder.phrases(
                         words: segWords,
                         maxWords: request.wordsPerCaption,
@@ -197,6 +198,17 @@ extension EditorViewModel {
             let cased = phrases.map { CaptionBuilder.Phrase(text: request.textCase.apply($0.text), start: $0.start, end: $0.end) }
             return CaptionBuilder.specs(for: cased, sourceClip: t.clip, trackIndex: 0, fps: fps, style: request.style, captionGroupId: groupId, transformFor: transformFor)
         }
+    }
+
+    /// True when the timed words reconstruct ~all of the segment's spoken text, so the
+    /// fixed-word-count path won't omit untimed/unmatched words. Compares alphanumerics.
+    private func wordsCover(_ seg: TranscriptionSegment, _ words: [TranscriptionWord]) -> Bool {
+        guard !words.isEmpty else { return false }
+        func alnum(_ s: String) -> Int { s.reduce(0) { $0 + ($1.isLetter || $1.isNumber ? 1 : 0) } }
+        let segCount = alnum(seg.text)
+        guard segCount > 0 else { return false }
+        let wordCount = words.reduce(0) { $0 + alnum($1.text) }
+        return Double(wordCount) >= 0.9 * Double(segCount)
     }
 
     // Words whose midpoint lands inside the segment, in transcript order.

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -19,6 +19,43 @@ enum CaptionBuilder {
         return enforceMinDuration(timed, minDuration: minDuration)
     }
 
+    /// Group words into phrases of at most `maxWords`, timed from each word's own
+    /// timestamps, starting a new phrase early when there's a long pause.
+    static func phrases(
+        words: [TranscriptionWord],
+        maxWords: Int,
+        minDuration: Double,
+        maxGap: Double = 0.7
+    ) -> [Phrase] {
+        let limit = max(1, maxWords)
+        var timed: [(text: String, start: Double, end: Double)] = []
+        var cursor = 0.0
+        for w in words {
+            let text = w.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            let start = w.start ?? cursor
+            let end = max(w.end ?? start, start)
+            cursor = max(cursor, end)
+            timed.append((text, start, end))
+        }
+        guard !timed.isEmpty else { return [] }
+
+        var phrases: [Phrase] = []
+        var group: [(text: String, start: Double, end: Double)] = []
+        func flush() {
+            guard let first = group.first, let last = group.last else { return }
+            phrases.append(Phrase(text: group.map(\.text).joined(separator: " "), start: first.start, end: last.end))
+            group.removeAll(keepingCapacity: true)
+        }
+        for w in timed {
+            if let last = group.last, w.start - last.end > maxGap { flush() }
+            group.append(w)
+            if group.count >= limit { flush() }
+        }
+        flush()
+        return enforceMinDuration(phrases, minDuration: minDuration)
+    }
+
     private static func split(_ text: String, fits: (String) -> Bool) -> [String] {
         let t = text.trimmingCharacters(in: .whitespaces)
         guard !t.isEmpty else { return [] }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -8,6 +8,7 @@ struct CaptionTab: View {
     @State private var selectedTrackId: String?
     @State private var selectedClipTargets: [String] = []
     @State private var textCase: EditorViewModel.CaptionCase = .auto
+    @State private var wordsPerCaption = 0   // 0 = automatic (segment + width)
     @State private var censorProfanity = false
     @State private var locale: Locale?
     @State private var supportedLocales: [Locale] = []
@@ -198,6 +199,19 @@ struct CaptionTab: View {
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                 }
                 .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).fixedSize().focusable(false)
+            }
+            InspectorRow(
+                icon: "text.word.spacing",
+                label: "Max words / caption",
+                labelHelp: "Auto follows sentences. Set a number to cap each caption at that many words (still splits early on a pause)."
+            ) {
+                ScrubbableNumberField(
+                    value: Double(wordsPerCaption),
+                    range: 0...12,
+                    format: "%.0f",
+                    displayTextOverride: { $0 < 1 ? "Auto" : "\(Int($0)) words" },
+                    onChanged: { wordsPerCaption = max(0, Int($0.rounded())) }
+                ) { wordsPerCaption = max(0, Int($0.rounded())) }
             }
             InspectorRow(icon: "exclamationmark.bubble", label: "Censor profanity") {
                 Toggle("", isOn: $censorProfanity)
@@ -394,7 +408,8 @@ struct CaptionTab: View {
         }
         let request = EditorViewModel.CaptionRequest(
             sourceClipIds: sourceIds, autoDetect: isAutoSource, style: style, center: center,
-            textCase: textCase, censorProfanity: censorProfanity, locale: locale
+            textCase: textCase, censorProfanity: censorProfanity, locale: locale,
+            wordsPerCaption: wordsPerCaption
         )
         Task {
             isGenerating = true

--- a/Tests/PalmierProTests/Captions/CaptionMaxWordsTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionMaxWordsTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Caption max words per caption")
+struct CaptionMaxWordsTests {
+
+    private func word(_ t: String, _ s: Double, _ e: Double) -> TranscriptionWord {
+        TranscriptionWord(text: t, start: s, end: e)
+    }
+
+    private var sixWords: [TranscriptionWord] {
+        [word("a", 0, 0.3), word("b", 0.3, 0.6), word("c", 0.6, 0.9),
+         word("d", 1.0, 1.3), word("e", 1.3, 1.6), word("f", 1.6, 1.9)]
+    }
+
+    @Test func capsAtThreeWordsWithRealTimings() {
+        let p = CaptionBuilder.phrases(words: sixWords, maxWords: 3, minDuration: 0.05)
+        #expect(p.count == 2)
+        #expect(p[0].text == "a b c")
+        #expect(p[0].start == 0)
+        #expect(abs(p[0].end - 0.9) < 0.001)
+        #expect(p[1].text == "d e f")
+    }
+
+    @Test func sixWordsFitOneCaption() {
+        #expect(CaptionBuilder.phrases(words: sixWords, maxWords: 6, minDuration: 0.05).count == 1)
+    }
+
+    @Test func longPauseSplitsEarly() {
+        let words = [word("hello", 0, 0.4), word("there", 2.0, 2.4)] // 1.6s gap
+        #expect(CaptionBuilder.phrases(words: words, maxWords: 6, minDuration: 0.05).count == 2)
+    }
+
+    @Test func emptyWordsProduceNothing() {
+        #expect(CaptionBuilder.phrases(words: [], maxWords: 3, minDuration: 0.05).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #91 (the words-per-caption half — timing drift was fixed separately by #189).

Adds an optional **Max words / caption** control in the Captions tab:
- `0` = **Auto** (current behaviour: sentence/segment + width).
- `1–12` = cap each caption at that many words, grouped from the real per-word timestamps (#189), splitting early on a long pause.

`CaptionRequest.wordsPerCaption` + `CaptionBuilder.phrases(words:maxWords:)`. 4 tests; builds clean on the macOS 26 SDK.

Rebased onto current main (supersedes my earlier #92, which predated #189).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caption UX and phrase-splitting logic only; guarded fallback when word timing is incomplete, with targeted tests.
> 
> **Overview**
> Adds an optional **Max words / caption** control in the Captions tab (`0` = **Auto**, `1–12` = fixed cap) and threads it through `CaptionRequest.wordsPerCaption`.
> 
> When a cap is set, caption generation can group per-word transcript timings into phrases of at most that many words via new `CaptionBuilder.phrases(words:maxWords:)`, splitting early on long pauses (~0.7s). `captionSpecs` only uses that path when `wordsCover` shows timed words match ~90% of the segment text; otherwise it keeps the existing segment + width-based splitting so untimed speech is not dropped.
> 
> Four unit tests cover word caps, pause splits, and empty input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b6876b60e014c057337501fb9566fc01089d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->