### PR TITLE
[timeline] Shift-drag trim edge for ripple trim

### DIFF
--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -93,6 +93,10 @@ enum MainMenuBuilder {
         deleteItem.keyEquivalentModifierMask = []
         menu.addItem(deleteItem)
 
+        let rippleDeleteItem = NSMenuItem(title: "Ripple Delete", action: #selector(EditorActions.rippleDeleteSelected(_:)), keyEquivalent: "\u{8}") // backspace
+        rippleDeleteItem.keyEquivalentModifierMask = [.shift]
+        menu.addItem(rippleDeleteItem)
+
         item.submenu = menu
         return item
     }
@@ -171,6 +175,7 @@ enum MainMenuBuilder {
     func trimStartToPlayhead(_ sender: Any?)
     func trimEndToPlayhead(_ sender: Any?)
     func deleteSelectedClips(_ sender: Any?)
+    func rippleDeleteSelected(_ sender: Any?)
     func importMedia(_ sender: Any?)
     func playPause(_ sender: Any?)
     func stepFrameForward(_ sender: Any?)

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -210,6 +210,13 @@ extension EditorWindowController: EditorActions {
     @objc func trimStartToPlayhead(_ sender: Any?) { editorViewModel.trimStartToPlayhead() }
     @objc func trimEndToPlayhead(_ sender: Any?) { editorViewModel.trimEndToPlayhead() }
     @objc func deleteSelectedClips(_ sender: Any?) { editorViewModel.deleteSelectedClips() }
+    @objc func rippleDeleteSelected(_ sender: Any?) {
+        if editorViewModel.selectedGap != nil {
+            editorViewModel.rippleDeleteSelectedGap()
+        } else {
+            editorViewModel.rippleDeleteSelectedClips()
+        }
+    }
     @objc func playPause(_ sender: Any?) { editorViewModel.togglePlayback() }
     @objc func stepFrameForward(_ sender: Any?) { editorViewModel.stepForward() }
     @objc func stepFrameBackward(_ sender: Any?) { editorViewModel.stepBackward() }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -155,7 +155,7 @@ extension EditorViewModel {
         trimClips(edits)
     }
 
-    private func trimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int) {
+    func trimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int) {
         let sourceDelta = Int((Double(delta) * clip.speed).rounded())
         // Image/Text clips have no source-material bound, so their trim fields can go negative
         let unbounded = clip.mediaType == .image || clip.mediaType == .text

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -31,49 +31,70 @@ extension EditorViewModel {
         undoManager?.setActionName(edits.count == 1 ? "Trim Clip" : "Trim Clips")
     }
 
-    /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
-    func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
-        guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return }
+    /// The resolved layout of a ripple trim: which clips resize, by how much, and how every
+    /// downstream clip shifts. Pure — `rippleTrimClip` applies it, the timeline view previews it.
+    struct RippleTrimPlan {
+        let durationDelta: Int
+        let targetIds: Set<String>
+        let shifts: [ClipShift]
+    }
+
+    /// Resolve a ripple trim without mutating anything. Binds the edit to the most-constrained
+    /// linked partner so A/V keeps equal durations, then computes the downstream shift on the
+    /// lead's track, linked-partner tracks, and sync-locked followers. Returns nil for a no-op.
+    func planRippleTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) -> RippleTrimPlan? {
+        guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return nil }
         let leadEnd = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex].endFrame
 
-        // Clips to resize: the lead, plus linked partners when propagation is on.
         var targets: [String] = [clipId]
         if propagateToLinked { targets.append(contentsOf: linkedPartnerIds(of: clipId)) }
         let targetIds = Set(targets)
 
-        // Each target's own source headroom caps how far it can ripple. 
-        // Bind the whole edit to the most-constrained partner (smallest achievable delta)
+        // Each target's own source headroom caps how far it can ripple; bind to the smallest.
         let durationDelta = targets
             .compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
             .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
             .min(by: { abs($0) < abs($1) }) ?? 0
