### PR TITLE
Fix window sizing for home, settings, and project windows

### DIFF
--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -24,7 +24,12 @@ struct HomeView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.black.opacity(AppTheme.Opacity.medium))
         }
-        .frame(minWidth: 760, minHeight: 480)
+        .frame(
+            minWidth: AppTheme.Window.homeMin.width,
+            maxWidth: .infinity,
+            minHeight: AppTheme.Window.homeMin.height,
+            maxHeight: .infinity
+        )
         .background(.ultraThinMaterial)
         .focusEffectDisabled()
         .task { await VisualModelLoader.shared.prepare() }
@@ -51,6 +56,7 @@ struct HomeView: View {
                 .padding(.bottom, AppTheme.Spacing.sm)
             projectGrid
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private var header: some View {
@@ -216,11 +222,12 @@ final class HomeWindowController: NSWindowController {
 
     private init() {
         let hostingController = NSHostingController(rootView: HomeView().tint(AppTheme.Accent.primary))
+        hostingController.sizingOptions = .minSize
         let window = NSWindow(contentViewController: hostingController)
         window.setContentSize(AppTheme.Window.homeDefault)
         window.minSize = AppTheme.Window.homeMin
         window.title = "Palmier Pro"
-        window.setFrameAutosaveName("PalmierProHome-v2")
+        window.setFrameAutosaveName("PalmierProHome-v4")
         window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -227,7 +227,7 @@ final class HomeWindowController: NSWindowController {
         window.setContentSize(AppTheme.Window.homeDefault)
         window.minSize = AppTheme.Window.homeMin
         window.title = "Palmier Pro"
-        window.setFrameAutosaveName("PalmierProHome-v4")
+        window.setFrameAutosaveName("PalmierProHome-v3")
         window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -333,15 +333,13 @@ final class VideoProject: NSDocument {
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = true
         window.backgroundColor = NSColor(AppTheme.Background.surfaceColor)
-        if !NSWindow.hasAutosavedFrame(name: autosaveName) {
-            window.fillVisibleScreen()
-        }
+        window.fillVisibleScreen()
 
         window.addTitlebarSwiftUI(TitleBarLeadingView().environment(editorViewModel), side: .leading, width: AppTheme.IconSize.lg + AppTheme.Spacing.sm)
         window.addTitlebarSwiftUI(TitleBarTrailingView().environment(editorViewModel), side: .trailing, width: AppTheme.Window.projectTitlebarTrailingWidth)
 
         let controller = EditorWindowController(editorViewModel: editorViewModel, window: window)
-        controller.shouldCascadeWindows = false
+        controller.shouldCascadeWindows = true
         controller.installKeyMonitor()
         addWindowController(controller)
 
@@ -524,10 +522,6 @@ final class VideoProject: NSDocument {
 // MARK: - NSWindow helper
 
 extension NSWindow {
-    static func hasAutosavedFrame(name: String) -> Bool {
-        UserDefaults.standard.object(forKey: "NSWindow Frame \(name)") != nil
-    }
-
     func fillVisibleScreen(using screen: NSScreen? = nil) {
         let target = screen ?? self.screen ?? NSScreen.main
         guard let frame = target?.visibleFrame else { return }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -323,22 +323,25 @@ final class VideoProject: NSDocument {
                     .environment(editorViewModel)
             }
         let hostingController = NSHostingController(rootView: editorView.tint(AppTheme.Accent.primary))
+        hostingController.sizingOptions = .minSize
 
+        let autosaveName = "PalmierProWindow-v2"
         let window = NSWindow(contentViewController: hostingController)
-        window.setContentSize(AppTheme.Window.projectDefault)
         window.minSize = AppTheme.Window.projectMin
-        window.setFrameAutosaveName("PalmierProWindow")
+        window.setFrameAutosaveName(autosaveName)
         window.appearance = NSAppearance(named: .darkAqua)
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = true
         window.backgroundColor = NSColor(AppTheme.Background.surfaceColor)
-        window.center()
+        if !NSWindow.hasAutosavedFrame(name: autosaveName) {
+            window.fillVisibleScreen()
+        }
 
         window.addTitlebarSwiftUI(TitleBarLeadingView().environment(editorViewModel), side: .leading, width: AppTheme.IconSize.lg + AppTheme.Spacing.sm)
         window.addTitlebarSwiftUI(TitleBarTrailingView().environment(editorViewModel), side: .trailing, width: AppTheme.Window.projectTitlebarTrailingWidth)
 
         let controller = EditorWindowController(editorViewModel: editorViewModel, window: window)
-        controller.shouldCascadeWindows = true
+        controller.shouldCascadeWindows = false
         controller.installKeyMonitor()
         addWindowController(controller)
 
@@ -521,6 +524,16 @@ final class VideoProject: NSDocument {
 // MARK: - NSWindow helper
 
 extension NSWindow {
+    static func hasAutosavedFrame(name: String) -> Bool {
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(name)") != nil
+    }
+
+    func fillVisibleScreen(using screen: NSScreen? = nil) {
+        let target = screen ?? self.screen ?? NSScreen.main
+        guard let frame = target?.visibleFrame else { return }
+        setFrame(frame, display: true)
+    }
+
     func addTitlebarSwiftUI<V: View>(_ view: V, side: NSLayoutConstraint.Attribute, width: CGFloat) {
         let host = NSHostingController(rootView: view.tint(AppTheme.Accent.primary))
         host.view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -325,23 +325,18 @@ final class VideoProject: NSDocument {
         let hostingController = NSHostingController(rootView: editorView.tint(AppTheme.Accent.primary))
         hostingController.sizingOptions = .minSize
 
-        let autosaveName = "PalmierProWindow-v2"
         let window = NSWindow(contentViewController: hostingController)
         window.minSize = AppTheme.Window.projectMin
-        window.setFrameAutosaveName(autosaveName)
         window.appearance = NSAppearance(named: .darkAqua)
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = true
         window.backgroundColor = NSColor(AppTheme.Background.surfaceColor)
-        if !NSWindow.hasAutosavedFrame(name: autosaveName) {
-            window.fillVisibleScreen()
-        }
+        window.fillVisibleScreen()
 
         window.addTitlebarSwiftUI(TitleBarLeadingView().environment(editorViewModel), side: .leading, width: AppTheme.IconSize.lg + AppTheme.Spacing.sm)
         window.addTitlebarSwiftUI(TitleBarTrailingView().environment(editorViewModel), side: .trailing, width: AppTheme.Window.projectTitlebarTrailingWidth)
 
         let controller = EditorWindowController(editorViewModel: editorViewModel, window: window)
-        controller.shouldCascadeWindows = true
         controller.installKeyMonitor()
         addWindowController(controller)
 
@@ -524,10 +519,6 @@ final class VideoProject: NSDocument {
 // MARK: - NSWindow helper
 
 extension NSWindow {
-    static func hasAutosavedFrame(name: String) -> Bool {
-        UserDefaults.standard.object(forKey: "NSWindow Frame \(name)") != nil
-    }
-
     func fillVisibleScreen(using screen: NSScreen? = nil) {
         let target = screen ?? self.screen ?? NSScreen.main
         guard let frame = target?.visibleFrame else { return }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -333,7 +333,9 @@ final class VideoProject: NSDocument {
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = true
         window.backgroundColor = NSColor(AppTheme.Background.surfaceColor)
-        window.fillVisibleScreen()
+        if !NSWindow.hasAutosavedFrame(name: autosaveName) {
+            window.fillVisibleScreen()
+        }
 
         window.addTitlebarSwiftUI(TitleBarLeadingView().environment(editorViewModel), side: .leading, width: AppTheme.IconSize.lg + AppTheme.Spacing.sm)
         window.addTitlebarSwiftUI(TitleBarTrailingView().environment(editorViewModel), side: .trailing, width: AppTheme.Window.projectTitlebarTrailingWidth)
@@ -522,6 +524,10 @@ final class VideoProject: NSDocument {
 // MARK: - NSWindow helper
 
 extension NSWindow {
+    static func hasAutosavedFrame(name: String) -> Bool {
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(name)") != nil
+    }
+
     func fillVisibleScreen(using screen: NSScreen? = nil) {
         let target = screen ?? self.screen ?? NSScreen.main
         guard let frame = target?.visibleFrame else { return }

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -58,9 +58,9 @@ struct SettingsView: View {
         }
         .frame(
             minWidth: AppTheme.Window.settingsMin.width,
-            idealWidth: AppTheme.Window.settingsDefault.width,
+            maxWidth: .infinity,
             minHeight: AppTheme.Window.settingsMin.height,
-            idealHeight: AppTheme.Window.settingsDefault.height
+            maxHeight: .infinity
         )
         .background(.ultraThinMaterial)
         .focusEffectDisabled()
@@ -120,29 +120,37 @@ private struct SettingsDetail: View {
             .padding(.top, AppTheme.Spacing.xxl)
             .padding(.bottom, AppTheme.Spacing.lgXl)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-                    switch tab {
-                    case .account:
-                        AccountPane()
-                    case .general:
-                        NotificationsPane()
-                        PrivacyPane()
-                    case .models:
-                        ModelsPane()
-                    case .agent:
-                        AgentPane()
-                    case .skills:
-                        SkillsPane()
-                    case .storage:
-                        StoragePane()
+            Group {
+                if tab == .skills {
+                    SkillsPane()
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+                            switch tab {
+                            case .account:
+                                AccountPane()
+                            case .general:
+                                NotificationsPane()
+                                PrivacyPane()
+                            case .models:
+                                ModelsPane()
+                            case .agent:
+                                AgentPane()
+                            case .skills:
+                                EmptyView()
+                            case .storage:
+                                StoragePane()
+                            }
+                        }
+                        .padding(.horizontal, AppTheme.Spacing.xlXxl)
+                        .padding(.bottom, AppTheme.Spacing.xlXxl)
                     }
+                    .scrollEdgeEffectStyle(.soft, for: .top)
                 }
-                .padding(.horizontal, AppTheme.Spacing.xlXxl)
-                .padding(.bottom, AppTheme.Spacing.xlXxl)
             }
-            .scrollEdgeEffectStyle(.soft, for: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
 
@@ -183,11 +191,12 @@ final class SettingsWindowController: NSWindowController {
     private init() {
         let initialView = SettingsView().tint(AppTheme.Accent.primary)
         let hosting = NSHostingController(rootView: AnyView(initialView))
+        hosting.sizingOptions = .minSize
         let window = NSWindow(contentViewController: hosting)
         window.setContentSize(AppTheme.Window.settingsDefault)
         window.minSize = AppTheme.Window.settingsMin
         window.title = "Settings"
-        window.setFrameAutosaveName("PalmierProSettings-v3")
+        window.setFrameAutosaveName("PalmierProSettings-v4")
         window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false

--- a/Sources/PalmierPro/Settings/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/SkillsPane.swift
@@ -141,6 +141,8 @@ struct SkillsPane: View {
             }
             .animation(.easeInOut(duration: 0.2), value: copyToast)
         }
+        .padding(.horizontal, AppTheme.Spacing.xlXxl)
+        .padding(.bottom, AppTheme.Spacing.xlXxl)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
             if selection == nil { selection = store.skills.first?.id }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -267,13 +267,13 @@ enum AppTheme {
     }
 
     enum Window {
-        static let homeDefault = NSSize(width: 1200, height: 1200)
+        static let homeDefault = NSSize(width: 1200, height: 1000)
         static let homeMin = NSSize(width: 760, height: 480)
         static let projectDefault = NSSize(width: 1600, height: 1000)
         static let projectMin = NSSize(width: 960, height: 600)
         static let projectTitlebarTrailingWidth: CGFloat = 280
-        static let settingsDefault = NSSize(width: 1200, height: 820)
-        static let settingsMin = NSSize(width: 860, height: 560)
+        static let settingsDefault = NSSize(width: 1200, height: 900)
+        static let settingsMin = NSSize(width: 860, height: 640)
     }
 
     enum Caption {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -267,7 +267,7 @@ enum AppTheme {
     }
 
     enum Window {
-        static let homeDefault = NSSize(width: 1200, height: 1000)
+        static let homeDefault = NSSize(width: 1200, height: 880)
         static let homeMin = NSSize(width: 760, height: 480)
         static let projectDefault = NSSize(width: 1600, height: 1000)
         static let projectMin = NSSize(width: 960, height: 600)

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -269,7 +269,6 @@ enum AppTheme {
     enum Window {
         static let homeDefault = NSSize(width: 1200, height: 880)
         static let homeMin = NSSize(width: 760, height: 480)
-        static let projectDefault = NSSize(width: 1600, height: 1000)
         static let projectMin = NSSize(width: 960, height: 600)
         static let projectTitlebarTrailingWidth: CGFloat = 280
         static let settingsDefault = NSSize(width: 1200, height: 900)


### PR DESCRIPTION
The window sizing has been bugging me.

Home/Settings page is a bit too small
Project Page should be full size by default

## Summary
- Stop `NSHostingController` from shrinking windows to intrinsic content size (`sizingOptions = .minSize`) for home, settings, and project windows
- Let settings (especially Skills) fill available height instead of opening too short
- Open project windows maximized to the visible screen area (not native full screen); cascade offsets when multiple projects are open
- Tune default dimensions: home 1200×880, settings 1200×900; bump autosave keys so new defaults apply

## Test plan
- [ ] Open home — window should be 1200×880, content fills height
- [ ] Open settings — window should be tall enough for Skills tab without feeling cramped
- [ ] Open a project — window should fill screen below menu bar/dock (not enter full screen)
- [ ] Open a second project — window should cascade offset, not stack invisibly
- [ ] Resize and reopen each window — saved size should persist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Window layout and default dimensions only; no auth, persistence, or media pipeline logic changes.
> 
> **Overview**
> Fixes **home**, **settings**, and **project** windows feeling too small or not using available space by changing how AppKit hosts SwiftUI and how root layouts expand.
> 
> **Home & settings:** Root views now use `AppTheme` minimum sizes with **unbounded max width/height** so content can fill the window. `NSHostingController.sizingOptions = .minSize` stops the host from shrinking the window to intrinsic SwiftUI size. Default sizes are retuned (home **1200×880**, settings **1200×900**, higher settings minimum height), and frame autosave names are bumped so new defaults apply.
> 
> **Settings / Skills:** The **Skills** tab is rendered **outside** the shared `ScrollView` so the two-pane Skills UI can grow vertically; other tabs stay scrollable. **Skills** gets its own horizontal/bottom padding when used as the full-height pane.
> 
> **Project editor:** New projects open framed to the screen’s **visible** area via `NSWindow.fillVisibleScreen()` instead of a fixed default size and centering. The project window drops fixed default content size, frame autosave, and explicit cascade configuration in favor of max-visible layout (still respects `projectMin`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe2058aba05983468ad45663079177c6bb15dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->