### PR TITLE
Per-clip blend modes

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -221,7 +221,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .setClipProperties,
-            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, or — for text clips only — content, fontName, fontSize, color, alignment. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
+            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, blendMode (video/image clips only), or — for text clips only — content, fontName, fontSize, color, alignment. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": [
@@ -252,6 +252,11 @@ enum ToolDefinitions {
                     "fontSize": ["type": "number", "description": "Text clips only. Font size in canvas points."],
                     "color": ["type": "string", "description": "Text clips only. Hex '#RRGGBB' or '#RRGGBBAA'."],
                     "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text clips only."],
+                    "blendMode": [
+                        "type": "string",
+                        "enum": BlendMode.allCases.map(\.rawValue),
+                        "description": "Video/image clips only. How the clip composites over the tracks below it (Premiere/Photoshop blend modes). 'normal' is the default (source-over) and clears any blend. Rejected on text/audio clips.",
+                    ],
                 ],
                 required: ["clipIds"]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -71,6 +71,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let fontSize: Double?
     let color: String?
     let alignment: String?
+    let blendMode: String?
 
     static let allowedKeys: Set<String> = [
         "clipIds",
@@ -78,6 +79,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
         "volume", "opacity",
         "transform",
         "content", "fontName", "fontSize", "color", "alignment",
+        "blendMode",
     ]
 
     var hasAnyProperty: Bool {
@@ -86,6 +88,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
             || transform != nil
             || content != nil || fontName != nil || fontSize != nil
             || color != nil || alignment != nil
+            || blendMode != nil
     }
 }
 
@@ -490,6 +493,22 @@ extension ToolExecutor {
             }
         }
 
+        // blendMode applies only to visual (video/image) clips. "normal" clears it.
+        var blendMode: BlendMode?
+        let setBlendMode = input.blendMode != nil
+        if let raw = input.blendMode {
+            let nonVisual = clipTypes.filter { $0.value == .text || $0.value == .audio }.map(\.key).sorted()
+            if !nonVisual.isEmpty {
+                throw ToolError("blendMode only applies to video/image clips: \(nonVisual.joined(separator: ", "))")
+            }
+            if raw != "normal" {
+                guard let m = BlendMode(rawValue: raw) else {
+                    throw ToolError("invalid blendMode '\(raw)'. Valid: \(BlendMode.allCases.map(\.rawValue).joined(separator: ", "))")
+                }
+                blendMode = m
+            }
+        }
+
         // Expand timing fields to linked partners via the shared model helper.
         // Partners drop trim/speed when they're text — handled per-partner below.
         let propagatesTiming = input.durationFrames != nil || input.trimStartFrame != nil
@@ -516,6 +535,8 @@ extension ToolExecutor {
                     fontSize: isText ? input.fontSize : nil,
                     color: isText ? color : nil,
                     alignment: isText ? alignment : nil,
+                    blendMode: blendMode,
+                    setBlendMode: setBlendMode,
                     clipId: id,
                     editor: editor
                 )
@@ -535,6 +556,7 @@ extension ToolExecutor {
                     speed:          partnerIsText ? nil : input.speed,
                     volume: nil, opacity: nil, transform: nil,
                     content: nil, fontName: nil, fontSize: nil, color: nil, alignment: nil,
+                    blendMode: nil, setBlendMode: false,
                     clipId: partnerId,
                     editor: editor
                 )