-        guard durationDelta != 0 else { return }
+        guard durationDelta != 0 else { return nil }
+
+        var shifts: [ClipShift] = []
+        for ti in timeline.tracks.indices {
+            let track = timeline.tracks[ti]
+            let holdsTarget = track.clips.contains { targetIds.contains($0.id) }
+            guard holdsTarget || track.syncLocked else { continue }
+            shifts += RippleEngine.computeRipplePush(
+                clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta, excludeIds: targetIds
+            )
+        }
+        return RippleTrimPlan(durationDelta: durationDelta, targetIds: targetIds, shifts: shifts)
+    }
+
+    /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
+    func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
+        guard let plan = planRippleTrim(clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked) else { return }
 
         // Pre-validate sync-locked followers (no resized clip of their own, but must absorb the shift).
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
-            guard track.syncLocked, !track.clips.contains(where: { targetIds.contains($0.id) }) else { continue }
-            let shifts = RippleEngine.computeRipplePush(clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta)
-            if let reason = validateShifts(trackIndex: ti, shifts: shifts) { refuseRipple(reason: reason); return }
+            guard track.syncLocked, !track.clips.contains(where: { plan.targetIds.contains($0.id) }) else { continue }
+            let trackIds = Set(track.clips.map(\.id))
+            let trackShifts = plan.shifts.filter { trackIds.contains($0.clipId) }
+            if let reason = validateShifts(trackIndex: ti, shifts: trackShifts) { refuseRipple(reason: reason); return }
         }
 
         withTimelineSwap(actionName: "Ripple Trim") {
-            for id in targets {
+            for id in plan.targetIds {
                 guard let l = findClip(id: id) else { continue }
                 let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
                 // A right-edge duration change maps to the same source-frame edge drag; left flips sign.
-                let fields = trimValues(for: c, edge: edge, delta: edge == .right ? durationDelta : -durationDelta)
+                let fields = trimValues(for: c, edge: edge, delta: edge == .right ? plan.durationDelta : -plan.durationDelta)
                 timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = fields.trimStart
                 timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = fields.trimEnd
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(max(1, c.durationFrames + durationDelta))
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(max(1, c.durationFrames + plan.durationDelta))
             }
-            for ti in timeline.tracks.indices {
-                let track = timeline.tracks[ti]
-                let holdsTarget = track.clips.contains { targetIds.contains($0.id) }
-                guard holdsTarget || track.syncLocked else { continue }
-                applyShifts(RippleEngine.computeRipplePush(
-                    clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta, excludeIds: targetIds
-                ))
+            applyShifts(plan.shifts)
+            for ti in timeline.tracks.indices where
+                timeline.tracks[ti].clips.contains(where: { plan.targetIds.contains($0.id) }) || timeline.tracks[ti].syncLocked {
                 sortClips(trackIndex: ti)
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -31,20 +31,17 @@ extension EditorViewModel {
         undoManager?.setActionName(edits.count == 1 ? "Trim Clip" : "Trim Clips")
     }
 
-    /// The resolved layout of a ripple trim: the resized clip(s) and how every downstream clip
-    /// shifts. Pure — `rippleTrimClip` applies it, the timeline view previews it, so the two
-    /// can't drift.
+    /// Ripple trim result: resized clips, shifted clips, and optional obstacle frame if clamped.
     struct RippleTrimPlan {
         struct Resize { let clipId: String; let trimStart: Int; let trimEnd: Int; let duration: Int }
         let durationDelta: Int
         let resizes: [Resize]
         let shifts: [ClipShift]
+        let blockedAtFrame: Int?
         var targetIds: Set<String> { Set(resizes.map(\.clipId)) }
     }
 
-    /// Resolve a ripple trim without mutating anything. Binds the edit to the most-constrained
-    /// linked partner so A/V keeps equal durations, then resolves each resize and the downstream
-    /// shift on the lead's track, linked-partner tracks, and sync-locked followers. Nil for a no-op.
+    /// Plans a non-destructive ripple trim, capped by the strictest linked or sync-locked constraint
     func planRippleTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) -> RippleTrimPlan? {
         guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return nil }
         let leadEnd = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex].endFrame
@@ -55,10 +52,24 @@ extension EditorViewModel {
         let targetClips = targets.compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
 
         // Each target's own source headroom caps how far it can ripple; bind to the smallest.
-        let durationDelta = targetClips
+        let sourceDelta = targetClips
             .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
             .min(by: { abs($0) < abs($1) }) ?? 0
-        guard durationDelta != 0 else { return nil }
+
+        // Shrinking shifts sync-locked followers left; clamp to the tightest available room.
+        var durationDelta = sourceDelta
+        var blockedAtFrame: Int?
+        if sourceDelta < 0 {
+            let limits = timeline.tracks.compactMap { track -> (room: Int, obstacle: Int)? in
+                guard track.syncLocked, !track.clips.contains(where: { targetIds.contains($0.id) }) else { return nil }
+                return syncLockedLeftRoom(track: track, insertFrame: leadEnd)
+            }
+            if let tightest = limits.min(by: { $0.room < $1.room }), sourceDelta < -tightest.room {
+                durationDelta = -tightest.room
+                blockedAtFrame = tightest.obstacle
+            }
+        }
+        guard durationDelta != 0 || blockedAtFrame != nil else { return nil }
 
         // A right-edge duration change maps to the same source-frame edge drag; left flips sign.
         let resizes = targetClips.map { c -> RippleTrimPlan.Resize in
@@ -70,26 +81,25 @@ extension EditorViewModel {
         var shifts: [ClipShift] = []
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
-            guard track.clips.contains(where: { targetIds.contains($0.id) }) || track.syncLocked else { continue }
+            let targetEnd = track.clips.first { targetIds.contains($0.id) }?.endFrame
+            guard targetEnd != nil || track.syncLocked else { continue }
             shifts += RippleEngine.computeRipplePush(
-                clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta, excludeIds: targetIds
+                clips: track.clips, insertFrame: targetEnd ?? leadEnd, pushAmount: durationDelta, excludeIds: targetIds
             )
         }
-        return RippleTrimPlan(durationDelta: durationDelta, resizes: resizes, shifts: shifts)
+        return RippleTrimPlan(durationDelta: durationDelta, resizes: resizes, shifts: shifts, blockedAtFrame: blockedAtFrame)
+    }
+
+    /// Max left shift for sync-locked clips before hitting the next obstacle; nil if no shift possible.
+    private func syncLockedLeftRoom(track: Track, insertFrame: Int) -> (room: Int, obstacle: Int)? {
+        guard let first = track.clips.filter({ $0.startFrame >= insertFrame }).map(\.startFrame).min() else { return nil }
+        let prevEnd = track.clips.filter { $0.startFrame < insertFrame }.map(\.endFrame).max() ?? 0
+        return (max(0, first - prevEnd), prevEnd)
     }
 
     /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
     func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
         guard let plan = planRippleTrim(clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked) else { return }
-
-        // Pre-validate sync-locked followers (no resized clip of their own, but must absorb the shift).
-        for ti in timeline.tracks.indices {
-            let track = timeline.tracks[ti]
-            guard track.syncLocked, !track.clips.contains(where: { plan.targetIds.contains($0.id) }) else { continue }
-            let trackIds = Set(track.clips.map(\.id))
-            let trackShifts = plan.shifts.filter { trackIds.contains($0.clipId) }
-            if let reason = validateShifts(trackIndex: ti, shifts: trackShifts) { refuseRipple(reason: reason); return }
-        }
 
         let touched = plan.targetIds.union(plan.shifts.map(\.clipId))
         withTimelineSwap(actionName: "Ripple Trim") {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -20,9 +20,7 @@ extension EditorViewModel {
 
     // MARK: - Public API
 
-    /// Trim one or more clips in a single undo group. Overwrite-style: each clip
-    /// resizes in place — no adjacent-clip shift on the same track, no sync-lock
-    /// push to other tracks.
+    /// Trim one or more clips in a single undo group. Overwrite-style
     func trimClips(_ edits: [(clipId: String, trimStartFrame: Int, trimEndFrame: Int)]) {
         guard !edits.isEmpty else { return }
         undoManager?.beginUndoGrouping()
@@ -31,6 +29,67 @@ extension EditorViewModel {
         }
         undoManager?.endUndoGrouping()
         undoManager?.setActionName(edits.count == 1 ? "Trim Clip" : "Trim Clips")
+    }
+
+    /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
+    func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
+        guard deltaFrames != 0, let loc = findClip(id: clipId) else { return }
+        let lead = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        let oldEnd = lead.endFrame
+
+        // Clips to resize: the lead, plus linked partners when propagation is on.
+        var targets: [String] = [clipId]
+        if propagateToLinked { targets.append(contentsOf: linkedPartnerIds(of: clipId)) }
+        let targetIds = Set(targets)
+
+        // Linked A/V share start/end/speed, so the lead's delta drives every track uniformly.
+        let durationDelta = rippleTrimValues(for: lead, edge: edge, delta: deltaFrames).durationDelta
+        guard durationDelta != 0 else { return }
+
+        // Pre-validate sync-locked followers (no resized clip of their own, but must absorb the shift).
+        for ti in timeline.tracks.indices {
+            let track = timeline.tracks[ti]
+            guard track.syncLocked, !track.clips.contains(where: { targetIds.contains($0.id) }) else { continue }
+            let shifts = RippleEngine.computeRipplePush(clips: track.clips, insertFrame: oldEnd, pushAmount: durationDelta)
+            if let reason = validateShifts(trackIndex: ti, shifts: shifts) { refuseRipple(reason: reason); return }
+        }
+
+        withTimelineSwap(actionName: "Ripple Trim") {
+            for id in targets {
+                guard let l = findClip(id: id) else { continue }
+                let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
+                let new = rippleTrimValues(for: c, edge: edge, delta: deltaFrames)
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = new.trimStart
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = new.trimEnd
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(max(1, c.durationFrames + durationDelta))
+            }
+            for ti in timeline.tracks.indices {
+                let track = timeline.tracks[ti]
+                let holdsTarget = track.clips.contains { targetIds.contains($0.id) }
+                guard holdsTarget || track.syncLocked else { continue }
+                applyShifts(RippleEngine.computeRipplePush(
+                    clips: track.clips, insertFrame: oldEnd, pushAmount: durationDelta, excludeIds: targetIds
+                ))
+                sortClips(trackIndex: ti)
+            }
+        }
+    }
+
+    /// New source trim and the resulting timeline-duration delta for a ripple trim of `clip`.
+    /// Mirrors the source↔timeline conversion and clamping in `trimClipInternal`.
+    private func rippleTrimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int, durationDelta: Int) {
+        let sourceDelta = Int((Double(delta) * clip.speed).rounded())
+        let unbounded = clip.mediaType == .image || clip.mediaType == .text
+        switch edge {
+        case .left:
+            let newStart = unbounded ? clip.trimStartFrame + sourceDelta : max(0, clip.trimStartFrame + sourceDelta)
+            let deltaTimeline = Int((Double(newStart - clip.trimStartFrame) / clip.speed).rounded())
+            return (newStart, clip.trimEndFrame, -deltaTimeline)
+        case .right:
+            let newEnd = unbounded ? clip.trimEndFrame - sourceDelta : max(0, clip.trimEndFrame - sourceDelta)
+            let deltaTimeline = Int((Double(newEnd - clip.trimEndFrame) / clip.speed).rounded())
+            return (clip.trimStartFrame, newEnd, -deltaTimeline)
+        }
     }
 
     /// Ripple delete: remove selected clips and close the gaps. Sync-locked tracks shift

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -31,17 +31,20 @@ extension EditorViewModel {
         undoManager?.setActionName(edits.count == 1 ? "Trim Clip" : "Trim Clips")
     }
 
-    /// The resolved layout of a ripple trim: which clips resize, by how much, and how every
-    /// downstream clip shifts. Pure — `rippleTrimClip` applies it, the timeline view previews it.
+    /// The resolved layout of a ripple trim: the resized clip(s) and how every downstream clip
+    /// shifts. Pure — `rippleTrimClip` applies it, the timeline view previews it, so the two
+    /// can't drift.
     struct RippleTrimPlan {
+        struct Resize { let clipId: String; let trimStart: Int; let trimEnd: Int; let duration: Int }
         let durationDelta: Int
-        let targetIds: Set<String>
+        let resizes: [Resize]
         let shifts: [ClipShift]
+        var targetIds: Set<String> { Set(resizes.map(\.clipId)) }
     }
 
     /// Resolve a ripple trim without mutating anything. Binds the edit to the most-constrained
-    /// linked partner so A/V keeps equal durations, then computes the downstream shift on the
-    /// lead's track, linked-partner tracks, and sync-locked followers. Returns nil for a no-op.
+    /// linked partner so A/V keeps equal durations, then resolves each resize and the downstream
+    /// shift on the lead's track, linked-partner tracks, and sync-locked followers. Nil for a no-op.
     func planRippleTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) -> RippleTrimPlan? {
         guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return nil }
         let leadEnd = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex].endFrame
@@ -49,24 +52,30 @@ extension EditorViewModel {
         var targets: [String] = [clipId]
         if propagateToLinked { targets.append(contentsOf: linkedPartnerIds(of: clipId)) }
         let targetIds = Set(targets)
+        let targetClips = targets.compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
 
         // Each target's own source headroom caps how far it can ripple; bind to the smallest.
-        let durationDelta = targets
-            .compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+        let durationDelta = targetClips
             .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
             .min(by: { abs($0) < abs($1) }) ?? 0
         guard durationDelta != 0 else { return nil }
 
+        // A right-edge duration change maps to the same source-frame edge drag; left flips sign.
+        let resizes = targetClips.map { c -> RippleTrimPlan.Resize in
+            let fields = trimValues(for: c, edge: edge, delta: edge == .right ? durationDelta : -durationDelta)
+            return .init(clipId: c.id, trimStart: fields.trimStart, trimEnd: fields.trimEnd,
+                         duration: max(1, c.durationFrames + durationDelta))
+        }
+
         var shifts: [ClipShift] = []
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
-            let holdsTarget = track.clips.contains { targetIds.contains($0.id) }
-            guard holdsTarget || track.syncLocked else { continue }
+            guard track.clips.contains(where: { targetIds.contains($0.id) }) || track.syncLocked else { continue }
             shifts += RippleEngine.computeRipplePush(
                 clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta, excludeIds: targetIds
             )
         }
-        return RippleTrimPlan(durationDelta: durationDelta, targetIds: targetIds, shifts: shifts)
+        return RippleTrimPlan(durationDelta: durationDelta, resizes: resizes, shifts: shifts)
     }
 
     /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
