### PR TITLE
[codex] Fix FCPXML import compatibility

### DIFF
--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -81,7 +81,7 @@ enum FCPXMLExporter {
             let enabled: Bool
         }
 
-        // One asset per source file (keyed by mediaRef)
+        // One asset per resolved source file.
         private struct MediaResource {
             let mediaRef: String
             let assetId: String
@@ -142,10 +142,11 @@ enum FCPXMLExporter {
             var children: [FCPXMLNode] = [
                 FCPXMLNode(name: "format", attributes: [
                     ("id", sequenceFormatId),
-                    ("name", "Palmier Timeline"),
+                    ("name", sequenceFormatName(width: seqWidth, height: seqHeight, fps: Double(fps))),
                     ("frameDuration", frameDuration(forFPS: Double(fps))),
                     ("width", "\(seqWidth)"),
                     ("height", "\(seqHeight)"),
+                    ("colorSpace", "1-1-1 (Rec. 709)"),
                 ]),
             ]
 
@@ -515,6 +516,7 @@ enum FCPXMLExporter {
 
         private func collectResources(from clips: [EmittableClip]) {
             struct Caps {
+                var mediaRefs: [String]
                 var hasVideo = false
                 var hasAudio = false
                 var duration = 0
@@ -530,28 +532,34 @@ enum FCPXMLExporter {
                       let entry = resolver.entry(for: clip.mediaRef),
                       let url = resolver.resolveURL(for: clip.mediaRef) else { continue }
 
+                let key = sourceKey(for: url)
                 let duration = sourceDurationFrames(for: entry, clip: clip)
                 let isVisual = clip.mediaType != .audio
                 // Audio clip → audio stream; video clip → audio too if the source file carries it.
                 let isAudio = clip.mediaType == .audio || (clip.mediaType == .video && entry.hasAudio == true)
-                var entryCaps = caps[clip.mediaRef] ?? {
-                    order.append(clip.mediaRef)
-                    return Caps(entry: entry, url: url)
+                var entryCaps = caps[key] ?? {
+                    order.append(key)
+                    return Caps(mediaRefs: [], entry: entry, url: url)
                 }()
+                if !entryCaps.mediaRefs.contains(clip.mediaRef) {
+                    entryCaps.mediaRefs.append(clip.mediaRef)
+                }
                 entryCaps.hasVideo = entryCaps.hasVideo || isVisual
                 entryCaps.hasAudio = entryCaps.hasAudio || isAudio
                 entryCaps.duration = max(entryCaps.duration, duration)
-                caps[clip.mediaRef] = entryCaps
+                caps[key] = entryCaps
             }
 
-            for ref in order {
-                guard let c = caps[ref] else { continue }
+            for key in order {
+                guard let c = caps[key] else { continue }
                 let id = resources.count + 1
-                resourceIndex[ref] = resources.count
+                for ref in c.mediaRefs {
+                    resourceIndex[ref] = resources.count
+                }
                 resources.append(MediaResource(
-                    mediaRef: ref,
+                    mediaRef: c.mediaRefs.first ?? c.entry.id,
                     assetId: "asset\(id)",
-                    formatId: c.hasVideo ? "format\(id)" : nil,
+                    formatId: c.hasVideo ? "r\(id + 1)" : nil,
                     compoundId: c.hasVideo ? "media\(id)" : nil,
                     entry: c.entry,
                     url: c.url,
@@ -562,6 +570,10 @@ enum FCPXMLExporter {
             }
         }
 
+        private func sourceKey(for url: URL) -> String {
+            url.standardizedFileURL.resolvingSymlinksInPath().path
+        }
+
         private func formatNode(for resource: MediaResource) -> FCPXMLNode? {
             guard let formatId = resource.formatId else { return nil }
             let width = resource.entry.sourceWidth ?? seqWidth
@@ -569,10 +581,11 @@ enum FCPXMLExporter {
             let rawFPS = resource.entry.sourceFPS ?? Double(fps)
             return FCPXMLNode(name: "format", attributes: [
                 ("id", formatId),
-                ("name", resource.entry.name),
+                ("name", videoFormatName(width: width, height: height, fps: rawFPS)),
                 ("frameDuration", frameDuration(forFPS: rawFPS)),
                 ("width", "\(width)"),
                 ("height", "\(height)"),
+                ("colorSpace", "1-1-1 (Rec. 709)"),
             ])
         }
 
@@ -580,7 +593,6 @@ enum FCPXMLExporter {
             var attrs: [(String, String)] = [
                 ("id", resource.assetId),
                 ("name", resource.entry.name),
-                ("uid", "io.palmier.media.\(resource.assetId)"),
                 ("start", "0s"),
                 ("duration", time(frames: resource.durationFrames)),
             ]
@@ -657,6 +669,41 @@ enum FCPXMLExporter {
             let numerator = frames / divisor
             let denominator = fps / divisor
             return denominator == 1 ? "\(numerator)s" : "\(numerator)/\(denominator)s"
+        }
+
+        private func videoFormatName(width: Int, height: Int, fps rawFPS: Double) -> String {
+            recognizedVideoFormatName(width: width, height: height, fps: rawFPS)
+                ?? "FFVideoFormat\(width)x\(height)p\(formatRateSuffix(forFPS: rawFPS))"
+        }
+
+        private func sequenceFormatName(width: Int, height: Int, fps rawFPS: Double) -> String {
+            recognizedVideoFormatName(width: width, height: height, fps: rawFPS) ?? "FFVideoFormatRateUndefined"
+        }
+
+        private func recognizedVideoFormatName(width: Int, height: Int, fps rawFPS: Double) -> String? {
+            let rate = formatRateSuffix(forFPS: rawFPS)
+            switch (width, height) {
+            case (1280, 720):
+                return "FFVideoFormat720p\(rate)"
+            case (1920, 1080):
+                return "FFVideoFormat1080p\(rate)"
+            case (3840, 2160):
+                return "FFVideoFormat3840x2160p\(rate)"
+            case (4096, 2160):
+                return "FFVideoFormat4096x2160p\(rate)"
+            default:
+                return nil
+            }
+        }
+
+        private func formatRateSuffix(forFPS rawFPS: Double) -> String {
+            let rounded = max(1, Int(rawFPS.rounded()))
+            let ntscRate = Double(rounded) * 1000.0 / 1001.0
+            if abs(rawFPS - ntscRate) < abs(rawFPS - Double(rounded)) {
+                let fps100 = Int((ntscRate * 100.0).rounded())
+                return "\(fps100 / 100)\(String(format: "%02d", fps100 % 100))"
+            }
+            return "\(rounded)"
         }
 
         private func frameDuration(forFPS rawFPS: Double) -> String {

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -70,6 +70,8 @@ struct FCPXMLExporterTests {
         #expect(xml.contains("<fcpxml version=\"1.10\">"))
         #expect(xml.contains("<resources>"))
         #expect(xml.contains("<format id=\"r1\""))
+        #expect(xml.contains("name=\"FFVideoFormat1080p30\""))
+        #expect(xml.contains("colorSpace=\"1-1-1 (Rec. 709)\""))
         #expect(xml.contains("<library>"))
         #expect(xml.contains("<event name=\"Palmier Export\">"))
         #expect(xml.contains("<project name=\"Timeline Export\">"))
@@ -115,6 +117,54 @@ struct FCPXMLExporterTests {
         #expect(clipCount == 2)        // two ref-clips reference it
     }
 
+    @Test func distinctMediaRefsWithSameSourceFileEmitOneAssetResource() throws {
+        let source = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("shared-source-\(UUID().uuidString).mp4")
+        let entryA = MediaManifestEntry(
+            id: "shared-a", name: "A", type: .video,
+            source: .external(absolutePath: source.path),
+            duration: 5,
+            sourceWidth: 1920,
+            sourceHeight: 1080,
+            hasAudio: true
+        )
+        let entryB = MediaManifestEntry(
+            id: "shared-b", name: "B", type: .video,
+            source: .external(absolutePath: source.path),
+            duration: 5,
+            sourceWidth: 1920,
+            sourceHeight: 1080,
+            hasAudio: true
+        )
+        let (resolver, tmpDir) = try makeResolver(entries: [entryA, entryB])
+        let clipA = Fixtures.clip(id: "a", mediaRef: "shared-a", start: 0, duration: 30)
+        let clipB = Fixtures.clip(id: "b", mediaRef: "shared-b", start: 60, duration: 30)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clipA, clipB])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        let assetCount = xml.components(separatedBy: "<asset id=\"asset").count - 1
+        let compoundCount = xml.components(separatedBy: "<media id=\"media").count - 1
+        #expect(assetCount == 1)
+        #expect(compoundCount == 1)
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"A\""))
+        #expect(xml.contains("<ref-clip ref=\"media1\" name=\"B\""))
+        #expect(!xml.contains("<asset id=\"asset2\""))
+    }
+
+    @Test func assetResourcesOmitSyntheticUID() throws {
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        let clip = Fixtures.clip(id: "clip", mediaRef: "media-v", start: 0, duration: 30)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+        let asset = xml.components(separatedBy: "<asset id=\"asset1\"").dropFirst().first?
+            .components(separatedBy: "</asset>").first ?? ""
+
+        #expect(!asset.contains("uid="))
+        #expect(!xml.contains("io.palmier.media.asset"))
+    }
+
     @Test func visualClipWrapsAssetInFullMediaCompoundClip() throws {
         // The compound clip must hold the FULL media (here 5s @30fps = 150 frames), independent of the
         // clip's trim/duration — that runway is what stops Resolve blacking a retimed tail. The ref-clip
@@ -127,8 +177,8 @@ struct FCPXMLExporterTests {
         let compound = xml.components(separatedBy: "<media id=\"media1\"").dropFirst().first?
             .components(separatedBy: "</media>").first ?? ""
 
-        #expect(compound.contains("<sequence format=\"format1\" duration=\"5s\""))
-        #expect(compound.contains("<clip name=\"media-v\" duration=\"5s\" start=\"0s\" offset=\"0s\" format=\"format1\">"))
+        #expect(compound.contains("<sequence format=\"r2\" duration=\"5s\""))
+        #expect(compound.contains("<clip name=\"media-v\" duration=\"5s\" start=\"0s\" offset=\"0s\" format=\"r2\">"))
         #expect(compound.contains("<video ref=\"asset1\" duration=\"5s\" start=\"0s\" offset=\"0s\"/>"))
         #expect(xml.contains("<adjust-conform type=\"fit\"/>"))
     }
@@ -151,7 +201,7 @@ struct FCPXMLExporterTests {
         #expect(!xml.contains("<asset id=\"asset2\""))
         let asset = xml.components(separatedBy: "<asset id=\"asset1\"").dropFirst().first?.components(separatedBy: "</asset>").first ?? ""
         #expect(asset.contains("hasVideo=\"1\""))
-        #expect(asset.contains("format=\"format1\""))
+        #expect(asset.contains("format=\"r2\""))
         #expect(asset.contains("videoSources=\"1\""))
         #expect(asset.contains("hasAudio=\"1\""))
         #expect(asset.contains("audioSources=\"1\""))
@@ -321,8 +371,33 @@ struct FCPXMLExporterTests {
 
         let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
 
-        #expect(xml.contains("<format id=\"format1\" name=\"media-v\" frameDuration=\"1/30s\" width=\"3413\" height=\"607\"/>"))
+        #expect(xml.contains("<format id=\"r2\" name=\"FFVideoFormat3413x607p30\" frameDuration=\"1/30s\" width=\"3413\" height=\"607\" colorSpace=\"1-1-1 (Rec. 709)\"/>"))
         #expect(!xml.contains("<adjust-transform"))
+    }
+
+    @Test func ntscSourceFormatUsesFinalCutRateSuffix() throws {
+        var entry = videoEntry(id: "media-v", in: NSTemporaryDirectory())
+        entry.sourceFPS = 29.97
+        let (resolver, tmpDir) = try makeResolver(entries: [entry])
+        let clip = Fixtures.clip(id: "clip-1", mediaRef: "media-v", start: 0, duration: 60)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        #expect(xml.contains("<format id=\"r2\" name=\"FFVideoFormat1080p2997\" frameDuration=\"1001/30000s\" width=\"1920\" height=\"1080\" colorSpace=\"1-1-1 (Rec. 709)\"/>"))
+    }
+
+    @Test func customTimelineFormatUsesFinalCutGenericPresetName() throws {
+        let (resolver, tmpDir) = try makeResolver(entries: [videoEntry(id: "media-v", in: NSTemporaryDirectory())])
+        let clip = Fixtures.clip(id: "clip-1", mediaRef: "media-v", start: 0, duration: 60)
+        var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        timeline.width = 1080
+        timeline.height = 1920
+
+        let xml = try export(timeline, resolver: resolver, tmpDir: tmpDir)
+
+        #expect(xml.contains("<format id=\"r1\" name=\"FFVideoFormatRateUndefined\" frameDuration=\"1/30s\" width=\"1080\" height=\"1920\" colorSpace=\"1-1-1 (Rec. 709)\"/>"))
+        #expect(xml.contains("<sequence format=\"r1\""))
     }
 
     @Test func centeredUnrotatedVideoOmitsTransform() throws {


### PR DESCRIPTION
## Summary
- Deduplicate FCPXML resources by resolved source file path
- Remove synthetic FCP asset UIDs that conflict with existing library media
- Emit Final Cut-compatible video format resources with Rec. 709 and custom timeline fallback names

## Validation
manually export and import to Davinci + FCP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all FCPXML resource and format output; wrong deduplication or format ids could break relinking or import, though behavior is covered by expanded exporter tests.
> 
> **Overview**
> Improves **FCPXML export** so imports into Final Cut Pro and DaVinci Resolve match their expectations for media resources and format metadata.
> 
> **Resource deduplication** now keys assets by the **resolved source file path** (not `mediaRef`), so multiple manifest entries pointing at the same file produce **one** asset/compound clip while each clip still resolves correctly.
> 
> **Assets** no longer emit synthetic `uid` values that could clash with library media on re-import. **Format** resources use Final Cut-style **`FFVideoFormat*`** names (including NTSC rate suffixes like `2997`), **`colorSpace="1-1-1 (Rec. 709)"`**, and per-source format ids **`r2`, `r3`, …** instead of `format1`. Non-standard sequence sizes fall back to **`FFVideoFormatRateUndefined`**.
> 
> Tests were updated and extended for shared-path deduplication, omitted UIDs, and format naming edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50f3629b97e54d259412b2dee21a680dbaaa6bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->