### PR TITLE
fix(project): open projects with a corrupt media.json instead of failing

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -3,13 +3,14 @@ import SwiftUI
 import AVFoundation
 import UniformTypeIdentifiers
 
-private struct ProjectPackageContents: Sendable {
+struct ProjectPackageContents: Sendable {
     var timeline: Timeline
     var manifest: MediaManifest?
     var generationLog: GenerationLog?
+    var manifestUnreadable: Bool = false
 }
 
-private struct ProjectPackageSnapshot: Sendable {
+struct ProjectPackageSnapshot: Sendable {
     var timeline: Data
     var manifest: Data?
     var generationLog: Data?
@@ -33,6 +34,9 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var loadedTimeline: Timeline?
     private nonisolated(unsafe) var loadedManifest: MediaManifest?
     private nonisolated(unsafe) var loadedGenerationLog: GenerationLog?
+
+    /// Set when media.json existed but failed to decode, so saves preserve it instead of clobbering.
+    private nonisolated(unsafe) var manifestLoadFailed = false
 
     /// Captured on main thread before writes may continue off-main.
     private nonisolated(unsafe) var snapshotTimeline: Data?
@@ -68,6 +72,7 @@ final class VideoProject: NSDocument {
         loadedTimeline = contents.timeline
         loadedManifest = contents.manifest
         loadedGenerationLog = contents.generationLog
+        manifestLoadFailed = contents.manifestUnreadable
         Log.project.notice(
             "read ok tracks=\(self.loadedTimeline?.tracks.count ?? 0)",
             telemetry: "Project read",
@@ -80,7 +85,7 @@ final class VideoProject: NSDocument {
         )
     }
 
-    private nonisolated static func readProjectPackage(at url: URL) throws -> ProjectPackageContents {
+    nonisolated static func readProjectPackage(at url: URL) throws -> ProjectPackageContents {
         let data = try requiredData(Project.timelineFilename, in: url)
         let timeline: Timeline
         do {
@@ -91,15 +96,20 @@ final class VideoProject: NSDocument {
         }
 
         let manifest: MediaManifest?
+        let manifestUnreadable: Bool
         if let manifestData = try optionalData(Project.manifestFilename, in: url) {
-            do {
-                manifest = try JSONDecoder().decode(MediaManifest.self, from: manifestData)
-            } catch {
-                Log.project.error("read manifest decode failed bytes=\(manifestData.count) error=\(error)")
-                throw CocoaError(.fileReadCorruptFile)
+            if let decoded = try? JSONDecoder().decode(MediaManifest.self, from: manifestData) {
+                manifest = decoded
+                manifestUnreadable = false
+            } else {
+                // A bad manifest must not lose the project; degrade to "media offline" and keep the file for recovery.
+                Log.project.error("read manifest decode failed bytes=\(manifestData.count); opening with empty manifest")
+                manifest = nil
+                manifestUnreadable = true
             }
         } else {
             manifest = nil
+            manifestUnreadable = false
         }
 
         let generationLog = try optionalData(Project.generationLogFilename, in: url)
@@ -108,7 +118,8 @@ final class VideoProject: NSDocument {
         return ProjectPackageContents(
             timeline: timeline,
             manifest: manifest,
-            generationLog: generationLog
+            generationLog: generationLog,
+            manifestUnreadable: manifestUnreadable
         )
     }
 
@@ -157,7 +168,7 @@ final class VideoProject: NSDocument {
 
     private func captureSaveSnapshot() {
         snapshotTimeline = try? JSONEncoder().encode(editorViewModel.timeline)
-        snapshotManifest = try? JSONEncoder().encode(editorViewModel.mediaManifest)
+        snapshotManifest = Self.manifestSnapshotData(manifest: editorViewModel.mediaManifest, loadFailed: manifestLoadFailed)
         snapshotGenerationLog = try? JSONEncoder().encode(editorViewModel.generationLog)
         snapshotThumbnail = captureThumbnail()
         snapshotChatSessionFiles = editorViewModel.agentService.sessions
@@ -166,6 +177,12 @@ final class VideoProject: NSDocument {
                 ChatSessionStore.encodeSession(session).map { (name: "\(session.id.uuidString).json", data: $0) }
             }
         snapshotPreparedForWrite = true
+    }
+
+    nonisolated static func manifestSnapshotData(manifest: MediaManifest, loadFailed: Bool) -> Data? {
+        // If the manifest failed to load, don't overwrite the (recoverable) original with an empty one.
+        if loadFailed && manifest.entries.isEmpty && manifest.folders.isEmpty { return nil }
+        return try? JSONEncoder().encode(manifest)
     }
 
     private nonisolated static func requiredData(_ name: String, in packageURL: URL) throws -> Data {
@@ -183,12 +200,14 @@ final class VideoProject: NSDocument {
         return try Data(contentsOf: url, options: [.mappedIfSafe])
     }
 
-    private nonisolated static func writeProjectPackage(_ snapshot: ProjectPackageSnapshot, to packageURL: URL, sourceURL: URL?) throws {
+    nonisolated static func writeProjectPackage(_ snapshot: ProjectPackageSnapshot, to packageURL: URL, sourceURL: URL?) throws {
         let fm = FileManager.default
         try createPackageDirectory(at: packageURL, fm: fm)
         try snapshot.timeline.write(to: packageURL.appendingPathComponent(Project.timelineFilename), options: .atomic)
         if let manifest = snapshot.manifest {
             try manifest.write(to: packageURL.appendingPathComponent(Project.manifestFilename), options: .atomic)
+        } else {
+            try copyPreservedFile(Project.manifestFilename, from: sourceURL, to: packageURL, fm: fm)
         }
         if let log = snapshot.generationLog {
             try log.write(to: packageURL.appendingPathComponent(Project.generationLogFilename), options: .atomic)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -164,6 +164,8 @@ final class VideoProject: NSDocument {
             to: url,
             sourceURL: snapshotSourceProjectURL
         )
+        // A real manifest was just written, so the unreadable original is gone; stop preserving it.
+        if snapshotManifest != nil { manifestLoadFailed = false }
     }
 
     private func captureSaveSnapshot() {

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -145,4 +145,27 @@ struct VideoProjectLoadTests {
         let after = try Data(contentsOf: bundle.appendingPathComponent(Project.manifestFilename))
         #expect(after == original)
     }
+
+    @MainActor
+    @Test func emptyingTheLibraryPersistsOnceAManifestHasBeenRewritten() async throws {
+        // After opening a corrupt-manifest project, rebuilding the library and saving writes a real
+        // manifest. Emptying the library and saving again must persist as empty, not resurrect the
+        // rebuilt entries from the no-longer-relevant load failure.
+        let bundle = try makeBundle()
+        defer { try? fm.removeItem(at: bundle) }
+        try Data("{ corrupt ".utf8).write(to: bundle.appendingPathComponent(Project.manifestFilename))
+
+        let doc = try await VideoProject.load(from: bundle)   // manifestLoadFailed = true
+
+        doc.editorViewModel.mediaManifest = sampleManifest()
+        try doc.write(to: bundle, ofType: VideoProject.typeIdentifier)
+        #expect(try VideoProject.readProjectPackage(at: bundle).manifest?.entries.count == 1)
+
+        doc.editorViewModel.mediaManifest = MediaManifest()
+        try doc.write(to: bundle, ofType: VideoProject.typeIdentifier)
+
+        let reopened = try VideoProject.readProjectPackage(at: bundle)
+        #expect(reopened.manifest?.entries.isEmpty == true)   // emptied library sticks
+        #expect(reopened.manifestUnreadable == false)         // valid (empty) manifest now
+    }
 }

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// A corrupt `media.json` must never make a project unopenable: the timeline lives in a
+/// separate file and is the real creative work. A bad manifest should degrade to "media
+/// offline" (like a missing manifest already does), and the original bytes must be preserved
+/// on disk so a newer build (e.g. after a schema change) can still recover the library.
+@Suite("VideoProject package load resilience")
+struct VideoProjectLoadTests {
+
+    private let fm = FileManager.default
+
+    private func makeBundle(tracks: Int = 1) throws -> URL {
+        let bundle = fm.temporaryDirectory
+            .appendingPathComponent("vp-load-\(UUID().uuidString).palmier", isDirectory: true)
+        try fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+        let timeline = Fixtures.timeline(
+            tracks: (0..<tracks).map { _ in Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)]) }
+        )
+        try JSONEncoder().encode(timeline)
+            .write(to: bundle.appendingPathComponent(Project.timelineFilename))
+        return bundle
+    }
+
+    private func sampleManifest() -> MediaManifest {
+        var m = MediaManifest()
+        m.entries = [
+            MediaManifestEntry(id: "a", name: "A", type: .video,
+                               source: .project(relativePath: "media/a.mp4"), duration: 1)
+        ]
+        return m
+    }
+
+    // MARK: - Read: graceful degrade
+
+    @Test func corruptManifestStillOpensWithIntactTimeline() throws {
+        let bundle = try makeBundle(tracks: 2)
+        defer { try? fm.removeItem(at: bundle) }
+        try Data("{ this is not valid manifest json ".utf8)
+            .write(to: bundle.appendingPathComponent(Project.manifestFilename))
+
+        let contents = try VideoProject.readProjectPackage(at: bundle)   // must NOT throw
+
+        #expect(contents.manifest == nil)
+        #expect(contents.manifestUnreadable == true)
+        #expect(contents.timeline.tracks.count == 2)   // creative work survives
+    }
+
+    @Test func missingManifestOpensAndIsNotFlaggedUnreadable() throws {
+        let bundle = try makeBundle()
+        defer { try? fm.removeItem(at: bundle) }
+
+        let contents = try VideoProject.readProjectPackage(at: bundle)
+
+        #expect(contents.manifest == nil)
+        #expect(contents.manifestUnreadable == false)   // missing != corrupt
+    }
+
+    @Test func validManifestDecodesNormally() throws {
+        let bundle = try makeBundle()
+        defer { try? fm.removeItem(at: bundle) }
+        try JSONEncoder().encode(sampleManifest())
+            .write(to: bundle.appendingPathComponent(Project.manifestFilename))
+
+        let contents = try VideoProject.readProjectPackage(at: bundle)
+
+        #expect(contents.manifest?.entries.count == 1)
+        #expect(contents.manifestUnreadable == false)
+    }
+
+    @Test func missingTimelineStillThrows() throws {
+        // project.json is the required file — degrading it would hide real corruption.
+        let bundle = fm.temporaryDirectory
+            .appendingPathComponent("vp-empty-\(UUID().uuidString).palmier", isDirectory: true)
+        try fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: bundle) }
+
+        #expect(throws: (any Error).self) {
+            try VideoProject.readProjectPackage(at: bundle)
+        }
+    }
+
+    // MARK: - Save: don't overwrite the original with an empty manifest
+
+    @Test func emptyManifestNotSerializedAfterLoadFailure() {
+        // Opening with a corrupt manifest leaves an empty in-memory manifest. Serializing it
+        // would overwrite the (recoverable) original on the next autosave — so it must be nil.
+        #expect(VideoProject.manifestSnapshotData(manifest: MediaManifest(), loadFailed: true) == nil)
+    }
+
+    @Test func rebuiltManifestIsSerializedAfterLoadFailure() {
+        // Once the user adds media, the manifest is no longer empty and must be written.
+        #expect(VideoProject.manifestSnapshotData(manifest: sampleManifest(), loadFailed: true) != nil)
+    }
+
+    @Test func manifestSerializedNormallyWhenLoadSucceeded() {
+        // Regression guard: ordinary saves still persist the (possibly empty) manifest.
+        #expect(VideoProject.manifestSnapshotData(manifest: MediaManifest(), loadFailed: false) != nil)
+    }
+
+    @Test func saveAsPreservesUnreadableManifestFile() throws {
+        let source = try makeBundle()
+        defer { try? fm.removeItem(at: source) }
+        let original = Data("ORIGINAL-CORRUPT-MANIFEST-BYTES".utf8)
+        try original.write(to: source.appendingPathComponent(Project.manifestFilename))
+
+        let dest = fm.temporaryDirectory
+            .appendingPathComponent("vp-dest-\(UUID().uuidString).palmier", isDirectory: true)
+        defer { try? fm.removeItem(at: dest) }
+
+        let snapshot = ProjectPackageSnapshot(
+            timeline: try JSONEncoder().encode(Fixtures.timeline()),
+            manifest: nil,                    // unreadable on open → nothing to write
+            generationLog: nil,
+            thumbnail: nil,
+            chatSessionFiles: []
+        )
+
+        try VideoProject.writeProjectPackage(snapshot, to: dest, sourceURL: source)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent(Project.manifestFilename).path))
+        let preserved = try Data(contentsOf: dest.appendingPathComponent(Project.manifestFilename))
+        #expect(preserved == original)   // bytes carried over verbatim
+    }
+
+    @Test func inPlaceSaveLeavesUnreadableManifestUntouched() throws {
+        // The common autosave path writes in place (source == dest). The original media.json
+        // must survive byte-for-byte rather than being clobbered with an empty manifest.
+        let bundle = try makeBundle()
+        defer { try? fm.removeItem(at: bundle) }
+        let original = Data("ORIGINAL-CORRUPT-MANIFEST-BYTES".utf8)
+        try original.write(to: bundle.appendingPathComponent(Project.manifestFilename))
+
+        let snapshot = ProjectPackageSnapshot(
+            timeline: try JSONEncoder().encode(Fixtures.timeline()),
+            manifest: nil,
+            generationLog: nil,
+            thumbnail: nil,
+            chatSessionFiles: []
+        )
+
+        try VideoProject.writeProjectPackage(snapshot, to: bundle, sourceURL: bundle)
+
+        let after = try Data(contentsOf: bundle.appendingPathComponent(Project.manifestFilename))
+        #expect(after == original)
+    }
+}


### PR DESCRIPTION
Closes #223.

## Problem

A project package stores the timeline (`project.json`) and the media manifest (`media.json`) in separate files. `VideoProject.readProjectPackage` throws `CocoaError(.fileReadCorruptFile)` when `media.json` fails to decode, which makes the **entire project unopenable** (surfaced via `NSAlert` in `AppState.openProjectAsync` as "The file couldn't be opened because it isn't in the correct format") even though the timeline, the actual creative work, is fully intact in `project.json`.

The `generationLog` two lines below already degrades with `try?`, and a *missing* `media.json` already opens fine, so a *corrupt* one being fatal is an inconsistency. Realistic triggers: a manifest schema change between builds (a project saved by a newer build opened in an older one), an iCloud/Dropbox sync conflict, or a partial write.

## Fix

1. Degrade a bad manifest to "media offline" (the same state a missing manifest already produces) so the project opens and its clips can be relinked.
2. Preserve the original `media.json`. Because the app `autosavesInPlace`, opening with an empty in-memory manifest would otherwise let the next autosave overwrite the recoverable original with an empty one. The document now tracks the load failure and, while the manifest is still empty, skips serializing it and copies the existing file forward instead, mirroring how `thumbnail.jpg` and the `media/` directory are already preserved in `writeProjectPackage`.

Once the user adds media (manifest no longer empty), it serializes normally; normal saves and new projects are unchanged. The only remaining `fileReadCorruptFile` throw is for the required `project.json`.

## Tests

New `VideoProjectLoadTests` (9 cases): corrupt manifest opens with intact timeline, missing-vs-corrupt distinction, valid manifest still decodes, missing `project.json` still throws, the don't-overwrite-empty decision (3 cases), and Save-As + in-place preservation of the original bytes.

`swift test` passes (834 tests). Verified the before/after end to end: original logic throws `NSCocoaErrorDomain Code 259`; with the fix the same corrupt package opens.

## Note for reviewers

To make the logic unit-testable, this widens four `private` declarations to `internal` (`readProjectPackage`, `writeProjectPackage`, and the two package structs), consistent with how existing tests exercise internals like `PalmierProjectExporter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core project load/save persistence and autosave behavior for manifest files; mistakes could lose or fail to recover user media metadata, though timeline integrity is preserved and behavior is heavily tested.
> 
> **Overview**
> **Corrupt `media.json` no longer blocks opening a project.** Load now treats a decode failure like a missing manifest (timeline opens, media appears offline) and sets `manifestUnreadable` instead of throwing `fileReadCorruptFile`. Missing or invalid `project.json` still fails hard.
> 
> **Autosave and Save-As no longer wipe recoverable manifest bytes.** When the manifest failed to load and the in-memory library is still empty, `manifestSnapshotData` omits manifest data from the snapshot and `writeProjectPackage` copies the existing `media.json` from the source package (same pattern as thumbnails). After a real manifest is written, `manifestLoadFailed` clears so later empty-library saves persist normally.
> 
> Package read/write helpers and structs are widened to `internal` for unit tests; **`VideoProjectLoadTests`** covers degrade-on-read, preserve-on-save, and the rebuild-then-empty flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e84fc72ce16b8d85a0b72f70f73ee402e79b09f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->