@@ -82,19 +91,16 @@ extension EditorViewModel {
             if let reason = validateShifts(trackIndex: ti, shifts: trackShifts) { refuseRipple(reason: reason); return }
         }
 
+        let touched = plan.targetIds.union(plan.shifts.map(\.clipId))
         withTimelineSwap(actionName: "Ripple Trim") {
-            for id in plan.targetIds {
-                guard let l = findClip(id: id) else { continue }
-                let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
-                // A right-edge duration change maps to the same source-frame edge drag; left flips sign.
-                let fields = trimValues(for: c, edge: edge, delta: edge == .right ? plan.durationDelta : -plan.durationDelta)
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = fields.trimStart
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = fields.trimEnd
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(max(1, c.durationFrames + plan.durationDelta))
+            for r in plan.resizes {
+                guard let l = findClip(id: r.clipId) else { continue }
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = r.trimStart
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = r.trimEnd
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(r.duration)
             }
             applyShifts(plan.shifts)
-            for ti in timeline.tracks.indices where
-                timeline.tracks[ti].clips.contains(where: { plan.targetIds.contains($0.id) }) || timeline.tracks[ti].syncLocked {
+            for ti in timeline.tracks.indices where timeline.tracks[ti].clips.contains(where: { touched.contains($0.id) }) {
                 sortClips(trackIndex: ti)
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -33,24 +33,27 @@ extension EditorViewModel {
 
     /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
     func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
-        guard deltaFrames != 0, let loc = findClip(id: clipId) else { return }
-        let lead = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        let oldEnd = lead.endFrame
+        guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return }
+        let leadEnd = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex].endFrame
 
         // Clips to resize: the lead, plus linked partners when propagation is on.
         var targets: [String] = [clipId]
         if propagateToLinked { targets.append(contentsOf: linkedPartnerIds(of: clipId)) }
         let targetIds = Set(targets)
 
-        // Linked A/V share start/end/speed, so the lead's delta drives every track uniformly.
-        let durationDelta = rippleTrimValues(for: lead, edge: edge, delta: deltaFrames).durationDelta
+        // Each target's own source headroom caps how far it can ripple. 
+        // Bind the whole edit to the most-constrained partner (smallest achievable delta)
+        let durationDelta = targets
+            .compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+            .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
+            .min(by: { abs($0) < abs($1) }) ?? 0
         guard durationDelta != 0 else { return }
 
         // Pre-validate sync-locked followers (no resized clip of their own, but must absorb the shift).
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
             guard track.syncLocked, !track.clips.contains(where: { targetIds.contains($0.id) }) else { continue }
-            let shifts = RippleEngine.computeRipplePush(clips: track.clips, insertFrame: oldEnd, pushAmount: durationDelta)
+            let shifts = RippleEngine.computeRipplePush(clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta)
             if let reason = validateShifts(trackIndex: ti, shifts: shifts) { refuseRipple(reason: reason); return }
         }
 
@@ -58,9 +61,10 @@ extension EditorViewModel {
             for id in targets {
                 guard let l = findClip(id: id) else { continue }
                 let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
-                let new = rippleTrimValues(for: c, edge: edge, delta: deltaFrames)
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = new.trimStart
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = new.trimEnd
+                // A right-edge duration change maps to the same source-frame edge drag; left flips sign.
+                let fields = trimValues(for: c, edge: edge, delta: edge == .right ? durationDelta : -durationDelta)
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = fields.trimStart
+                timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = fields.trimEnd
                 timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(max(1, c.durationFrames + durationDelta))
             }
             for ti in timeline.tracks.indices {
@@ -68,28 +72,20 @@ extension EditorViewModel {
                 let holdsTarget = track.clips.contains { targetIds.contains($0.id) }
                 guard holdsTarget || track.syncLocked else { continue }
                 applyShifts(RippleEngine.computeRipplePush(
-                    clips: track.clips, insertFrame: oldEnd, pushAmount: durationDelta, excludeIds: targetIds
+                    clips: track.clips, insertFrame: leadEnd, pushAmount: durationDelta, excludeIds: targetIds
                 ))
                 sortClips(trackIndex: ti)
             }
         }
     }
 
-    /// New source trim and the resulting timeline-duration delta for a ripple trim of `clip`.
-    /// Mirrors the source↔timeline conversion and clamping in `trimClipInternal`.
-    private func rippleTrimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int, durationDelta: Int) {
-        let sourceDelta = Int((Double(delta) * clip.speed).rounded())
-        let unbounded = clip.mediaType == .image || clip.mediaType == .text
-        switch edge {
-        case .left:
-            let newStart = unbounded ? clip.trimStartFrame + sourceDelta : max(0, clip.trimStartFrame + sourceDelta)
-            let deltaTimeline = Int((Double(newStart - clip.trimStartFrame) / clip.speed).rounded())
-            return (newStart, clip.trimEndFrame, -deltaTimeline)
-        case .right:
-            let newEnd = unbounded ? clip.trimEndFrame - sourceDelta : max(0, clip.trimEndFrame - sourceDelta)
-            let deltaTimeline = Int((Double(newEnd - clip.trimEndFrame) / clip.speed).rounded())
-            return (clip.trimStartFrame, newEnd, -deltaTimeline)
-        }
+    /// Achievable timeline-duration delta for a ripple trim of `clip` from a drag of `delta`
+    /// timeline frames. Reuses `trimValues` for the source clamp, then converts the realised
+    /// source-trim change back to a timeline-length delta (positive = longer).
+    private func rippleTrimDurationDelta(for clip: Clip, edge: TrimEdge, delta: Int) -> Int {
+        let fields = trimValues(for: clip, edge: edge, delta: delta)
+        let sourceShift = (fields.trimStart - clip.trimStartFrame) + (fields.trimEnd - clip.trimEndFrame)
+        return -Int((Double(sourceShift) / clip.speed).rounded())
     }
 
     /// Ripple delete: remove selected clips and close the gaps. Sync-locked tracks shift

--- a/Sources/PalmierPro/Help/ShortcutsPane.swift
+++ b/Sources/PalmierPro/Help/ShortcutsPane.swift
@@ -21,6 +21,7 @@ struct ShortcutsPane: View {
             ("] or W", "Trim End to Playhead"),
             ("Backspace", "Delete"),
             ("Shift + Backspace", "Ripple Delete"),
+            ("Shift + Drag Edge", "Ripple Trim"),
             ("Opt + Drag", "Duplicate Clip"),
         ]),
         ShortcutGroup(title: "Timeline", shortcuts: [

--- a/Sources/PalmierPro/Timeline/DragState.swift
+++ b/Sources/PalmierPro/Timeline/DragState.swift
@@ -80,6 +80,7 @@ enum DragState {
         let hasNoSourceMedia: Bool
         /// When true, trim applies to link-group partners too.
         let propagateToLinked: Bool
+        let isRipple: Bool
         var deltaFrames: Int = 0
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -85,7 +85,15 @@ final class TimelineInputController {
             // Linked behavior is always on; Option is the per-drag override.
             let linkedOn = !isOption
 
-            if isShift {
+            let localX = point.x - rect.minX
+            let onTrimHandle = !isOption && Self.isOnTrimZone(localX: localX, clipWidth: rect.width)
+            let rippleTrim = isShift && onTrimHandle
+
+            if rippleTrim {
+                if !editor.selectedClipIds.contains(clip.id) {
+                    editor.selectedClipIds = linkedOn ? editor.expandToLinkGroup([clip.id]) : [clip.id]
+                }
+            } else if isShift {
                 if editor.selectedClipIds.contains(clip.id) {
                     if linkedOn {
                         editor.selectedClipIds.subtract(editor.expandToLinkGroup([clip.id]))
@@ -103,7 +111,6 @@ final class TimelineInputController {
                 editor.selectedClipIds = linkedOn ? editor.expandToLinkGroup([clip.id]) : [clip.id]
             }
 
-            let localX = point.x - rect.minX
             let isCommand = event.modifierFlags.contains(.command)
 
             if let edge = fadeKneeHit(at: point, clip: clip, clipRect: rect) {
@@ -141,7 +148,8 @@ final class TimelineInputController {
                     originalStartFrame: clip.startFrame,
                     originalDuration: clip.durationFrames,
                     hasNoSourceMedia: clip.mediaType == .image || clip.mediaType == .text,
-                    propagateToLinked: linkedOn
+                    propagateToLinked: linkedOn,
+                    isRipple: rippleTrim
                 ))
             } else if !isOption, localX >= rect.width - Trim.handleWidth {
                 dragState = .trimRight(DragState.TrimDrag(
@@ -152,7 +160,8 @@ final class TimelineInputController {
                     originalStartFrame: clip.startFrame,
                     originalDuration: clip.durationFrames,
                     hasNoSourceMedia: clip.mediaType == .image || clip.mediaType == .text,
-                    propagateToLinked: linkedOn
+                    propagateToLinked: linkedOn,
+                    isRipple: rippleTrim
                 ))
             } else {
                 let grabFrame = geometry.frameAt(x: point.x)
@@ -439,22 +448,30 @@ final class TimelineInputController {
 
         case .trimLeft(let drag):
             if drag.deltaFrames != 0 {
-                editor.commitTrim(
-                    clipId: drag.clipId,
-                    edge: .left,
-                    deltaFrames: drag.deltaFrames,
-                    propagateToLinked: drag.propagateToLinked
-                )
+                if drag.isRipple {
+                    editor.rippleTrimClip(clipId: drag.clipId, edge: .left, deltaFrames: drag.deltaFrames, propagateToLinked: drag.propagateToLinked)
+                } else {
+                    editor.commitTrim(
+                        clipId: drag.clipId,
+                        edge: .left,
+                        deltaFrames: drag.deltaFrames,
+                        propagateToLinked: drag.propagateToLinked
+                    )
+                }
             }
 
         case .trimRight(let drag):
             if drag.deltaFrames != 0 {
-                editor.commitTrim(
-                    clipId: drag.clipId,
-                    edge: .right,
-                    deltaFrames: drag.deltaFrames,
-                    propagateToLinked: drag.propagateToLinked
-                )
+                if drag.isRipple {
+                    editor.rippleTrimClip(clipId: drag.clipId, edge: .right, deltaFrames: drag.deltaFrames, propagateToLinked: drag.propagateToLinked)
+                } else {
+                    editor.commitTrim(
+                        clipId: drag.clipId,
+                        edge: .right,
+                        deltaFrames: drag.deltaFrames,
+                        propagateToLinked: drag.propagateToLinked
+                    )
+                }
             }
 
         case .audioVolumeKf(let drag):

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -359,7 +359,9 @@ final class TimelineView: NSView {
                 }
 
                 if let (drag, isLeft) = trimDrag,
-                   clip.id == drag.clipId || trimPartnerIds.contains(clip.id) {
+                   clip.id == drag.clipId || trimPartnerIds.contains(clip.id),
+                   // Ripple drags with no resize preview at rest.
+                   !(drag.isRipple && rippleResizeByClip[clip.id] == nil) {
                     var previewClip = clip
                     if let resize = rippleResizeByClip[clip.id] {
                         // Ripple: start stays anchored; the plan's resize grows/shrinks the tail.
@@ -414,6 +416,17 @@ final class TimelineView: NSView {
                                   displayName: editor.clipDisplayLabel(for: clip),
                                   linkOffset: linkOffsets[clip.id],
                                   fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
+            }
+        }
+
+        // Red wall at the obstacle frame — the sync-locked clip edge the ripple butts against.
+        if let wall = ripplePlan?.blockedAtFrame {
+            let x = geo.xForFrame(wall)
+            let line = NSRect(x: x - AppTheme.BorderWidth.thick / 2, y: Double(geo.rulerHeight),
+                              width: AppTheme.BorderWidth.thick, height: Double(max(0, bounds.height - geo.rulerHeight)))
+            if line.intersects(dirtyRect) {
+                ctx.setFillColor(AppTheme.Status.error.cgColor)
+                ctx.fill(line)
             }
         }
     }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -295,6 +295,18 @@ final class TimelineView: NSView {
             return Set(editor.linkedPartnerIds(of: drag.clipId))
         }()
 
+        // Live ripple-trim layout: downstream clips shift while the edge is dragged.
+        let ripplePlan: EditorViewModel.RippleTrimPlan? = {
+            guard let (drag, isLeft) = trimDrag, drag.isRipple else { return nil }
+            return editor.planRippleTrim(
+                clipId: drag.clipId, edge: isLeft ? .left : .right,
+                deltaFrames: drag.deltaFrames, propagateToLinked: drag.propagateToLinked
+            )
+        }()
+        let rippleShiftByClip: [String: Int] = ripplePlan.map {
+            Dictionary(uniqueKeysWithValues: $0.shifts.map { ($0.clipId, $0.newStartFrame) })
+        } ?? [:]
+
         let linkOffsets = editor.linkGroupOffsets()
 
         clipDisplayRects.removeAll(keepingCapacity: true)
@@ -346,14 +358,24 @@ final class TimelineView: NSView {
                 if let (drag, isLeft) = trimDrag,
                    clip.id == drag.clipId || trimPartnerIds.contains(clip.id) {
                     var previewClip = clip
-                    let sourceDelta = Int((Double(drag.deltaFrames) * clip.speed).rounded())
-                    if isLeft {
-                        previewClip.startFrame = clip.startFrame + drag.deltaFrames
-                        previewClip.trimStartFrame = clip.trimStartFrame + sourceDelta
-                        previewClip.durationFrames = clip.durationFrames - drag.deltaFrames
+                    if let plan = ripplePlan {
+                        // Ripple: start stays anchored; the duration delta (clamped to the most
+                        // constrained partner) grows/shrinks the tail and ripples downstream.
+                        let edge: EditorViewModel.TrimEdge = isLeft ? .left : .right
+                        let fields = editor.trimValues(for: clip, edge: edge, delta: edge == .right ? plan.durationDelta : -plan.durationDelta)
+                        previewClip.trimStartFrame = fields.trimStart
+                        previewClip.trimEndFrame = fields.trimEnd
+                        previewClip.durationFrames = max(1, clip.durationFrames + plan.durationDelta)
                     } else {
-                        previewClip.durationFrames = clip.durationFrames + drag.deltaFrames
-                        previewClip.trimEndFrame = clip.trimEndFrame - sourceDelta
+                        let sourceDelta = Int((Double(drag.deltaFrames) * clip.speed).rounded())
+                        if isLeft {
+                            previewClip.startFrame = clip.startFrame + drag.deltaFrames
+                            previewClip.trimStartFrame = clip.trimStartFrame + sourceDelta
+                            previewClip.durationFrames = clip.durationFrames - drag.deltaFrames
+                        } else {
+                            previewClip.durationFrames = clip.durationFrames + drag.deltaFrames
+                            previewClip.trimEndFrame = clip.trimEndFrame - sourceDelta
+                        }
                     }
                     let previewRect = geo.clipRect(for: previewClip, trackIndex: ti)
                     clipDisplayRects[clip.id] = previewRect
@@ -362,6 +384,22 @@ final class TimelineView: NSView {
                                           isSelected: isSelected, context: ctx,
                                           cache: editor.mediaVisualCache,
                                           displayName: editor.clipDisplayLabel(for: clip),
+                                          fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
+                    }
+                    continue
+                }
+
+                if let shiftedStart = rippleShiftByClip[clip.id] {
+                    var shiftedClip = clip
+                    shiftedClip.startFrame = shiftedStart
+                    let shiftedRect = geo.clipRect(for: shiftedClip, trackIndex: ti)
+                    clipDisplayRects[clip.id] = shiftedRect
+                    if shiftedRect.intersects(dirtyRect) {
+                        ClipRenderer.draw(shiftedClip, type: clip.mediaType, in: shiftedRect,
+                                          isSelected: isSelected, context: ctx,
+                                          cache: editor.mediaVisualCache,
+                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          linkOffset: linkOffsets[clip.id],
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
                     }
                     continue

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -306,6 +306,9 @@ final class TimelineView: NSView {
         let rippleShiftByClip: [String: Int] = ripplePlan.map {
             Dictionary(uniqueKeysWithValues: $0.shifts.map { ($0.clipId, $0.newStartFrame) })
         } ?? [:]
+        let rippleResizeByClip: [String: EditorViewModel.RippleTrimPlan.Resize] = ripplePlan.map {
+            Dictionary(uniqueKeysWithValues: $0.resizes.map { ($0.clipId, $0) })
+        } ?? [:]
 
         let linkOffsets = editor.linkGroupOffsets()
 
@@ -358,14 +361,11 @@ final class TimelineView: NSView {
                 if let (drag, isLeft) = trimDrag,
                    clip.id == drag.clipId || trimPartnerIds.contains(clip.id) {
                     var previewClip = clip
-                    if let plan = ripplePlan {
-                        // Ripple: start stays anchored; the duration delta (clamped to the most
-                        // constrained partner) grows/shrinks the tail and ripples downstream.
-                        let edge: EditorViewModel.TrimEdge = isLeft ? .left : .right
-                        let fields = editor.trimValues(for: clip, edge: edge, delta: edge == .right ? plan.durationDelta : -plan.durationDelta)
-                        previewClip.trimStartFrame = fields.trimStart
-                        previewClip.trimEndFrame = fields.trimEnd
-                        previewClip.durationFrames = max(1, clip.durationFrames + plan.durationDelta)
+                    if let resize = rippleResizeByClip[clip.id] {
+                        // Ripple: start stays anchored; the plan's resize grows/shrinks the tail.
+                        previewClip.trimStartFrame = resize.trimStart
+                        previewClip.trimEndFrame = resize.trimEnd
+                        previewClip.durationFrames = resize.duration
                     } else {
                         let sourceDelta = Int((Double(drag.deltaFrames) * clip.speed).rounded())
                         if isLeft {

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -121,6 +121,50 @@ struct RippleTrimTests {
         #expect(plan?.durationDelta == 10)
     }
 
+    @Test func outOfSyncPartnerRipplesFromItsOwnEnd() {
+        // Audio partner ends 10 frames before the video lead. Each track's downstream must shift
+        // relative to its own resized clip's end, not the lead's, so neither overlaps.
+        var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var a1 = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 90, trimEnd: 50)
+        v1.linkGroupId = "g"
+        a1.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [v1, Fixtures.clip(id: "v2", start: 100, duration: 50)]),
+            Fixtures.audioTrack(clips: [a1, Fixtures.clip(id: "a2", mediaType: .audio, start: 90, duration: 50)]),
+        ])
+        e.rippleTrimClip(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: true)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 120], [120, 170]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 110], [110, 160]])
+    }
+
+    @Test func shrinkClampsAtSyncLockedObstacle() {
+        // Lead ends at 100; the follower b1 sits at 120 with b0 ending at 90, so its downstream can
+        // slide left only 30. A 50-frame shrink clamps to 30. The wall is the obstacle b0's edge
+        // (frame 90 on track 1) — NOT the trimmed clip's stopped edge (frame 70 on track 0).
+        let a = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 100)])
+        let b = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "b0", start: 60, duration: 30),
+            Fixtures.clip(id: "b1", start: 120, duration: 50),
+        ])
+        let e = editor([a, b])
+        let plan = e.planRippleTrim(clipId: "c1", edge: .right, deltaFrames: -50, propagateToLinked: false)
+        #expect(plan?.durationDelta == -30)
+        #expect(plan?.blockedAtFrame == 90)
+        e.rippleTrimClip(clipId: "c1", edge: .right, deltaFrames: -50, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 70]])
+        #expect(spans(e.timeline.tracks[1]) == [[60, 90], [90, 140]])
+    }
+
+    @Test func extendNeverBlocksOnSyncLock() {
+        // Extends push followers right, which is always safe — no clamp, no wall.
+        let a = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 50)])
+        let b = Fixtures.videoTrack(clips: [Fixtures.clip(id: "b1", start: 100, duration: 50)])
+        let e = editor([a, b])
+        let plan = e.planRippleTrim(clipId: "c1", edge: .right, deltaFrames: 20, propagateToLinked: false)
+        #expect(plan?.durationDelta == 20)
+        #expect(plan?.blockedAtFrame == nil)
+    }
+
     @Test func unlinkedTrimLeavesPartnerTrackAlone() {
         // propagateToLinked off: only the lead's track ripples.
         var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -94,6 +94,32 @@ struct RippleTrimTests {
         #expect(spans(e.timeline.tracks[1]) == [[0, 110], [110, 160]])
     }
 
+    @Test func planExposesDownstreamShiftsForPreview() {
+        // The view previews from the same plan the commit applies: c2 shifts forward by 20.
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 50),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        let plan = e.planRippleTrim(clipId: "c1", edge: .right, deltaFrames: 20, propagateToLinked: false)
+        #expect(plan?.durationDelta == 20)
+        #expect(plan?.shifts == [ClipShift(clipId: "c2", newStartFrame: 120)])
+    }
+
+    @Test func planClampsDeltaToConstrainedPartner() {
+        // Preview must reflect the same source clamp as the commit (audio caps at 10).
+        var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var a1 = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100, trimEnd: 10)
+        v1.linkGroupId = "g"
+        a1.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [v1]),
+            Fixtures.audioTrack(clips: [a1]),
+        ])
+        let plan = e.planRippleTrim(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: true)
+        #expect(plan?.durationDelta == 10)
+    }
+
     @Test func unlinkedTrimLeavesPartnerTrackAlone() {
         // propagateToLinked off: only the lead's track ripples.
         var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -78,6 +78,22 @@ struct RippleTrimTests {
         #expect(spans(e.timeline.tracks[1]) == [[0, 120], [120, 170]])
     }
 
+    @Test func linkedExtendClampsToMostConstrainedPartner() {
+        // Video has 50 frames of tail headroom, audio only 10. A 20-frame extend binds to the
+        // audio's limit so both grow by 10 and stay the same length.
+        var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var a1 = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100, trimEnd: 10)
+        v1.linkGroupId = "g"
+        a1.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [v1, Fixtures.clip(id: "v2", start: 100, duration: 50)]),
+            Fixtures.audioTrack(clips: [a1, Fixtures.clip(id: "a2", mediaType: .audio, start: 100, duration: 50)]),
+        ])
+        e.rippleTrimClip(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: true)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 110], [110, 160]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 110], [110, 160]])
+    }
+
     @Test func unlinkedTrimLeavesPartnerTrackAlone() {
         // propagateToLinked off: only the lead's track ripples.
         var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -104,6 +104,7 @@ struct RippleTrimTests {
         let plan = e.planRippleTrim(clipId: "c1", edge: .right, deltaFrames: 20, propagateToLinked: false)
         #expect(plan?.durationDelta == 20)
         #expect(plan?.shifts == [ClipShift(clipId: "c2", newStartFrame: 120)])
+        #expect(plan?.resizes.first?.duration == 120)
     }
 
     @Test func planClampsDeltaToConstrainedPartner() {

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private func editor(_ tracks: [Track]) -> EditorViewModel {
+    let e = EditorViewModel()
+    e.timeline = Fixtures.timeline(tracks: tracks)
+    return e
+}
+
+private func spans(_ track: Track) -> [[Int]] {
+    track.clips.sorted { $0.startFrame < $1.startFrame }.map { [$0.startFrame, $0.endFrame] }
+}
+
+@Suite("EditorViewModel — rippleTrimClip")
+@MainActor
+struct RippleTrimTests {
+
+    @Test func rightExtendPushesDownstream() {
+        // c1 has 50 frames of tail headroom; extend the out-point by 20 and c2 rides forward.
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 50),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        e.rippleTrimClip(clipId: "c1", edge: .right, deltaFrames: 20, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 120], [120, 170]])
+    }
+
+    @Test func rightShrinkPullsDownstreamBack() {
+        // Shrinking the out-point by 20 closes the gap: c2 slides left to stay contiguous.
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        e.rippleTrimClip(clipId: "c1", edge: .right, deltaFrames: -20, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 80], [80, 130]])
+    }
+
+    @Test func extendNeverOverwritesFollowingClip() {
+        // Without ripple this would overlap c2; ripple keeps every clip intact.
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 80),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        e.rippleTrimClip(clipId: "c1", edge: .right, deltaFrames: 60, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 160], [160, 210]])
+    }
+
+    @Test func leftRippleAnchorsStartAndShiftsDownstream() {
+        // Head trim keeps the left edge butted at frame 0; the in-point reveals earlier source
+        // and the duration delta ripples downstream.
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimStart: 30),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        e.rippleTrimClip(clipId: "c1", edge: .left, deltaFrames: -20, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 120], [120, 170]])
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "c1" }?.trimStartFrame == 10)
+    }
+
+    @Test func linkedPartnerRipplesInSync() {
+        // Video + linked audio extend together and each track's downstream clip rides forward.
+        var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var a1 = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100, trimEnd: 50)
+        v1.linkGroupId = "g"
+        a1.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [v1, Fixtures.clip(id: "v2", start: 100, duration: 50)]),
+            Fixtures.audioTrack(clips: [a1, Fixtures.clip(id: "a2", mediaType: .audio, start: 100, duration: 50)]),
+        ])
+        e.rippleTrimClip(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: true)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 120], [120, 170]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 120], [120, 170]])
+    }
+
+    @Test func unlinkedTrimLeavesPartnerTrackAlone() {
+        // propagateToLinked off: only the lead's track ripples.
+        var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var a1 = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100, trimEnd: 50)
+        v1.linkGroupId = "g"
+        a1.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [v1]),
+            Fixtures.audioTrack(clips: [a1]),
+        ])
+        e.rippleTrimClip(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: false)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 120]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 100]])
+    }
+}


