### PR TITLE
[generation] persist generation recovery jobs

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -64,7 +64,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .getMedia,
-            description: "Call before referencing any asset. Every mediaRef/reference ID in other tools comes from the IDs returned here. Also exposes generationStatus (generating | downloading | failed | none) for async-generated and -imported assets.",
+            description: "Call before referencing any asset. Every mediaRef/reference ID in other tools comes from the IDs returned here. Also exposes generationStatus (preparing | generating | downloading | failed | none) for async-generated and async-imported assets.",
             inputSchema: objectSchema()
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -282,6 +282,8 @@ extension ToolExecutor {
         let url = asset.url
         guard FileManager.default.fileExists(atPath: url.path) else {
             switch asset.generationStatus {
+            case .preparing:
+                throw ToolError("Asset \(asset.id) is still preparing. Poll get_media and retry once generationStatus becomes 'none'.")
             case .downloading:
                 throw ToolError("Asset \(asset.id) is still downloading. Poll get_media and retry once generationStatus becomes 'none'.")
             case .generating:
@@ -730,7 +732,7 @@ extension ToolExecutor {
             "id": asset.id, "name": asset.name,
             "type": asset.type.rawValue, "duration": asset.duration.jsonRounded(toPlaces: 3),
             "fileName": asset.url.lastPathComponent,
-            "generationStatus": generationStatusString(asset.generationStatus),
+            "generationStatus": asset.generationStatus.serialized,
         ]
         if let w = asset.sourceWidth { meta["sourceWidth"] = w }
         if let h = asset.sourceHeight { meta["sourceHeight"] = h }
@@ -746,16 +748,6 @@ extension ToolExecutor {
               let obj = try? JSONSerialization.jsonObject(with: data)
         else { return nil }
         return obj
-    }
-
-    private static func generationStatusString(_ status: MediaAsset.GenerationStatus) -> String {
-        switch status {
-        case .none: "none"
-        case .generating: "generating"
-        case .downloading: "downloading"
-        case .rendering: "rendering"
-        case .failed(let message): "failed: \(message)"
-        }
     }
 
     private static func imagePropertiesSummary(at url: URL) -> [String: Any]? {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -373,8 +373,10 @@ extension EditorViewModel {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard let self else { return }
-                if self.missingMediaRefs != missing {
-                    self.missingMediaRefs = missing
+                let recovering = Set(self.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
+                let resolved = missing.subtracting(recovering)
+                if self.missingMediaRefs != resolved {
+                    self.missingMediaRefs = resolved
                 }
                 self.missingMediaRefreshTask = nil
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -373,7 +373,7 @@ extension EditorViewModel {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard let self else { return }
-                let recovering = Set(self.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
+                let recovering = Set(self.mediaAssets.lazy.filter { $0.isGenerating || $0.isRecoveringGeneration }.map(\.id))
                 let resolved = missing.subtracting(recovering)
                 if self.missingMediaRefs != resolved {
                     self.missingMediaRefs = resolved

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -119,11 +119,10 @@ private enum MediaImportScanner {
 extension EditorViewModel {
 
     func importMediaAsset(_ asset: MediaAsset, skipAppend: Bool = false) {
-        if !skipAppend {
+        if !skipAppend, !mediaAssets.contains(where: { $0.id == asset.id }) {
             mediaAssets.append(asset)
         }
-        let entry = asset.toManifestEntry(projectURL: projectURL)
-        mediaManifest.entries.append(entry)
+        updateManifestMetadata(for: asset)
         Log.project.notice(
             "media imported asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
             telemetry: "Media asset imported",
@@ -458,12 +457,11 @@ extension EditorViewModel {
     }
 
     func updateManifestMetadata(for asset: MediaAsset) {
+        let entry = asset.toManifestEntry(projectURL: projectURL)
         if let idx = mediaManifest.entries.firstIndex(where: { $0.id == asset.id }) {
-            mediaManifest.entries[idx].duration = asset.duration
-            mediaManifest.entries[idx].sourceWidth = asset.sourceWidth
-            mediaManifest.entries[idx].sourceHeight = asset.sourceHeight
-            mediaManifest.entries[idx].sourceFPS = asset.sourceFPS
-            mediaManifest.entries[idx].hasAudio = asset.hasAudio
+            mediaManifest.entries[idx] = entry
+        } else {
+            mediaManifest.entries.append(entry)
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -208,6 +208,7 @@ final class EditorViewModel {
     // MARK: - Document bridge
 
     weak var undoManager: UndoManager?
+    @ObservationIgnored var onProjectCheckpointRequired: (() -> Void)?
     var isDocumentEdited: Bool = false
 
     func telemetrySnapshot() -> [String: Any] {

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -465,8 +465,7 @@ final class GenerationService {
             }
         }
 
-        // Stream ended without a terminal update: finish from persisted URLs if we
-        // have them, otherwise leave placeholders generating to retry on reopen.
+        // Stream ended without a terminal update: finish from persisted URLs, else retry on reopen.
         let persisted = placeholders.compactMap(\.generationInput?.resultURLs).first ?? []
         guard !persisted.isEmpty else { return }
         await finalizeSuccess(

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -17,6 +17,12 @@ final class FirstOnlyFlag {
 final class GenerationService {
 
     private static let uploadCacheTTL: TimeInterval = 6 * 24 * 60 * 60
+    private var resumedBackendJobIds: Set<String> = []
+
+    private struct PreparedReferences {
+        let uploaded: [String]
+        let tempFiles: [URL]
+    }
 
     @discardableResult
     func generate(
@@ -47,12 +53,14 @@ final class GenerationService {
         var placeholders: [MediaAsset] = []
         let destDir = Self.destinationDirectory(for: projectURL)
 
-        for _ in 0..<count {
+        for outputIndex in 0..<count {
+            var placeholderInput = genInput
+            placeholderInput.outputIndex = outputIndex
             let placeholder = createPlaceholder(
                 type: assetType,
                 name: baseName,
                 duration: placeholderDuration,
-                genInput: genInput,
+                genInput: placeholderInput,
                 folderId: resolvedFolderId,
                 destDir: destDir,
                 fileExtension: fileExtension,
@@ -61,54 +69,17 @@ final class GenerationService {
             placeholders.append(placeholder)
         }
         let primaryId = placeholders[0].id
-        let refURLs = references.map(\.url)
 
         Task { @MainActor in
-            var tempToCleanup: [URL] = []
-            defer { Self.cleanupTempFiles(tempToCleanup) }
             do {
-                let uploaded: [String]
-                if let preUploadedURLs, !preUploadedURLs.isEmpty {
-                    uploaded = preUploadedURLs
-                } else {
-                    var urlsToUpload = refURLs
-                    let refTypes = references.map(\.type)
-                    if let trim = trimmedSourceOverride, trim.hasTrim, !urlsToUpload.isEmpty {
-                        Log.generation.notice("using trimmed source: frames \(trim.trimStartFrame)+\(trim.sourceFramesConsumed) of \(urlsToUpload[0].lastPathComponent)")
-                        let extracted = try await VideoTrimExtractor.extract(trim)
-                        urlsToUpload[0] = extracted
-                        tempToCleanup.append(extracted)
-                    }
-                    if let preprocessRef, !references.isEmpty {
-                        let snapshot = references
-                        let rewrites: [(Int, URL?)] = try await withThrowingTaskGroup(of: (Int, URL?).self) { group in
-                            for (i, asset) in snapshot.enumerated() {
-                                group.addTask { (i, try await preprocessRef(i, asset)) }
-                            }
-                            var results: [(Int, URL?)] = []
-                            for try await r in group { results.append(r) }
-                            return results
-                        }
-                        for (i, rewritten) in rewrites {
-                            if let rewritten {
-                                urlsToUpload[i] = rewritten
-                                tempToCleanup.append(rewritten)
-                            }
-                        }
-                    }
-                    // Cache against the MediaAsset only when asset bytes are pristine (not trimmed, not preprocessed)
-                    let trimmedFirst = trimmedSourceOverride?.hasTrim == true
-                    let cacheKeys: [MediaAsset?] = references.enumerated().map { (i, asset) in
-                        if preprocessRef != nil { return nil }
-                        if i == 0 && trimmedFirst { return nil }
-                        return asset
-                    }
-                    uploaded = try await uploadReferences(
-                        at: urlsToUpload,
-                        types: refTypes,
-                        cacheKeys: cacheKeys,
-                    )
-                }
+                let prepared = try await self.prepareReferences(
+                    references: references,
+                    trimmedSourceOverride: trimmedSourceOverride,
+                    preUploadedURLs: preUploadedURLs,
+                    preprocessRef: preprocessRef
+                )
+                defer { Self.cleanupTempFiles(prepared.tempFiles) }
+                let uploaded = prepared.uploaded
 
                 var finalGenInput = genInput
                 if let snapshotRefs {
@@ -119,8 +90,12 @@ final class GenerationService {
                 if finalGenInput.createdAt == nil {
                     finalGenInput.createdAt = Date()
                 }
-                for placeholder in placeholders {
-                    placeholder.generationInput = finalGenInput
+                for (outputIndex, placeholder) in placeholders.enumerated() {
+                    var storedInput = finalGenInput
+                    storedInput.outputIndex = outputIndex
+                    updateGenerationMetadata(placeholder, editor: editor) { input in
+                        input = storedInput
+                    }
                 }
 
                 let params = buildParams(uploaded)
@@ -137,13 +112,83 @@ final class GenerationService {
                 let message = error.localizedDescription
                 Log.generation.error("upload failed model=\(genInput.model) error=\(message)")
                 for placeholder in placeholders {
-                    placeholder.generationStatus = .failed("Upload failed: \(message)")
+                    updateGenerationMetadata(placeholder, editor: editor, status: .failed("Upload failed: \(message)"))
                 }
                 onFailure?()
             }
         }
 
         return primaryId
+    }
+
+    private func prepareReferences(
+        references: [MediaAsset],
+        trimmedSourceOverride: TrimmedSource?,
+        preUploadedURLs: [String]?,
+        preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+    ) async throws -> PreparedReferences {
+        if let preUploadedURLs, !preUploadedURLs.isEmpty {
+            return PreparedReferences(uploaded: preUploadedURLs, tempFiles: [])
+        }
+
+        var tempFiles: [URL] = []
+        do {
+            var urlsToUpload = references.map(\.url)
+            let refTypes = references.map(\.type)
+            if let trim = trimmedSourceOverride, trim.hasTrim, !urlsToUpload.isEmpty {
+                Log.generation.notice("using trimmed source: frames \(trim.trimStartFrame)+\(trim.sourceFramesConsumed) of \(urlsToUpload[0].lastPathComponent)")
+                let extracted = try await VideoTrimExtractor.extract(trim)
+                urlsToUpload[0] = extracted
+                tempFiles.append(extracted)
+            }
+            if let preprocessRef, !references.isEmpty {
+                let rewrites = try await preprocessedReferenceURLs(references: references, preprocessRef: preprocessRef)
+                for (i, rewritten) in rewrites {
+                    guard let rewritten else { continue }
+                    urlsToUpload[i] = rewritten
+                    tempFiles.append(rewritten)
+                }
+            }
+            let uploaded = try await uploadReferences(
+                at: urlsToUpload,
+                types: refTypes,
+                cacheKeys: uploadCacheKeys(
+                    references: references,
+                    trimmedFirstReference: trimmedSourceOverride?.hasTrim == true,
+                    hasPreprocess: preprocessRef != nil
+                ),
+            )
+            return PreparedReferences(uploaded: uploaded, tempFiles: tempFiles)
+        } catch {
+            Self.cleanupTempFiles(tempFiles)
+            throw error
+        }
+    }
+
+    private func preprocessedReferenceURLs(
+        references: [MediaAsset],
+        preprocessRef: @escaping @Sendable (Int, MediaAsset) async throws -> URL?
+    ) async throws -> [(Int, URL?)] {
+        try await withThrowingTaskGroup(of: (Int, URL?).self) { group in
+            for (i, asset) in references.enumerated() {
+                group.addTask { (i, try await preprocessRef(i, asset)) }
+            }
+            var results: [(Int, URL?)] = []
+            for try await result in group { results.append(result) }
+            return results
+        }
+    }
+
+    private func uploadCacheKeys(
+        references: [MediaAsset],
+        trimmedFirstReference: Bool,
+        hasPreprocess: Bool
+    ) -> [MediaAsset?] {
+        references.enumerated().map { index, asset in
+            if hasPreprocess { return nil }
+            if index == 0 && trimmedFirstReference { return nil }
+            return asset
+        }
     }
 
     private static func cleanupTempFiles(_ urls: [URL]) {
@@ -174,9 +219,9 @@ final class GenerationService {
             duration: duration,
             generationInput: genInput
         )
-        placeholder.generationStatus = .generating
+        placeholder.generationStatus = .preparing
         placeholder.folderId = folderId
-        editor.mediaAssets.append(placeholder)
+        editor.importMediaAsset(placeholder)
         return placeholder
     }
 
@@ -189,7 +234,9 @@ final class GenerationService {
 
     @discardableResult
     private func downloadAndFinalize(asset: MediaAsset, remoteURL: URL, editor: EditorViewModel) async -> Bool {
-        asset.generationStatus = .downloading
+        if asset.generationStatus != .downloading {
+            updateGenerationMetadata(asset, editor: editor, status: .downloading)
+        }
         do {
             let (tempURL, _) = try await URLSession.shared.download(from: remoteURL)
             let realExt = remoteURL.pathExtension.lowercased()
@@ -212,7 +259,7 @@ final class GenerationService {
             let message = error.localizedDescription
             Log.generation.error("download failed url=\(remoteURL.absoluteString) error=\(message)")
             asset.pendingDownloadURL = remoteURL
-            asset.generationStatus = .failed(message)
+            updateGenerationMetadata(asset, editor: editor, status: .failed(message))
             return false
         }
     }
@@ -222,6 +269,55 @@ final class GenerationService {
         Task { @MainActor in
             await downloadAndFinalize(asset: asset, remoteURL: remoteURL, editor: editor)
         }
+    }
+
+    func resumePendingGenerations(editor: EditorViewModel) {
+        func sorted(_ assets: [MediaAsset]) -> [MediaAsset] {
+            assets.sorted {
+                let left = $0.generationInput?.outputIndex ?? 0
+                let right = $1.generationInput?.outputIndex ?? 0
+                return left < right
+            }
+        }
+
+        let pending = editor.mediaAssets.filter { $0.isGenerating && $0.canResumeGeneration }
+
+        let byBackendJob = Dictionary(grouping: pending.compactMap { asset -> (String, MediaAsset)? in
+            guard let backendJobId = asset.generationInput?.backendJobId, !backendJobId.isEmpty else { return nil }
+            return (backendJobId, asset)
+        }, by: { $0.0 })
+
+        for (backendJobId, group) in byBackendJob where !resumedBackendJobIds.contains(backendJobId) {
+            let placeholders = sorted(group.map { $0.1 })
+            resumedBackendJobIds.insert(backendJobId)
+            Task { @MainActor [weak self, weak editor] in
+                guard let self, let editor else { return }
+                await self.monitorBackendJob(
+                    backendJobId: backendJobId,
+                    placeholders: placeholders,
+                    editor: editor,
+                    onComplete: nil,
+                    onFailure: nil
+                )
+                self.resumedBackendJobIds.remove(backendJobId)
+            }
+        }
+    }
+
+    private func updateGenerationMetadata(
+        _ asset: MediaAsset,
+        editor: EditorViewModel,
+        status: MediaAsset.GenerationStatus? = nil,
+        mutateInput: ((inout GenerationInput) -> Void)? = nil
+    ) {
+        if let status {
+            asset.generationStatus = status
+        }
+        if let mutateInput, var input = asset.generationInput {
+            mutateInput(&input)
+            asset.generationInput = input
+        }
+        editor.updateManifestMetadata(for: asset)
     }
 
     /// Uploads each reference and returns the hosted URLs.
@@ -313,21 +409,67 @@ final class GenerationService {
             let message = error.localizedDescription
             Log.generation.error("submit failed model=\(genInput.model) error=\(message)")
             for placeholder in placeholders {
-                placeholder.generationStatus = .failed(message)
+                updateGenerationMetadata(placeholder, editor: editor, status: .failed(message))
             }
             onFailure?()
             return
         }
 
-        guard let publisher = GenerationBackend.subscribe(jobId: jobId) else {
-            for placeholder in placeholders {
-                placeholder.generationStatus = .failed("Backend not configured")
+        for placeholder in placeholders {
+            updateGenerationMetadata(placeholder, editor: editor, status: .generating) { input in
+                input.backendJobId = jobId
             }
-            onFailure?()
+        }
+        editor.onProjectCheckpointRequired?()
+
+        await monitorBackendJob(
+            backendJobId: jobId,
+            placeholders: placeholders,
+            editor: editor,
+            failIfUnavailable: true,
+            onComplete: onComplete,
+            onFailure: onFailure
+        )
+    }
+
+    private func monitorBackendJob(
+        backendJobId: String,
+        placeholders: [MediaAsset],
+        editor: EditorViewModel,
+        failIfUnavailable: Bool = false,
+        onComplete: (@MainActor (MediaAsset) -> Void)?,
+        onFailure: (@MainActor () -> Void)?
+    ) async {
+        guard let publisher = GenerationBackend.subscribe(jobId: backendJobId) else {
+            if failIfUnavailable {
+                for placeholder in placeholders {
+                    updateGenerationMetadata(placeholder, editor: editor, status: .failed("Backend not configured"))
+                }
+                editor.onProjectCheckpointRequired?()
+                onFailure?()
+            }
             return
         }
 
-        let stream = AsyncStream<BackendGenerationJob?> { continuation in
+        for await jobOpt in backendJobStream(from: publisher) {
+            guard let job = jobOpt else { continue }
+            if await applyBackendJobUpdate(
+                job: job,
+                backendJobId: backendJobId,
+                placeholders: placeholders,
+                editor: editor,
+                onComplete: onComplete,
+                onFailure: onFailure
+            ) {
+                return
+            }
+        }
+    }
+
+    private func backendJobStream<Failure: Error>(
+        from publisher: AnyPublisher<BackendGenerationJob?, Failure>
+    ) -> AsyncStream<BackendGenerationJob?> {
+        AsyncStream<BackendGenerationJob?> { continuation in
             let cancellable = publisher
                 .receive(on: DispatchQueue.main)
                 .sink(
@@ -336,31 +478,74 @@ final class GenerationService {
                 )
             continuation.onTermination = { _ in cancellable.cancel() }
         }
+    }
 
-        for await jobOpt in stream {
-            guard let job = jobOpt else { continue }
-            switch job.status {
-            case .succeeded:
-                await finalizeSuccess(
-                    job: job,
-                    placeholders: placeholders,
-                    editor: editor,
-                    onComplete: onComplete,
-                    onFailure: onFailure,
-                )
-                return
-            case .failed:
-                let message = job.errorMessage ?? "Generation failed"
-                Log.generation.error("job \(jobId) failed: \(message)")
-                for placeholder in placeholders {
-                    placeholder.generationStatus = .failed(message)
+    private func applyBackendJobUpdate(
+        job: BackendGenerationJob,
+        backendJobId: String,
+        placeholders: [MediaAsset],
+        editor: EditorViewModel,
+        onComplete: (@MainActor (MediaAsset) -> Void)?,
+        onFailure: (@MainActor () -> Void)?
+    ) async -> Bool {
+        switch job.status {
+        case .succeeded:
+            if updateBackendJobMetadata(
+                placeholders,
+                backendJobId: backendJobId,
+                editor: editor
+            ) {
+                editor.onProjectCheckpointRequired?()
+            }
+            await finalizeSuccess(
+                job: job,
+                placeholders: placeholders,
+                editor: editor,
+                onComplete: onComplete,
+                onFailure: onFailure,
+            )
+            return true
+        case .failed:
+            let message = job.errorMessage ?? "Generation failed"
+            Log.generation.error("job \(backendJobId) failed: \(message)")
+            for placeholder in placeholders {
+                updateGenerationMetadata(placeholder, editor: editor, status: .failed(message)) { input in
+                    input.backendJobId = backendJobId
                 }
-                onFailure?()
-                return
-            case .queued, .running:
+            }
+            editor.onProjectCheckpointRequired?()
+            onFailure?()
+            return true
+        case .queued, .running:
+            if updateBackendJobMetadata(
+                placeholders,
+                backendJobId: backendJobId,
+                editor: editor
+            ) {
+                editor.onProjectCheckpointRequired?()
+            }
+            return false
+        }
+    }
+
+    @discardableResult
+    private func updateBackendJobMetadata(
+        _ placeholders: [MediaAsset],
+        backendJobId: String,
+        editor: EditorViewModel
+    ) -> Bool {
+        var changed = false
+        for placeholder in placeholders {
+            guard placeholder.generationStatus != .generating ||
+                    placeholder.generationInput?.backendJobId != backendJobId else {
                 continue
             }
+            updateGenerationMetadata(placeholder, editor: editor, status: .generating) { input in
+                input.backendJobId = backendJobId
+            }
+            changed = true
         }
+        return changed
     }
 
     private func finalizeSuccess(
@@ -374,7 +559,7 @@ final class GenerationService {
         guard !urlStrings.isEmpty else {
             Log.generation.error("backend job succeeded with no resultUrls")
             for placeholder in placeholders {
-                placeholder.generationStatus = .failed("No URL in response")
+                updateGenerationMetadata(placeholder, editor: editor, status: .failed("No URL in response"))
             }
             onFailure?()
             return
@@ -385,9 +570,13 @@ final class GenerationService {
 
         var finalized: [MediaAsset] = []
         for (i, placeholder) in placeholders.enumerated() {
-            guard i < urlStrings.count, let remote = URL(string: urlStrings[i]) else {
-                placeholder.generationStatus = .failed("No URL for placeholder")
+            let outputIndex = placeholder.generationInput?.outputIndex ?? i
+            guard outputIndex < urlStrings.count, let remote = URL(string: urlStrings[outputIndex]) else {
+                updateGenerationMetadata(placeholder, editor: editor, status: .failed("No URL for placeholder"))
                 continue
+            }
+            updateGenerationMetadata(placeholder, editor: editor, status: .downloading) { input in
+                input.resultURLs = urlStrings
             }
             if await downloadAndFinalize(asset: placeholder, remoteURL: remote, editor: editor) {
                 onComplete?(placeholder)

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -464,6 +464,16 @@ final class GenerationService {
                 return
             }
         }
+
+        // Stream ended without a terminal update: finish from persisted URLs or fail.
+        let persisted = placeholders.compactMap(\.generationInput?.resultURLs).first ?? []
+        await finalizeSuccess(
+            urlStrings: persisted,
+            placeholders: placeholders,
+            editor: editor,
+            onComplete: onComplete,
+            onFailure: onFailure
+        )
     }
 
     private func backendJobStream<Failure: Error>(
@@ -498,7 +508,7 @@ final class GenerationService {
                 editor.onProjectCheckpointRequired?()
             }
             await finalizeSuccess(
-                job: job,
+                urlStrings: job.resultUrls ?? [],
                 placeholders: placeholders,
                 editor: editor,
                 onComplete: onComplete,
@@ -549,13 +559,12 @@ final class GenerationService {
     }
 
     private func finalizeSuccess(
-        job: BackendGenerationJob,
+        urlStrings: [String],
         placeholders: [MediaAsset],
         editor: EditorViewModel,
         onComplete: (@MainActor (MediaAsset) -> Void)?,
         onFailure: (@MainActor () -> Void)?
     ) async {
-        let urlStrings = job.resultUrls ?? []
         guard !urlStrings.isEmpty else {
             Log.generation.error("backend job succeeded with no resultUrls")
             for placeholder in placeholders {

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -280,15 +280,7 @@ final class GenerationService {
             }
         }
 
-        let pending = editor.mediaAssets.filter { asset in
-            guard asset.canResumeGeneration else { return false }
-            if asset.isGenerating { return true }
-            // Download failed after results were persisted: re-subscribe to retry.
-            if case .failed = asset.generationStatus {
-                return asset.generationInput?.resultURLs?.isEmpty == false
-            }
-            return false
-        }
+        let pending = editor.mediaAssets.filter(\.isRecoveringGeneration)
 
         let byBackendJob = Dictionary(grouping: pending.compactMap { asset -> (String, MediaAsset)? in
             guard let backendJobId = asset.generationInput?.backendJobId, !backendJobId.isEmpty else { return nil }
@@ -473,8 +465,10 @@ final class GenerationService {
             }
         }
 
-        // Stream ended without a terminal update: finish from persisted URLs or fail.
+        // Stream ended without a terminal update: finish from persisted URLs if we
+        // have them, otherwise leave placeholders generating to retry on reopen.
         let persisted = placeholders.compactMap(\.generationInput?.resultURLs).first ?? []
+        guard !persisted.isEmpty else { return }
         await finalizeSuccess(
             urlStrings: persisted,
             placeholders: placeholders,

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -280,7 +280,15 @@ final class GenerationService {
             }
         }
 
-        let pending = editor.mediaAssets.filter { $0.isGenerating && $0.canResumeGeneration }
+        let pending = editor.mediaAssets.filter { asset in
+            guard asset.canResumeGeneration else { return false }
+            if asset.isGenerating { return true }
+            // Download failed after results were persisted: re-subscribe to retry.
+            if case .failed = asset.generationStatus {
+                return asset.generationInput?.resultURLs?.isEmpty == false
+            }
+            return false
+        }
 
         let byBackendJob = Dictionary(grouping: pending.compactMap { asset -> (String, MediaAsset)? in
             guard let backendJobId = asset.generationInput?.backendJobId, !backendJobId.isEmpty else { return nil }
@@ -546,7 +554,8 @@ final class GenerationService {
     ) -> Bool {
         var changed = false
         for placeholder in placeholders {
-            guard placeholder.generationStatus != .generating ||
+            guard placeholder.generationStatus != .downloading,
+                    placeholder.generationStatus != .generating ||
                     placeholder.generationInput?.backendJobId != backendJobId else {
                 continue
             }

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -78,7 +78,6 @@ final class MediaAsset: Identifiable {
     var isGenerating: Bool {
         generationStatus == .preparing || generationStatus == .generating || generationStatus == .downloading || generationStatus == .rendering
     }
-    /// In-flight, or a failed download that can retry from persisted results.
     var isRecoveringGeneration: Bool {
         guard canResumeGeneration else { return false }
         if isGenerating { return true }

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -32,18 +32,55 @@ final class MediaAsset: Identifiable {
 
     enum GenerationStatus: Equatable {
         case none
+        case preparing
         case generating
         case downloading
         case rendering
         case failed(String)
+
+        var serialized: String {
+            switch self {
+            case .none: "none"
+            case .preparing: "preparing"
+            case .generating: "generating"
+            case .downloading: "downloading"
+            case .rendering: "rendering"
+            case .failed(let message): "failed: \(message)"
+            }
+        }
+
+        // .none/.preparing are transient and must not restore as in-progress.
+        var manifestValue: String? {
+            switch self {
+            case .none, .preparing: nil
+            default: serialized
+            }
+        }
+
+        init(serialized value: String?) {
+            switch value {
+            case "preparing": self = .preparing
+            case "generating": self = .generating
+            case "downloading": self = .downloading
+            case "rendering": self = .rendering
+            case let value? where value.hasPrefix("failed: "):
+                self = .failed(String(value.dropFirst("failed: ".count)))
+            default: self = .none
+            }
+        }
     }
 
     var isGenerated: Bool { generationInput != nil }
+    var canResumeGeneration: Bool {
+        guard let generationInput else { return false }
+        return generationInput.backendJobId?.isEmpty == false
+    }
     var isGenerating: Bool {
-        generationStatus == .generating || generationStatus == .downloading || generationStatus == .rendering
+        generationStatus == .preparing || generationStatus == .generating || generationStatus == .downloading || generationStatus == .rendering
     }
     var generatingLabel: String {
         switch generationStatus {
+        case .preparing: "Preparing..."
         case .downloading: "Downloading..."
         case .rendering: "Rendering..."
         default: "Generating..."
@@ -71,6 +108,8 @@ final class MediaAsset: Identifiable {
         self.folderId = entry.folderId
         self.cachedRemoteURL = entry.cachedRemoteURL
         self.cachedRemoteURLExpiresAt = entry.cachedRemoteURLExpiresAt
+        let restoredStatus = GenerationStatus(serialized: entry.generationStatus)
+        self.generationStatus = restoredStatus == .preparing && !canResumeGeneration ? .none : restoredStatus
     }
 
     /// Produce a serializable manifest entry from this asset.
@@ -90,6 +129,7 @@ final class MediaAsset: Identifiable {
             hasAudio: hasAudio, folderId: folderId,
             cachedRemoteURL: fresh,
             cachedRemoteURLExpiresAt: fresh == nil ? nil : cachedRemoteURLExpiresAt,
+            generationStatus: generationStatus.manifestValue,
         )
     }
 

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -78,6 +78,13 @@ final class MediaAsset: Identifiable {
     var isGenerating: Bool {
         generationStatus == .preparing || generationStatus == .generating || generationStatus == .downloading || generationStatus == .rendering
     }
+    /// In-flight, or a failed download that can retry from persisted results.
+    var isRecoveringGeneration: Bool {
+        guard canResumeGeneration else { return false }
+        if isGenerating { return true }
+        if case .failed = generationStatus { return generationInput?.resultURLs?.isEmpty == false }
+        return false
+    }
     var generatingLabel: String {
         switch generationStatus {
         case .preparing: "Preparing..."

--- a/Sources/PalmierPro/Models/MediaManifest.swift
+++ b/Sources/PalmierPro/Models/MediaManifest.swift
@@ -31,6 +31,7 @@ struct MediaManifestEntry: Codable, Sendable, Equatable, Identifiable {
     var folderId: String?
     var cachedRemoteURL: String?
     var cachedRemoteURLExpiresAt: Date?
+    var generationStatus: String?
 }
 
 struct GenerationInput: Codable, Sendable, Equatable {
@@ -60,6 +61,9 @@ struct GenerationInput: Codable, Sendable, Equatable {
     var referenceVideoAssetIds: [String]?
     var referenceAudioAssetIds: [String]?
     var createdAt: Date?
+    var backendJobId: String?
+    var outputIndex: Int?
+    var resultURLs: [String]?
 }
 
 enum MediaSource: Codable, Sendable, Equatable {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -508,7 +508,7 @@ final class VideoProject: NSDocument {
         for candidate in candidates {
             guard let asset = assetsByID[candidate.id] else { continue }
             guard existingRefs.contains(candidate.id) else {
-                if asset.isGenerating, asset.canResumeGeneration {
+                if asset.isRecoveringGeneration {
                     asset.generationStatus = .generating
                     editorViewModel.updateManifestMetadata(for: asset)
                     continue

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -42,6 +42,7 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var snapshotChatSessionFiles: [(name: String, data: Data)] = []
     private nonisolated(unsafe) var snapshotSourceProjectURL: URL?
     private nonisolated(unsafe) var snapshotPreparedForWrite = false
+    private var generationCheckpointAutosaveScheduled = false
 
     // MARK: - Persistence
 
@@ -257,6 +258,21 @@ final class VideoProject: NSDocument {
         editorViewModel.isDocumentEdited = isDocumentEdited
     }
 
+    private func scheduleGenerationCheckpointAutosave() {
+        guard fileURL != nil, !generationCheckpointAutosaveScheduled else { return }
+        generationCheckpointAutosaveScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.generationCheckpointAutosaveScheduled = false
+            guard self.fileURL != nil else { return }
+            self.autosave(withImplicitCancellability: false) { error in
+                if let error {
+                    Log.project.error("generation checkpoint autosave failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
     override var displayName: String! {
         get { fileURL?.deletingPathExtension().lastPathComponent ?? Project.defaultProjectName }
         set { super.displayName = newValue }
@@ -299,6 +315,9 @@ final class VideoProject: NSDocument {
         editorViewModel.agentService.loadSessions(from: fileURL)
         editorViewModel.agentService.onSessionsChanged = { [weak self] in
             self?.updateChangeCount(.changeDone)
+        }
+        editorViewModel.onProjectCheckpointRequired = { [weak self] in
+            self?.scheduleGenerationCheckpointAutosave()
         }
 
         if let manifest = loadedManifest {
@@ -489,10 +508,19 @@ final class VideoProject: NSDocument {
         for candidate in candidates {
             guard let asset = assetsByID[candidate.id] else { continue }
             guard existingRefs.contains(candidate.id) else {
+                if asset.canResumeGeneration {
+                    asset.generationStatus = .generating
+                    editorViewModel.updateManifestMetadata(for: asset)
+                    continue
+                }
                 Log.project.warning("restore: media file missing id=\(candidate.id) name=\(candidate.name) path=\(candidate.url.path)")
                 missing += 1
                 missingRefs.insert(candidate.id)
                 continue
+            }
+            if asset.generationStatus != .none {
+                asset.generationStatus = .none
+                editorViewModel.updateManifestMetadata(for: asset)
             }
             restored += 1
             if asset.type == .audio || asset.type == .video {
@@ -508,6 +536,7 @@ final class VideoProject: NSDocument {
         }
 
         editorViewModel.missingMediaRefs = missingRefs
+        editorViewModel.generationService.resumePendingGenerations(editor: editorViewModel)
         Log.project.notice(
             "restore ok restored=\(restored) missing=\(missing)",
             telemetry: "Media restored",

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -518,7 +518,7 @@ final class VideoProject: NSDocument {
                 missingRefs.insert(candidate.id)
                 continue
             }
-            if asset.generationStatus != .none {
+            if asset.generationStatus != .none, !asset.canResumeGeneration {
                 asset.generationStatus = .none
                 editorViewModel.updateManifestMetadata(for: asset)
             }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -508,7 +508,7 @@ final class VideoProject: NSDocument {
         for candidate in candidates {
             guard let asset = assetsByID[candidate.id] else { continue }
             guard existingRefs.contains(candidate.id) else {
-                if asset.canResumeGeneration {
+                if asset.isGenerating, asset.canResumeGeneration {
                     asset.generationStatus = .generating
                     editorViewModel.updateManifestMetadata(for: asset)
                     continue


### PR DESCRIPTION
## Summary
- persist backend generation job metadata on generated media placeholders
- recover submitted generations by resubscribing to Convex when a project reopens
- keep generation status serialization in one place and avoid restoring transient preparing state
- update manifest writes so generated placeholders and finalized assets keep recovery metadata in sync

## Why
If the app closed before the generation is downloaded, we are not recovering from that

## Impact
Submitted generations become recoverable once backend returns a job id

## Validation
manual test:

1. normal generation
2. submitted generation, saved, quit app and come back before generation is done -> pick up the status and subscribe again
3. submitted generation, saved, quit app and come back after generation is done -> download

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generation lifecycle, manifest persistence, and project autosave on job checkpoints—incorrect recovery could leave stuck placeholders or duplicate monitoring, but changes are scoped to async generation flows rather than core timeline editing.
> 
> **Overview**
> **Generation recovery** now survives closing the app mid-job: placeholders persist `backendJobId`, `outputIndex`, `resultURLs`, and `generationStatus` in the media manifest, trigger **checkpoint autosaves** when job metadata changes, and on reopen **`resumePendingGenerations`** re-subscribes to Convex per backend job (deduped) and finishes downloads—including mapping multi-output results by `outputIndex`.
> 
> Placeholders start in a new **`preparing`** status (upload/refs) before **`generating`**; agent **`get_media`** / **`inspect_media`** document and handle that state. Status serialization moves to **`GenerationStatus.serialized`** / manifest rules so transient **`preparing`**/`none` aren’t wrongly restored.
> 
> **Media library** paths are tightened: **`importMediaAsset`** avoids duplicate in-memory assets and always syncs manifest via **`updateManifestMetadata`** (full entry replace/append); recovering/generating assets are excluded from **missing-media** offline detection when files aren’t on disk yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60984cc9e6a87f91c29fd25830345658c35b0170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->