### PR TITLE
[fix] code warnings

### DIFF
--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -252,12 +252,14 @@ final class ExportService {
             fps: timeline.fps,
             renderSize: renderSize
         )
-        let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
-        mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
+        let animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,
             in: parent
         )
-        session.videoComposition = mutableVC
+        session.videoComposition = CompositionBuilder.addingAnimationTool(
+            animationTool,
+            to: result.videoComposition
+        )
         return (session, result, renderSize)
     }
 

--- a/Sources/PalmierPro/Generation/Edit/VideoTrimExtractor.swift
+++ b/Sources/PalmierPro/Generation/Edit/VideoTrimExtractor.swift
@@ -79,11 +79,12 @@ enum VideoTrimExtractor {
         let targetFps: Int32 = nominal >= 24 && nominal <= 60
             ? Int32(Float(nominal).rounded())
             : 30
-        let videoComposition = try await AVMutableVideoComposition.videoComposition(
+        let videoComposition = try await AVVideoComposition.videoComposition(
             withPropertiesOf: composition
         )
-        videoComposition.frameDuration = CMTime(value: 1, timescale: targetFps)
-        session.videoComposition = videoComposition
+        var videoConfig = videoComposition.palmierConfiguration()
+        videoConfig.frameDuration = CMTime(value: 1, timescale: targetFps)
+        session.videoComposition = AVVideoComposition(configuration: videoConfig)
 
         Log.generation.notice("trim-extract start frames=\(trim.trimStartFrame)..<\(trim.trimStartFrame + trim.sourceFramesConsumed) timelineFps=\(trim.fps) sourceFps=\(nominal) outFps=\(targetFps)")
         try await session.export(to: outputURL, as: .mp4)

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -199,7 +199,7 @@ final class GenerationService {
             }
             let destinationURL = asset.url
             try await Task.detached(priority: .utility) {
-                try FileIO.moveReplacingDestination(from: tempURL, to: destinationURL)
+                _ = try FileIO.moveReplacingDestination(from: tempURL, to: destinationURL)
             }.value
 
             asset.pendingDownloadURL = nil

--- a/Sources/PalmierPro/Preview/AlphaVideoNormalizer.swift
+++ b/Sources/PalmierPro/Preview/AlphaVideoNormalizer.swift
@@ -100,13 +100,18 @@ enum AlphaVideoNormalizer {
                 guard !alreadyResumed else { return }
                 cont.resume(with: result)
             }
-            input.requestMediaDataWhenReady(on: queue) {
-                while input.isReadyForMoreMediaData {
-                    guard let sample = readerOutput.copyNextSampleBuffer() else {
-                        if reader.status == .failed {
-                            finish(.failure(reader.error ?? NormalizeError.readFailed))
+            nonisolated(unsafe) let unsafeReader = reader
+            nonisolated(unsafe) let unsafeReaderOutput = readerOutput
+            nonisolated(unsafe) let unsafeWriter = writer
+            nonisolated(unsafe) let unsafeInput = input
+            nonisolated(unsafe) let unsafeAdaptor = adaptor
+            unsafeInput.requestMediaDataWhenReady(on: queue) {
+                while unsafeInput.isReadyForMoreMediaData {
+                    guard let sample = unsafeReaderOutput.copyNextSampleBuffer() else {
+                        if unsafeReader.status == .failed {
+                            finish(.failure(unsafeReader.error ?? NormalizeError.readFailed))
                         } else {
-                            input.markAsFinished()
+                            unsafeInput.markAsFinished()
                             finish(.success(()))
                         }
                         return
@@ -114,8 +119,8 @@ enum AlphaVideoNormalizer {
                     guard let pixelBuffer = CMSampleBufferGetImageBuffer(sample) else { continue }
                     premultiply(pixelBuffer)
                     let pts = CMSampleBufferGetPresentationTimeStamp(sample)
-                    if !adaptor.append(pixelBuffer, withPresentationTime: pts) {
-                        finish(.failure(writer.error ?? NormalizeError.appendFailed))
+                    if !unsafeAdaptor.append(pixelBuffer, withPresentationTime: pts) {
+                        finish(.failure(unsafeWriter.error ?? NormalizeError.appendFailed))
                         return
                     }
                 }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -424,6 +424,15 @@ enum CompositionBuilder {
         return (audioMix, AVVideoComposition(configuration: vcConfig))
     }
 
+    static func addingAnimationTool(
+        _ animationTool: AVVideoCompositionCoreAnimationTool,
+        to videoComposition: AVVideoComposition
+    ) -> AVVideoComposition {
+        var config = videoComposition.palmierConfiguration()
+        config.animationTool = animationTool
+        return AVVideoComposition(configuration: config)
+    }
+
     /// One instruction per segment between clip boundaries, layers bottom → top.
     /// The black-background track is excluded — FrameRenderer fills black itself.
     private static func compositorInstructions(

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -52,12 +52,14 @@ enum TimelineRenderer {
             fps: timeline.fps,
             renderSize: renderSize
         )
-        let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
-        mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
+        let animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer,
             in: parent
         )
-        session.videoComposition = mutableVC
+        session.videoComposition = CompositionBuilder.addingAnimationTool(
+            animationTool,
+            to: result.videoComposition
+        )
 
         let timescale = CMTimeScale(timeline.fps)
         session.timeRange = CMTimeRange(

--- a/Sources/PalmierPro/Search/Query/VisualSearch.swift
+++ b/Sources/PalmierPro/Search/Query/VisualSearch.swift
@@ -24,11 +24,13 @@ enum VisualSearch {
             guard dim == query.count, index.header.count > 0 else { continue }
             var scores = [Float](repeating: 0, count: index.header.count)
             // scores = vectors (count×dim) · query
-            cblas_sgemv(
-                CblasRowMajor, CblasNoTrans,
-                Int32(index.header.count), Int32(dim),
-                1, index.vectors, Int32(dim),
-                query, 1, 0, &scores, 1
+            vDSP_mmul(
+                index.vectors, 1,
+                query, 1,
+                &scores, 1,
+                vDSP_Length(index.header.count),
+                1,
+                vDSP_Length(dim)
             )
             // Keep only the best frame of each shot so one scene doesn't flood results.
             var bestPerShot: [Double: (row: Int, score: Float)] = [:]

--- a/Sources/PalmierPro/Utilities/AVVideoComposition+Configuration.swift
+++ b/Sources/PalmierPro/Utilities/AVVideoComposition+Configuration.swift
@@ -1,0 +1,16 @@
+import AVFoundation
+
+extension AVVideoComposition {
+    func palmierConfiguration() -> AVVideoComposition.Configuration {
+        var config = AVVideoComposition.Configuration()
+        config.customVideoCompositorClass = customVideoCompositorClass
+        config.frameDuration = frameDuration
+        config.sourceTrackIDForFrameTiming = sourceTrackIDForFrameTiming
+        config.renderSize = renderSize
+        config.renderScale = renderScale
+        config.instructions = instructions
+        config.animationTool = animationTool
+        config.sourceSampleDataTrackIDs = sourceSampleDataTrackIDs
+        return config
+    }
+}

--- a/Tests/PalmierProTests/Export/LottieExportTests.swift
+++ b/Tests/PalmierProTests/Export/LottieExportTests.swift
@@ -47,7 +47,7 @@ struct LottieExportTests {
         gen.appliesPreferredTrackTransform = true
         gen.requestedTimeToleranceBefore = .zero
         gen.requestedTimeToleranceAfter = .zero
-        let frame = try gen.copyCGImage(at: CMTime(value: 0, timescale: 600), actualTime: nil)
+        let frame = try await gen.image(at: CMTime(value: 0, timescale: 600)).image
         let rep = NSBitmapImageRep(cgImage: frame)
         let topLeft = try #require(rep.colorAt(x: frame.width / 4, y: frame.height / 4))
         let bottomRight = try #require(rep.colorAt(x: frame.width * 3 / 4, y: frame.height * 3 / 4))

--- a/Tests/PalmierProTests/Media/LottieDotLottieTests.swift
+++ b/Tests/PalmierProTests/Media/LottieDotLottieTests.swift
@@ -46,7 +46,7 @@ struct LottieDotLottieTests {
         let gen = AVAssetImageGenerator(asset: asset)
         gen.requestedTimeToleranceBefore = .zero
         gen.requestedTimeToleranceAfter = .zero
-        let cg = try gen.copyCGImage(at: .zero, actualTime: nil)
+        let cg = try await gen.image(at: .zero).image
         let rep = NSBitmapImageRep(cgImage: cg)
         let left = try #require(rep.colorAt(x: cg.width / 4, y: cg.height / 2))
         let right = try #require(rep.colorAt(x: cg.width * 3 / 4, y: cg.height / 2))

--- a/Tests/PalmierProTests/Media/LottieVideoGeneratorTests.swift
+++ b/Tests/PalmierProTests/Media/LottieVideoGeneratorTests.swift
@@ -93,9 +93,10 @@ struct LottieVideoGeneratorTests {
         let gen = AVAssetImageGenerator(asset: asset)
         gen.requestedTimeToleranceBefore = .zero
         gen.requestedTimeToleranceAfter = .zero
+        nonisolated(unsafe) let unsafeGen = gen
 
-        func sample(_ seconds: Double) throws -> (top: NSColor, bottom: NSColor) {
-            let frame = try gen.copyCGImage(at: CMTime(seconds: seconds, preferredTimescale: 600), actualTime: nil)
+        func sample(_ seconds: Double) async throws -> (top: NSColor, bottom: NSColor) {
+            let frame = try await unsafeGen.image(at: CMTime(seconds: seconds, preferredTimescale: 600)).image
             let rep = NSBitmapImageRep(cgImage: frame)
             return (
                 try #require(rep.colorAt(x: frame.width / 4, y: frame.height / 4)),
@@ -104,12 +105,12 @@ struct LottieVideoGeneratorTests {
         }
 
         // Pixels round-trip with correct orientation: red top-left, transparent/black bottom-right.
-        let start = try sample(0)
+        let start = try await sample(0)
         #expect(start.top.redComponent > 0.7)
         #expect(start.bottom.redComponent < 0.3)
 
         // Past the animation, the frozen last frame is still present (clip is extendable).
-        let frozen = try sample(5)
+        let frozen = try await sample(5)
         #expect(frozen.top.redComponent > 0.7)
     }
 }

--- a/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
@@ -38,7 +38,7 @@ struct CompositorRenderTests {
     ) async throws -> Frame {
         var urls = imageURLs
         if urls["pattern"] == nil { urls["pattern"] = try await CompositorFixtures.patternVideoURL() }
-        nonisolated(unsafe) let resolved = urls
+        let resolved = urls
         let result = try await CompositionBuilder.build(
             timeline: timeline, resolveURL: { resolved[$0] }, renderSize: renderSize
         )
@@ -216,7 +216,7 @@ extension CompositorRenderTests {
 
     @Test func topLayerWinsInStack() async throws {
         // Opaque full-frame top over a flipped bg → top wins everywhere.
-        var top = CompositorFixtures.patternClip(id: "top")
+        let top = CompositorFixtures.patternClip(id: "top")
         var bg = CompositorFixtures.patternClip(id: "bg")
         bg.transform = Transform(flipHorizontal: true)
         let f = try await Self.render(Self.timelineWith(

--- a/Tests/PalmierProTests/Rendering/CustomCompositorSpikeTests.swift
+++ b/Tests/PalmierProTests/Rendering/CustomCompositorSpikeTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// blue, the custom compositor ran; if it also contains the text layer's red box, the
 /// animation tool post-processed on top of custom compositor output.
 final class SpikeSolidBlueCompositor: NSObject, AVVideoCompositing {
-    nonisolated(unsafe) static let ciContext = CIContext()
+    static let ciContext = CIContext()
 
     var sourcePixelBufferAttributes: [String: any Sendable]? {
         [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
@@ -74,19 +74,19 @@ struct CustomCompositorSpikeTests {
             renderSize: renderSize
         )
 
-        let mutableVC = result.videoComposition.mutableCopy() as! AVMutableVideoComposition
-        mutableVC.customVideoCompositorClass = SpikeSolidBlueCompositor.self
+        var videoConfig = result.videoComposition.palmierConfiguration()
+        videoConfig.customVideoCompositorClass = SpikeSolidBlueCompositor.self
         let (parent, videoLayer) = TextLayerController.buildForExport(
             timeline: timeline, fps: timeline.fps, renderSize: renderSize
         )
-        mutableVC.animationTool = AVVideoCompositionCoreAnimationTool(
+        videoConfig.animationTool = AVVideoCompositionCoreAnimationTool(
             postProcessingAsVideoLayer: videoLayer, in: parent
         )
 
         let session = try #require(AVAssetExportSession(
             asset: result.composition, presetName: AVAssetExportPreset1280x720
         ))
-        session.videoComposition = mutableVC
+        session.videoComposition = AVVideoComposition(configuration: videoConfig)
 
         let outURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("spike-\(UUID().uuidString).mp4")

--- a/Tests/PalmierProTests/Rendering/EffectTests.swift
+++ b/Tests/PalmierProTests/Rendering/EffectTests.swift
@@ -111,7 +111,7 @@ struct EffectRenderingTests {
     @Test func exposureChangesRenderedBrightness() async throws {
         let renderSize = CompositorFixtures.renderSize
         let videoURL = try await CompositorFixtures.midtoneVideoURL()
-        nonisolated(unsafe) let urls = ["midtone": videoURL]
+        let urls = ["midtone": videoURL]
 
         func meanLuma(ev: Double?) async throws -> Double {
             var clip = CompositorFixtures.midtoneClip()
@@ -145,7 +145,7 @@ struct EffectRenderingTests {
     @Test func everyCatalogEffectRendersAndChangesPixels() async throws {
         let renderSize = CompositorFixtures.renderSize
         let videoURL = try await CompositorFixtures.midtoneVideoURL()
-        nonisolated(unsafe) let urls = ["midtone": videoURL]
+        let urls = ["midtone": videoURL]
 
         let nonDefault: [String: [String: Double]] = [
             "color.exposure": ["ev": -2],
@@ -203,7 +203,7 @@ struct EffectRenderingTests {
     @Test func curvesEffectAppliesCompiledCube() async throws {
         let renderSize = CompositorFixtures.renderSize
         let videoURL = try await CompositorFixtures.midtoneVideoURL()
-        nonisolated(unsafe) let urls = ["midtone": videoURL]
+        let urls = ["midtone": videoURL]
 
         func meanLuma(_ curve: GradeCurve?) async throws -> Double {
             var clip = CompositorFixtures.midtoneClip()
@@ -256,7 +256,7 @@ struct EffectRenderingTests {
 
         let renderSize = CompositorFixtures.renderSize
         let videoURL = try await CompositorFixtures.patternVideoURL()
-        nonisolated(unsafe) let urls = ["pattern": videoURL]
+        let urls = ["pattern": videoURL]
 
         var effect = Effect.make("color.lut", ["intensity": 1])
         effect.params["path"] = EffectParam(string: cubeURL.path)
@@ -284,7 +284,7 @@ struct EffectRenderingTests {
     @Test func disabledAndUnknownEffectsArePassthrough() async throws {
         let renderSize = CompositorFixtures.renderSize
         let videoURL = try await CompositorFixtures.patternVideoURL()
-        nonisolated(unsafe) let urls = ["pattern": videoURL]
+        let urls = ["pattern": videoURL]
 
         func frame(_ effects: [Effect]?) async throws -> [UInt8] {
             var clip = CompositorFixtures.patternClip()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly warning-driven API and test updates with equivalent behavior; video pipeline changes are localized to configuration copying rather than compositor logic.
> 
> **Overview**
> Cleans up compiler warnings by adopting newer **immutable** `AVVideoComposition` APIs instead of `AVMutableVideoComposition` + `mutableCopy()` when attaching text **animation tools** or tweaking **frame duration** (export, timeline render, trim extract).
> 
> Adds `AVVideoComposition.palmierConfiguration()` and `CompositionBuilder.addingAnimationTool(_:to:)` so existing compositor settings are copied into `AVVideoComposition.Configuration` before rebuilding.
> 
> **Concurrency / API hygiene:** `AlphaVideoNormalizer` marks reader/writer handles `nonisolated(unsafe)` inside the export callback; visual search replaces `cblas_sgemv` with `vDSP_mmul`; generation download discards the unused `FileIO.moveReplacingDestination` return value.
> 
> **Tests** move to async `AVAssetImageGenerator.image(at:)` and drop redundant `nonisolated(unsafe)` / `var` where the compiler complained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19df79bc105b18c795ce8a96bd3e53c654316ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->