### PR TITLE
Animated Captions

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -52,9 +52,12 @@ enum AgentInstructions {
           • move_clips: change track and/or startFrame. Linked partners follow the frame delta; \
             track changes don't propagate.
           • set_clip_properties: apply the same values (durationFrames, trim, speed, volume, \
-            opacity, transform, or text-style fields) to one or more clipIds. For per-clip \
-            differences, make separate calls. Setting volume or opacity here clears any \
-            existing keyframes on that property.
+            opacity, transform, or text-style fields) to one or more clipIds. For text clips \
+            the full style is editable — content, font, size, color, alignment, the per-word \
+            animation preset, and the background, border, and shadow objects (each a patch: \
+            send {enabled:true/false} to toggle, {color:"#hex"} to recolor). Same fields are \
+            available up front on add_texts. For per-clip differences, make separate calls. \
+            Setting volume or opacity here clears any existing keyframes on that property.
           • set_keyframes: replace the keyframe track for one (clipId, property) pair. Empty \
             array clears. Frames are clip-relative.
           • split_clips: pass one or more cut points (each atFrame strictly inside its clip) in \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -222,7 +222,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .setClipProperties,
-            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, or — for text clips only — content, fontName, fontSize, color, alignment. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
+            description: "Apply the same property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volume, opacity, transform, or — for text clips only — content, fontName, fontSize, color, alignment, captionWordAnimation, and the background/border/shadow style objects. All values are applied to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volume and opacity are 0.0–1.0. transform uses 0–1 normalized canvas coords, partial merge (pass only centerY to reposition vertically); flipHorizontal/flipVertical mirror the clip across the corresponding axis (no effect on text clips). When a text clip's content or font changes without an explicit transform, the bounding box auto-refits. Text-only fields with any non-text clip in clipIds are rejected.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volume or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volume, opacity, transform, text*) don't propagate. trim and speed are skipped for text partners.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": [
@@ -253,6 +253,14 @@ enum ToolDefinitions {
                     "fontSize": ["type": "number", "description": "Text clips only. Font size in canvas points."],
                     "color": ["type": "string", "description": "Text clips only. Hex '#RRGGBB' or '#RRGGBBAA'."],
                     "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text clips only."],
+                    "captionWordAnimation": [
+                        "type": "string",
+                        "enum": CaptionWordAnimation.allCases.map(\.rawValue),
+                        "description": "Text/caption clips only. Per-word animation preset (pop/bounce/fadeUp, or none to disable). Word timings are baked at caption generation — changing the preset reuses existing timings; to re-time words, regenerate with add_captions.",
+                    ],
+                    "background": textFillSchema(thing: "solid box drawn behind the text"),
+                    "border": textFillSchema(thing: "outline drawn around the text box"),
+                    "shadow": textShadowSchema(),
                 ],
                 required: ["clipIds"]
             )
@@ -366,7 +374,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addTexts,
-            description: "Adds one or more text clips (titles, captions, lower-thirds) in a single undoable action. Text renders as an overlay on top of visual media. Transform uses 0–1 normalized canvas coords: (0.5,0.5) is center, (0.5,0.1) top-center, (0.5,0.9) bottom-center. Omit transform to center + auto-fit. Pass only centerX/centerY to reposition with auto-fit size (common for lower-thirds). Pass all four fields to override the box entirely. Colors are hex '#RRGGBB' or '#RRGGBBAA'.\n\ntrackIndex is optional. Omit it on all entries and the tool auto-creates one new video track at the top and places all text clips there — the common case for captions. To target existing tracks, set trackIndex on every entry (audio tracks rejected). Mixing (some entries specify, others omit) is rejected — split into two calls.\n\nTracks work as layers: clips on the SAME track are sequential — if a new clip's range overlaps an existing (or earlier-batch) clip on that track, the existing clip is trimmed/split/removed to make room, matching the UI's drag-onto-track overwrite behavior. To show multiple text clips at the same time (stacked titles, simultaneous labels), put each on a DIFFERENT trackIndex so they layer instead of trimming each other.\n\nFor captioning spoken audio, prefer add_captions — it transcribes and places styled caption clips in one call. Use add_texts only for bespoke text (titles, lower-thirds) or captioning a custom range by hand. Unknown fields are rejected.",
+            description: "Adds one or more text clips (titles, captions, lower-thirds) in a single undoable action. Text renders as an overlay on top of visual media. Transform uses 0–1 normalized canvas coords: (0.5,0.5) is center, (0.5,0.1) top-center, (0.5,0.9) bottom-center. Omit transform to center + auto-fit. Pass only centerX/centerY to reposition with auto-fit size (common for lower-thirds). Pass all four fields to override the box entirely. Colors are hex '#RRGGBB' or '#RRGGBBAA'.\n\ntrackIndex is optional. Omit it on all entries and the tool auto-creates one new video track at the top and places all text clips there — the common case for captions. To target existing tracks, set trackIndex on every entry (audio tracks rejected). Mixing (some entries specify, others omit) is rejected — split into two calls.\n\nTracks work as layers: clips on the SAME track are sequential — if a new clip's range overlaps an existing (or earlier-batch) clip on that track, the existing clip is trimmed/split/removed to make room, matching the UI's drag-onto-track overwrite behavior. To show multiple text clips at the same time (stacked titles, simultaneous labels), put each on a DIFFERENT trackIndex so they layer instead of trimming each other.\n\nStyle each clip with fontName, fontSize, color, alignment, and the optional background, border, and shadow objects (each {enabled, color}; shadow also takes offsetX/offsetY/blur). Background and border are off by default; shadow is on.\n\nFor captioning spoken audio, prefer add_captions — it transcribes and places styled caption clips in one call. Use add_texts only for bespoke text (titles, lower-thirds) or captioning a custom range by hand. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -393,6 +401,9 @@ enum ToolDefinitions {
                                 "fontSize": ["type": "number", "description": "Font size in canvas points (default 96). On a 1080p canvas ~50 is a caption, ~120 is a title."],
                                 "color": ["type": "string", "description": "Hex '#RRGGBB' or '#RRGGBBAA' (default '#FFFFFF')"],
                                 "alignment": ["type": "string", "enum": ["left", "center", "right"], "description": "Text alignment (default 'center')"],
+                                "background": textFillSchema(thing: "solid box drawn behind the text (off by default)"),
+                                "border": textFillSchema(thing: "outline drawn around the text box (off by default)"),
+                                "shadow": textShadowSchema(),
                             ],
                             "required": ["startFrame", "durationFrames", "content"],
                         ],
@@ -403,7 +414,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addCaptions,
-            description: "Auto-caption spoken audio: transcribes on-device and places styled caption clips on a new track — the same pipeline as the editor's Captions tab. This is the reliable path for 'caption this'; prefer it over hand-placing add_texts from a transcript. Omit clipIds to auto-pick the track with the most speech; pass clipIds to caption specific clips (e.g. only the interview).",
+            description: "Auto-caption spoken audio: transcribes on-device and places styled caption clips on a new track — the same pipeline as the editor's Captions tab. This is the reliable path for 'caption this'; prefer it over hand-placing add_texts from a transcript. Omit clipIds to auto-pick the track with the most speech; pass clipIds to caption specific clips (e.g. only the interview). Words pop in per-word by default (wordAnimation), synced to speech timing.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": ["type": "array", "items": ["type": "string"], "description": "Optional. Audio/video clips to caption. Omit to auto-detect the primary spoken track."],
@@ -415,6 +426,11 @@ enum ToolDefinitions {
                     "centerY": ["type": "number", "description": "Optional vertical center 0–1 (default 0.9, near the bottom)."],
                     "textCase": ["type": "string", "enum": ["auto", "upper", "lower"], "description": "Optional letter case (default auto)."],
                     "censorProfanity": ["type": "boolean", "description": "Optional. Mask profanity (default false)."],
+                    "wordAnimation": [
+                        "type": "string",
+                        "enum": CaptionWordAnimation.allCases.map(\.rawValue),
+                        "description": "Optional per-word animation preset synced to speech (default pop). Use none for static captions.",
+                    ],
                 ]
             )
         ),
@@ -842,6 +858,34 @@ enum ToolDefinitions {
             dict["required"] = required
         }
         return dict
