### PR TITLE
Show generating overlay (not offline) for generating clips in timeline preview

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -611,6 +611,7 @@ extension EditorViewModel {
         case .text, .lottie:
             break
         }
+        refreshPreviewForFinalizedAsset(asset)
         Log.project.notice(
             "media finalize ok asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
             telemetry: "Media asset finalize finished",
@@ -624,6 +625,22 @@ extension EditorViewModel {
                 "hasAudio": asset.hasAudio
             ]
         )
+    }
+
+    private func refreshPreviewForFinalizedAsset(_ asset: MediaAsset) {
+        let usedOnTimeline = timeline.tracks.contains { track in
+            track.clips.contains { $0.mediaRef == asset.id }
+        }
+        if usedOnTimeline {
+            timelineRenderRevision &+= 1
+            videoEngine?.rebuild()
+        }
+        if case .mediaAsset(let id, _, let type) = activePreviewTab,
+           id == asset.id,
+           type != .image {
+            videoEngine?.previewAsset(asset)
+            videoEngine?.seek(to: sourcePlayheadFrame, mode: .exact)
+        }
     }
 
     struct TextClipSpec {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -31,7 +31,7 @@ struct PreviewContainerView: View {
                     }
                     if let asset = activeMediaAsset, asset.isGenerating {
                         generatingPreview(label: asset.generatingLabel)
-                    } else if let label = timelineGeneratingLabel(timelineState: timelineState) {
+                    } else if case .generating(let label) = timelineState {
                         generatingPreview(label: label)
                     }
                     if let overlay = offlineOverlay(timelineState: timelineState) {
@@ -245,18 +245,12 @@ struct PreviewContainerView: View {
     }
 
     private enum TimelineFrameState {
-        /// An online clip covers the frame; no overlay needed.
         case covered
-        /// A clip whose media is still generating covers the frame.
         case generating(String)
-        /// Only offline clip(s) cover the frame.
         case offline(Clip)
         case none
     }
 
-    /// Classifies the clip(s) under the timeline playhead. A generating clip's
-    /// source file doesn't exist on disk yet, so it must report as generating —
-    /// not offline — exactly like its timeline track does.
     private var timelineFrameState: TimelineFrameState {
         guard isTimeline else { return .none }
         let hasOffline = !editor.offlineMediaRefs.isEmpty
@@ -269,8 +263,8 @@ struct PreviewContainerView: View {
         var generatingLabel: String?
         for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
             for clip in track.clips where clip.mediaType != .text {
-                guard clip.contains(timelineFrame: frame) else { continue }
-                if let asset = editor.mediaAssets.first(where: { $0.id == clip.mediaRef }), asset.isGenerating {
+                guard clip.contains(timelineFrame: frame), clip.opacityAt(frame: frame) > 0.01 else { continue }
+                if let asset = generatingAsset(for: clip) {
                     generatingLabel = generatingLabel ?? asset.generatingLabel
                 } else if editor.isMediaOffline(clip.mediaRef) {
                     offline = offline ?? clip
@@ -282,6 +276,10 @@ struct PreviewContainerView: View {
         if let generatingLabel { return .generating(generatingLabel) }
         if let offline { return .offline(offline) }
         return .none
+    }
+
+    private func generatingAsset(for clip: Clip) -> MediaAsset? {
+        editor.mediaAssets.first { $0.id == clip.mediaRef && $0.isGenerating }
     }
 
     private struct OfflineOverlay { let assetId: String?; let path: String?; let isUnprocessable: Bool }
@@ -297,11 +295,6 @@ struct PreviewContainerView: View {
                 isUnprocessable: editor.isMediaUnprocessable(clip.mediaRef)
             )
         }
-        return nil
-    }
-
-    private func timelineGeneratingLabel(timelineState: TimelineFrameState) -> String? {
-        if case .generating(let label) = timelineState { return label }
         return nil
     }
 

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -20,6 +20,7 @@ struct PreviewContainerView: View {
                 let fitSize = fitSize(in: geo.size, aspect: aspect)
                 let scaledWidth = fitSize.width * editor.canvasZoom
                 let scaledHeight = fitSize.height * editor.canvasZoom
+                let timelineState = timelineFrameState
                 ZStack {
                     PreviewView()
                     if isImage {
@@ -30,8 +31,10 @@ struct PreviewContainerView: View {
                     }
                     if let asset = activeMediaAsset, asset.isGenerating {
                         generatingPreview(label: asset.generatingLabel)
+                    } else if let label = timelineGeneratingLabel(timelineState: timelineState) {
+                        generatingPreview(label: label)
                     }
-                    if let overlay = offlineOverlay {
+                    if let overlay = offlineOverlay(timelineState: timelineState) {
                         offlinePreview(assetId: overlay.assetId, path: overlay.path, isUnprocessable: overlay.isUnprocessable)
                     }
                     if editor.cropEditingActive {
@@ -241,39 +244,64 @@ struct PreviewContainerView: View {
         return editor.isMediaOffline(asset.id)
     }
 
-    /// The offline clip blacking out the current timeline frame, or nil when an online clip covers it.
-    private var timelineOfflineClip: Clip? {
-        guard isTimeline else { return nil }
-        guard !editor.offlineMediaRefs.isEmpty || !editor.unprocessableMediaRefs.isEmpty else { return nil }
+    private enum TimelineFrameState {
+        /// An online clip covers the frame; no overlay needed.
+        case covered
+        /// A clip whose media is still generating covers the frame.
+        case generating(String)
+        /// Only offline clip(s) cover the frame.
+        case offline(Clip)
+        case none
+    }
+
+    /// Classifies the clip(s) under the timeline playhead. A generating clip's
+    /// source file doesn't exist on disk yet, so it must report as generating —
+    /// not offline — exactly like its timeline track does.
+    private var timelineFrameState: TimelineFrameState {
+        guard isTimeline else { return .none }
+        let hasOffline = !editor.offlineMediaRefs.isEmpty
+            || !editor.unprocessableMediaRefs.isEmpty
+            || !editor.missingMediaRefs.isEmpty
+        let hasGenerating = editor.mediaAssets.contains(where: \.isGenerating)
+        guard hasOffline || hasGenerating else { return .none }
         let frame = editor.playheadState.timelineFrame
         var offline: Clip?
+        var generatingLabel: String?
         for track in editor.timeline.tracks where track.type != .audio && !track.hidden {
             for clip in track.clips where clip.mediaType != .text {
                 guard clip.contains(timelineFrame: frame) else { continue }
-                if editor.isMediaOffline(clip.mediaRef) {
+                if let asset = editor.mediaAssets.first(where: { $0.id == clip.mediaRef }), asset.isGenerating {
+                    generatingLabel = generatingLabel ?? asset.generatingLabel
+                } else if editor.isMediaOffline(clip.mediaRef) {
                     offline = offline ?? clip
                 } else {
-                    return nil
+                    return .covered
                 }
             }
         }
-        return offline
+        if let generatingLabel { return .generating(generatingLabel) }
+        if let offline { return .offline(offline) }
+        return .none
     }
 
     private struct OfflineOverlay { let assetId: String?; let path: String?; let isUnprocessable: Bool }
 
-    /// Resolved once per render so the timeline scan runs at most once.
-    private var offlineOverlay: OfflineOverlay? {
+    private func offlineOverlay(timelineState: TimelineFrameState) -> OfflineOverlay? {
         if activeMediaMissing, let id = activeMediaAsset?.id {
             return OfflineOverlay(assetId: id, path: activeMediaAsset?.url.path, isUnprocessable: editor.isMediaUnprocessable(id))
         }
-        if let clip = timelineOfflineClip {
+        if case .offline(let clip) = timelineState {
             return OfflineOverlay(
                 assetId: clip.mediaRef,
                 path: editor.mediaResolver.expectedURL(for: clip.mediaRef)?.path,
                 isUnprocessable: editor.isMediaUnprocessable(clip.mediaRef)
             )
         }
+        return nil
+    }
+
+    private func timelineGeneratingLabel(timelineState: TimelineFrameState) -> String? {
+        if case .generating(let label) = timelineState { return label }
         return nil
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A video that is still generating but already placed on the timeline showed up as **Media Offline** in the preview area when the playhead was over it.

The timeline *clip body* already handled this correctly — `ClipRenderer` suppresses the red "offline" wash when a clip's media is generating (`isMissing && !isGenerating`). But the **preview** did not. Because a generating clip's source file does not exist on disk yet, `PreviewContainerView.timelineOfflineClip` classified it as offline and rendered the "Media Offline" overlay instead of the generating indicator.

## Fix

Reworked the timeline-playhead scan in `PreviewContainerView` into a single `timelineFrameState` resolver that distinguishes three cases for the clip(s) under the playhead:

- `covered` — an online clip covers the frame (no overlay)
- `generating(label)` — a clip whose media is still generating
- `offline(clip)` — only offline clip(s) cover the frame

A generating clip now shows the `GeneratingOverlay` (`Generating…` / `Downloading...` / `Rendering...`, using `MediaAsset.generatingLabel`) in the timeline preview, matching how it already renders on the timeline track, and is no longer treated as offline.

The scan is still resolved once per render (computed in the body and passed to both the generating and offline overlay helpers), and it now early-exits unless there is offline/missing media or a generating asset present.

## Notes

- No behavior change for genuinely offline media: it still shows the "Media Offline" overlay with relink options.
- This project is macOS-only (AppKit/AVFoundation), so it could not be compiled in the Linux cloud environment. Change is self-contained and uses existing APIs (`MediaAsset.isGenerating`, `MediaAsset.generatingLabel`, `EditorViewModel.isMediaOffline`, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffc449c2-995f-4675-b6c8-ff13234de8c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffc449c2-995f-4675-b6c8-ff13234de8c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

