### PR TITLE
Fix aspect ratio clip distortion

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -51,27 +51,28 @@ extension EditorViewModel {
             }
         }
 
-        // Reflow clips to the new canvas aspect. Untouched auto-fit clips re-fit to fill;
-        // manually adjusted or keyframed clips keep their scale handle (width) and have their
-        // height recomputed so the image stays undistorted against the new canvas.
+        // Keep visual scale proportional when the canvas aspect changes.
         if width != prevWidth || height != prevHeight {
             for ti in timeline.tracks.indices {
                 for ci in timeline.tracks[ti].clips.indices {
                     var clip = timeline.tracks[ti].clips[ci]
                     guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
-                          let sw = asset.sourceWidth, let sh = asset.sourceHeight,
-                          sw > 0, sh > 0, width > 0, height > 0 else { continue }
+                          let oldAspect = mediaCanvasAspect(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight),
+                          let newAspect = mediaCanvasAspect(for: asset, canvasWidth: width, canvasHeight: height) else { continue }
 
                     let scaleAnimated = clip.scaleTrack?.isActive ?? false
+                    let oldFit = fitTransform(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight)
                     if !scaleAnimated,
-                       clip.transform == fitTransform(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight) {
-                        clip.transform = fitTransform(for: asset, canvasWidth: width, canvasHeight: height)
+                       transformScale(clip.transform, matches: oldFit) {
+                        let newFit = fitTransform(for: asset, canvasWidth: width, canvasHeight: height)
+                        clip.transform.width = newFit.width
+                        clip.transform.height = newFit.height
                     } else {
-                        let newAspect = (Double(sw) / Double(sh)) / (Double(width) / Double(height))
-                        clip.transform.height = clip.transform.width / newAspect
+                        let heightScale = oldAspect / newAspect
+                        clip.transform.height *= heightScale
                         if var track = clip.scaleTrack, track.isActive {
                             for ki in track.keyframes.indices {
-                                track.keyframes[ki].value.b = track.keyframes[ki].value.a / newAspect
+                                track.keyframes[ki].value.b *= heightScale
                             }
                             clip.scaleTrack = track
                         }
@@ -91,6 +92,10 @@ extension EditorViewModel {
         }
         undoManager?.setActionName("Change Project Settings")
         notifyTimelineChanged()
+    }
+
+    private func transformScale(_ transform: Transform, matches other: Transform) -> Bool {
+        abs(transform.width - other.width) < 0.0001 && abs(transform.height - other.height) < 0.0001
     }
 
     func checkProjectSettings(for assets: [MediaAsset]) -> ProjectSettingsAction {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -51,15 +51,32 @@ extension EditorViewModel {
             }
         }
 
-        // Refit auto-fitted clips to the new canvas aspect
+        // Reflow clips to the new canvas aspect. Untouched auto-fit clips re-fit to fill;
+        // manually adjusted or keyframed clips keep their scale handle (width) and have their
+        // height recomputed so the image stays undistorted against the new canvas.
         if width != prevWidth || height != prevHeight {
             for ti in timeline.tracks.indices {
                 for ci in timeline.tracks[ti].clips.indices {
-                    let clip = timeline.tracks[ti].clips[ci]
-                    guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { continue }
-                    if clip.transform == fitTransform(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight) {
-                        timeline.tracks[ti].clips[ci].transform = fitTransform(for: asset, canvasWidth: width, canvasHeight: height)
+                    var clip = timeline.tracks[ti].clips[ci]
+                    guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
+                          let sw = asset.sourceWidth, let sh = asset.sourceHeight,
+                          sw > 0, sh > 0, width > 0, height > 0 else { continue }
+
+                    let scaleAnimated = clip.scaleTrack?.isActive ?? false
+                    if !scaleAnimated,
+                       clip.transform == fitTransform(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight) {
+                        clip.transform = fitTransform(for: asset, canvasWidth: width, canvasHeight: height)
+                    } else {
+                        let newAspect = (Double(sw) / Double(sh)) / (Double(width) / Double(height))
+                        clip.transform.height = clip.transform.width / newAspect
+                        if var track = clip.scaleTrack, track.isActive {
+                            for ki in track.keyframes.indices {
+                                track.keyframes[ki].value.b = track.keyframes[ki].value.a / newAspect
+                            }
+                            clip.scaleTrack = track
+                        }
                     }
+                    timeline.tracks[ti].clips[ci] = clip
                 }
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -467,28 +467,31 @@ final class EditorViewModel {
     }
 
     func fitTransform(for asset: MediaAsset, canvasWidth: Int, canvasHeight: Int) -> Transform {
-        guard let sw = asset.sourceWidth, let sh = asset.sourceHeight,
-              sw > 0, sh > 0, canvasWidth > 0, canvasHeight > 0 else {
+        guard let relativeAspect = mediaCanvasAspect(for: asset, canvasWidth: canvasWidth, canvasHeight: canvasHeight) else {
             return Transform()
         }
         let canvasAspect = Double(canvasWidth) / Double(canvasHeight)
-        let sourceAspect = Double(sw) / Double(sh)
+        let sourceAspect = relativeAspect * canvasAspect
         if abs(canvasAspect - sourceAspect) < Defaults.aspectTolerance {
             return Transform()
         }
-        if sourceAspect > canvasAspect {
-            return Transform(width: 1.0, height: canvasAspect / sourceAspect)
+        if relativeAspect > 1 {
+            return Transform(width: 1.0, height: 1.0 / relativeAspect)
         }
-        return Transform(width: sourceAspect / canvasAspect, height: 1.0)
+        return Transform(width: relativeAspect, height: 1.0)
+    }
+
+    func mediaCanvasAspect(for asset: MediaAsset, canvasWidth: Int, canvasHeight: Int) -> Double? {
+        guard let sw = asset.sourceWidth, let sh = asset.sourceHeight,
+              sw > 0, sh > 0, canvasWidth > 0, canvasHeight > 0 else { return nil }
+        let canvasAspect = Double(canvasWidth) / Double(canvasHeight)
+        return (Double(sw) / Double(sh)) / canvasAspect
     }
 
     /// Source aspect ratio relative to canvas; nil when source dimensions are unknown.
     func mediaCanvasAspect(for clip: Clip) -> Double? {
-        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
-              let sw = asset.sourceWidth, let sh = asset.sourceHeight,
-              sw > 0, sh > 0 else { return nil }
-        let canvasAspect = Double(timeline.width) / Double(timeline.height)
-        return (Double(sw) / Double(sh)) / canvasAspect
+        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { return nil }
+        return mediaCanvasAspect(for: asset, canvasWidth: timeline.width, canvasHeight: timeline.height)
     }
 
     /// Largest centered crop of `target` aspect inside the source.


### PR DESCRIPTION
Before and after. media used to stretch weirdly when you change aspect ratio. now it fills.

<img width="1549" height="1042" alt="Screenshot 2026-06-28 at 10 56 45 PM" src="https://github.com/user-attachments/assets/844826a8-0192-47a5-8544-dfc42cd9ac5d" />
<img width="2351" height="1408" alt="Screenshot 2026-06-28 at 10 57 02 PM" src="https://github.com/user-attachments/assets/7fbee377-6254-42d5-9db2-ed3b30a408d7" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core fit/transform behavior for every clip on resolution changes, including animated scale keyframes, which can affect preview and export framing.
> 
> **Overview**
> Fixes **stretching/distortion** when the timeline resolution or aspect ratio changes by reworking how clips are refit during `applyTimelineSettings`.
> 
> **Fit math** now goes through a shared `mediaCanvasAspect(for:canvasWidth:canvasHeight:)` helper, and `fitTransform` uses that **relative aspect** so letterboxing/pillarboxing stays consistent across canvas sizes.
> 
> On aspect change, clips that still match the previous auto-fit get new fit width/height only; clips with custom or animated scale keep proportion by scaling transform height with `oldAspect / newAspect` and applying the same factor to active `scaleTrack` keyframe **height** values. A small `transformScale` helper replaces exact transform equality checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4992563782bc0a860f893c1dd59af7a77534b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->