### PR TITLE
[timeline] Add select forward and ripple insert preview

### DIFF
--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -75,6 +75,16 @@ enum MainMenuBuilder {
         menu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
         menu.addItem(.separator())
 
+        let selectForwardTrackItem = NSMenuItem(title: "Select Forward on Track", action: #selector(EditorActions.selectForwardOnTrack(_:)), keyEquivalent: "a")
+        selectForwardTrackItem.keyEquivalentModifierMask = []
+        menu.addItem(selectForwardTrackItem)
+
+        let selectForwardAllItem = NSMenuItem(title: "Select Forward on All Tracks", action: #selector(EditorActions.selectForwardOnAllTracks(_:)), keyEquivalent: "a")
+        selectForwardAllItem.keyEquivalentModifierMask = [.shift]
+        menu.addItem(selectForwardAllItem)
+
+        menu.addItem(.separator())
+
         let splitItem = NSMenuItem(title: "Split at Playhead", action: #selector(EditorActions.splitAtPlayhead(_:)), keyEquivalent: "k")
         splitItem.keyEquivalentModifierMask = [.command]
         menu.addItem(splitItem)
@@ -174,6 +184,8 @@ enum MainMenuBuilder {
     func splitAtPlayhead(_ sender: Any?)
     func trimStartToPlayhead(_ sender: Any?)
     func trimEndToPlayhead(_ sender: Any?)
+    func selectForwardOnTrack(_ sender: Any?)
+    func selectForwardOnAllTracks(_ sender: Any?)
     func deleteSelectedClips(_ sender: Any?)
     func rippleDeleteSelected(_ sender: Any?)
     func importMedia(_ sender: Any?)

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -53,6 +53,14 @@ final class EditorWindowController: NSWindowController {
         }
 
         switch event.keyCode {
+        case 0: // A key
+            if editorViewModel.focusedPanel == .timeline,
+               mods.intersection([.command, .option, .control]).isEmpty {
+                editorViewModel.selectForwardFromCurrentSelection(scope: shift ? .allTracks : .track)
+                return true
+            }
+            return false
+
         case 49: // Space
             editorViewModel.togglePlayback()
             return true
@@ -209,6 +217,8 @@ extension EditorWindowController: EditorActions {
     @objc func splitAtPlayhead(_ sender: Any?) { editorViewModel.splitAtPlayhead() }
     @objc func trimStartToPlayhead(_ sender: Any?) { editorViewModel.trimStartToPlayhead() }
     @objc func trimEndToPlayhead(_ sender: Any?) { editorViewModel.trimEndToPlayhead() }
+    @objc func selectForwardOnTrack(_ sender: Any?) { editorViewModel.selectForwardFromCurrentSelection(scope: .track) }
+    @objc func selectForwardOnAllTracks(_ sender: Any?) { editorViewModel.selectForwardFromCurrentSelection(scope: .allTracks) }
     @objc func deleteSelectedClips(_ sender: Any?) { editorViewModel.deleteSelectedClips() }
     @objc func rippleDeleteSelected(_ sender: Any?) {
         if editorViewModel.selectedGap != nil {
@@ -299,6 +309,8 @@ extension EditorWindowController: EditorActions {
             return true
         case #selector(copy(_:)), #selector(cut(_:)):
             return canHandleClipboardShortcut() && !editorViewModel.selectedClipIds.isEmpty
+        case #selector(selectForwardOnTrack(_:)), #selector(selectForwardOnAllTracks(_:)):
+            return editorViewModel.focusedPanel == .timeline && !editorViewModel.selectedClipIds.isEmpty
         case #selector(paste(_:)):
             if editorViewModel.focusedPanel == .media {
                 return MediaTab.clipboardHasImportableMedia()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -322,11 +322,14 @@ extension EditorViewModel {
 
     func materialize(plan: DropPlan) -> (visual: Int?, audio: Int?) {
         let visualIdx = plan.visualTarget.map { materializeTrackIndex(target: $0, type: .video) }
-        let audioIdx: Int? = plan.audioTarget.map { audio in
-            let shifted = plan.visualTarget.map { shiftAfterVisualInsertion(audio: audio, visual: $0) } ?? audio
-            return materializeTrackIndex(target: shifted, type: .audio)
-        }
+        let audioIdx = audioTargetAfterVisualInsertion(plan: plan).map { materializeTrackIndex(target: $0, type: .audio) }
         return (visualIdx, audioIdx)
+    }
+
+    func audioTargetAfterVisualInsertion(plan: DropPlan) -> TrackDropTarget? {
+        plan.audioTarget.map { audio in
+            plan.visualTarget.map { shiftAfterVisualInsertion(audio: audio, visual: $0) } ?? audio
+        }
     }
 
     /// Resolve a `TrackDropTarget` into a concrete track index, creating a new track if needed.

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -274,6 +274,22 @@ extension EditorViewModel {
         let visualTarget: TrackDropTarget?
         let audioTarget: TrackDropTarget?
 
+        var visualAssets: [MediaAsset] {
+            placements.filter(\.hasVisual).map(\.asset)
+        }
+
+        var audioOnlyAssets: [MediaAsset] {
+            placements.filter { !$0.hasVisual && $0.hasAudio }.map(\.asset)
+        }
+
+        var visualDurationFrames: Int {
+            placements.filter(\.hasVisual).reduce(0) { $0 + $1.durationFrames }
+        }
+
+        var audioOnlyDurationFrames: Int {
+            placements.filter { !$0.hasVisual && $0.hasAudio }.reduce(0) { $0 + $1.durationFrames }
+        }
+
         struct Placement {
             let asset: MediaAsset
             let startFrame: Int

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -305,25 +305,38 @@ extension EditorViewModel {
 
     struct RippleInsertPreviewPlan: Equatable {
         let gapRangesByTrackIndex: [Int: FrameRange]
+        let newTrackGapRangesByTarget: [TrackDropTarget: FrameRange]
         let shiftDeltasByClipId: [String: Int]
     }
 
     func planRippleInsertPreview(dropPlan plan: DropPlan, atFrame: Int) -> RippleInsertPreviewPlan? {
         var gapLengthsByTrackIndex: [Int: Int] = [:]
+        var newTrackGapLengthsByTarget: [TrackDropTarget: Int] = [:]
         var shiftDeltasByClipId: [String: Int] = [:]
 
-        func affectedTrackIndexes(for target: TrackDropTarget) -> Set<Int> {
+        func currentTrackIndex(for target: TrackDropTarget, shiftedBy visualTarget: TrackDropTarget?) -> Int? {
+            guard case .existingTrack(var index) = target else { return nil }
+            if case .newTrackAt(let visualInsertIndex) = visualTarget,
+               index > visualInsertIndex {
+                index -= 1
+            }
+            return timeline.tracks.indices.contains(index) ? index : nil
+        }
+
+        func affectedTrackIndexes(for target: TrackDropTarget, shiftedBy visualTarget: TrackDropTarget?) -> Set<Int> {
             var indexes = Set(timeline.tracks.indices.filter { timeline.tracks[$0].syncLocked })
-            if case .existingTrack(let index) = target,
-               timeline.tracks.indices.contains(index) {
+            if let index = currentTrackIndex(for: target, shiftedBy: visualTarget) {
                 indexes.insert(index)
             }
             return indexes
         }
 
-        func addPush(target: TrackDropTarget?, pushAmount: Int) {
+        func addPush(target: TrackDropTarget?, shiftedBy visualTarget: TrackDropTarget?, pushAmount: Int) {
             guard let target, pushAmount > 0 else { return }
-            for trackIndex in affectedTrackIndexes(for: target) {
+            if case .newTrackAt = target {
+                newTrackGapLengthsByTarget[target, default: 0] += pushAmount
+            }
+            for trackIndex in affectedTrackIndexes(for: target, shiftedBy: visualTarget) {
                 let clips = timeline.tracks[trackIndex].clips
                 let startFramesByClipId = Dictionary(uniqueKeysWithValues: clips.map { ($0.id, $0.startFrame) })
                 let shifts = RippleEngine.computeRipplePush(clips: clips, insertFrame: atFrame, pushAmount: pushAmount)
@@ -335,15 +348,19 @@ extension EditorViewModel {
             }
         }
 
-        addPush(target: plan.visualTarget, pushAmount: plan.visualDurationFrames)
-        addPush(target: plan.audioTarget, pushAmount: plan.audioOnlyDurationFrames)
+        addPush(target: plan.visualTarget, shiftedBy: nil, pushAmount: plan.visualDurationFrames)
+        addPush(target: audioTargetAfterVisualInsertion(plan: plan), shiftedBy: plan.visualTarget, pushAmount: plan.audioOnlyDurationFrames)
 
-        guard !gapLengthsByTrackIndex.isEmpty || !shiftDeltasByClipId.isEmpty else { return nil }
+        guard !gapLengthsByTrackIndex.isEmpty || !newTrackGapLengthsByTarget.isEmpty || !shiftDeltasByClipId.isEmpty else { return nil }
         let gapRangesByTrackIndex = gapLengthsByTrackIndex.mapValues {
+            FrameRange(start: atFrame, end: atFrame + $0)
+        }
+        let newTrackGapRangesByTarget = newTrackGapLengthsByTarget.mapValues {
             FrameRange(start: atFrame, end: atFrame + $0)
         }
         return RippleInsertPreviewPlan(
             gapRangesByTrackIndex: gapRangesByTrackIndex,
+            newTrackGapRangesByTarget: newTrackGapRangesByTarget,
             shiftDeltasByClipId: shiftDeltasByClipId
         )
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -303,6 +303,51 @@ extension EditorViewModel {
         return created
     }
 
+    struct RippleInsertPreviewPlan: Equatable {
+        let gapRangesByTrackIndex: [Int: FrameRange]
+        let shiftDeltasByClipId: [String: Int]
+    }
+
+    func planRippleInsertPreview(dropPlan plan: DropPlan, atFrame: Int) -> RippleInsertPreviewPlan? {
+        var gapLengthsByTrackIndex: [Int: Int] = [:]
+        var shiftDeltasByClipId: [String: Int] = [:]
+
+        func affectedTrackIndexes(for target: TrackDropTarget) -> Set<Int> {
+            var indexes = Set(timeline.tracks.indices.filter { timeline.tracks[$0].syncLocked })
+            if case .existingTrack(let index) = target,
+               timeline.tracks.indices.contains(index) {
+                indexes.insert(index)
+            }
+            return indexes
+        }
+
+        func addPush(target: TrackDropTarget?, pushAmount: Int) {
+            guard let target, pushAmount > 0 else { return }
+            for trackIndex in affectedTrackIndexes(for: target) {
+                let clips = timeline.tracks[trackIndex].clips
+                let startFramesByClipId = Dictionary(uniqueKeysWithValues: clips.map { ($0.id, $0.startFrame) })
+                let shifts = RippleEngine.computeRipplePush(clips: clips, insertFrame: atFrame, pushAmount: pushAmount)
+                for shift in shifts {
+                    guard let originalStartFrame = startFramesByClipId[shift.clipId] else { continue }
+                    shiftDeltasByClipId[shift.clipId, default: 0] += shift.newStartFrame - originalStartFrame
+                }
+                gapLengthsByTrackIndex[trackIndex, default: 0] += pushAmount
+            }
+        }
+
+        addPush(target: plan.visualTarget, pushAmount: plan.visualDurationFrames)
+        addPush(target: plan.audioTarget, pushAmount: plan.audioOnlyDurationFrames)
+
+        guard !gapLengthsByTrackIndex.isEmpty || !shiftDeltasByClipId.isEmpty else { return nil }
+        let gapRangesByTrackIndex = gapLengthsByTrackIndex.mapValues {
+            FrameRange(start: atFrame, end: atFrame + $0)
+        }
+        return RippleInsertPreviewPlan(
+            gapRangesByTrackIndex: gapRangesByTrackIndex,
+            shiftDeltasByClipId: shiftDeltasByClipId
+        )
+    }
+
     struct RippleInsertSpec {
         let asset: MediaAsset
         let durationFrames: Int

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
@@ -1,0 +1,46 @@
+extension EditorViewModel {
+    enum SelectForwardScope {
+        case track
+        case allTracks
+    }
+
+    func selectForwardFromCurrentSelection(scope: SelectForwardScope) {
+        guard let anchorId = forwardSelectionAnchorId() else { return }
+        selectForward(from: anchorId, scope: scope)
+    }
+
+    func selectForward(from clipId: String, scope: SelectForwardScope) {
+        guard let anchorLoc = findClip(id: clipId) else { return }
+        let anchorClip = timeline.tracks[anchorLoc.trackIndex].clips[anchorLoc.clipIndex]
+        var ids: Set<String> = []
+
+        for (trackIndex, track) in timeline.tracks.enumerated() {
+            guard scope == .allTracks || trackIndex == anchorLoc.trackIndex else { continue }
+            for clip in track.clips where clip.startFrame >= anchorClip.startFrame {
+                ids.insert(clip.id)
+            }
+        }
+
+        selectedClipIds = expandToLinkGroup(ids)
+        selectedGap = nil
+        selectedTimelineRange = nil
+    }
+
+    private func forwardSelectionAnchorId() -> String? {
+        timeline.tracks.enumerated()
+            .flatMap { trackIndex, track in
+                track.clips
+                    .filter { selectedClipIds.contains($0.id) }
+                    .map { (trackIndex: trackIndex, clip: $0) }
+            }
+            .sorted {
+                if $0.clip.startFrame == $1.clip.startFrame {
+                    return $0.trackIndex < $1.trackIndex
+                }
+                return $0.clip.startFrame < $1.clip.startFrame
+            }
+            .first?
+            .clip
+            .id
+    }
+}

--- a/Sources/PalmierPro/Help/ShortcutsPane.swift
+++ b/Sources/PalmierPro/Help/ShortcutsPane.swift
@@ -16,12 +16,15 @@ struct ShortcutsPane: View {
             ("C", "Razor Tool"),
         ]),
         ShortcutGroup(title: "Editing", shortcuts: [
+            ("A", "Select Forward on Track"),
+            ("Shift + A", "Select Forward on All Tracks"),
             ("Cmd + K", "Split at Playhead"),
             ("[ or Q", "Trim Start to Playhead"),
             ("] or W", "Trim End to Playhead"),
             ("Backspace", "Delete"),
             ("Shift + Backspace", "Ripple Delete"),
             ("Shift + Drag Edge", "Ripple Trim"),
+            ("Cmd + Drag Media", "Ripple Insert"),
             ("Opt + Drag", "Duplicate Clip"),
         ]),
         ShortcutGroup(title: "Timeline", shortcuts: [

--- a/Sources/PalmierPro/Timeline/TimelineGeometry.swift
+++ b/Sources/PalmierPro/Timeline/TimelineGeometry.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-enum TrackDropTarget: Equatable {
+enum TrackDropTarget: Equatable, Hashable {
     case existingTrack(Int)
     case newTrackAt(Int) // insert new track before this index
 }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -621,19 +621,8 @@ final class TimelineView: NSView {
         switch target {
         case .existingTrack(let idx):
             return geo.clipRect(for: probe, trackIndex: idx)
-        case .newTrackAt(let idx):
-            let trackCount = editor.timeline.tracks.count
-            let top = geo.rulerHeight + Layout.dropZoneHeight
-            let y: CGFloat
-            if trackCount == 0 {
-                y = top + CGFloat(idx) * height
-            } else if idx >= trackCount {
-                let last = trackCount - 1
-                let bottom = geo.trackY(at: last) + geo.trackHeight(at: last)
-                y = bottom + CGFloat(idx - trackCount) * height
-            } else {
-                y = geo.trackY(at: idx) - height
-            }
+        case .newTrackAt:
+            guard let y = geo.ghostY(for: target, height: height) else { return .zero }
             return geo.clipRect(for: probe, atY: Double(y), height: height)
         }
     }
@@ -654,20 +643,28 @@ final class TimelineView: NSView {
         ctx.setFillColor(AppTheme.Accent.timecodeNSColor.withAlphaComponent(AppTheme.Opacity.faint).cgColor)
         ctx.setStrokeColor(AppTheme.Accent.timecodeNSColor.withAlphaComponent(AppTheme.Opacity.medium).cgColor)
         ctx.setLineWidth(AppTheme.BorderWidth.thin)
-        for (trackIndex, range) in preview.gapRangesByTrackIndex where editor.timeline.tracks.indices.contains(trackIndex) {
+
+        func drawBand(range: FrameRange, y: CGFloat, height: CGFloat) {
             let minX = geo.xForFrame(range.start)
             let maxX = geo.xForFrame(range.end)
-            guard maxX > minX else { continue }
-            let y = geo.trackY(at: trackIndex)
-            let height = max(CGFloat.zero, geo.trackHeight(at: trackIndex) - AppTheme.Spacing.xs)
+            guard maxX > minX else { return }
             let rect = NSRect(
                 x: minX,
                 y: y + AppTheme.Spacing.xxs,
                 width: maxX - minX,
-                height: height
+                height: max(CGFloat.zero, height - AppTheme.Spacing.xs)
             )
             ctx.addRect(rect.insetBy(dx: AppTheme.BorderWidth.hairline, dy: AppTheme.BorderWidth.hairline))
             ctx.drawPath(using: .fillStroke)
+        }
+
+        for (trackIndex, range) in preview.gapRangesByTrackIndex where editor.timeline.tracks.indices.contains(trackIndex) {
+            drawBand(range: range, y: geo.trackY(at: trackIndex), height: geo.trackHeight(at: trackIndex))
+        }
+
+        for (target, range) in preview.newTrackGapRangesByTarget {
+            guard let y = geo.ghostY(for: target) else { continue }
+            drawBand(range: range, y: y, height: Layout.trackHeight)
         }
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -202,10 +202,14 @@ final class TimelineView: NSView {
         let geo = geometry
         let scrollOffset = enclosingScrollView?.contentView.bounds.origin ?? .zero
         let visibleWidth = enclosingScrollView?.contentView.bounds.width ?? bounds.width
+        let rippleInsertPreview = currentRippleInsertPreview()
 
         drawTrackBackgrounds(geometry: geo, context: ctx)
         drawTimelineRangeSelectionTrackFill(geometry: geo, context: ctx)
-        drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx)
+        if let rippleInsertPreview {
+            drawRippleInsertGapBand(preview: rippleInsertPreview, geometry: geo, context: ctx)
+        }
+        drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx, rippleInsertPreview: rippleInsertPreview)
         drawGapSelection(geometry: geo, context: ctx)
         syncGeneratingClipOverlays(geometry: geo)
 
@@ -213,6 +217,7 @@ final class TimelineView: NSView {
             drawExternalDragGhosts(assets: assets, segments: externalDragSegments, target: target, frame: externalDragFrame, geometry: geo, dirtyRect: bounds, context: ctx)
             if externalDragIsRippleInsert {
                 drawRippleInsertIndicator(atFrame: externalDragFrame, geometry: geo, context: ctx)
+                drawRippleInsertBadge(atFrame: externalDragFrame, geometry: geo, scrollOffset: scrollOffset, visibleWidth: visibleWidth, context: ctx)
             }
         }
 
@@ -268,7 +273,12 @@ final class TimelineView: NSView {
 
     // MARK: - Clip drawing with ghost support
 
-    private func drawClips(geometry geo: TimelineGeometry, dirtyRect: NSRect, context ctx: CGContext) {
+    private func drawClips(
+        geometry geo: TimelineGeometry,
+        dirtyRect: NSRect,
+        context ctx: CGContext,
+        rippleInsertPreview: EditorViewModel.RippleInsertPreviewPlan? = nil
+    ) {
         let moveDrag: DragState.MoveClipDrag? = {
             if case .moveClip(let drag) = inputController.dragState { return drag }
             return nil
@@ -318,6 +328,21 @@ final class TimelineView: NSView {
                 let isSelected = editor.selectedClipIds.contains(clip.id)
                 let clipMissing = editor.isClipMediaOffline(clip)
                 let clipGenerating = editor.isClipMediaGenerating(clip)
+
+                if let shiftDelta = rippleInsertPreview?.shiftDeltasByClipId[clip.id] {
+                    var previewClip = clip
+                    previewClip.startFrame += shiftDelta
+                    let previewRect = geo.clipRect(for: previewClip, trackIndex: ti)
+                    clipDisplayRects[clip.id] = previewRect
+                    if previewRect.intersects(dirtyRect) {
+                        ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
+                                          isSelected: isSelected, opacity: CGFloat(AppTheme.Opacity.prominent), context: ctx,
+                                          cache: editor.mediaVisualCache,
+                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
+                    }
+                    continue
+                }
 
                 if let drag = moveDrag, allDraggedIds.contains(clip.id) {
                     let originalRect = geo.clipRect(for: clip, trackIndex: ti)
@@ -613,28 +638,103 @@ final class TimelineView: NSView {
         }
     }
 
-    // MARK: - Ripple-insert indicator
+    // MARK: - Ripple-insert preview
+
+    private func currentRippleInsertPreview() -> EditorViewModel.RippleInsertPreviewPlan? {
+        guard externalDragIsRippleInsert,
+              let assets = externalDragAssets,
+              !assets.isEmpty,
+              let target = externalDropTarget else { return nil }
+
+        let plan = editor.resolveDropPlan(cursor: target, assets: assets, atFrame: externalDragFrame, segments: externalDragSegments)
+        return editor.planRippleInsertPreview(dropPlan: plan, atFrame: externalDragFrame)
+    }
+
+    private func drawRippleInsertGapBand(preview: EditorViewModel.RippleInsertPreviewPlan, geometry geo: TimelineGeometry, context ctx: CGContext) {
+        ctx.setFillColor(AppTheme.Accent.timecodeNSColor.withAlphaComponent(AppTheme.Opacity.faint).cgColor)
+        ctx.setStrokeColor(AppTheme.Accent.timecodeNSColor.withAlphaComponent(AppTheme.Opacity.medium).cgColor)
+        ctx.setLineWidth(AppTheme.BorderWidth.thin)
+        for (trackIndex, range) in preview.gapRangesByTrackIndex where editor.timeline.tracks.indices.contains(trackIndex) {
+            let minX = geo.xForFrame(range.start)
+            let maxX = geo.xForFrame(range.end)
+            guard maxX > minX else { continue }
+            let y = geo.trackY(at: trackIndex)
+            let height = max(CGFloat.zero, geo.trackHeight(at: trackIndex) - AppTheme.Spacing.xs)
+            let rect = NSRect(
+                x: minX,
+                y: y + AppTheme.Spacing.xxs,
+                width: maxX - minX,
+                height: height
+            )
+            ctx.addRect(rect.insetBy(dx: AppTheme.BorderWidth.hairline, dy: AppTheme.BorderWidth.hairline))
+            ctx.drawPath(using: .fillStroke)
+        }
+    }
 
     private func drawRippleInsertIndicator(atFrame frame: Int, geometry geo: TimelineGeometry, context ctx: CGContext) {
         let x = geo.xForFrame(frame)
         let top = Double(geo.rulerHeight)
         let bottom = Double(bounds.height)
 
-        let color = NSColor.white.cgColor
+        let color = AppTheme.Accent.timecodeNSColor.cgColor
         ctx.setStrokeColor(color)
         ctx.setFillColor(color)
-        ctx.setLineWidth(2)
+        ctx.setLineWidth(AppTheme.BorderWidth.thick)
         ctx.move(to: CGPoint(x: x, y: top))
         ctx.addLine(to: CGPoint(x: x, y: bottom))
         ctx.strokePath()
 
-        let arrowW: CGFloat = 7
-        let arrowH: CGFloat = 10
+        let arrowW = AppTheme.Spacing.sm
+        let arrowH = AppTheme.Spacing.md
         ctx.move(to: CGPoint(x: x, y: top))
         ctx.addLine(to: CGPoint(x: x + arrowW, y: top + Double(arrowH) / 2))
         ctx.addLine(to: CGPoint(x: x, y: top + Double(arrowH)))
         ctx.closePath()
         ctx.fillPath()
+    }
+
+    private func drawRippleInsertBadge(
+        atFrame frame: Int,
+        geometry geo: TimelineGeometry,
+        scrollOffset: CGPoint,
+        visibleWidth: CGFloat,
+        context ctx: CGContext
+    ) {
+        let text = NSAttributedString(
+            string: "Ripple Insert",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs),
+                .foregroundColor: AppTheme.Text.primary
+            ]
+        )
+        let textSize = text.size()
+        let width = textSize.width + AppTheme.Spacing.md * 2
+        let height = textSize.height + AppTheme.Spacing.xs * 2
+        let minX = scrollOffset.x + AppTheme.Spacing.xs
+        let maxX = max(minX, scrollOffset.x + visibleWidth - width - AppTheme.Spacing.xs)
+        let proposedX = CGFloat(geo.xForFrame(frame)) + AppTheme.Spacing.md
+        let rect = NSRect(
+            x: min(maxX, max(minX, proposedX)),
+            y: scrollOffset.y + geo.rulerHeight + AppTheme.Spacing.xs,
+            width: width,
+            height: height
+        )
+        let path = CGPath(
+            roundedRect: rect,
+            cornerWidth: AppTheme.Radius.sm,
+            cornerHeight: AppTheme.Radius.sm,
+            transform: nil
+        )
+
+        ctx.setFillColor(AppTheme.Background.prominent.withAlphaComponent(AppTheme.Opacity.prominent).cgColor)
+        ctx.addPath(path)
+        ctx.fillPath()
+        ctx.setStrokeColor(AppTheme.Accent.timecodeNSColor.withAlphaComponent(AppTheme.Opacity.strong).cgColor)
+        ctx.setLineWidth(AppTheme.BorderWidth.thin)
+        ctx.addPath(path)
+        ctx.strokePath()
+
+        text.draw(in: rect.insetBy(dx: AppTheme.Spacing.md, dy: AppTheme.Spacing.xs))
     }
 
     // MARK: - Track drawing
@@ -755,6 +855,16 @@ final class TimelineView: NSView {
 
         // Timeline actions
         var timelineItems: [NSMenuItem] = []
+        let selectForwardTrackItem = NSMenuItem(title: "Select Forward on Track", action: #selector(performSelectForwardOnTrack(_:)), keyEquivalent: "")
+        selectForwardTrackItem.target = self
+        selectForwardTrackItem.representedObject = clip.id
+        timelineItems.append(selectForwardTrackItem)
+
+        let selectForwardAllItem = NSMenuItem(title: "Select Forward on All Tracks", action: #selector(performSelectForwardOnAllTracks(_:)), keyEquivalent: "")
+        selectForwardAllItem.target = self
+        selectForwardAllItem.representedObject = clip.id
+        timelineItems.append(selectForwardAllItem)
+
         let copyItem = NSMenuItem(title: "Copy", action: #selector(performCopyClips(_:)), keyEquivalent: "")
         copyItem.target = self
         timelineItems.append(copyItem)
@@ -862,6 +972,18 @@ final class TimelineView: NSView {
         return editor.timeline.tracks.flatMap(\.clips).compactMap { clip in
             selected.contains(clip.id) ? clip.id : nil
         }
+    }
+
+    @objc private func performSelectForwardOnTrack(_ sender: Any?) {
+        guard let clipId = (sender as? NSMenuItem)?.representedObject as? String else { return }
+        editor.selectForward(from: clipId, scope: .track)
+        needsDisplay = true
+    }
+
+    @objc private func performSelectForwardOnAllTracks(_ sender: Any?) {
+        guard let clipId = (sender as? NSMenuItem)?.representedObject as? String else { return }
+        editor.selectForward(from: clipId, scope: .allTracks)
+        needsDisplay = true
     }
 
     @objc private func performAddClipsToChat(_ sender: Any?) {
@@ -1059,11 +1181,11 @@ final class TimelineView: NSView {
                 }
             }
 
-            let visualAssets = assets.filter { $0.type.isVisual }
+            let visualAssets = plan.visualAssets
             if !visualAssets.isEmpty, let vIdx = visualIdx {
                 insert(visualAssets, vIdx, audioIdx)
             }
-            let audioOnlyAssets = assets.filter { $0.type == .audio }
+            let audioOnlyAssets = plan.audioOnlyAssets
             if !audioOnlyAssets.isEmpty, let aIdx = audioIdx {
                 insert(audioOnlyAssets, aIdx, nil)
             }

--- a/Tests/PalmierProTests/Timeline/RippleInsertPreviewTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleInsertPreviewTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private func previewEditor(_ tracks: [Track]) -> EditorViewModel {
+    let e = EditorViewModel()
+    e.timeline = Fixtures.timeline(tracks: tracks)
+    return e
+}
+
+@MainActor
+private func asset(id: String, type: ClipType, duration: Double, hasAudio: Bool? = nil) -> MediaAsset {
+    let asset = MediaAsset(id: id, url: URL(fileURLWithPath: "/tmp/\(id)"), type: type, name: id, duration: duration)
+    if let hasAudio { asset.hasAudio = hasAudio }
+    return asset
+}
+
+@Suite("EditorViewModel - ripple insert preview")
+@MainActor
+struct RippleInsertPreviewTests {
+
+    @Test func mixedVisualAndAudioOnlyDropUsesSeparateTargetTrackPushes() {
+        var videoTrack = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "video-tail", start: 100, duration: 30),
+        ])
+        videoTrack.syncLocked = false
+        var audioTrack = Fixtures.audioTrack(clips: [
+            Fixtures.clip(id: "audio-tail", mediaType: .audio, start: 100, duration: 30),
+        ])
+        audioTrack.syncLocked = false
+        let e = previewEditor([videoTrack, audioTrack])
+        let video = asset(id: "video", type: .video, duration: 2)
+        let audio = asset(id: "audio", type: .audio, duration: 1)
+
+        let plan = e.resolveDropPlan(cursor: .existingTrack(0), assets: [video, audio], atFrame: 50)
+        let preview = e.planRippleInsertPreview(dropPlan: plan, atFrame: 50)
+
+        #expect(plan.visualAssets.map(\.id) == ["video"])
+        #expect(plan.audioOnlyAssets.map(\.id) == ["audio"])
+        #expect(preview?.gapRangesByTrackIndex[0] == FrameRange(start: 50, end: 110))
+        #expect(preview?.gapRangesByTrackIndex[1] == FrameRange(start: 50, end: 80))
+        #expect(preview?.shiftDeltasByClipId["video-tail"] == 60)
+        #expect(preview?.shiftDeltasByClipId["audio-tail"] == 30)
+    }
+
+    @Test func syncLockedFollowerReceivesBothMixedDropPushes() {
+        var videoTrack = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "video-tail", start: 100, duration: 30),
+        ])
+        videoTrack.syncLocked = false
+        var audioTrack = Fixtures.audioTrack(clips: [
+            Fixtures.clip(id: "audio-tail", mediaType: .audio, start: 100, duration: 30),
+        ])
+        audioTrack.syncLocked = false
+        var syncTrack = Fixtures.audioTrack(clips: [
+            Fixtures.clip(id: "sync-tail", mediaType: .audio, start: 100, duration: 30),
+        ])
+        syncTrack.syncLocked = true
+        let e = previewEditor([videoTrack, audioTrack, syncTrack])
+        let video = asset(id: "video", type: .video, duration: 2)
+        let audio = asset(id: "audio", type: .audio, duration: 1)
+
+        let plan = e.resolveDropPlan(cursor: .existingTrack(0), assets: [video, audio], atFrame: 50)
+        let preview = e.planRippleInsertPreview(dropPlan: plan, atFrame: 50)
+
+        #expect(preview?.gapRangesByTrackIndex[2] == FrameRange(start: 50, end: 140))
+        #expect(preview?.shiftDeltasByClipId["sync-tail"] == 90)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/RippleInsertPreviewTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleInsertPreviewTests.swift
@@ -67,4 +67,28 @@ struct RippleInsertPreviewTests {
         #expect(preview?.gapRangesByTrackIndex[2] == FrameRange(start: 50, end: 140))
         #expect(preview?.shiftDeltasByClipId["sync-tail"] == 90)
     }
+
+    @Test func newTrackDropShowsShiftedVisualAndAudioTargetGaps() {
+        var videoTrack = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "video-tail", start: 100, duration: 30),
+        ])
+        videoTrack.syncLocked = false
+        var audioTrack = Fixtures.audioTrack(clips: [
+            Fixtures.clip(id: "audio-tail", mediaType: .audio, start: 100, duration: 30),
+        ])
+        audioTrack.syncLocked = false
+        let e = previewEditor([videoTrack, audioTrack])
+        let video = asset(id: "video", type: .video, duration: 2)
+        let audio = asset(id: "audio", type: .audio, duration: 1)
+
+        let plan = e.resolveDropPlan(cursor: .newTrackAt(1), assets: [video, audio], atFrame: 50)
+        let preview = e.planRippleInsertPreview(dropPlan: plan, atFrame: 50)
+
+        #expect(plan.visualTarget == .newTrackAt(1))
+        #expect(plan.audioTarget == .newTrackAt(1))
+        #expect(preview?.newTrackGapRangesByTarget[.newTrackAt(1)] == FrameRange(start: 50, end: 110))
+        #expect(preview?.newTrackGapRangesByTarget[.newTrackAt(2)] == FrameRange(start: 50, end: 80))
+        #expect(preview?.gapRangesByTrackIndex.isEmpty == true)
+        #expect(preview?.shiftDeltasByClipId.isEmpty == true)
+    }
 }

--- a/Tests/PalmierProTests/Timeline/TimelineForwardSelectionTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineForwardSelectionTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private func editor(_ tracks: [Track]) -> EditorViewModel {
+    let e = EditorViewModel()
+    e.timeline = Fixtures.timeline(tracks: tracks)
+    return e
+}
+
+@Suite("EditorViewModel - select forward")
+@MainActor
+struct TimelineForwardSelectionTests {
+
+    @Test func selectForwardOnTrackIncludesAnchorAndLaterClipsOnlyOnAnchorTrack() {
+        let e = editor([
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "before", start: 0, duration: 20),
+                Fixtures.clip(id: "anchor", start: 30, duration: 20),
+                Fixtures.clip(id: "after", start: 70, duration: 20),
+            ]),
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "other", mediaType: .audio, start: 40, duration: 20),
+            ]),
+        ])
+
+        e.selectForward(from: "anchor", scope: .track)
+
+        #expect(e.selectedClipIds == ["anchor", "after"])
+    }
+
+    @Test func selectForwardOnAllTracksUsesAnchorFrameAcrossTimeline() {
+        let e = editor([
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "before", start: 0, duration: 20),
+                Fixtures.clip(id: "anchor", start: 30, duration: 20),
+            ]),
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "sameFrame", mediaType: .audio, start: 30, duration: 20),
+                Fixtures.clip(id: "after", mediaType: .audio, start: 90, duration: 20),
+            ]),
+        ])
+
+        e.selectForward(from: "anchor", scope: .allTracks)
+
+        #expect(e.selectedClipIds == ["anchor", "sameFrame", "after"])
+    }
+
+    @Test func selectForwardExpandsLinkedPartners() {
+        var anchor = Fixtures.clip(id: "anchor", start: 30, duration: 20)
+        anchor.linkGroupId = "g1"
+        var linkedAudio = Fixtures.clip(id: "linkedAudio", mediaType: .audio, start: 10, duration: 20)
+        linkedAudio.linkGroupId = "g1"
+        let e = editor([
+            Fixtures.videoTrack(clips: [anchor]),
+            Fixtures.audioTrack(clips: [linkedAudio]),
+        ])
+
+        e.selectForward(from: "anchor", scope: .track)
+
+        #expect(e.selectedClipIds == ["anchor", "linkedAudio"])
+    }
+
+    @Test func currentSelectionUsesEarliestSelectedClipAsAnchor() {
+        let e = editor([
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "first", start: 20, duration: 20),
+                Fixtures.clip(id: "second", start: 60, duration: 20),
+                Fixtures.clip(id: "third", start: 100, duration: 20),
+            ]),
+        ])
+        e.selectedClipIds = ["second", "third"]
+
+        e.selectForwardFromCurrentSelection(scope: .track)
+
+        #expect(e.selectedClipIds == ["second", "third"])
+    }
+}


### PR DESCRIPTION
## Summary
- add Select Forward on Track and Select Forward on All Tracks commands, shortcuts, menu items, and clip context menu actions
- document existing Command-drag ripple insert in keyboard shortcuts
- improve Command-drag ripple insert preview with a badge, insert line, gap band, and shifted downstream clip positions
<img width="327" height="70" alt="Screenshot 2026-06-27 at 11 15 23 PM" src="https://github.com/user-attachments/assets/0ba1edab-f4a4-4f75-afd7-89aaec61027b" />
<img width="1920" height="1080" alt="Screenshot 2026-06-27 at 11 15 44 PM" src="https://github.com/user-attachments/assets/4da3ef94-0ddd-4211-8f58-ac89b2518335" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timeline selection shortcuts and ripple-insert preview math (sync-locked tracks, mixed A/V drops); preview-only for drag but drop commit paths were refactored to use DropPlan helpers.
> 
> **Overview**
> Adds **select forward** editing: from an anchor clip (earliest selected clip, or the clip in context menus), **A** on the timeline selects that clip and everything at or after its start on the current track; **Shift + A** does the same across all tracks, with link groups expanded. Wired through Edit menu, key monitor, clip context menu, and shortcuts help. **Cmd + A** remains Select All.
> 
> **Command-drag ripple insert** from the media panel gets a live preview: `planRippleInsertPreview` computes gap bands per track (including new-track drops), downstream clip shift deltas, and sync-locked pushes; the timeline draws gap highlights, shifted clip ghosts, a styled insert line, and a **Ripple Insert** badge. Drop handling uses `DropPlan` visual/audio-only splits and shared audio-target shifting after visual track insertion.
> 
> Unit tests cover forward selection (track vs all-tracks, links, anchor) and ripple preview (mixed drops, sync-locked followers, new-track targets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5bc6ac192a44eddc16042c76575ad8f19922132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->