+    }
+
+    /// Shared `{enabled?, color?}` schema for the text background and border fills. Patch
+    /// semantics: omitted sub-fields keep their current value.
+    private static func textFillSchema(thing: String) -> [String: Any] {
+        [
+            "type": "object",
+            "description": "Text clips only. A \(thing). Patch — omitted sub-fields keep their current value.",
+            "properties": [
+                "enabled": ["type": "boolean", "description": "Toggle it on or off."],
+                "color": ["type": "string", "description": "Hex '#RRGGBB' or '#RRGGBBAA'."],
+            ],
+        ]
+    }
+
+    /// Shared schema for the text drop shadow.
+    private static func textShadowSchema() -> [String: Any] {
+        [
+            "type": "object",
+            "description": "Text clips only. Drop shadow behind the glyphs. Patch — omitted sub-fields keep their current value.",
+            "properties": [
+                "enabled": ["type": "boolean", "description": "Toggle the shadow on or off."],
+                "color": ["type": "string", "description": "Hex '#RRGGBB' or '#RRGGBBAA'; the alpha sets shadow strength."],
+                "offsetX": ["type": "number", "description": "Horizontal offset in canvas points (positive = right)."],
+                "offsetY": ["type": "number", "description": "Vertical offset in canvas points (negative = up)."],
+                "blur": ["type": "number", "description": "Blur radius in canvas points (>= 0)."],
+            ],
+        ]
     }
 }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -3,8 +3,16 @@ import Foundation
 
 extension ToolExecutor {
     private static let addCaptionsAllowedKeys: Set<String> = [
-        "clipIds", "fontName", "fontSize", "color", "centerX", "centerY", "textCase", "censorProfanity", "language",
+        "clipIds", "fontName", "fontSize", "color", "centerX", "centerY", "textCase", "censorProfanity", "language", "wordAnimation",
     ]
+
+    static func parseWordAnimation(_ raw: String?, path: String) throws -> CaptionWordAnimation? {
+        guard let raw else { return nil }
+        guard let parsed = CaptionWordAnimation(rawValue: raw) else {
+            throw ToolError("\(path): must be one of \(CaptionWordAnimation.allCases.map(\.rawValue).joined(separator: ", ")) (got \(raw))")
+        }
+        return parsed
+    }
 
     func addCaptions(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.addCaptionsAllowedKeys, path: "add_captions")
@@ -30,6 +38,8 @@ extension ToolExecutor {
             textCase = parsed
         }
 
+        let wordAnimation = try Self.parseWordAnimation(args.string("wordAnimation"), path: "add_captions.wordAnimation") ?? .pop
+
         let request = EditorViewModel.CaptionRequest(
             sourceClipIds: clipIds,
             autoDetect: clipIds.isEmpty,
@@ -37,7 +47,8 @@ extension ToolExecutor {
             center: center,
             textCase: textCase,
             censorProfanity: args.bool("censorProfanity") ?? false,
-            locale: locale
+            locale: locale,
+            wordAnimation: wordAnimation
         )
 
         let ids = try await editor.generateCaptions(for: request)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -71,13 +71,15 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let fontSize: Double?
     let color: String?
     let alignment: String?
+    let captionWordAnimation: String?
 
     static let allowedKeys: Set<String> = [
         "clipIds",
         "durationFrames", "trimStartFrame", "trimEndFrame", "speed",
         "volume", "opacity",
         "transform",
-        "content", "fontName", "fontSize", "color", "alignment",
+        "content", "fontName", "fontSize", "color", "alignment", "captionWordAnimation",
+        "background", "border", "shadow",
     ]
 
     var hasAnyProperty: Bool {
@@ -85,7 +87,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
             || speed != nil || volume != nil || opacity != nil
             || transform != nil
             || content != nil || fontName != nil || fontSize != nil
-            || color != nil || alignment != nil
+            || color != nil || alignment != nil || captionWordAnimation != nil
     }
 }
 
@@ -442,12 +444,16 @@ extension ToolExecutor {
 
     // MARK: set_clip_properties
 
-    private static let textOnlyKeys: Set<String> = ["content", "fontName", "fontSize", "color", "alignment"]
+    private static let textOnlyKeys: Set<String> = ["content", "fontName", "fontSize", "color", "alignment", "captionWordAnimation", "background", "border", "shadow"]
 
     func setClipProperties(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: SetClipPropertiesInput = try decodeToolArgs(args, path: "set_clip_properties")
         guard !input.clipIds.isEmpty else { throw ToolError("Missing or empty 'clipIds' array") }
-        guard input.hasAnyProperty else {
+        let backgroundPatch = try parseFillPatch(args["background"] as? [String: Any], path: "set_clip_properties.background")
+        let borderPatch = try parseFillPatch(args["border"] as? [String: Any], path: "set_clip_properties.border")
+        let shadowPatch = try parseShadowPatch(args["shadow"] as? [String: Any], path: "set_clip_properties.shadow")
+        let hasStylePatch = backgroundPatch != nil || borderPatch != nil || shadowPatch != nil
+        guard input.hasAnyProperty || hasStylePatch else {
             throw ToolError("set_clip_properties needs at least one property to apply")
         }
         if let df = input.durationFrames, df < 1 {
@@ -470,6 +476,7 @@ extension ToolExecutor {
         }
         let color = try parseColorHex(input.color, path: "set_clip_properties")
         let alignment = try parseAlignment(input.alignment, path: "set_clip_properties")
+        let captionWordAnimation = try Self.parseWordAnimation(input.captionWordAnimation, path: "set_clip_properties.captionWordAnimation")
 
         // Resolve clipIds + collect types so we can reject text-only fields on non-text clips.
         var clipTypes: [String: ClipType] = [:]
@@ -483,6 +490,10 @@ extension ToolExecutor {
             input.fontSize  != nil ? "fontSize"  : nil,
             input.color     != nil ? "color"     : nil,
             input.alignment != nil ? "alignment" : nil,
+            input.captionWordAnimation != nil ? "captionWordAnimation" : nil,
+            backgroundPatch != nil ? "background" : nil,
+            borderPatch     != nil ? "border"     : nil,
+            shadowPatch     != nil ? "shadow"     : nil,
         ].compactMap { $0 }
         if !textOnlyUsed.isEmpty {
             let nonText = clipTypes.filter { $0.value != .text }.map { $0.key }.sorted()
@@ -517,11 +528,16 @@ extension ToolExecutor {
                     fontSize: isText ? input.fontSize : nil,
                     color: isText ? color : nil,
                     alignment: isText ? alignment : nil,
+                    captionWordAnimation: isText ? captionWordAnimation : nil,
+                    background: isText ? backgroundPatch : nil,
+                    border: isText ? borderPatch : nil,
+                    shadow: isText ? shadowPatch : nil,
                     clipId: id,
                     editor: editor
                 )
-                // Match the inspector: refit bbox after content/font change when caller didn't set a box.
-                if isText && input.transform == nil && (input.content != nil || input.fontName != nil || input.fontSize != nil) {
+                let needsTextRefit = input.content != nil || input.fontName != nil || input.fontSize != nil
+                    || backgroundPatch != nil || borderPatch != nil || shadowPatch != nil
+                if isText && input.transform == nil && needsTextRefit {
                     editor.fitTextClipToContent(clipId: id)
                 }
                 summaries.append("\(id)\(changed.isEmpty ? " (no-op)" : ": \(changed.joined(separator: ", "))")")
@@ -536,6 +552,8 @@ extension ToolExecutor {
                     speed:          partnerIsText ? nil : input.speed,
                     volume: nil, opacity: nil, transform: nil,
                     content: nil, fontName: nil, fontSize: nil, color: nil, alignment: nil,
+                    captionWordAnimation: nil,
+                    background: nil, border: nil, shadow: nil,
                     clipId: partnerId,
                     editor: editor
                 )
@@ -560,6 +578,10 @@ extension ToolExecutor {
         fontSize: Double?,
         color: TextStyle.RGBA?,
         alignment: TextStyle.Alignment?,
+        captionWordAnimation: CaptionWordAnimation?,
+        background: ((inout TextStyle.Fill) -> Void)?,
+        border: ((inout TextStyle.Fill) -> Void)?,
+        shadow: ((inout TextStyle.Shadow) -> Void)?,
         clipId: String,
         editor: EditorViewModel
     ) -> [String] {
@@ -600,14 +622,27 @@ extension ToolExecutor {
                 clip.transform = next
                 changed.append("transform")
             }
-            if content != nil || fontName != nil || fontSize != nil || color != nil || alignment != nil {
-                if let c = content { clip.textContent = c; changed.append("content") }
+            if let c = content {
+                clip.textContent = c
+                clip.reconcileCaptionWords(to: c)
+                changed.append("content")
+            }
+            let touchesStyle = fontName != nil || fontSize != nil || color != nil || alignment != nil
+                || background != nil || border != nil || shadow != nil
+            if touchesStyle {
                 var style = clip.textStyle ?? TextStyle()
                 if let f = fontName  { style.fontName = f; changed.append("fontName") }
                 if let s = fontSize  { style.fontSize = s; changed.append("fontSize") }
                 if let c = color     { style.color = c; changed.append("color") }
                 if let a = alignment { style.alignment = a; changed.append("alignment") }
+                if let background { background(&style.background); changed.append("background") }
+                if let border     { border(&style.border); changed.append("border") }
+                if let shadow      { shadow(&style.shadow); changed.append("shadow") }
                 clip.textStyle = style
+            }
+            if let animation = captionWordAnimation {
+                clip.captionWordAnimation = animation.isAnimated ? animation : nil
+                changed.append("captionWordAnimation")
             }
         }
         return changed

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+TextStyle.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+TextStyle.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+func parseFillPatch(_ dict: [String: Any]?, path: String) throws -> ((inout TextStyle.Fill) -> Void)? {
+    guard let dict else { return nil }
+    try validateUnknownKeys(dict, allowed: ["enabled", "color"], path: path)
+    let enabled = dict.bool("enabled")
+    let color = try parseColorHex(dict.string("color"), path: "\(path).color")
+    guard enabled != nil || color != nil else { return nil }
+    return { fill in
+        if let enabled { fill.enabled = enabled }
+        if let color { fill.color = color }
+    }
+}
+
+func parseShadowPatch(_ dict: [String: Any]?, path: String) throws -> ((inout TextStyle.Shadow) -> Void)? {
+    guard let dict else { return nil }
+    try validateUnknownKeys(dict, allowed: ["enabled", "color", "offsetX", "offsetY", "blur"], path: path)
+    let enabled = dict.bool("enabled")
+    let color = try parseColorHex(dict.string("color"), path: "\(path).color")
+    let offsetX = dict.double("offsetX")
+    let offsetY = dict.double("offsetY")
+    let blur = dict.double("blur")
+    if let b = blur, b < 0 { throw ToolError("\(path).blur must be >= 0 (got \(b))") }
+    guard enabled != nil || color != nil || offsetX != nil || offsetY != nil || blur != nil else { return nil }
+    return { shadow in
+        if let enabled { shadow.enabled = enabled }
+        if let color { shadow.color = color }
+        if let offsetX { shadow.offsetX = offsetX }
+        if let offsetY { shadow.offsetY = offsetY }
+        if let blur { shadow.blur = blur }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -13,6 +13,7 @@ extension ToolExecutor {
     private static let addTextsAllowedKeys: Set<String> = [
         "trackIndex", "startFrame", "durationFrames", "content",
         "transform", "fontName", "fontSize", "color", "alignment",
+        "background", "border", "shadow",
     ]
 
     private func parseAddTextTransform(
@@ -81,6 +82,9 @@ extension ToolExecutor {
             if let s = entry.double("fontSize") { style.fontSize = s }
             if let c = try parseColorHex(entry.string("color"), path: path) { style.color = c }
             if let a = try parseAlignment(entry.string("alignment"), path: path) { style.alignment = a }
+            if let bg = try parseFillPatch(entry["background"] as? [String: Any], path: "\(path).background") { bg(&style.background) }
+            if let bd = try parseFillPatch(entry["border"] as? [String: Any], path: "\(path).border") { bd(&style.border) }
+            if let sh = try parseShadowPatch(entry["shadow"] as? [String: Any], path: "\(path).shadow") { sh(&style.shadow) }
 
             let transform = try parseAddTextTransform(
                 entry["transform"] as? [String: Any],

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -10,6 +10,7 @@ extension EditorViewModel {
         var textCase: CaptionCase = .auto
         var censorProfanity: Bool = false
         var locale: Locale? = nil
+        var wordAnimation: CaptionWordAnimation = .pop
     }
 
     enum CaptionCase: String, CaseIterable, Sendable {
@@ -182,8 +183,30 @@ extension EditorViewModel {
 
         return targets.flatMap { t -> [TextClipSpec] in
             guard let phrases = phrasesByClip[t.id] else { return [] }
-            let cased = phrases.map { CaptionBuilder.Phrase(text: request.textCase.apply($0.text), start: $0.start, end: $0.end) }
-            return CaptionBuilder.specs(for: cased, sourceClip: t.clip, trackIndex: 0, fps: fps, style: request.style, captionGroupId: groupId, transformFor: transformFor)
+            let cased = phrases.map { phrase in
+                CaptionBuilder.Phrase(
+                    text: request.textCase.apply(phrase.text),
+                    start: phrase.start,
+                    end: phrase.end,
+                    words: phrase.words.map {
+                        CaptionBuilder.WordTiming(
+                            text: request.textCase.apply($0.text),
+                            start: $0.start,
+                            end: $0.end
+                        )
+                    }
+                )
+            }
+            return CaptionBuilder.specs(
+                for: cased,
+                sourceClip: t.clip,
+                trackIndex: 0,
+                fps: fps,
+                style: request.style,
+                captionGroupId: groupId,
+                wordAnimation: request.wordAnimation,
+                transformFor: transformFor
+            )
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -635,6 +635,8 @@ extension EditorViewModel {
         /// When nil the box is auto-fit to content and centered on the canvas.
         let transform: Transform?
         var captionGroupId: String? = nil
+        var captionWordAnimation: CaptionWordAnimation? = nil
+        var captionWords: [CaptionWordTiming]? = nil
     }
 
     /// Batch variant of `addTextClip` for agent flows.
@@ -678,6 +680,8 @@ extension EditorViewModel {
                 clip.textContent = spec.content
                 clip.textStyle = spec.style
                 clip.captionGroupId = spec.captionGroupId
+                clip.captionWordAnimation = spec.captionWordAnimation
+                clip.captionWords = spec.captionWords
                 timeline.tracks[spec.trackIndex].clips.append(clip)
                 createdIds[i] = clip.id
             }

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -19,6 +19,7 @@ struct TextTab: View {
                 backgroundRow
                 borderRow
                 shadowRow
+                animationRow
             }
             InspectorSection("Layout") {
                 alignmentRow
@@ -36,12 +37,18 @@ struct TextTab: View {
                 text: Binding(
                     get: { clip.textContent ?? "" },
                     set: { new in
-                        editor.applyClipProperty(clipId: clip.id, rebuild: true) { $0.textContent = new }
+                        editor.applyClipProperty(clipId: clip.id, rebuild: true) {
+                            $0.textContent = new
+                            $0.reconcileCaptionWords(to: new)
+                        }
                         editor.fitTextClipToContent(clipId: clip.id)
                     }
                 ),
                 onCommit: { new in
-                    editor.commitClipProperty(clipId: clip.id) { $0.textContent = new }
+                    editor.commitClipProperty(clipId: clip.id) {
+                        $0.textContent = new
+                        $0.reconcileCaptionWords(to: new)
+                    }
                     editor.fitTextClipToContent(clipId: clip.id)
                 }
             )
@@ -154,6 +161,32 @@ struct TextTab: View {
             setEnabled: { $0.background.enabled = $1 },
             setColor: { $0.background.color = $1 }
         )
+    }
+
+    @ViewBuilder private var animationRow: some View {
+        if clip.captionWords?.isEmpty == false {
+            InspectorRow(icon: "sparkles", label: "Animation") {
+                Picker(
+                    "",
+                    selection: Binding(
+                        get: { clip.captionWordAnimation ?? .none },
+                        set: { new in
+                            editor.commitClipProperty(clipId: clip.id) {
+                                $0.captionWordAnimation = new.isAnimated ? new : nil
+                            }
+                        }
+                    )
+                ) {
+                    ForEach(CaptionWordAnimation.allCases, id: \.self) { kind in
+                        Text(kind.label).tag(kind)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+                .tint(AppTheme.Text.primaryColor.opacity(AppTheme.Opacity.strong))
+            }
+        }
     }
 
     private var borderRow: some View {

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -1,10 +1,17 @@
 import Foundation
 
 enum CaptionBuilder {
+    struct WordTiming: Equatable {
+        var text: String
+        var start: Double
+        var end: Double
+    }
+
     struct Phrase: Equatable {
         var text: String
         var start: Double
         var end: Double
+        var words: [WordTiming] = []
     }
 
     /// Splits a transcript segment into screen-ready phrases and times them.
@@ -63,10 +70,10 @@ enum CaptionBuilder {
     /// Time phrases from word runs by matching shared characters, so timing holds when
     /// runs don't split on spaces (contractions, split numbers, punctuation runs).
     private static func time(_ texts: [String], segment: TranscriptionSegment, words: [TranscriptionWord]) -> [Phrase] {
-        let timed = words.compactMap { w -> (count: Int, start: Double, end: Double)? in
+        let timed = words.compactMap { w -> (text: String, count: Int, start: Double, end: Double)? in
             guard let s = w.start, let e = w.end else { return nil }
             let count = alphanumericCount(w.text)
-            return count > 0 ? (count, s, e) : nil
+            return count > 0 ? (w.text, count, s, e) : nil
         }
         guard !timed.isEmpty else { return distribute(texts, start: segment.start, end: segment.end) }
 
@@ -77,17 +84,44 @@ enum CaptionBuilder {
             var got = 0
             var first: (start: Double, end: Double)?
             var last: (start: Double, end: Double)?
+            var wordTimings: [WordTiming] = []
             while idx < timed.count, got < want {
                 let run = timed[idx]
                 if first == nil { first = (run.start, run.end) }
                 last = (run.start, run.end)
+                wordTimings.append(WordTiming(text: run.text, start: run.start, end: run.end))
                 got += run.count
                 idx += 1
             }
             guard let f = first, let l = last else { break }
-            phrases.append(Phrase(text: text, start: f.start, end: l.end))
+            let merged = mergeWordTimings(wordTimings, phraseText: text)
+            phrases.append(Phrase(text: text, start: f.start, end: l.end, words: merged))
         }
         return phrases.count == texts.count ? phrases : distribute(texts, start: segment.start, end: segment.end)
+    }
+
+    private static func mergeWordTimings(_ runs: [WordTiming], phraseText: String) -> [WordTiming] {
+        let tokens = phraseText.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard !tokens.isEmpty, !runs.isEmpty else { return [] }
+
+        var merged: [WordTiming] = []
+        var idx = 0
+        for token in tokens {
+            let want = alphanumericCount(token)
+            var got = 0
+            var first: WordTiming?
+            var last: WordTiming?
+            while idx < runs.count, got < want {
+                let run = runs[idx]
+                if first == nil { first = run }
+                last = run
+                got += alphanumericCount(run.text)
+                idx += 1
+            }
+            guard let f = first, let l = last else { return [] }
+            merged.append(WordTiming(text: token, start: f.start, end: l.end))
+        }
+        return merged.count == tokens.count ? merged : []
     }
 
     private static func alphanumericCount(_ text: String) -> Int {
@@ -120,9 +154,24 @@ enum CaptionBuilder {
                 let shift = out[i].end - out[i + 1].start
                 out[i + 1].start += shift
                 out[i + 1].end += shift
+                for j in out[i + 1].words.indices {
+                    out[i + 1].words[j].start += shift
+                    out[i + 1].words[j].end += shift
+                }
             }
         }
         return out
+    }
+
+    private static func relativeFrame(sourceSeconds t: Double, clip: Clip, startFrame s: Int, fps: Int) -> Int {
+        let sourceFrame = t * Double(fps)
+        let offsetFromTrim = sourceFrame - Double(clip.trimStartFrame)
+        let frame = Double(clip.startFrame) + offsetFromTrim / max(clip.speed, 0.0001)
+        return Int(frame.rounded()) - s
+    }
+
+    private static func clamp(_ value: Int, _ low: Int, _ high: Int) -> Int {
+        min(max(value, low), max(low, high))
     }
 
     static func specs(
@@ -132,6 +181,7 @@ enum CaptionBuilder {
         fps: Int,
         style: TextStyle,
         captionGroupId: String?,
+        wordAnimation: CaptionWordAnimation = .none,
         transformFor: (String) -> Transform? = { _ in nil },
         minDurationFrames: Int = 1
     ) -> [EditorViewModel.TextClipSpec] {
@@ -146,14 +196,29 @@ enum CaptionBuilder {
             let mappedEnd = sourceClip.timelineFrame(sourceSeconds: p.end, fps: fps)
             let s = mappedStart ?? sourceClip.startFrame
             let e = mappedEnd ?? sourceClip.endFrame
+            let duration = max(minDurationFrames, min(sourceClip.endFrame, e) - max(sourceClip.startFrame, s))
+
+            var captionWords: [CaptionWordTiming]? = nil
+            let tokenTimings = mergeWordTimings(p.words, phraseText: p.text)
+            if wordAnimation.isAnimated, !tokenTimings.isEmpty {
+                captionWords = tokenTimings.map { w in
+                    let relStart = clamp(relativeFrame(sourceSeconds: w.start, clip: sourceClip, startFrame: s, fps: fps), 0, duration - 1)
+                    let relEnd = clamp(relativeFrame(sourceSeconds: w.end, clip: sourceClip, startFrame: s, fps: fps), relStart + 1, duration)
+                    return CaptionWordTiming(text: w.text, startFrame: relStart, endFrame: relEnd)
+                }
+            }
+            let animated = captionWords?.isEmpty == false
+
             return EditorViewModel.TextClipSpec(
                 trackIndex: trackIndex,
                 startFrame: s,
-                durationFrames: max(minDurationFrames, min(sourceClip.endFrame, e) - max(sourceClip.startFrame, s)),
+                durationFrames: duration,
                 content: p.text,
                 style: style,
                 transform: transformFor(p.text),
-                captionGroupId: captionGroupId
+                captionGroupId: captionGroupId,
+                captionWordAnimation: animated ? wordAnimation : nil,
+                captionWords: animated ? captionWords : nil
             )
         }
     }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -11,10 +11,11 @@ struct CaptionTab: View {
     @State private var censorProfanity = false
     @State private var locale: Locale?
     @State private var supportedLocales: [Locale] = []
+    @State private var wordAnimation: CaptionWordAnimation = .pop
     @State private var isGenerating = false
     @State private var note: String?
 
-    private static let previewText = "Captions will look like this"
+    private static let previewWords = ["Captions", "will", "pop", "in"]
 
     private var aspect: CGFloat { CGFloat(editor.timeline.width) / CGFloat(max(1, editor.timeline.height)) }
 
@@ -206,6 +207,16 @@ struct CaptionTab: View {
                     .controlSize(.mini)
                     .tint(AppTheme.Text.primaryColor.opacity(AppTheme.Opacity.strong))
             }
+            InspectorRow(icon: "sparkles", label: "Animation") {
+                Menu {
+                    ForEach(CaptionWordAnimation.allCases, id: \.self) { kind in
+                        Button(kind.label) { wordAnimation = kind }
+                    }
+                } label: {
+                    menuValueLabel(wordAnimation.label)
+                }
+                .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).fixedSize().focusable(false)
+            }
         }
     }
 
@@ -284,8 +295,9 @@ struct CaptionTab: View {
             GeometryReader { geo in
                 let canvasW = CGFloat(max(1, editor.timeline.width))
                 let canvasH = CGFloat(max(1, editor.timeline.height))
+                let previewText = Self.previewWords.joined(separator: " ")
                 let natural = TextLayout.naturalSize(
-                    content: Self.previewText,
+                    content: previewText,
                     style: style,
                     maxWidth: canvasW * AppTheme.ComponentSize.captionPreviewMaxTextWidthRatio,
                     canvasHeight: canvasH
@@ -293,9 +305,7 @@ struct CaptionTab: View {
                 let scale = geo.size.height / TextLayout.referenceCanvasHeight
                 let boxWidth = natural.width / canvasW * geo.size.width
                 let boxHeight = natural.height / canvasH * geo.size.height
-                Text(Self.previewText)
-                    .font(Font(style.resolvedFont(size: CGFloat(style.fontSize * style.fontScale) * scale)))
-                    .foregroundStyle(style.color.swiftUIColor)
+                AnimatedCaptionPreview(words: Self.previewWords, style: style, animation: wordAnimation, scale: scale)
                     .frame(width: boxWidth, height: boxHeight)
                     .background(style.background.enabled ? style.background.color.swiftUIColor : Color.clear)
                     .overlay {
@@ -394,7 +404,8 @@ struct CaptionTab: View {
         }
         let request = EditorViewModel.CaptionRequest(
             sourceClipIds: sourceIds, autoDetect: isAutoSource, style: style, center: center,
-            textCase: textCase, censorProfanity: censorProfanity, locale: locale
+            textCase: textCase, censorProfanity: censorProfanity, locale: locale,
+            wordAnimation: wordAnimation
         )
         Task {
             isGenerating = true
@@ -404,6 +415,41 @@ struct CaptionTab: View {
                 if ids.isEmpty { note = "No speech detected." }
             } catch {
                 note = error.localizedDescription
+            }
+        }
+    }
+}
+
+private struct AnimatedCaptionPreview: View {
+    let words: [String]
+    let style: TextStyle
+    let animation: CaptionWordAnimation
+    let scale: CGFloat
+
+    var body: some View {
+        SwiftUI.TimelineView(.animation(minimumInterval: 1.0 / 30)) { timeline in
+            let phase = timeline.date.timeIntervalSinceReferenceDate
+                .truncatingRemainder(dividingBy: previewCycleLength)
+            wordRow(at: phase)
+        }
+    }
+
+    private var previewCycleLength: Double {
+        AppTheme.Caption.previewWordStaggerSeconds * Double(words.count + 3)
+    }
+
+    private func wordRow(at phase: Double) -> some View {
+        let fontSize = CGFloat(style.fontSize * style.fontScale) * scale
+        let stagger = AppTheme.Caption.previewWordStaggerSeconds
+        return HStack(spacing: AppTheme.Spacing.xs) {
+            ForEach(Array(words.enumerated()), id: \.offset) { index, word in
+                let relFrame = Int(max(0, (phase - Double(index) * stagger) * 30))
+                let appearance = animation.appearance(at: relFrame, wordStartFrame: 0)
+                let offsetY = animation.verticalOffset(at: relFrame, wordStartFrame: 0) * fontSize
+                Text(AttributedString(style.fillAttributedString(content: word, size: fontSize)))
+                    .scaleEffect(appearance.scale)
+                    .opacity(Double(appearance.opacity))
+                    .offset(y: offsetY)
             }
         }
     }

--- a/Sources/PalmierPro/Models/CaptionWordAnimation.swift
+++ b/Sources/PalmierPro/Models/CaptionWordAnimation.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+import Foundation
+
+enum CaptionWordAnimation: String, Codable, Sendable, CaseIterable {
+    case none
+    case pop
+    case bounce
+    case fadeUp
+
+    var label: String {
+        switch self {
+        case .none: "Static"
+        case .pop: "Pop"
+        case .bounce: "Bounce"
+        case .fadeUp: "Fade Up"
+        }
+    }
+
+    var isAnimated: Bool { self != .none }
+
+    func appearance(at frame: Int, wordStartFrame: Int) -> (scale: CGFloat, opacity: Float) {
+        guard isAnimated else {
+            return frame >= wordStartFrame ? (1, 1) : (1, 0)
+        }
+        let elapsed = frame - wordStartFrame
+        guard elapsed >= 0 else { return startAppearance(for: self) }
+
+        let duration = AppTheme.Caption.wordAnimationDurationFrames
+        if elapsed >= duration { return (1, 1) }
+
+        let t = Double(elapsed) / Double(max(1, duration))
+        switch self {
+        case .none:
+            return (1, 1)
+        case .pop:
+            let eased = 1 - pow(1 - t, 3)
+            return (
+                CGFloat(AppTheme.Caption.wordPopStartScale + (1 - AppTheme.Caption.wordPopStartScale) * eased),
+                Float(eased)
+            )
+        case .bounce:
+            let overshoot = 1 + 0.18 * sin(t * .pi)
+            let scale = AppTheme.Caption.wordPopStartScale + (overshoot - AppTheme.Caption.wordPopStartScale) * t
+            return (CGFloat(min(scale, 1.12)), Float(min(t * 1.4, 1)))
+        case .fadeUp:
+            let eased = 1 - pow(1 - t, 2)
+            return (1, Float(eased))
+        }
+    }
+
+    func verticalOffset(at frame: Int, wordStartFrame: Int) -> CGFloat {
+        guard self == .fadeUp else { return 0 }
+        let elapsed = frame - wordStartFrame
+        guard elapsed >= 0 else { return AppTheme.Caption.wordFadeUpOffset }
+        let duration = AppTheme.Caption.wordAnimationDurationFrames
+        if elapsed >= duration { return 0 }
+        let t = Double(elapsed) / Double(max(1, duration))
+        let eased = 1 - pow(1 - t, 2)
+        return CGFloat((1 - eased) * AppTheme.Caption.wordFadeUpOffset)
+    }
+
+    private func startAppearance(for kind: CaptionWordAnimation) -> (scale: CGFloat, opacity: Float) {
+        switch kind {
+        case .fadeUp: (1, 0)
+        default: (CGFloat(AppTheme.Caption.wordPopStartScale), 0)
+        }
+    }
+}
+
+struct CaptionWordTiming: Codable, Sendable, Equatable {
+    var text: String
+    var startFrame: Int
+    var endFrame: Int
+}

--- a/Sources/PalmierPro/Models/TextLayout.swift
+++ b/Sources/PalmierPro/Models/TextLayout.swift
@@ -6,6 +6,12 @@ enum TextLayout {
     static let shadowPadding: CGFloat = 12
     static let referenceCanvasHeight: CGFloat = 1080
 
+    struct WordFrame: Equatable {
+        var text: String
+        /// Origin and size within the phrase text box (top-left origin).
+        var rect: CGRect
+    }
+
     static func naturalSize(
         content: String,
         style: TextStyle,
@@ -30,5 +36,60 @@ enum TextLayout {
             width: max(1, ceil(bounding.width) + shadowPad + slack),
             height: max(1, ceil(bounding.height) + slack)
         )
+    }
+
+    static func wordFrames(
+        content: String,
+        words: [CaptionWordTiming],
+        style: TextStyle,
+        boxSize: CGSize,
+        canvasHeight: CGFloat
+    ) -> [WordFrame] {
+        guard !content.isEmpty, !words.isEmpty else { return [] }
+        let canvasScale = canvasHeight / referenceCanvasHeight
+        let fontSize = CGFloat(style.fontSize * style.fontScale) * canvasScale
+        let attr = NSAttributedString(string: content, attributes: style.fillAttributes(size: fontSize))
+        let storage = NSTextStorage(attributedString: attr)
+        let layout = NSLayoutManager()
+        storage.addLayoutManager(layout)
+        let container = NSTextContainer(size: boxSize)
+        container.lineFragmentPadding = 0
+        layout.addTextContainer(container)
+        layout.ensureLayout(for: container)
+
+        let ns = content as NSString
+        let tokenRanges = tokenRanges(in: ns)
+        guard !tokenRanges.isEmpty else { return [] }
+
+        var frames: [WordFrame] = []
+        for index in words.indices {
+            let range = tokenRanges[min(index, tokenRanges.count - 1)]
+            let glyphRange = layout.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+            var rect = layout.boundingRect(forGlyphRange: glyphRange, in: container)
+            let lineRect = layout.lineFragmentRect(forGlyphAt: glyphRange.location, effectiveRange: nil)
+            rect.origin.y = lineRect.origin.y
+            rect.size.height = lineRect.height
+            frames.append(WordFrame(text: ns.substring(with: range), rect: rect))
+        }
+        return frames
+    }
+
+    private static func tokenRanges(in ns: NSString) -> [NSRange] {
+        let whitespace = CharacterSet.whitespacesAndNewlines
+        var ranges: [NSRange] = []
+        var loc = 0
+        while loc < ns.length {
+            while loc < ns.length, isWhitespace(ns.character(at: loc), whitespace) { loc += 1 }
+            guard loc < ns.length else { break }
+            let start = loc
+            while loc < ns.length, !isWhitespace(ns.character(at: loc), whitespace) { loc += 1 }
+            ranges.append(NSRange(location: start, length: loc - start))
+        }
+        return ranges
+    }
+
+    private static func isWhitespace(_ unit: unichar, _ set: CharacterSet) -> Bool {
+        guard let scalar = Unicode.Scalar(unit) else { return false }
+        return set.contains(scalar)
     }
 }

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -134,14 +134,32 @@ extension TextStyle {
         return p
     }
 
-    /// `includeColor: false` for bounding measurement (color doesn't affect size).
-    func attributes(size: CGFloat, includeColor: Bool = true) -> [NSAttributedString.Key: Any] {
-        var attrs: [NSAttributedString.Key: Any] = [
+    func fillAttributes(size: CGFloat) -> [NSAttributedString.Key: Any] {
+        [
             .font: resolvedFont(size: size),
             .paragraphStyle: paragraphStyle,
+            .foregroundColor: nsColor,
         ]
-        if includeColor { attrs[.foregroundColor] = nsColor }
+    }
+
+    /// Left-aligned attributed string for a single animated caption word.
+    func wordFillString(content: String, size: CGFloat) -> NSAttributedString {
+        var attrs = fillAttributes(size: size)
+        let paragraph = (attrs[.paragraphStyle] as? NSParagraphStyle)?.mutableCopy() as! NSMutableParagraphStyle
+        paragraph.alignment = .left
+        attrs[.paragraphStyle] = paragraph
+        return NSAttributedString(string: content, attributes: attrs)
+    }
+
+    /// `includeColor: false` for bounding measurement (color doesn't affect size).
+    func attributes(size: CGFloat, includeColor: Bool = true) -> [NSAttributedString.Key: Any] {
+        var attrs = fillAttributes(size: size)
+        if !includeColor { attrs.removeValue(forKey: .foregroundColor) }
         return attrs
+    }
+
+    func fillAttributedString(content: String, size: CGFloat) -> NSAttributedString {
+        NSAttributedString(string: content, attributes: fillAttributes(size: size))
     }
 }
 

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -97,6 +97,8 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     // Text clips only.
     var textContent: String?
     var textStyle: TextStyle?
+    var captionWordAnimation: CaptionWordAnimation?
+    var captionWords: [CaptionWordTiming]?
 
     // Keyframe tracks for each animatable property. Nil when no animation exists.
     var opacityTrack: KeyframeTrack<Double>?
@@ -113,13 +115,22 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case trimStartFrame, trimEndFrame, speed, volume
         case fadeInFrames, fadeOutFrames, fadeInInterpolation, fadeOutInterpolation
         case opacity, transform, crop
-        case linkGroupId, captionGroupId, textContent, textStyle
+        case linkGroupId, captionGroupId, textContent, textStyle, captionWordAnimation, captionWords
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
         case effects
     }
 
     /// Frame where this clip ends on the timeline
     var endFrame: Int { startFrame + durationFrames }
+
+    mutating func reconcileCaptionWords(to newContent: String) {
+        guard let words = captionWords, !words.isEmpty else { return }
+        let tokens = newContent.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard tokens.count == words.count else { captionWords = nil; return }
+        captionWords = zip(tokens, words).map {
+            CaptionWordTiming(text: $0.0, startFrame: $0.1.startFrame, endFrame: $0.1.endFrame)
+        }
+    }
 
     /// Source frames consumed by the visible portion
     var sourceFramesConsumed: Int { Int((Double(durationFrames) * speed).rounded()) }
@@ -354,6 +365,8 @@ extension Clip {
             captionGroupId: try? c.decode(String.self, forKey: .captionGroupId),
             textContent: try? c.decode(String.self, forKey: .textContent),
             textStyle: try? c.decode(TextStyle.self, forKey: .textStyle),
+            captionWordAnimation: try? c.decode(CaptionWordAnimation.self, forKey: .captionWordAnimation),
+            captionWords: try? c.decode([CaptionWordTiming].self, forKey: .captionWords),
             opacityTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .opacityTrack),
             positionTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .positionTrack),
             scaleTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .scaleTrack),

--- a/Sources/PalmierPro/Preview/TextLayerController.swift
+++ b/Sources/PalmierPro/Preview/TextLayerController.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import AppKit
 import QuartzCore
 
-/// Preview owns a long-lived `CATextLayer` tree with imperative opacity;
+/// Preview owns a long-lived text layer tree with imperative opacity;
 /// export hands a one-shot tree to `AVVideoCompositionCoreAnimationTool`.
 @MainActor
 final class TextLayerController {
@@ -16,7 +16,7 @@ final class TextLayerController {
 
     private var clips: [Clip] = []
     private var videoRect: CGRect = .zero
-    private var layersByID: [String: CATextLayer] = [:]
+    private var layersByID: [String: CALayer] = [:]
     private var currentFrame = 0
 
     // Materialize layers slightly early so playback never hitches on typesetting.
@@ -34,7 +34,7 @@ final class TextLayerController {
         reconcile(restyle: false)
     }
 
-    // Only clips within the preroll window own a CATextLayer; everything else stays unmaterialized.
+    // Only clips within the preroll window own layers; everything else stays unmaterialized.
     private func reconcile(restyle: Bool) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -45,21 +45,17 @@ final class TextLayerController {
                   currentFrame < clip.endFrame else { continue }
             needed.insert(clip.id)
 
-            let layer: CATextLayer
+            let layer: CALayer
             if let existing = layersByID[clip.id] {
                 layer = existing
-                if restyle { Self.applyStyle(to: layer, clip: clip, containerSize: videoRect.size) }
+                if restyle { Self.rebuildClipLayer(layer, clip: clip, containerSize: videoRect.size) }
             } else {
-                layer = Self.makeTextLayer()
-                Self.applyStyle(to: layer, clip: clip, containerSize: videoRect.size)
+                layer = Self.makeClipLayer(clip: clip, containerSize: videoRect.size)
                 layersByID[clip.id] = layer
                 textRoot.addSublayer(layer)
             }
             layer.zPosition = CGFloat(index)
-
-            let visible = currentFrame >= clip.startFrame
-            let target: Float = visible ? Float(clip.opacityAt(frame: currentFrame)) : 0
-            if layer.opacity != target { layer.opacity = target }
+            Self.updateClipLayer(layer, clip: clip, frame: currentFrame, containerSize: videoRect.size)
         }
 
         for (id, layer) in layersByID where !needed.contains(id) {
@@ -90,10 +86,13 @@ final class TextLayerController {
         let fpsD = Double(max(1, fps))
         let totalSeconds = max(0.001, Double(max(1, timeline.totalFrames)) / fpsD)
         for clip in visibleTextClips(in: timeline) {
-            let layer = makeTextLayer()
-            applyStyle(to: layer, clip: clip, containerSize: renderSize)
-            applyOpacityAnimation(to: layer, clip: clip, fps: fps, totalSeconds: totalSeconds)
-            layer.displayIfNeeded()
+            let layer = makeClipLayer(clip: clip, containerSize: renderSize)
+            if usesCaptionWords(clip) {
+                applyAnimatedClipExport(to: layer, clip: clip, fps: fps, totalSeconds: totalSeconds, containerSize: renderSize)
+            } else {
+                applyOpacityAnimation(to: layer, clip: clip, fps: fps, totalSeconds: totalSeconds)
+            }
+            displayTextTree(layer)
             parent.addSublayer(layer)
         }
         return (parent, videoLayer)
@@ -108,10 +107,8 @@ final class TextLayerController {
         host.frame = CGRect(origin: .zero, size: canvasSize)
         host.isGeometryFlipped = true
         for clip in visibleTextClips(in: timeline) {
-            let layer = makeTextLayer()
-            applyStyle(to: layer, clip: clip, containerSize: canvasSize)
-            let visible = frame >= clip.startFrame && frame < clip.endFrame
-            layer.opacity = visible ? Float(clip.opacityAt(frame: frame)) : 0
+            let layer = makeClipLayer(clip: clip, containerSize: canvasSize)
+            updateClipLayer(layer, clip: clip, frame: frame, containerSize: canvasSize)
             host.addSublayer(layer)
         }
         return host
@@ -129,13 +126,54 @@ final class TextLayerController {
         return result
     }
 
+    private static func usesCaptionWords(_ clip: Clip) -> Bool {
+        clip.captionWords?.isEmpty == false
+    }
+
+    private static func makeClipLayer(clip: Clip, containerSize: CGSize) -> CALayer {
+        if usesCaptionWords(clip) {
+            return makeAnimatedClipLayer(clip: clip, containerSize: containerSize)
+        }
+        return makeStaticClipLayer(clip: clip, containerSize: containerSize)
+    }
+
+    private static func rebuildClipLayer(_ layer: CALayer, clip: Clip, containerSize: CGSize) {
+        layer.sublayers?.forEach { $0.removeFromSuperlayer() }
+        if usesCaptionWords(clip) {
+            configureAnimatedClipLayer(layer, clip: clip, containerSize: containerSize)
+        } else {
+            configureStaticClipLayer(layer, clip: clip, containerSize: containerSize)
+        }
+    }
+
+    private static func updateClipLayer(_ layer: CALayer, clip: Clip, frame: Int, containerSize: CGSize) {
+        let visible = frame >= clip.startFrame && frame < clip.endFrame
+        let clipOpacity = visible ? Float(clip.opacityAt(frame: frame)) : 0
+        if usesCaptionWords(clip) {
+            layer.opacity = clipOpacity
+            guard visible, let words = clip.captionWords else { return }
+            let animation = clip.captionWordAnimation ?? .none
+            let relFrame = frame - clip.startFrame
+            let wordLayers = layer.sublayers ?? []
+            for (index, word) in words.enumerated() where index < wordLayers.count {
+                applyWordAppearance(
+                    to: wordLayers[index],
+                    animation: animation,
+                    relFrame: relFrame,
+                    word: word
+                )
+            }
+        } else {
+            layer.opacity = clipOpacity
+        }
+    }
+
     private static func makeTextLayer() -> CATextLayer {
         let layer = CATextLayer()
         layer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
         layer.isWrapped = true
         layer.truncationMode = .none
         layer.allowsFontSubpixelQuantization = true
-        // NSNull suppresses CATextLayer's implicit per-property cross-fade.
         layer.actions = [
             "contents": NSNull(),
             "bounds": NSNull(),
@@ -147,32 +185,140 @@ final class TextLayerController {
         return layer
     }
 
+    private static func makeBaseLayer() -> CALayer {
+        let layer = CALayer()
+        layer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        layer.actions = [
+            "bounds": NSNull(),
+            "position": NSNull(),
+            "opacity": NSNull(),
+            "transform": NSNull(),
+        ]
+        return layer
+    }
+
     private static let referenceCanvasHeight: CGFloat = 1080
 
-    private static func applyStyle(to layer: CATextLayer, clip: Clip, containerSize: CGSize) {
-        let style = clip.textStyle ?? TextStyle()
-        let content = clip.textContent ?? ""
-        let scale = containerSize.height / referenceCanvasHeight
-
+    private static func clipBoxFrame(clip: Clip, containerSize: CGSize) -> CGRect {
         let tl = clip.transform.topLeft
-        layer.frame = CGRect(
+        return CGRect(
             x: tl.x * containerSize.width,
             y: tl.y * containerSize.height,
             width: clip.transform.width * containerSize.width,
             height: clip.transform.height * containerSize.height
         )
+    }
+
+    private static func makeStaticClipLayer(clip: Clip, containerSize: CGSize) -> CALayer {
+        let layer = makeBaseLayer()
+        configureStaticClipLayer(layer, clip: clip, containerSize: containerSize)
+        return layer
+    }
+
+    private static func configureStaticClipLayer(_ layer: CALayer, clip: Clip, containerSize: CGSize) {
+        let style = clip.textStyle ?? TextStyle()
+        let scale = containerSize.height / referenceCanvasHeight
+        layer.frame = clipBoxFrame(clip: clip, containerSize: containerSize)
+        applyBoxChrome(to: layer, style: style, scale: scale)
 
         let fontSize = CGFloat(style.fontSize * style.fontScale) * scale
-        layer.string = NSAttributedString(
-            string: content,
-            attributes: style.attributes(size: fontSize)
+        addTextContent(
+            to: layer,
+            content: clip.textContent ?? "",
+            style: style,
+            fontSize: fontSize,
+            alignment: style.alignment.caTextAlignmentMode,
+            wrapped: true,
+            shadowOnFill: true,
+            scale: scale
         )
-        layer.alignmentMode = style.alignment.caTextAlignmentMode
+    }
+
+    private static func addTextContent(
+        to container: CALayer,
+        content: String,
+        style: TextStyle,
+        fontSize: CGFloat,
+        alignment: CATextLayerAlignmentMode,
+        wrapped: Bool,
+        shadowOnFill: Bool,
+        scale: CGFloat
+    ) {
+        let fill = makeTextLayer()
+        fill.isWrapped = wrapped
+        fill.frame = CGRect(origin: .zero, size: container.bounds.size)
+        fill.string = NSAttributedString(string: content, attributes: style.fillAttributes(size: fontSize))
+        fill.alignmentMode = alignment
+        if shadowOnFill { applyWordShadow(to: fill, style: style, scale: scale) }
+        container.addSublayer(fill)
+    }
+
+    private static func addWordContent(
+        to wordHost: CALayer,
+        content: String,
+        style: TextStyle,
+        fontSize: CGFloat,
+        glyphRect: CGRect,
+        shadowOnFill: Bool,
+        scale: CGFloat
+    ) {
+        let fill = makeTextLayer()
+        fill.isWrapped = false
+        fill.frame = CGRect(origin: .zero, size: glyphRect.size)
+        fill.alignmentMode = .left
+        fill.string = style.wordFillString(content: content, size: fontSize)
+        if shadowOnFill { applyWordShadow(to: fill, style: style, scale: scale) }
+        wordHost.addSublayer(fill)
+    }
+
+    private static func makeAnimatedClipLayer(clip: Clip, containerSize: CGSize) -> CALayer {
+        let layer = makeBaseLayer()
+        configureAnimatedClipLayer(layer, clip: clip, containerSize: containerSize)
+        return layer
+    }
+
+    private static func configureAnimatedClipLayer(_ layer: CALayer, clip: Clip, containerSize: CGSize) {
+        let style = clip.textStyle ?? TextStyle()
+        let scale = containerSize.height / referenceCanvasHeight
+        let box = clipBoxFrame(clip: clip, containerSize: containerSize)
+        layer.frame = box
 
         layer.backgroundColor = style.background.enabled ? style.background.color.nsColor.cgColor : nil
         layer.borderColor = style.border.enabled ? style.border.color.nsColor.cgColor : nil
         layer.borderWidth = style.border.enabled ? AppTheme.BorderWidth.thin * scale : 0
 
+        guard let words = clip.captionWords else { return }
+        let wordFrames = TextLayout.wordFrames(
+            content: clip.textContent ?? "",
+            words: words,
+            style: style,
+            boxSize: box.size,
+            canvasHeight: containerSize.height
+        )
+        let fontSize = CGFloat(style.fontSize * style.fontScale) * scale
+        for (index, layout) in wordFrames.enumerated() where index < words.count {
+            let wordHost = makeBaseLayer()
+            wordHost.frame = layout.rect
+            addWordContent(
+                to: wordHost,
+                content: layout.text,
+                style: style,
+                fontSize: fontSize,
+                glyphRect: layout.rect,
+                shadowOnFill: true,
+                scale: scale
+            )
+            layer.addSublayer(wordHost)
+        }
+    }
+
+    private static func applyBoxChrome(to layer: CALayer, style: TextStyle, scale: CGFloat) {
+        layer.backgroundColor = style.background.enabled ? style.background.color.nsColor.cgColor : nil
+        layer.borderColor = style.border.enabled ? style.border.color.nsColor.cgColor : nil
+        layer.borderWidth = style.border.enabled ? AppTheme.BorderWidth.thin * scale : 0
+    }
+
+    private static func applyWordShadow(to layer: CATextLayer, style: TextStyle, scale: CGFloat) {
         if style.shadow.enabled {
             layer.shadowColor = style.shadow.color.nsColor.cgColor
             layer.shadowOpacity = 1
@@ -187,9 +333,115 @@ final class TextLayerController {
         }
     }
 
-    /// Export-time opacity
+    private static func applyWordAppearance(
+        to layer: CALayer,
+        animation: CaptionWordAnimation,
+        relFrame: Int,
+        word: CaptionWordTiming
+    ) {
+        let appearance = animation.appearance(at: relFrame, wordStartFrame: word.startFrame)
+        layer.opacity = appearance.opacity
+        let offsetY = animation.verticalOffset(at: relFrame, wordStartFrame: word.startFrame) * layer.bounds.height
+        layer.setAffineTransform(
+            CGAffineTransform(translationX: 0, y: offsetY)
+                .scaledBy(x: appearance.scale, y: appearance.scale)
+        )
+    }
+
+    private static func applyAnimatedClipExport(
+        to layer: CALayer,
+        clip: Clip,
+        fps: Int,
+        totalSeconds: Double,
+        containerSize: CGSize
+    ) {
+        applyOpacityAnimation(to: layer, clip: clip, fps: fps, totalSeconds: totalSeconds)
+        guard let words = clip.captionWords, !words.isEmpty else { return }
+        let animation = clip.captionWordAnimation ?? .none
+        let wordLayers = layer.sublayers ?? []
+        for (index, word) in words.enumerated() where index < wordLayers.count {
+            applyWordExportAnimation(
+                to: wordLayers[index],
+                clip: clip,
+                word: word,
+                animation: animation,
+                fps: fps,
+                totalSeconds: totalSeconds
+            )
+        }
+    }
+
+    private static func applyWordExportAnimation(
+        to layer: CALayer,
+        clip: Clip,
+        word: CaptionWordTiming,
+        animation: CaptionWordAnimation,
+        fps: Int,
+        totalSeconds: Double
+    ) {
+        let fpsD = Double(max(1, fps))
+        let total = max(0.001, totalSeconds)
+        let totalFrames = max(1, Int((total * fpsD).rounded()))
+
+        var opacityTimes: [NSNumber] = [NSNumber(value: 0)]
+        var opacityValues: [NSNumber] = []
+        var scaleTimes: [NSNumber] = [NSNumber(value: 0)]
+        var scaleValues: [NSNumber] = []
+        var offsetTimes: [NSNumber] = [NSNumber(value: 0)]
+        var offsetValues: [NSNumber] = []
+
+        for frame in 0..<totalFrames {
+            let inClip = frame >= clip.startFrame && frame < clip.endFrame
+            let relFrame = inClip ? frame - clip.startFrame : -1
+            let appearance = inClip
+                ? animation.appearance(at: relFrame, wordStartFrame: word.startFrame)
+                : (scale: CGFloat(0.55), opacity: Float(0))
+            let offsetY = inClip
+                ? animation.verticalOffset(at: relFrame, wordStartFrame: word.startFrame) * layer.bounds.height
+                : 0
+
+            opacityValues.append(NSNumber(value: appearance.opacity))
+            opacityTimes.append(NSNumber(value: Double(frame + 1) / Double(totalFrames)))
+            scaleValues.append(NSNumber(value: Float(appearance.scale)))
+            scaleTimes.append(NSNumber(value: Double(frame + 1) / Double(totalFrames)))
+            offsetValues.append(NSNumber(value: Float(offsetY)))
+            offsetTimes.append(NSNumber(value: Double(frame + 1) / Double(totalFrames)))
+        }
+
+        layer.opacity = 0
+        addDiscreteAnimation(to: layer, keyPath: "opacity", values: opacityValues, keyTimes: opacityTimes, duration: total)
+        addDiscreteAnimation(to: layer, keyPath: "transform.scale", values: scaleValues, keyTimes: scaleTimes, duration: total)
+        if animation == .fadeUp {
+            addDiscreteAnimation(to: layer, keyPath: "transform.translation.y", values: offsetValues, keyTimes: offsetTimes, duration: total)
+        }
+    }
+
+    private static func displayTextTree(_ layer: CALayer) {
+        layer.displayIfNeeded()
+        layer.sublayers?.forEach { displayTextTree($0) }
+    }
+
+    private static func addDiscreteAnimation(
+        to layer: CALayer,
+        keyPath: String,
+        values: [NSNumber],
+        keyTimes: [NSNumber],
+        duration: Double
+    ) {
+        let anim = CAKeyframeAnimation(keyPath: keyPath)
+        anim.calculationMode = .discrete
+        anim.values = values
+        anim.keyTimes = keyTimes
+        anim.beginTime = AVCoreAnimationBeginTimeAtZero
+        anim.duration = duration
+        anim.fillMode = .both
+        anim.isRemovedOnCompletion = false
+        layer.add(anim, forKey: keyPath)
+    }
+
+    /// Export-time opacity for a whole clip or static text layer.
     private static func applyOpacityAnimation(
-        to layer: CATextLayer,
+        to layer: CALayer,
         clip: Clip,
         fps: Int,
         totalSeconds: Double
@@ -200,8 +452,6 @@ final class TextLayerController {
 
         layer.opacity = 0
 
-        // Discrete keyframes: values[i] holds in [keyTimes[i], keyTimes[i+1]),
-        // so values.count == keyTimes.count - 1. https://developer.apple.com/documentation/quartzcore/cakeyframeanimation
         var keyTimes: [NSNumber] = [NSNumber(value: 0)]
         var values: [NSNumber] = []
         for frame in 0..<totalFrames {
@@ -211,14 +461,6 @@ final class TextLayerController {
             keyTimes.append(NSNumber(value: Double(frame + 1) / Double(totalFrames)))
         }
 
-        let anim = CAKeyframeAnimation(keyPath: "opacity")
-        anim.calculationMode = .discrete
-        anim.values = values
-        anim.keyTimes = keyTimes
-        anim.beginTime = AVCoreAnimationBeginTimeAtZero
-        anim.duration = total
-        anim.fillMode = .both
-        anim.isRemovedOnCompletion = false
-        layer.add(anim, forKey: "opacity")
+        addDiscreteAnimation(to: layer, keyPath: "opacity", values: values, keyTimes: keyTimes, duration: total)
     }
 }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -286,6 +286,10 @@ enum AppTheme {
         static let defaultCenterY: CGFloat = 0.9
         static let defaultCenter = CGPoint(x: centerSnapValue, y: defaultCenterY)
         static let minDisplayDuration: Double = 0.7
+        static let wordAnimationDurationFrames: Int = 8
+        static let wordPopStartScale: Double = 0.55
+        static let wordFadeUpOffset: Double = 0.35
+        static let previewWordStaggerSeconds: Double = 0.28
     }
 
     enum GenerationPanel {

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1339,6 +1339,130 @@ struct ToolExecutorTextFolderTests {
         #expect(result.isError)
     }
 
+    @Test func setClipPropertiesUpdatesCaptionWordAnimation() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        var clip = Clip(mediaRef: "", mediaType: .text, startFrame: 0, durationFrames: 30)
+        clip.textContent = "hi"
+        clip.captionWordAnimation = .pop
+        h.editor.timeline.tracks[0].clips.append(clip)
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "captionWordAnimation": "bounce",
+        ])
+        #expect(result.isError == false)
+        #expect(h.editor.timeline.tracks[0].clips[0].captionWordAnimation == .bounce)
+    }
+
+    @Test func addTextsAppliesBackgroundBorderShadow() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "durationFrames": 30,
+                "content": "Styled",
+                "background": ["enabled": true, "color": "#112233"],
+                "border": ["enabled": true],
+                "shadow": ["enabled": false, "offsetX": 4, "blur": 10],
+            ]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let style = try #require(h.editor.timeline.tracks[0].clips[0].textStyle)
+        #expect(style.background.enabled)
+        #expect(style.background.color.r == Double(0x11) / 255.0)
+        #expect(style.border.enabled)
+        #expect(style.shadow.enabled == false)
+        #expect(style.shadow.offsetX == 4)
+        #expect(style.shadow.blur == 10)
+    }
+
+    @Test func setClipPropertiesTogglesBackgroundAndPatchesColorOnly() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        var clip = Clip(mediaRef: "", mediaType: .text, startFrame: 0, durationFrames: 30)
+        clip.textContent = "hi"
+        clip.textStyle = TextStyle()
+        h.editor.timeline.tracks[0].clips.append(clip)
+
+        // Toggle background on.
+        var result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "background": ["enabled": true, "color": "#FF0000"],
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        var style = try #require(h.editor.timeline.tracks[0].clips[0].textStyle)
+        #expect(style.background.enabled)
+        #expect(style.background.color.r == 1)
+
+        // Color-only patch must leave enabled untouched.
+        result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "background": ["color": "#00FF00"],
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        style = try #require(h.editor.timeline.tracks[0].clips[0].textStyle)
+        #expect(style.background.enabled)
+        #expect(style.background.color.g == 1)
+    }
+
+    @Test func setClipPropertiesShadowToggleRefitsBoundingBox() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        var result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "durationFrames": 30,
+                "content": "hello",
+            ]]
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let clipId = h.editor.timeline.tracks[0].clips[0].id
+
+        result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clipId],
+            "shadow": ["enabled": false],
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let withoutShadowW = h.editor.timeline.tracks[0].clips[0].transform.width
+
+        result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clipId],
+            "shadow": ["enabled": true, "blur": 8],
+        ])
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let withShadowW = h.editor.timeline.tracks[0].clips[0].transform.width
+        #expect(withShadowW > withoutShadowW)
+    }
+
+    @Test func setClipPropertiesRejectsBackgroundOnNonTextClip() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let clip = Clip(mediaRef: "vid", mediaType: .video, startFrame: 0, durationFrames: 30)
+        h.editor.timeline.tracks[0].clips.append(clip)
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "background": ["enabled": true],
+        ])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("background"))
+    }
+
+    @Test func setClipPropertiesRejectsInvalidShadowColor() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        var clip = Clip(mediaRef: "", mediaType: .text, startFrame: 0, durationFrames: 30)
+        clip.textContent = "hi"
+        h.editor.timeline.tracks[0].clips.append(clip)
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "shadow": ["color": "nope"],
+        ])
+        #expect(result.isError)
+    }
+
     // MARK: - create_folder + move_to_folder
 
     @Test func createFolderAddsRootLevelFolder() async throws {

--- a/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
@@ -48,6 +48,17 @@ struct CaptionBuilderTests {
         #expect(phrases.map(\.end) == [3.0, 7.0])
     }
 
+    @Test func minDurationShiftMovesWordTimingsWithPhrase() {
+        let seg = TranscriptionSegment(text: "aa bbbb", start: 0, end: 6)
+        let words = [
+            TranscriptionWord(text: "aa", start: 0, end: 1),
+            TranscriptionWord(text: "bbbb", start: 2, end: 6),
+        ]
+        let phrases = CaptionBuilder.phrases(for: seg, words: words, fits: { $0.count <= 4 }, minDuration: 3)
+        #expect(phrases[1].words.map(\.start) == [3.0])
+        #expect(phrases[1].words.map(\.end) == [7.0])
+    }
+
     @Test func keepsOverlongSingleWord() {
         let phrases = CaptionBuilder.phrases(for: segment("supercalifragilistic", 0, 1), fits: { _ in false }, minDuration: 0)
         #expect(phrases.map(\.text) == ["supercalifragilistic"])

--- a/Tests/PalmierProTests/Captions/CaptionWordAnimationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionWordAnimationTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("CaptionWordAnimation")
+struct CaptionWordAnimationTests {
+    @Test func popStartsHiddenThenScalesIn() {
+        let anim = CaptionWordAnimation.pop
+        let before = anim.appearance(at: 0, wordStartFrame: 5)
+        #expect(before.opacity == 0)
+        #expect(before.scale < 1)
+
+        let during = anim.appearance(at: 6, wordStartFrame: 5)
+        #expect(during.opacity > 0)
+        #expect(during.scale > before.scale)
+
+        let after = anim.appearance(at: 20, wordStartFrame: 5)
+        #expect(after.opacity == 1)
+        #expect(after.scale == 1)
+    }
+
+    @Test func staticShowsWordsOnlyAfterStart() {
+        let anim = CaptionWordAnimation.none
+        #expect(anim.appearance(at: 4, wordStartFrame: 5).opacity == 0)
+        #expect(anim.appearance(at: 5, wordStartFrame: 5).opacity == 1)
+    }
+}
+
+@Suite("Clip caption word reconcile")
+struct ClipReconcileCaptionWordsTests {
+    private func clip(content: String, words: [CaptionWordTiming]) -> Clip {
+        var c = Clip(mediaRef: "m", startFrame: 0, durationFrames: 120)
+        c.textContent = content
+        c.captionWordAnimation = .pop
+        c.captionWords = words
+        return c
+    }
+
+    @Test func typoFixKeepsTimings() {
+        var c = clip(content: "the pillow word", words: [
+            CaptionWordTiming(text: "the", startFrame: 0, endFrame: 5),
+            CaptionWordTiming(text: "pillow", startFrame: 5, endFrame: 10),
+            CaptionWordTiming(text: "word", startFrame: 10, endFrame: 15),
+        ])
+        c.reconcileCaptionWords(to: "the filler word")
+        #expect(c.captionWords?.map(\.text) == ["the", "filler", "word"])
+        #expect(c.captionWords?.map(\.startFrame) == [0, 5, 10])
+    }
+
+    @Test func wordCountChangeDropsTimings() {
+        var c = clip(content: "the filler word", words: [
+            CaptionWordTiming(text: "the", startFrame: 0, endFrame: 5),
+            CaptionWordTiming(text: "filler", startFrame: 5, endFrame: 10),
+            CaptionWordTiming(text: "word", startFrame: 10, endFrame: 15),
+        ])
+        c.reconcileCaptionWords(to: "the filler")
+        #expect(c.captionWords == nil)
+    }
+}
+
+@Suite("CaptionBuilder word timings")
+struct CaptionBuilderWordTimingTests {
+    private func word(_ text: String, _ start: Double, _ end: Double) -> TranscriptionWord {
+        TranscriptionWord(text: text, start: start, end: end)
+    }
+
+    @Test func attachesWordTimingsToPhrases() {
+        let seg = TranscriptionSegment(text: "hello world", start: 0, end: 2)
+        let words = [word("hello", 0, 0.8), word("world", 0.9, 2.0)]
+        let phrases = CaptionBuilder.phrases(for: seg, words: words, fits: { _ in true }, minDuration: 0)
+        #expect(phrases.count == 1)
+        #expect(phrases[0].words.map(\.text) == ["hello", "world"])
+        #expect(phrases[0].words.map(\.start) == [0, 0.9])
+    }
+
+    @Test func mergesSplitContractionRunsIntoPhraseTokens() {
+        let seg = TranscriptionSegment(text: "don't know", start: 0, end: 2)
+        let words = [
+            word("don", 0, 0.4),
+            word("t", 0.4, 0.5),
+            word("know", 0.6, 2.0),
+        ]
+        let phrases = CaptionBuilder.phrases(for: seg, words: words, fits: { _ in true }, minDuration: 0)
+        #expect(phrases.count == 1)
+        #expect(phrases[0].words.map(\.text) == ["don't", "know"])
+        #expect(phrases[0].words.map(\.start) == [0, 0.6])
+        #expect(phrases[0].words.map(\.end) == [0.5, 2.0])
+
+        let clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 60)
+        let specs = CaptionBuilder.specs(
+            for: phrases,
+            sourceClip: clip,
+            trackIndex: 0,
+            fps: 30,
+            style: TextStyle(),
+            captionGroupId: "g",
+            wordAnimation: .pop
+        )
+        #expect(specs[0].captionWords?.map(\.text) == ["don't", "know"])
+        #expect(specs[0].captionWords?.count == 2)
+    }
+
+    @Test func specsIncludeCaptionWordsWhenAnimated() {
+        let clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 120)
+        let phrase = CaptionBuilder.Phrase(
+            text: "hello world",
+            start: 0,
+            end: 2,
+            words: [
+                CaptionBuilder.WordTiming(text: "hello", start: 0, end: 0.8),
+                CaptionBuilder.WordTiming(text: "world", start: 0.9, end: 2),
+            ]
+        )
+        let specs = CaptionBuilder.specs(
+            for: [phrase],
+            sourceClip: clip,
+            trackIndex: 0,
+            fps: 30,
+            style: TextStyle(),
+            captionGroupId: "g1",
+            wordAnimation: .pop
+        )
+        #expect(specs.count == 1)
+        #expect(specs[0].captionWordAnimation == .pop)
+        #expect(specs[0].captionWords?.map(\.text) == ["hello", "world"])
+        #expect(specs[0].captionWords?.map(\.startFrame) == [0, 27])
+    }
+
+    @Test func trimmedClipKeepsEveryWordInOrder() {
+        var clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 60)
+        clip.trimStartFrame = 30
+        let phrase = CaptionBuilder.Phrase(
+            text: "alpha beta gamma",
+            start: 0.5,
+            end: 2.5,
+            words: [
+                CaptionBuilder.WordTiming(text: "alpha", start: 0.5, end: 0.9),
+                CaptionBuilder.WordTiming(text: "beta", start: 1.5, end: 1.9),
+                CaptionBuilder.WordTiming(text: "gamma", start: 2.4, end: 2.5),
+            ]
+        )
+        let specs = CaptionBuilder.specs(
+            for: [phrase], sourceClip: clip, trackIndex: 0, fps: 30,
+            style: TextStyle(), captionGroupId: "g", wordAnimation: .pop
+        )
+        #expect(specs.count == 1)
+        let words = specs[0].captionWords
+        #expect(words?.map(\.text) == ["alpha", "beta", "gamma"])
+        let starts = words?.map(\.startFrame) ?? []
+        #expect(starts == starts.sorted())
+        #expect(starts.first == 0)
+    }
+
+    @Test func noWordTimingsMeansNoAnimation() {
+        let clip = Clip(mediaRef: "m", startFrame: 0, durationFrames: 60)
+        let phrase = CaptionBuilder.Phrase(text: "hello world", start: 0, end: 2, words: [])
+        let specs = CaptionBuilder.specs(
+            for: [phrase], sourceClip: clip, trackIndex: 0, fps: 30,
+            style: TextStyle(), captionGroupId: "g", wordAnimation: .pop
+        )
+        #expect(specs.count == 1)
+        #expect(specs[0].captionWordAnimation == nil)
+        #expect(specs[0].captionWords == nil)
+    }
+}

--- a/Tests/PalmierProTests/Rendering/TextLayerOpacityAnimationTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextLayerOpacityAnimationTests.swift
@@ -7,16 +7,16 @@ import Testing
 @MainActor
 struct TextLayerOpacityAnimationTests {
 
-    private func animation(for clip: Clip, fps: Int = 30) -> (anim: CAKeyframeAnimation?, layer: CATextLayer?) {
+    private func animation(for clip: Clip, fps: Int = 30) -> (anim: CAKeyframeAnimation?, layer: CALayer?) {
         let track = Fixtures.videoTrack(clips: [clip])
         let timeline = Fixtures.timeline(fps: fps, tracks: [track])
         let (parent, videoLayer) = TextLayerController.buildForExport(
             timeline: timeline, fps: fps, renderSize: CGSize(width: 1920, height: 1080)
         )
         _ = videoLayer
-        let textLayer = parent.sublayers?.dropFirst().first as? CATextLayer
-        let anim = textLayer?.animation(forKey: "opacity") as? CAKeyframeAnimation
-        return (anim, textLayer)
+        let clipLayer = parent.sublayers?.dropFirst().first
+        let anim = clipLayer?.animation(forKey: "opacity") as? CAKeyframeAnimation
+        return (anim, clipLayer)
     }
 
     private func textClip(start: Int, duration: Int, fadeIn: Int = 0, fadeOut: Int = 0) -> Clip {
@@ -86,5 +86,16 @@ struct TextLayerOpacityAnimationTests {
         let (_, layer) = animation(for: clip)
         #expect(layer?.borderColor != nil)
         #expect(layer?.borderWidth == AppTheme.BorderWidth.thin)
+    }
+
+    @Test func staticCaptionWordsUsePerWordLayers() {
+        var clip = textClip(start: 0, duration: 60)
+        clip.textContent = "hello world"
+        clip.captionWords = [
+            CaptionWordTiming(text: "hello", startFrame: 0, endFrame: 10),
+            CaptionWordTiming(text: "world", startFrame: 10, endFrame: 20),
+        ]
+        let (_, layer) = animation(for: clip)
+        #expect(layer?.sublayers?.count == 2)
     }
 }

--- a/Tests/PalmierProTests/Rendering/TextLayoutTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextLayoutTests.swift
@@ -1,0 +1,77 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("TextLayout")
+struct TextLayoutTests {
+
+    @Test func wordFramesKeepTopToBottomLineOrder() {
+        var style = TextStyle()
+        style.fontSize = 48
+        style.alignment = .center
+        let content = "Hello world foo bar"
+        let words = [
+            CaptionWordTiming(text: "Hello", startFrame: 0, endFrame: 5),
+            CaptionWordTiming(text: "world", startFrame: 5, endFrame: 10),
+            CaptionWordTiming(text: "foo", startFrame: 10, endFrame: 15),
+            CaptionWordTiming(text: "bar", startFrame: 15, endFrame: 20),
+        ]
+        let box = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: 120,
+            canvasHeight: 1080
+        )
+        let frames = TextLayout.wordFrames(
+            content: content,
+            words: words,
+            style: style,
+            boxSize: box,
+            canvasHeight: 1080
+        )
+        #expect(frames.count == 4)
+        let firstLine = frames.filter { $0.text == "Hello" || $0.text == "world" }
+        let secondLine = frames.filter { $0.text == "foo" || $0.text == "bar" }
+        let firstY = firstLine.map(\.rect.origin.y).max() ?? 0
+        let secondY = secondLine.map(\.rect.origin.y).min() ?? 0
+        #expect(secondY > firstY)
+    }
+
+    @Test func wordFramesPairByIndexNotText() {
+        var style = TextStyle()
+        style.fontSize = 48
+        let content = "hello world end"
+        let words = [
+            CaptionWordTiming(text: "hello,", startFrame: 0, endFrame: 5),
+            CaptionWordTiming(text: "world", startFrame: 5, endFrame: 10),
+            CaptionWordTiming(text: "end.", startFrame: 10, endFrame: 15),
+        ]
+        let box = TextLayout.naturalSize(
+            content: content, style: style, maxWidth: 1000, canvasHeight: 1080
+        )
+        let frames = TextLayout.wordFrames(
+            content: content, words: words, style: style, boxSize: box, canvasHeight: 1080
+        )
+        #expect(frames.count == words.count)
+        #expect(frames[0].rect.minX < frames[1].rect.minX)
+        #expect(frames[1].rect.minX < frames[2].rect.minX)
+    }
+
+    @Test func wordFramesShareLineHeightOnSameLine() {
+        var style = TextStyle()
+        style.fontSize = 48
+        let content = "big g"
+        let words = [
+            CaptionWordTiming(text: "big", startFrame: 0, endFrame: 5),
+            CaptionWordTiming(text: "g", startFrame: 5, endFrame: 10),
+        ]
+        let box = TextLayout.naturalSize(
+            content: content, style: style, maxWidth: 400, canvasHeight: 1080
+        )
+        let frames = TextLayout.wordFrames(
+            content: content, words: words, style: style, boxSize: box, canvasHeight: 1080
+        )
+        #expect(frames.count == 2)
+        #expect(frames[0].rect.height == frames[1].rect.height)
+        #expect(frames[0].rect.origin.y == frames[1].rect.origin.y)
+    }
+}


### PR DESCRIPTION
Animate captions in three ways: pop, fade and bounce.
Have the agent also be able to set animations and adjust background to captions.

TLDR:

> Captions can animate word-by-word (pop, bounce, fade up, or static reveal) using transcript timings baked at generation time, with preview and export rendering each word on its own layer instead of showing the whole phrase at once.
> 
> The agent and inspector gained matching controls: add_captions / set_clip_properties can set word animation plus text background, border, and shadow, and the bounding box refits when those style fields change.
> 
> Under the hood, transcript runs are merged into phrase tokens (so contractions like don't stay in sync), min-duration phrase shifts move word timings with them, and the Captions tab preview matches playback for fade-up motion.


Example below:

https://github.com/user-attachments/assets/45d72fbd-e52e-4b8c-940c-d005ef8b3e3b


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caption generation, timeline model persistence, and Core Animation export paths; regressions could affect caption timing, text layout, or exported video overlays, but changes are scoped to text/caption clips with broad test coverage.
> 
> **Overview**
> Adds **per-word caption animation** (pop, bounce, fade up, or static) driven by transcript timings baked at generation. Clips store `captionWordAnimation` and clip-relative `captionWords`; **preview and export** render animated captions as per-word layers in `TextLayerController` instead of one phrase layer.
> 
> **Caption pipeline:** `CaptionBuilder` attaches word timings to phrases (including contraction merge and min-duration shifts), maps them to timeline frames in `specs`, and the Captions tab / Text inspector expose an animation picker with a live preview.
> 
> **Agent & tools:** `add_captions` accepts `wordAnimation` (default pop); `add_texts` and `set_clip_properties` gain patchable **background, border, and shadow** plus `captionWordAnimation`. Content edits call `reconcileCaptionWords` to keep timings when token count is unchanged; style patches trigger text refit like font changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a79d89e82162575c986cb58ad493823fc54a6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->