@@ -559,6 +581,8 @@ extension ToolExecutor {
         fontSize: Double?,
         color: TextStyle.RGBA?,
         alignment: TextStyle.Alignment?,
+        blendMode: BlendMode?,
+        setBlendMode: Bool,
         clipId: String,
         editor: EditorViewModel
     ) -> [String] {
@@ -586,6 +610,7 @@ extension ToolExecutor {
             // Setting a scalar clears any existing keyframe track on the same property.
             if let v = volume         { clip.volume  = v; clip.volumeTrack  = nil; changed.append("volume") }
             if let v = opacity        { clip.opacity = v; clip.opacityTrack = nil; changed.append("opacity") }
+            if setBlendMode           { clip.blendMode = blendMode; changed.append("blendMode") }
             if let t = transform {
                 let cur = clip.transform
                 var next = Transform(

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -18,19 +18,34 @@ enum FrameRenderer {
         var accum = CIImage(color: .black).cropped(to: renderRect)
         for layer in instruction.layers {
             guard let buffer = sourceFrame(layer.trackID) else { continue }
-            if let image = composedLayer(layer, buffer: buffer, frame: frame,
-                                         renderSize: instruction.renderSize) {
-                accum = composite(image, over: accum, mode: layer.clip.blendMode ?? .normal)
+            let mode = layer.clip.blendMode ?? .normal
+            // Source-over bakes opacity into alpha; blend modes apply it as a fade of
+            // the blend RESULT (Photoshop/Premiere semantics), so don't bake it there.
+            let isNormal = mode.ciFilterName == nil
+            guard let image = composedLayer(layer, buffer: buffer, frame: frame,
+                                            renderSize: instruction.renderSize,
+                                            bakeOpacity: isNormal) else { continue }
+            if isNormal {
+                accum = image.composited(over: accum)
+            } else {
+                let opacity = min(1.0, max(0.0, layer.clip.opacityAt(frame: frame)))
+                accum = blend(image, over: accum, filter: mode.ciFilterName!, opacity: opacity)
             }
         }
         context.render(accum, to: output, bounds: renderRect, colorSpace: nil)
         tag709(output)
     }
 
-    /// Composite `image` over `background` using the clip's blend mode (source-over for normal).
-    private static func composite(_ image: CIImage, over background: CIImage, mode: BlendMode) -> CIImage {
-        guard let name = mode.ciFilterName else { return image.composited(over: background) }
-        return image.applyingFilter(name, parameters: [kCIInputBackgroundImageKey: background])
+    /// Blend `image` over `background` at full strength, then fade the result back toward
+    /// the background by `opacity` — so opacity/fades scale the blend, not the source alpha.
+    private static func blend(_ image: CIImage, over background: CIImage, filter name: String, opacity: Double) -> CIImage {
+        let blended = image.applyingFilter(name, parameters: [kCIInputBackgroundImageKey: background])
+        guard opacity < 1 else { return blended }
+        let f = CIFilter(name: "CIDissolveTransition")
+        f?.setValue(background, forKey: kCIInputImageKey)
+        f?.setValue(blended, forKey: "inputTargetImage")
+        f?.setValue(opacity, forKey: "inputTime")
+        return f?.outputImage ?? blended
     }
 
     /// Tag output Rec. 709 at the buffer level so downstream reads our bytes correctly.
@@ -47,7 +62,8 @@ enum FrameRenderer {
         _ layer: LayerPlan,
         buffer: CVPixelBuffer,
         frame: Int,
-        renderSize: CGSize
+        renderSize: CGSize,
+        bakeOpacity: Bool = true
     ) -> CIImage? {
         let clip = layer.clip
         let alpha = min(1.0, max(0.0, clip.opacityAt(frame: frame)))
@@ -94,7 +110,7 @@ enum FrameRenderer {
         let ci = flipY(srcHeight).concatenating(av).concatenating(flipY(renderSize.height))
         image = image.transformed(by: ci)
 
-        if alpha < 1 {
+        if bakeOpacity, alpha < 1 {
             // Alpha only — CIColorMatrix re-premultiplies by the result's alpha, so
             // scaling RGB too would double the fade.
             image = image.applyingFilter("CIColorMatrix", parameters: [

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -20,11 +20,17 @@ enum FrameRenderer {
             guard let buffer = sourceFrame(layer.trackID) else { continue }
             if let image = composedLayer(layer, buffer: buffer, frame: frame,
                                          renderSize: instruction.renderSize) {
-                accum = image.composited(over: accum)
+                accum = composite(image, over: accum, mode: layer.clip.blendMode ?? .normal)
             }
         }
         context.render(accum, to: output, bounds: renderRect, colorSpace: nil)
         tag709(output)
+    }
+
+    /// Composite `image` over `background` using the clip's blend mode (source-over for normal).
+    private static func composite(_ image: CIImage, over background: CIImage, mode: BlendMode) -> CIImage {
+        guard let name = mode.ciFilterName else { return image.composited(over: background) }
+        return image.applyingFilter(name, parameters: [kCIInputBackgroundImageKey: background])
     }
 
     /// Tag output Rec. 709 at the buffer level so downstream reads our bytes correctly.

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -39,13 +39,16 @@ enum FrameRenderer {
     /// Blend `image` over `background` at full strength, then fade the result back toward
     /// the background by `opacity` — so opacity/fades scale the blend, not the source alpha.
     private static func blend(_ image: CIImage, over background: CIImage, filter name: String, opacity: Double) -> CIImage {
+        // CI blend filters output only the foreground's extent; composite back over the
+        // background so areas outside the clip keep the layers below (no black regions).
         let blended = image.applyingFilter(name, parameters: [kCIInputBackgroundImageKey: background])
+            .composited(over: background)
         guard opacity < 1 else { return blended }
         let f = CIFilter(name: "CIDissolveTransition")
         f?.setValue(background, forKey: kCIInputImageKey)
         f?.setValue(blended, forKey: "inputTargetImage")
         f?.setValue(opacity, forKey: "inputTime")
-        return f?.outputImage ?? blended
+        return (f?.outputImage ?? blended).cropped(to: background.extent)
     }
 
     /// Tag output Rec. 709 at the buffer level so downstream reads our bytes correctly.

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -474,6 +474,7 @@ struct InspectorView: View {
                     }
                     cropRow(single: single)
                     flipRow(clips: clips)
+                    blendRow(clips: clips)
                 }
                 .padding(.leading, sectionContentIndent)
             }
@@ -704,6 +705,31 @@ struct InspectorView: View {
     }
 
     // MARK: - Flip
+
+    private func blendRow(clips: [Clip]) -> some View {
+        let current = clips.first?.blendMode ?? .normal
+        let mixed = clips.count > 1 && !clips.allSatisfy { ($0.blendMode ?? .normal) == current }
+        return propertyRow(label: "Blend") {
+            Menu {
+                ForEach(BlendMode.allCases, id: \.self) { m in
+                    Button(m.displayName) {
+                        commitToClips(clips, actionName: "Blend Mode") { c in
+                            editor.commitClipProperty(clipId: c.id) { $0.blendMode = (m == .normal ? nil : m) }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: AppTheme.Spacing.xxs) {
+                    Text(mixed ? "—" : current.displayName)
+                    Image(systemName: "chevron.up.chevron.down").font(.system(size: AppTheme.FontSize.xxs))
+                }
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+            }
+            .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).fixedSize().focusable(false)
+        }
+        .frame(height: KeyframesMetrics.rowHeight)
+    }
 
     @ViewBuilder
     private func flipRow(clips: [Clip]) -> some View {

--- a/Sources/PalmierPro/Models/BlendMode.swift
+++ b/Sources/PalmierPro/Models/BlendMode.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// How a visual clip composites over the layers below it. `normal` = source-over.
+enum BlendMode: String, Codable, Sendable, CaseIterable {
+    case normal, darken, multiply, colorBurn, lighten, screen, colorDodge
+    case overlay, softLight, hardLight, difference, exclusion
+    case hue, saturation, color, luminosity
+
+    var displayName: String {
+        switch self {
+        case .normal: "Normal"
+        case .darken: "Darken"
+        case .multiply: "Multiply"
+        case .colorBurn: "Color Burn"
+        case .lighten: "Lighten"
+        case .screen: "Screen"
+        case .colorDodge: "Color Dodge"
+        case .overlay: "Overlay"
+        case .softLight: "Soft Light"
+        case .hardLight: "Hard Light"
+        case .difference: "Difference"
+        case .exclusion: "Exclusion"
+        case .hue: "Hue"
+        case .saturation: "Saturation"
+        case .color: "Color"
+        case .luminosity: "Luminosity"
+        }
+    }
+
+    /// Core Image blend-filter name; nil for `normal` (plain source-over compositing).
+    var ciFilterName: String? {
+        switch self {
+        case .normal: nil
+        case .darken: "CIDarkenBlendMode"
+        case .multiply: "CIMultiplyBlendMode"
+        case .colorBurn: "CIColorBurnBlendMode"
+        case .lighten: "CILightenBlendMode"
+        case .screen: "CIScreenBlendMode"
+        case .colorDodge: "CIColorDodgeBlendMode"
+        case .overlay: "CIOverlayBlendMode"
+        case .softLight: "CISoftLightBlendMode"
+        case .hardLight: "CIHardLightBlendMode"
+        case .difference: "CIDifferenceBlendMode"
+        case .exclusion: "CIExclusionBlendMode"
+        case .hue: "CIHueBlendMode"
+        case .saturation: "CISaturationBlendMode"
+        case .color: "CIColorBlendMode"
+        case .luminosity: "CILuminosityBlendMode"
+        }
+    }
+}

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -108,6 +108,9 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
 
     var effects: [Effect]?
 
+    /// How this clip composites over the tracks below it. nil = normal (source-over).
+    var blendMode: BlendMode?
+
     private enum CodingKeys: String, CodingKey {
         case id, mediaRef, mediaType, sourceClipType, startFrame, durationFrames
         case trimStartFrame, trimEndFrame, speed, volume
@@ -115,7 +118,7 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case opacity, transform, crop
         case linkGroupId, captionGroupId, textContent, textStyle
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
-        case effects
+        case effects, blendMode
     }
 
     /// Frame where this clip ends on the timeline
@@ -360,7 +363,8 @@ extension Clip {
             rotationTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .rotationTrack),
             cropTrack: try? c.decode(KeyframeTrack<Crop>.self, forKey: .cropTrack),
             volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack),
-            effects: try? c.decode([Effect].self, forKey: .effects)
+            effects: try? c.decode([Effect].self, forKey: .effects),
+            blendMode: try? c.decode(BlendMode.self, forKey: .blendMode)
         )
     }
 }

--- a/Tests/PalmierProTests/Agent/SetClipBlendModeTests.swift
+++ b/Tests/PalmierProTests/Agent/SetClipBlendModeTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("set_clip_properties — blendMode")
+@MainActor
+struct SetClipBlendModeTests {
+
+    private func harness() -> (ToolHarness, String) {
+        let clip = Fixtures.clip(id: "v1", start: 0, duration: 30)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        return (ToolHarness(timeline: timeline), clip.id)
+    }
+
+    private func blendMode(_ h: ToolHarness, _ id: String) -> BlendMode? {
+        h.editor.timeline.tracks[0].clips[0].blendMode
+    }
+
+    @Test func setsBlendMode() async {
+        let (h, id) = harness()
+        let r = await h.runRaw("set_clip_properties", args: ["clipIds": [id], "blendMode": "screen"])
+        #expect(r.isError == false)
+        #expect(blendMode(h, id) == .screen)
+    }
+
+    @Test func normalClearsBlendMode() async {
+        let (h, id) = harness()
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": [id], "blendMode": "multiply"])
+        #expect(blendMode(h, id) == .multiply)
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": [id], "blendMode": "normal"])
+        #expect(blendMode(h, id) == nil)
+    }
+
+    @Test func invalidBlendModeErrors() async {
+        let (h, id) = harness()
+        let r = await h.runRaw("set_clip_properties", args: ["clipIds": [id], "blendMode": "glow"])
+        #expect(r.isError)
+    }
+
+    @Test func rejectedOnAudioClip() async {
+        let clip = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 30)
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [clip])]))
+        let r = await h.runRaw("set_clip_properties", args: ["clipIds": ["a1"], "blendMode": "screen"])
+        #expect(r.isError)
+    }
+}

--- a/Tests/PalmierProTests/Rendering/BlendModeTests.swift
+++ b/Tests/PalmierProTests/Rendering/BlendModeTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import Foundation
+@testable import PalmierPro
+
+@Suite("Blend modes")
+struct BlendModeTests {
+
+    @Test func normalHasNoFilterEverythingElseDoes() {
+        #expect(BlendMode.normal.ciFilterName == nil)
+        for mode in BlendMode.allCases where mode != .normal {
+            #expect(mode.ciFilterName != nil, "\(mode) should map to a CIFilter")
+        }
+        #expect(BlendMode.screen.ciFilterName == "CIScreenBlendMode")
+        #expect(BlendMode.multiply.ciFilterName == "CIMultiplyBlendMode")
+    }
+
+    @Test func clipBlendModeRoundTrips() throws {
+        var clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 30)
+        clip.blendMode = .overlay
+        let decoded = try JSONDecoder().decode(Clip.self, from: JSONEncoder().encode(clip))
+        #expect(decoded.blendMode == .overlay)
+    }
+
+    @Test func oldClipJSONDecodesWithNilBlendMode() throws {
+        let json = #"{"mediaRef":"m","startFrame":0,"durationFrames":30}"#
+        let clip = try JSONDecoder().decode(Clip.self, from: Data(json.utf8))
+        #expect(clip.blendMode == nil)
+    }
+}


### PR DESCRIPTION
Closes #98.

Adds 16 Premiere-style **per-clip blend modes** (multiply, screen, overlay, lighten, darken, soft light, luminosity, …) on top of the new Metal/Core Image compositor (#8).

- Applied at the **layer compositing** stage in `FrameRenderer` (a clip blends with the tracks below it) — not a per-clip pixel effect.
- `Clip.blendMode` (Codable, backward-compatible; nil = Normal / source-over).
- **Blend** picker in the clip inspector's Transform section (multi-select aware).
- Core Image blend filters; renders in preview **and** export. 3 tests.

Rebased onto current main (supersedes the blend half of my earlier #99; chroma key/grading already landed via #8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core frame compositor path used for preview and export; behavior changes for non-normal blends and opacity interaction, though changes are localized and covered by tests.
> 
> **Overview**
> Adds **16 Premiere-style per-clip blend modes** (multiply, screen, overlay, etc.) so each visual layer composites over the tracks below it—not as a per-pixel effect stack entry.
> 
> **Model & UI:** New `BlendMode` enum maps to Core Image filters; `Clip.blendMode` is Codable (`nil` = Normal, backward-compatible). The clip inspector Transform section gets a **Blend** menu with multi-select mixed-state handling.
> 
> **Rendering:** `FrameRenderer` branches on blend mode: Normal keeps source-over with opacity baked into alpha; non-normal modes use CI blend filters, composite back over the full canvas to avoid holes, and apply opacity as a fade on the **blend result** (Premiere/Photoshop-style).
> 
> **Agent:** `set_clip_properties` accepts `blendMode` for video/image only; `"normal"` clears the property; text/audio are rejected.
> 
> Tests cover agent validation, JSON round-trip, and CI filter mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3783cb7e0ef925bc29d534a0afa59b2ab575ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->