### PR TITLE
[timeline] drag to reorder tracks via header grip handle

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -50,6 +50,27 @@ extension EditorViewModel {
         removeTracks(ids: [id])
     }
 
+    // MARK: - Reorder
+    /// Instantly move the track with `id` to `targetIndex`, clamped to its track type zone. No undo.
+    func reorderTrackLive(id: String, to targetIndex: Int) {
+        guard let from = timeline.tracks.firstIndex(where: { $0.id == id }) else { return }
+        let z = zones
+        let isAudio = timeline.tracks[from].type == .audio
+        let lower = isAudio ? z.firstAudioIndex : 0
+        let upper = isAudio ? z.trackCount - 1 : z.firstAudioIndex - 1
+        let dest = max(lower, min(upper, targetIndex))
+        guard dest != from else { return }
+        let track = timeline.tracks.remove(at: from)
+        timeline.tracks.insert(track, at: dest)
+    }
+
+    /// Register a single undo step for a completed live reorder.
+    func commitTrackReorder(before: Timeline) {
+        guard before != timeline else { return }
+        registerTimelineSwap(undoState: before, redoState: timeline, actionName: "Reorder Track")
+        notifyTimelineChanged()
+    }
+
     func removeTracks(ids: [String]) {
         let set = Set(ids)
         guard timeline.tracks.contains(where: { set.contains($0.id) }) else { return }

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -22,6 +22,7 @@ struct TimelineContainerView: NSViewRepresentable {
         let timelineView = TimelineView(editor: editor)
         timelineView.autoresizingMask = []
         scrollView.documentView = timelineView
+        headerView.requestCanvasRedraw = { [weak timelineView] in timelineView?.needsDisplay = true }
 
         scrollView.frame = NSRect(x: Layout.trackHeaderWidth, y: 0, width: 0, height: 0)
         scrollView.autoresizingMask = [.width, .height]

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -4,6 +4,8 @@ import AppKit
 final class TimelineHeaderView: NSView {
     unowned var editor: EditorViewModel
 
+    var requestCanvasRedraw: (() -> Void)?
+
     private static let headerBg = AppTheme.Background.surface.cgColor
     private static let labelAttrs: [NSAttributedString.Key: Any] = [
         .font: NSFont.systemFont(ofSize: AppTheme.FontSize.sm, weight: .medium),
@@ -208,6 +210,7 @@ final class TimelineHeaderView: NSView {
             editor.reorderTrackLive(id: drag.id, to: geo.trackAt(y: Double(point.y)))
             NSCursor.closedHand.set()
             needsDisplay = true
+            requestCanvasRedraw?()
             return
         }
 

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -14,6 +14,7 @@ final class TimelineHeaderView: NSView {
     var muteButtonRects: [Int: NSRect] = [:]
     var hideButtonRects: [Int: NSRect] = [:]
     var syncLockButtonRects: [Int: NSRect] = [:]
+    var dragHandleRects: [Int: NSRect] = [:]
 
     init(editor: EditorViewModel) {
         self.editor = editor
@@ -45,6 +46,7 @@ final class TimelineHeaderView: NSView {
         muteButtonRects.removeAll()
         hideButtonRects.removeAll()
         syncLockButtonRects.removeAll()
+        dragHandleRects.removeAll()
         let stripWidth: CGFloat = 3
         let iconSize: CGFloat = 14
         let iconConfig = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
@@ -56,15 +58,27 @@ final class TimelineHeaderView: NSView {
             let y = geo.trackY(at: i)
             let h = geo.trackHeight(at: i)
 
+            // Lift the row being dragged
+            if reorderDrag?.id == track.id {
+                ctx.setFillColor(AppTheme.Background.prominent.cgColor)
+                ctx.fill(NSRect(x: 0, y: y, width: headerWidth, height: h))
+            }
+
             // Color-coded left border strip
             ctx.setFillColor(track.type.themeColor.cgColor)
             ctx.fill(NSRect(x: 0, y: y, width: stripWidth, height: h))
+
+            // Drag handle (reorder grip)
+            let gripX = stripWidth + 6
+            let gripRect = NSRect(x: gripX, y: y + (h - iconSize) / 2, width: iconSize, height: iconSize)
+            drawSymbol("line.3.horizontal", in: gripRect, tint: AppTheme.Text.secondary.withAlphaComponent(0.4), config: iconConfig, context: ctx)
+            dragHandleRects[i] = gripRect.insetBy(dx: -4, dy: -4)
 
             // Track label
             let str = NSAttributedString(string: editor.timelineTrackDisplayLabel(at: i), attributes: Self.labelAttrs)
             let labelSize = str.size()
             let labelY = y + (h - labelSize.height) / 2
-            str.draw(at: NSPoint(x: stripWidth + 6, y: labelY))
+            str.draw(at: NSPoint(x: gripX + iconSize + 6, y: labelY))
 
 
             let iconY = y + (h - iconSize) / 2
@@ -135,6 +149,7 @@ final class TimelineHeaderView: NSView {
     // MARK: - Input handling (mute/hide/resize)
 
     private var resizeDrag: (trackIndex: Int, originalHeight: CGFloat)?
+    private var reorderDrag: (id: String, before: Timeline)?
 
     private func hitTestResizeHandle(at point: NSPoint) -> Int? {
         let geo = TimelineGeometry(editor: editor, bounds: bounds)
@@ -172,14 +187,31 @@ final class TimelineHeaderView: NSView {
             }
         }
 
+        for (ti, rect) in dragHandleRects {
+            if rect.contains(point) {
+                reorderDrag = (editor.timeline.tracks[ti].id, editor.timeline)
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+
         if let ti = hitTestResizeHandle(at: point) {
             resizeDrag = (ti, editor.timeline.tracks[ti].displayHeight)
         }
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let drag = resizeDrag else { return }
         let point = convert(event.locationInWindow, from: nil)
+
+        if let drag = reorderDrag {
+            let geo = TimelineGeometry(editor: editor, bounds: bounds)
+            editor.reorderTrackLive(id: drag.id, to: geo.trackAt(y: Double(point.y)))
+            NSCursor.closedHand.set()
+            needsDisplay = true
+            return
+        }
+
+        guard let drag = resizeDrag else { return }
         let geo = TimelineGeometry(editor: editor, bounds: bounds)
         let trackTop = geo.trackY(at: drag.trackIndex)
         let newHeight = max(TrackSize.minHeight, min(TrackSize.maxHeight, point.y - trackTop))
@@ -190,6 +222,13 @@ final class TimelineHeaderView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        if let drag = reorderDrag {
+            reorderDrag = nil
+            editor.commitTrackReorder(before: drag.before)
+            needsDisplay = true
+            return
+        }
+
         guard let drag = resizeDrag else { return }
         let finalHeight = editor.timeline.tracks[drag.trackIndex].displayHeight
         if finalHeight != drag.originalHeight {
@@ -202,7 +241,9 @@ final class TimelineHeaderView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        if hitTestResizeHandle(at: point) != nil {
+        if dragHandleRects.values.contains(where: { $0.contains(point) }) {
+            NSCursor.openHand.set()
+        } else if hitTestResizeHandle(at: point) != nil {
             NSCursor.resizeUpDown.set()
         } else {
             NSCursor.arrow.set()


### PR DESCRIPTION
Add a grip handle to each track header that reorders tracks within their video/audio zone via live reshuffle. Direct array mutation during drag, single undo step on release; the dragged row is highlighted.

<img width="624" height="185" alt="Screenshot 2026-06-27 at 10 34 24 PM" src="https://github.com/user-attachments/assets/64782981-924b-4c49-85d7-689139f40606" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live timeline array mutation during drag can briefly desync UI from undo until release, but scope is track order only within existing zone rules.
> 
> **Overview**
> Adds **drag-to-reorder** for timeline tracks from a new grip handle on each track header, with reordering limited to the video/image zone or the audio zone (same rules as insert).
> 
> While dragging, `reorderTrackLive` reshuffles `timeline.tracks` immediately with no undo steps; on mouse up, `commitTrackReorder` records one **Reorder Track** undo via `registerTimelineSwap`. The dragged header row uses a prominent background, open/closed hand cursors, and `requestCanvasRedraw` keeps the scrollable timeline canvas in sync during the drag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25cb6bbfc95a0013c390ebe6e37f41f2456be84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->