### PR TITLE
[fix] fcpxml format

### DIFF
--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -68,7 +68,7 @@ enum FCPXMLExporter {
         private let seqHeight: Int
         private let sequenceFormatId = "r1"
         private let titleEffectId = "titleBasic"
-        private var resourceIndex: [MediaResourceKey: Int] = [:]
+        private var resourceIndex: [String: Int] = [:]
         private var resources: [MediaResource] = []
         private var nextTextStyleId = 1
 
@@ -78,27 +78,18 @@ enum FCPXMLExporter {
             let enabled: Bool
         }
 
-        private enum MediaResourceKind: Hashable {
-            case visual
-            case audio
-        }
-
-        private struct MediaResourceKey: Hashable {
-            let mediaRef: String
-            let kind: MediaResourceKind
-        }
-
+        // One asset per source file, keyed by mediaRef. A synced A/V source is split into separate
+        // video/audio clips in our model, but FCP/Resolve expect a single asset carrying both streams
         private struct MediaResource {
-            let key: MediaResourceKey
+            let mediaRef: String
             let assetId: String
             let formatId: String?
-            // Visual clips ref a compound clip (retime needs it; see `timeMapNode`); nil for audio.
             let compoundId: String?
             let entry: MediaManifestEntry
             let url: URL
             var durationFrames: Int
-            var needsVideo: Bool { key.kind == .visual }
-            var needsAudio: Bool { key.kind == .audio }
+            let hasVideo: Bool
+            let hasAudio: Bool
         }
 
         init(timeline: Timeline, resolver: MediaResolver, version: FCPXMLVersion) {
@@ -227,11 +218,11 @@ enum FCPXMLExporter {
 
         private func assetClipNode(for item: EmittableClip) -> FCPXMLNode? {
             let clip = item.clip
-            guard let i = resourceIndex[resourceKey(for: clip)] else { return nil }
+            guard let i = resourceIndex[clip.mediaRef] else { return nil }
             let resource = resources[i]
 
-            // Visual → <ref-clip> over the compound clip; audio → plain <asset-clip>.
-            if let compoundId = resource.compoundId {
+            // Visual clip → <ref-clip> over the compound clip; audio clip → plain <asset-clip>.
+            if clip.mediaType != .audio, let compoundId = resource.compoundId {
                 let attrs: [(String, String)] = [
                     ("ref", compoundId),
                     ("name", resolver.displayName(for: clip.mediaRef)),
@@ -251,7 +242,7 @@ enum FCPXMLExporter {
                 ].compactMap { $0 })
             }
 
-            let attrs: [(String, String)] = [
+            var attrs: [(String, String)] = [
                 ("ref", resource.assetId),
                 ("name", resolver.displayName(for: clip.mediaRef)),
                 ("lane", "\(item.lane)"),
@@ -260,6 +251,8 @@ enum FCPXMLExporter {
                 ("duration", time(frames: clip.durationFrames)),
                 ("enabled", item.enabled ? "1" : "0"),
             ]
+            // The asset may also carry video (shared source); pin this clip to the audio stream only.
+            if resource.hasVideo { attrs.append(("srcEnable", "audio")) }
             return FCPXMLNode(
                 name: "asset-clip",
                 attributes: attrs,
@@ -461,35 +454,52 @@ enum FCPXMLExporter {
         }
 
         private func collectResources(from clips: [EmittableClip]) {
+            struct Caps {
+                var hasVideo = false
+                var hasAudio = false
+                var duration = 0
+                let entry: MediaManifestEntry
+                let url: URL
+            }
+            var order: [String] = []
+            var caps: [String: Caps] = [:]
+
             for item in clips {
                 let clip = item.clip
                 guard clip.mediaType != .text, clip.mediaType != .lottie,
                       let entry = resolver.entry(for: clip.mediaRef),
                       let url = resolver.resolveURL(for: clip.mediaRef) else { continue }
 
-                let key = resourceKey(for: clip)
                 let duration = sourceDurationFrames(for: entry, clip: clip)
-                if let i = resourceIndex[key] {
-                    resources[i].durationFrames = max(resources[i].durationFrames, duration)
-                    continue
-                }
+                let isVisual = clip.mediaType != .audio
+                // Audio clip → audio stream; video clip → audio too if the source file carries it.
+                let isAudio = clip.mediaType == .audio || (clip.mediaType == .video && entry.hasAudio == true)
+                var entryCaps = caps[clip.mediaRef] ?? {
+                    order.append(clip.mediaRef)
+                    return Caps(entry: entry, url: url)
+                }()
+                entryCaps.hasVideo = entryCaps.hasVideo || isVisual
+                entryCaps.hasAudio = entryCaps.hasAudio || isAudio
+                entryCaps.duration = max(entryCaps.duration, duration)
+                caps[clip.mediaRef] = entryCaps
+            }
 
+            for ref in order {
+                guard let c = caps[ref] else { continue }
                 let id = resources.count + 1
-                resourceIndex[key] = resources.count
+                resourceIndex[ref] = resources.count
                 resources.append(MediaResource(
-                    key: key,
+                    mediaRef: ref,
                     assetId: "asset\(id)",
-                    formatId: key.kind == .visual ? "format\(id)" : nil,
-                    compoundId: key.kind == .visual ? "media\(id)" : nil,
-                    entry: entry,
-                    url: url,
-                    durationFrames: duration
+                    formatId: c.hasVideo ? "format\(id)" : nil,
+                    compoundId: c.hasVideo ? "media\(id)" : nil,
+                    entry: c.entry,
+                    url: c.url,
+                    durationFrames: c.duration,
+                    hasVideo: c.hasVideo,
+                    hasAudio: c.hasAudio
                 ))
             }
-        }
-
-        private func resourceKey(for clip: Clip) -> MediaResourceKey {
-            MediaResourceKey(mediaRef: clip.mediaRef, kind: clip.mediaType == .audio ? .audio : .visual)
         }
 
         private func formatNode(for resource: MediaResource) -> FCPXMLNode? {
@@ -514,14 +524,18 @@ enum FCPXMLExporter {
                 ("start", "0s"),
                 ("duration", time(frames: resource.durationFrames)),
             ]
-            if resource.needsVideo {
+            if resource.hasVideo {
                 attrs.append(("hasVideo", "1"))
+                attrs.append(("videoSources", "1"))
                 if let formatId = resource.formatId {
                     attrs.append(("format", formatId))
                 }
             }
-            if resource.needsAudio {
+            if resource.hasAudio {
                 attrs.append(("hasAudio", "1"))
+                attrs.append(("audioSources", "1"))
+                attrs.append(("audioChannels", "2"))
+                attrs.append(("audioRate", "48000"))
             }
             return FCPXMLNode(name: "asset", attributes: attrs, children: [
                 FCPXMLNode(name: "media-rep", attributes: [

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -71,8 +71,7 @@ enum FCPXMLExporter {
         private var resourceIndex: [String: Int] = [:]
         private var resources: [MediaResource] = []
         private var nextTextStyleId = 1
-        // Linked video+audio pairs collapse into one <ref-clip>: the audio partner is dropped and its
-        // volume rides on the video clip. Keeps Resolve from importing a phantom second video track.
+        // A synced A/V pair collapses into one ref-clip; the audio partner is dropped, its volume kept.
         private var linkedAudioForVideo: [String: Clip] = [:]
         private var redundantAudioClipIds: Set<String> = []
 
@@ -82,8 +81,8 @@ enum FCPXMLExporter {
             let enabled: Bool
         }
 
-        // One asset per source file, keyed by mediaRef. A synced A/V source is split into separate
-        // video/audio clips in our model, but FCP/Resolve expect a single asset carrying both streams
+        // One asset per source file (keyed by mediaRef): two assets sharing a media-rep src break
+        // Resolve's relinker.
         private struct MediaResource {
             let mediaRef: String
             let assetId: String
@@ -117,9 +116,8 @@ enum FCPXMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
         }
 
-        /// A linkGroup with exactly one video and one audio clip on the same source, perfectly aligned,
-        /// is a synced A/V pair. Collapse it: the video <ref-clip> carries both streams, the audio is
-        /// dropped. Mismatched timing means the user edited them apart, so leave both in place.
+        /// One video + one audio clip sharing a linkGroup, source, and timing is a synced pair the video
+        /// ref-clip can carry whole. Mismatched timing means they were edited apart — leave both.
         private func indexLinkedPairs(_ clips: [EmittableClip]) {
             var byGroup: [String: (videos: [Clip], audios: [Clip])] = [:]
             for item in clips {
@@ -169,8 +167,8 @@ enum FCPXMLExporter {
         private func compoundClipNode(for resource: MediaResource) -> FCPXMLNode? {
             guard let compoundId = resource.compoundId else { return nil }
             let dur = time(frames: resource.durationFrames)
-            // When the source has audio, wrap the whole asset (<asset-clip> = video + audio) so a single
-            // outer <ref-clip> can deliver both streams; the outer srcEnable then gates what plays.
+            // <asset-clip> carries both streams so the outer ref-clip can deliver audio; <clip>/<video>
+            // is video-only. Outer srcEnable gates what actually plays.
             let innerClip: FCPXMLNode
             if resource.hasAudio {
                 innerClip = FCPXMLNode(name: "asset-clip", attributes: [
@@ -265,9 +263,8 @@ enum FCPXMLExporter {
             guard let i = resourceIndex[clip.mediaRef] else { return nil }
             let resource = resources[i]
 
-            // Video/image → <ref-clip> over the compound. A linked audio partner rides along (srcEnable
-            // omitted = both streams, its volume carried here); otherwise pin to video so a source's own
-            // audio doesn't leak in.
+            // Video/image → <ref-clip>. A linked audio partner rides along (srcEnable omitted = both
+            // streams, its volume carried here); otherwise pin to video so the source's audio stays out.
             if clip.mediaType != .audio, let compoundId = resource.compoundId {
                 let linkedAudio = linkedAudioForVideo[clip.id]
                 var attrs: [(String, String)] = [
@@ -290,9 +287,8 @@ enum FCPXMLExporter {
                 ].compactMap { $0 })
             }
 
-            // Audio against an A/V source: a bare <asset-clip srcEnable="audio"> still imports as a video
-            // clip in Resolve (it honors srcEnable on <ref-clip>, not <asset-clip>), so route through the
-            // compound too. A pure-audio source has no compound → plain <asset-clip>.
+            // Audio against an A/V source must go through the compound too: Resolve honors srcEnable on
+            // <ref-clip> but not <asset-clip>, so a bare audio asset-clip imports as a video clip.
             if clip.mediaType == .audio, let compoundId = resource.compoundId {
                 let attrs: [(String, String)] = [
                     ("ref", compoundId),
@@ -598,6 +594,7 @@ enum FCPXMLExporter {
                 }
             }
             if resource.hasAudio {
+                // We don't probe channels/rate; 2ch/48k is FCP's default and doesn't affect relinking.
                 attrs.append(("hasAudio", "1"))
                 attrs.append(("audioSources", "1"))
                 attrs.append(("audioChannels", "2"))

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -81,8 +81,7 @@ enum FCPXMLExporter {
             let enabled: Bool
         }
 
-        // One asset per source file (keyed by mediaRef): two assets sharing a media-rep src break
-        // Resolve's relinker.
+        // One asset per source file (keyed by mediaRef)
         private struct MediaResource {
             let mediaRef: String
             let assetId: String
@@ -116,9 +115,7 @@ enum FCPXMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
         }
 
-        /// One video + one audio clip sharing a linkGroup, source, timing, and enabled state is a synced
-        /// pair the video ref-clip can carry whole. Mismatched timing or enabled (e.g. a muted audio
-        /// track under a shown video) means they're independent — leave both so each keeps its own state.
+        // Video + audio with matching linkGroup, source, timing, and enabled state are a synced pair
         private func indexLinkedPairs(_ clips: [EmittableClip]) {
             var byGroup: [String: (videos: [EmittableClip], audios: [EmittableClip])] = [:]
             for item in clips {
@@ -289,8 +286,7 @@ enum FCPXMLExporter {
                 ].compactMap { $0 })
             }
 
-            // Audio against an A/V source must go through the compound too: Resolve honors srcEnable on
-            // <ref-clip> but not <asset-clip>, so a bare audio asset-clip imports as a video clip.
+            // Audio against an A/V source must go through the compound too
             if clip.mediaType == .audio, let compoundId = resource.compoundId {
                 let attrs: [(String, String)] = [
                     ("ref", compoundId),

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -71,6 +71,10 @@ enum FCPXMLExporter {
         private var resourceIndex: [String: Int] = [:]
         private var resources: [MediaResource] = []
         private var nextTextStyleId = 1
+        // Linked video+audio pairs collapse into one <ref-clip>: the audio partner is dropped and its
+        // volume rides on the video clip. Keeps Resolve from importing a phantom second video track.
+        private var linkedAudioForVideo: [String: Clip] = [:]
+        private var redundantAudioClipIds: Set<String> = []
 
         private struct EmittableClip {
             let clip: Clip
@@ -104,12 +108,37 @@ enum FCPXMLExporter {
         func build() -> String {
             let clips = emittableClips()
             collectResources(from: clips)
+            indexLinkedPairs(clips)
             let hasTitles = clips.contains { $0.clip.mediaType == .text }
             let root = FCPXMLNode(name: "fcpxml", attributes: [("version", version.rawValue)], children: [
                 resourcesNode(hasTitles: hasTitles),
                 libraryNode(clips: clips),
             ])
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
+        }
+
+        /// A linkGroup with exactly one video and one audio clip on the same source, perfectly aligned,
+        /// is a synced A/V pair. Collapse it: the video <ref-clip> carries both streams, the audio is
+        /// dropped. Mismatched timing means the user edited them apart, so leave both in place.
+        private func indexLinkedPairs(_ clips: [EmittableClip]) {
+            var byGroup: [String: (videos: [Clip], audios: [Clip])] = [:]
+            for item in clips {
+                guard let group = item.clip.linkGroupId else { continue }
+                switch item.clip.mediaType {
+                case .video, .image: byGroup[group, default: ([], [])].videos.append(item.clip)
+                case .audio: byGroup[group, default: ([], [])].audios.append(item.clip)
+                default: break
+                }
+            }
+            for (_, pair) in byGroup {
+                guard pair.videos.count == 1, pair.audios.count == 1 else { continue }
+                let v = pair.videos[0], a = pair.audios[0]
+                guard v.mediaRef == a.mediaRef,
+                      v.startFrame == a.startFrame, v.durationFrames == a.durationFrames,
+                      v.trimStartFrame == a.trimStartFrame, abs(v.speed - a.speed) < 0.0001 else { continue }
+                linkedAudioForVideo[v.id] = a
+                redundantAudioClipIds.insert(a.id)
+            }
         }
 
         private func resourcesNode(hasTitles: Bool) -> FCPXMLNode {
@@ -140,19 +169,33 @@ enum FCPXMLExporter {
         private func compoundClipNode(for resource: MediaResource) -> FCPXMLNode? {
             guard let compoundId = resource.compoundId else { return nil }
             let dur = time(frames: resource.durationFrames)
-            let video = FCPXMLNode(name: "video", attributes: [
-                ("ref", resource.assetId),
-                ("duration", dur),
-                ("start", "0s"),
-                ("offset", "0s"),
-            ])
-            let innerClip = FCPXMLNode(name: "clip", attributes: [
-                ("name", resource.entry.name),
-                ("duration", dur),
-                ("start", "0s"),
-                ("offset", "0s"),
-                ("format", resource.formatId ?? sequenceFormatId),
-            ], children: [video])
+            // When the source has audio, wrap the whole asset (<asset-clip> = video + audio) so a single
+            // outer <ref-clip> can deliver both streams; the outer srcEnable then gates what plays.
+            let innerClip: FCPXMLNode
+            if resource.hasAudio {
+                innerClip = FCPXMLNode(name: "asset-clip", attributes: [
+                    ("ref", resource.assetId),
+                    ("name", resource.entry.name),
+                    ("duration", dur),
+                    ("start", "0s"),
+                    ("offset", "0s"),
+                    ("format", resource.formatId ?? sequenceFormatId),
+                ])
+            } else {
+                let video = FCPXMLNode(name: "video", attributes: [
+                    ("ref", resource.assetId),
+                    ("duration", dur),
+                    ("start", "0s"),
+                    ("offset", "0s"),
+                ])
+                innerClip = FCPXMLNode(name: "clip", attributes: [
+                    ("name", resource.entry.name),
+                    ("duration", dur),
+                    ("start", "0s"),
+                    ("offset", "0s"),
+                    ("format", resource.formatId ?? sequenceFormatId),
+                ], children: [video])
+            }
             let sequence = FCPXMLNode(name: "sequence", attributes: [
                 ("format", resource.formatId ?? sequenceFormatId),
                 ("duration", dur),
@@ -200,6 +243,7 @@ enum FCPXMLExporter {
 
         private func storyNodes(for clips: [EmittableClip]) -> [FCPXMLNode] {
             clips
+                .filter { !redundantAudioClipIds.contains($0.clip.id) }
                 .sorted {
                     if $0.clip.startFrame != $1.clip.startFrame { return $0.clip.startFrame < $1.clip.startFrame }
                     return $0.lane < $1.lane
@@ -221,8 +265,35 @@ enum FCPXMLExporter {
             guard let i = resourceIndex[clip.mediaRef] else { return nil }
             let resource = resources[i]
 
-            // Visual clip → <ref-clip> over the compound clip; audio clip → plain <asset-clip>.
+            // Video/image → <ref-clip> over the compound. A linked audio partner rides along (srcEnable
+            // omitted = both streams, its volume carried here); otherwise pin to video so a source's own
+            // audio doesn't leak in.
             if clip.mediaType != .audio, let compoundId = resource.compoundId {
+                let linkedAudio = linkedAudioForVideo[clip.id]
+                var attrs: [(String, String)] = [
+                    ("ref", compoundId),
+                    ("name", resolver.displayName(for: clip.mediaRef)),
+                    ("lane", "\(item.lane)"),
+                    ("offset", time(frames: clip.startFrame)),
+                    ("start", clipStart(for: clip)),
+                    ("duration", time(frames: clip.durationFrames)),
+                    ("enabled", item.enabled ? "1" : "0"),
+                ]
+                if linkedAudio == nil { attrs.append(("srcEnable", "video")) }
+                return FCPXMLNode(name: "ref-clip", attributes: attrs, children: [
+                    timeMapNode(for: clip, mediaFrames: resource.durationFrames),
+                    FCPXMLNode(name: "adjust-conform", attributes: [("type", "fit")]),
+                    cropNode(for: clip),
+                    transformNode(for: clip),
+                    blendNode(for: clip),
+                    linkedAudio.flatMap(volumeNode),
+                ].compactMap { $0 })
+            }
+
+            // Audio against an A/V source: a bare <asset-clip srcEnable="audio"> still imports as a video
+            // clip in Resolve (it honors srcEnable on <ref-clip>, not <asset-clip>), so route through the
+            // compound too. A pure-audio source has no compound → plain <asset-clip>.
+            if clip.mediaType == .audio, let compoundId = resource.compoundId {
                 let attrs: [(String, String)] = [
                     ("ref", compoundId),
                     ("name", resolver.displayName(for: clip.mediaRef)),
@@ -231,18 +302,15 @@ enum FCPXMLExporter {
                     ("start", clipStart(for: clip)),
                     ("duration", time(frames: clip.durationFrames)),
                     ("enabled", item.enabled ? "1" : "0"),
-                    ("srcEnable", "video"),
+                    ("srcEnable", "audio"),
                 ]
                 return FCPXMLNode(name: "ref-clip", attributes: attrs, children: [
                     timeMapNode(for: clip, mediaFrames: resource.durationFrames),
-                    FCPXMLNode(name: "adjust-conform", attributes: [("type", "fit")]),
-                    cropNode(for: clip),
-                    transformNode(for: clip),
-                    blendNode(for: clip),
+                    volumeNode(for: clip),
                 ].compactMap { $0 })
             }
 
-            var attrs: [(String, String)] = [
+            let attrs: [(String, String)] = [
                 ("ref", resource.assetId),
                 ("name", resolver.displayName(for: clip.mediaRef)),
                 ("lane", "\(item.lane)"),
@@ -251,8 +319,6 @@ enum FCPXMLExporter {
                 ("duration", time(frames: clip.durationFrames)),
                 ("enabled", item.enabled ? "1" : "0"),
             ]
-            // The asset may also carry video (shared source); pin this clip to the audio stream only.
-            if resource.hasVideo { attrs.append(("srcEnable", "audio")) }
             return FCPXMLNode(
                 name: "asset-clip",
                 attributes: attrs,

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -116,26 +116,28 @@ enum FCPXMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
         }
 
-        /// One video + one audio clip sharing a linkGroup, source, and timing is a synced pair the video
-        /// ref-clip can carry whole. Mismatched timing means they were edited apart — leave both.
+        /// One video + one audio clip sharing a linkGroup, source, timing, and enabled state is a synced
+        /// pair the video ref-clip can carry whole. Mismatched timing or enabled (e.g. a muted audio
+        /// track under a shown video) means they're independent — leave both so each keeps its own state.
         private func indexLinkedPairs(_ clips: [EmittableClip]) {
-            var byGroup: [String: (videos: [Clip], audios: [Clip])] = [:]
+            var byGroup: [String: (videos: [EmittableClip], audios: [EmittableClip])] = [:]
             for item in clips {
                 guard let group = item.clip.linkGroupId else { continue }
                 switch item.clip.mediaType {
-                case .video, .image: byGroup[group, default: ([], [])].videos.append(item.clip)
-                case .audio: byGroup[group, default: ([], [])].audios.append(item.clip)
+                case .video, .image: byGroup[group, default: ([], [])].videos.append(item)
+                case .audio: byGroup[group, default: ([], [])].audios.append(item)
                 default: break
                 }
             }
             for (_, pair) in byGroup {
                 guard pair.videos.count == 1, pair.audios.count == 1 else { continue }
                 let v = pair.videos[0], a = pair.audios[0]
-                guard v.mediaRef == a.mediaRef,
-                      v.startFrame == a.startFrame, v.durationFrames == a.durationFrames,
-                      v.trimStartFrame == a.trimStartFrame, abs(v.speed - a.speed) < 0.0001 else { continue }
-                linkedAudioForVideo[v.id] = a
-                redundantAudioClipIds.insert(a.id)
+                guard v.clip.mediaRef == a.clip.mediaRef, v.enabled == a.enabled,
+                      v.clip.startFrame == a.clip.startFrame, v.clip.durationFrames == a.clip.durationFrames,
+                      v.clip.trimStartFrame == a.clip.trimStartFrame, abs(v.clip.speed - a.clip.speed) < 0.0001
+                else { continue }
+                linkedAudioForVideo[v.clip.id] = a.clip
+                redundantAudioClipIds.insert(a.clip.id)
             }
         }
 

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -30,14 +30,16 @@ struct FCPXMLExporterTests {
         in dir: String,
         duration: Double = 5,
         sourceWidth: Int = 1920,
-        sourceHeight: Int = 1080
+        sourceHeight: Int = 1080,
+        hasAudio: Bool? = nil
     ) -> MediaManifestEntry {
         MediaManifestEntry(
             id: id, name: id, type: .video,
             source: .external(absolutePath: (dir as NSString).appendingPathComponent("\(id).mp4")),
             duration: duration,
             sourceWidth: sourceWidth,
-            sourceHeight: sourceHeight
+            sourceHeight: sourceHeight,
+            hasAudio: hasAudio
         )
     }
 
@@ -132,7 +134,9 @@ struct FCPXMLExporterTests {
     }
 
     @Test func sameMediaRefVideoAndAudioShareOneAsset() throws {
-        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        // Unlinked video + audio on the same A/V source (no linkGroup): each stays on its own lane but
+        // both route through the compound so srcEnable is honored (Resolve ignores it on bare asset-clips).
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory(), hasAudio: true)])
         let video = Fixtures.clip(id: "video", mediaRef: "media-v", mediaType: .video, start: 0, duration: 30)
         let audio = Fixtures.clip(id: "audio", mediaRef: "media-v", mediaType: .audio, start: 0, duration: 30)
         let timeline = Fixtures.timeline(tracks: [
@@ -153,12 +157,35 @@ struct FCPXMLExporterTests {
         #expect(asset.contains("audioSources=\"1\""))
         #expect(asset.contains("audioChannels=\"2\""))
         #expect(asset.contains("audioRate=\"48000\""))
-        // Video routes through a compound clip via <ref-clip srcEnable="video">; audio is an
-        // <asset-clip srcEnable="audio"> against the same asset, so neither pulls the other's stream.
+        // Both clips are <ref-clip>s over the compound, gated by srcEnable so neither pulls the other's
+        // stream. The compound itself wraps the asset as an <asset-clip> to carry audio.
         #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
         #expect(xml.contains("srcEnable=\"video\""))
-        #expect(xml.contains("<asset-clip ref=\"asset1\" name=\"media-v\" lane=\"-1\""))
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"-1\""))
         #expect(xml.contains("srcEnable=\"audio\""))
+    }
+
+    @Test func linkedAvPairCollapsesToOneRefClip() throws {
+        // A synced A/V pair (shared linkGroup, aligned) becomes a single <ref-clip> carrying both streams.
+        // The separate audio clip is dropped so Resolve doesn't import a phantom second video track.
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory(), hasAudio: true)])
+        var video = Fixtures.clip(id: "video", mediaRef: "media-v", mediaType: .video, start: 0, duration: 30)
+        var audio = Fixtures.clip(id: "audio", mediaRef: "media-v", mediaType: .audio, start: 0, duration: 30, volume: 0.5)
+        video.linkGroupId = "pair"
+        audio.linkGroupId = "pair"
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        // One timeline element: the video ref-clip, no srcEnable (both streams play). No audio lane.
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
+        #expect(!xml.contains("lane=\"-1\""))
+        #expect(!xml.contains("srcEnable="))
+        // The dropped audio clip's volume rides on the surviving ref-clip.
+        #expect(xml.contains("<adjust-volume amount=\"-6.0206\"/>"))
     }
 
     @Test func visualTrackLanesPreserveTopOverBottom() throws {

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -131,7 +131,7 @@ struct FCPXMLExporterTests {
         #expect(xml.contains("<adjust-conform type=\"fit\"/>"))
     }
 
-    @Test func sameMediaRefVideoAndAudioUseSeparateAssets() throws {
+    @Test func sameMediaRefVideoAndAudioShareOneAsset() throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
         let video = Fixtures.clip(id: "video", mediaRef: "media-v", mediaType: .video, start: 0, duration: 30)
         let audio = Fixtures.clip(id: "audio", mediaRef: "media-v", mediaType: .audio, start: 0, duration: 30)
@@ -141,18 +141,24 @@ struct FCPXMLExporterTests {
         ])
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
-        let videoAsset = xml.components(separatedBy: "<asset id=\"asset1\"").dropFirst().first?.components(separatedBy: "</asset>").first ?? ""
-        let audioAsset = xml.components(separatedBy: "<asset id=\"asset2\"").dropFirst().first?.components(separatedBy: "</asset>").first ?? ""
 
-        #expect(videoAsset.contains("hasVideo=\"1\""))
-        #expect(videoAsset.contains("format=\"format1\""))
-        #expect(!videoAsset.contains("hasAudio"))
-        #expect(audioAsset.contains("hasAudio=\"1\""))
-        #expect(!audioAsset.contains("hasVideo"))
-        // Video routes through a compound clip via <ref-clip>; audio stays a plain <asset-clip>.
+        // One asset per source file, carrying both streams — Resolve's relinker fails on two assets
+        // sharing a media-rep src.
+        #expect(!xml.contains("<asset id=\"asset2\""))
+        let asset = xml.components(separatedBy: "<asset id=\"asset1\"").dropFirst().first?.components(separatedBy: "</asset>").first ?? ""
+        #expect(asset.contains("hasVideo=\"1\""))
+        #expect(asset.contains("format=\"format1\""))
+        #expect(asset.contains("videoSources=\"1\""))
+        #expect(asset.contains("hasAudio=\"1\""))
+        #expect(asset.contains("audioSources=\"1\""))
+        #expect(asset.contains("audioChannels=\"2\""))
+        #expect(asset.contains("audioRate=\"48000\""))
+        // Video routes through a compound clip via <ref-clip srcEnable="video">; audio is an
+        // <asset-clip srcEnable="audio"> against the same asset, so neither pulls the other's stream.
         #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
         #expect(xml.contains("srcEnable=\"video\""))
-        #expect(xml.contains("<asset-clip ref=\"asset2\" name=\"media-v\" lane=\"-1\""))
+        #expect(xml.contains("<asset-clip ref=\"asset1\" name=\"media-v\" lane=\"-1\""))
+        #expect(xml.contains("srcEnable=\"audio\""))
     }
 
     @Test func visualTrackLanesPreserveTopOverBottom() throws {
@@ -460,10 +466,11 @@ struct FCPXMLExporterTests {
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
+        // Pure audio source → no srcEnable (it has no video stream to disambiguate).
         #expect(xml.contains("<asset-clip ref=\"asset1\""))
+        #expect(!xml.contains("srcEnable="))
         #expect(!xml.contains("<fadeIn"))
-        #expect(!xml.contains("audioSources="))
-        #expect(!xml.contains("audioChannels="))
+        #expect(!xml.contains("<audio-channel-source"))
     }
 
     // MARK: - Titles

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -188,6 +188,28 @@ struct FCPXMLExporterTests {
         #expect(xml.contains("<adjust-volume amount=\"-6.0206\"/>"))
     }
 
+    @Test func mutedAudioTrackKeepsLinkedPairSeparate() throws {
+        // A muted audio track under a shown video has divergent enabled state, so the pair must NOT
+        // collapse — else the audio would ride the (enabled) video clip and lose its mute.
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory(), hasAudio: true)])
+        var video = Fixtures.clip(id: "video", mediaRef: "media-v", mediaType: .video, start: 0, duration: 30)
+        var audio = Fixtures.clip(id: "audio", mediaRef: "media-v", mediaType: .audio, start: 0, duration: 30)
+        video.linkGroupId = "pair"
+        audio.linkGroupId = "pair"
+        var audioTrack = Fixtures.audioTrack(clips: [audio])
+        audioTrack.muted = true
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [video]), audioTrack])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        // Both survive on their own lanes; the audio is a disabled ref-clip, video stays enabled video-only.
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"1\""))
+        #expect(xml.contains("srcEnable=\"video\""))
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v\" lane=\"-1\""))
+        #expect(xml.contains("srcEnable=\"audio\""))
+        #expect(xml.contains("enabled=\"0\""))
+    }
+
     @Test func visualTrackLanesPreserveTopOverBottom() throws {
         let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
         let top = Fixtures.clip(id: "top", mediaRef: "media-v", start: 0, duration: 30)


### PR DESCRIPTION
from user feedback, exporting fcpxml to davinci is creating two separate `<asset>` entries in `<resources>` for **each** clip with video and audio, instead of a single combined asset. This is because of our model from Premiere that separate audio and video.

fix: dedup by source file into a single <asset> carrying both streams (hasVideo/hasAudio + videoSources/audioSources/audioChannels/audioRate).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FCPXML resource and story-line generation for all video/audio exports; regressions could affect Resolve/FCP import behavior beyond the DaVinci duplicate-asset case.
> 
> **Overview**
> Fixes DaVinci Resolve FCPXML import by emitting **one `<asset>` per source file** instead of separate video/audio assets for the same `mediaRef`. Resources are keyed by `mediaRef` and merged with `hasVideo`/`hasAudio`, plus default `videoSources`/`audioSources`/`audioChannels`/`audioRate` on combined assets.
> 
> Timeline emission now routes A/V sources through compound `<ref-clip>`s with **`srcEnable`** (`video` vs `audio`) so streams don’t bleed; compounds use an inner `<asset-clip>` when the source has audio. **Synced linked pairs** (matching `linkGroupId`, timing, and enabled state) collapse to a single video `<ref-clip>` without `srcEnable`, with the partner audio dropped and its volume applied on the survivor; **muted/disabled mismatches** keep separate lanes.
> 
> Tests were updated/added for shared assets, linked collapse, and muted-track separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b7f7307dadbbdd4a845efce95c9e2c55ea3deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->