### PR DESCRIPTION
from user's feedback: there is no ripple extend currently.

fix:

Shift+drag a clip's trim handle resizes from that edge and ripples every clip after it (plus sync-locked followers) instead of overwriting. Bare drag keeps overwrite trim. Matches the existing Shift=ripple convention used by ripple delete.

- Right edge: extend pushes downstream forward, shrink closes the gap.
- Left edge: start stays anchored, in-point changes, downstream ripples.
- Linked A/V resize and ripple in sync; refuses when a sync-locked follower can't absorb the shift.
- Source-material caps still apply; images/text extend unbounded.

rippleTrimClip reuses RippleEngine.computeRipplePush and validateShifts; rippleTrimValues mirrors the source/timeline conversion in trimClipInternal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline edit/ripple math (linked A/V, sync-lock clamps, and commit vs preview), so regressions could corrupt clip layout; scope is well covered by new unit tests.
> 
> **Overview**
> Adds **ripple trim**: **Shift + drag** a clip’s left or right trim handle resizes from that edge and pushes or pulls everything after it on the track (and on **sync-locked** tracks), instead of overwrite trim. Plain edge drag still uses the existing overwrite `commitTrim` path.
> 
> `EditorViewModel` gains **`planRippleTrim`** / **`rippleTrimClip`** with a shared **`RippleTrimPlan`** (resizes, downstream shifts via `RippleEngine.computeRipplePush`, source-headroom caps, linked-partner clamping, and shrink limits on sync-locked followers with **`blockedAtFrame`** for UI). **`trimValues`** is exposed for reuse from the linking module.
> 
> Timeline input tags trim drags with **`isRipple`** when Shift is held on a handle; mouse-up calls **`rippleTrimClip`** instead of **`commitTrim`**. **`TimelineView`** previews the same plan during the drag (shifted clips + resize) and draws a red obstacle line when clamped.
> 
> Docs: keyboard shortcuts list **Shift + Drag Edge**; Edit menu wires **Shift+Backspace** ripple delete through **`rippleDeleteSelected`** (clips vs gap). New **`RippleTrimTests`** cover extend/shrink, links, sync-lock clamp, and preview parity with commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8478ed80625c072930be985f4d4833903357e543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->