### PR TITLE
Predefined Video Layouts

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -64,6 +64,16 @@ enum AgentInstructions {
             waveform — referenceClipId stays, the target(s) move. Use for dual-system sound \
             or multicam (pass targetClipIds); it returns per-clip confidence and refuses \
             weak matches.
+          • apply_layout: for any multi-video composition (split screen, picture-in-picture, \
+            grid), use this instead of hand-setting transforms. Pick a named layout and assign \
+            a clip to each slot; it fills every region without stretching (crops the source to \
+            the slot shape) in one undoable step, and stacks PIP insets on top. The crop is \
+            centered by default — when centering chops something off (a forehead, a subject to \
+            one side), bias it: anchor ('top', 'bottom', …) is a coarse shortcut, anchorX/anchorY \
+            (0–1) give fine control for in-between framing (e.g. anchorY 0.35 nudges slightly \
+            up). Re-call with adjusted anchorX/anchorY to fine-tune. Don't compute centerX/width by hand or loop on \
+            inspect_timeline to "align" a layout — apply_layout already lands it; only \
+            inspect_timeline afterward if you need to verify a non-standard arrangement.
         - speed 1.0 is normal; <1.0 stretches the clip longer on the timeline; >1.0 shortens \
           it. trim* values are source offsets, not timeline offsets.
         - Edits are undoable and effectively free. Don't ask permission for individual edits — \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -9,6 +9,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case removeClips = "remove_clips"
     case removeTracks = "remove_tracks"
     case moveClips = "move_clips"
+    case applyLayout = "apply_layout"
     case setClipProperties = "set_clip_properties"
     case setKeyframes = "set_keyframes"
     case splitClips = "split_clips"
@@ -218,6 +219,46 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: ["moves"]
+            )
+        ),
+        AgentTool(
+            name: .applyLayout,
+            description: "Arrange multiple clips into a common multi-video layout (split screen, picture-in-picture, grid) in one undoable action — the fast path for composing several videos in one frame. Use this instead of hand-setting transforms and screenshot-checking alignment with inspect_timeline.\n\nYou pick a named layout and assign a clip to each of its slots; the tool computes every transform and crop so each clip FILLS its region edge-to-edge WITHOUT stretching — the source is cropped to the slot's shape (cover), like a layout template the videos are dropped into. Pass fit='fit' to letterbox the whole source inside its slot instead (no crop, may leave bars) — use only when the full frame must stay visible (e.g. a screen recording).\n\nThe crop is centered by default. When that chops off something important (a face cropped at the forehead, a subject off to one side), bias which part survives: 'anchor' is a coarse shortcut ('top' keeps the top, etc.), while anchorX/anchorY (0–1) give continuous control for in-between framing — e.g. anchorY 0.35 moves the crop only slightly toward the top, not all the way. To nudge framing after the fact, call apply_layout again with adjusted anchorX/anchorY (clipId mode re-crops in place).\n\nTwo modes (don't mix across slots):\n• Place new clips: give each slot a 'mediaRef' (from get_media) plus top-level startFrame (default 0) and durationFrames. Creates one stacked video track per slot at that time range; for PIP the inset is placed on top automatically. Video clips bring their linked audio.\n• Re-layout existing clips: give each slot a 'clipId'. Only transforms/crop change — timing and tracks are untouched (so existing track order decides stacking).\n\nEvery slot of the chosen layout must be filled. Layouts and their slot names:\n  • full — main\n  • side_by_side — left, right\n  • top_bottom — top, bottom\n  • pip_bottom_right / pip_bottom_left / pip_top_right / pip_top_left — main, inset\n  • grid_2x2 — top_left, top_right, bottom_left, bottom_right\n  • main_sidebar — main (70%), sidebar (30%)\n  • three_up — left, center, right",
+            inputSchema: objectSchema(
+                properties: [
+                    "layout": [
+                        "type": "string",
+                        "enum": VideoLayout.allCases.map(\.rawValue),
+                        "description": "Which layout template to apply.",
+                    ],
+                    "slots": [
+                        "type": "array",
+                        "description": "One entry per slot of the chosen layout. Each entry names a 'slot' and gives exactly one of 'mediaRef' (place a new clip) or 'clipId' (re-layout an existing clip). Don't mix the two across slots.",
+                        "items": objectSchema(
+                            properties: [
+                                "slot": ["type": "string", "description": "Slot name for the chosen layout (e.g. 'left', 'inset', 'top_right')."],
+                                "mediaRef": ["type": "string", "description": "Asset ID from get_media to place into this slot. Use this OR clipId."],
+                                "clipId": ["type": "string", "description": "Existing clip to move into this slot (transform/crop only). Use this OR mediaRef."],
+                                "anchor": [
+                                    "type": "string",
+                                    "enum": ["center", "top", "bottom", "left", "right", "top_left", "top_right", "bottom_left", "bottom_right"],
+                                    "description": "Coarse shortcut for which part of the source to keep when cover-cropping (default center). For in-between framing use anchorX/anchorY instead — the named values are just shortcuts for them.",
+                                ],
+                                "anchorX": ["type": "number", "description": "Fine horizontal framing, 0–1: 0 keeps the left edge, 0.5 centers (default), 1 keeps the right. Only affects slots cropped horizontally. Overrides anchor's x."],
+                                "anchorY": ["type": "number", "description": "Fine vertical framing, 0–1: 0 keeps the top (e.g. a forehead), 0.5 centers (default), 1 keeps the bottom. Nudge by small amounts (e.g. 0.35) to move the crop gradually. Only affects slots cropped vertically. Overrides anchor's y."],
+                            ],
+                            required: ["slot"]
+                        ),
+                    ],
+                    "startFrame": ["type": "integer", "description": "Placement mode only (mediaRef slots). Project frame where the layout begins. Default 0."],
+                    "durationFrames": ["type": "integer", "description": "Placement mode only (mediaRef slots). Length of the placed clips in project frames. Required when placing new clips."],
+                    "fit": [
+                        "type": "string",
+                        "enum": [LayoutFit.fill.rawValue, LayoutFit.fit.rawValue],
+                        "description": "How each clip fills its slot. 'fill' (default) covers the slot and center-crops the source (no stretch). 'fit' letterboxes the whole source inside the slot.",
+                    ],
+                ],
+                required: ["layout", "slots"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+fileprivate struct ApplyLayoutInput: DecodableToolArgs {
+    struct SlotEntry: Decodable {
+        let slot: String
+        let mediaRef: String?
+        let clipId: String?
+        let anchor: String?
+        let anchorX: Double?
+        let anchorY: Double?
+        static let allowedKeys: Set<String> = ["slot", "mediaRef", "clipId", "anchor", "anchorX", "anchorY"]
+    }
+    let layout: String
+    let slots: [SlotEntry]
+    let startFrame: Int?
+    let durationFrames: Int?
+    let fit: String?
+    static let allowedKeys: Set<String> = ["layout", "slots", "startFrame", "durationFrames", "fit"]
+}
+
+extension ToolExecutor {
+
+    /// Named anchors → normalized (anchorX, anchorY); y grows downward so "top" is y 0.
+    static let layoutAnchors: [String: (x: Double, y: Double)] = [
+        "center": (0.5, 0.5),
+        "top": (0.5, 0), "bottom": (0.5, 1), "left": (0, 0.5), "right": (1, 0.5),
+        "top_left": (0, 0), "top_right": (1, 0), "bottom_left": (0, 1), "bottom_right": (1, 1),
+    ]
+
+    /// Named `anchor` sets coarse framing; numeric `anchorX`/`anchorY` (0–1) override per axis.
+    private func resolveAnchor(_ e: ApplyLayoutInput.SlotEntry, path: String) throws -> (x: Double, y: Double) {
+        var anchor = Self.layoutAnchors["center"]!
+        if let raw = e.anchor {
+            guard let a = Self.layoutAnchors[raw] else {
+                throw ToolError("\(path): invalid anchor '\(raw)'. Valid: \(Self.layoutAnchors.keys.sorted().joined(separator: ", ")), or anchorX/anchorY for in-between values.")
+            }
+            anchor = a
+        }
+        for (axis, v) in [("anchorX", e.anchorX), ("anchorY", e.anchorY)] where v != nil {
+            guard (0...1).contains(v!) else { throw ToolError("\(path): \(axis) must be between 0 and 1 (got \(v!))") }
+        }
+        if let ax = e.anchorX { anchor.x = ax }
+        if let ay = e.anchorY { anchor.y = ay }
+        return anchor
+    }
+
+    func applyLayout(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: ApplyLayoutInput = try decodeToolArgs(args, path: "apply_layout")
+        for (i, raw) in (args["slots"] as? [Any] ?? []).enumerated() {
+            if let d = raw as? [String: Any] {
+                try validateUnknownKeys(d, allowed: ApplyLayoutInput.SlotEntry.allowedKeys, path: "slots[\(i)]")
+            }
+        }
+        guard let layout = VideoLayout(rawValue: input.layout) else {
+            throw ToolError("unknown layout '\(input.layout)'. Valid: \(VideoLayout.allCases.map(\.rawValue).joined(separator: ", "))")
+        }
+        guard let fit = LayoutFit(rawValue: input.fit ?? "fill") else {
+            throw ToolError("invalid fit '\(input.fit ?? "")'. Valid: fill, fit")
+        }
+        guard !input.slots.isEmpty else { throw ToolError("apply_layout needs a non-empty 'slots' array") }
+
+        let slotById = Dictionary(uniqueKeysWithValues: layout.slots.map { ($0.id, $0) })
+
+        var seen = Set<String>()
+        var seenClips = Set<String>()
+        var usesMedia = false, usesClip = false
+        var entries: [(slot: LayoutSlot, entry: ApplyLayoutInput.SlotEntry, anchor: (x: Double, y: Double))] = []
+        for (i, e) in input.slots.enumerated() {
+            guard let slot = slotById[e.slot] else {
+                throw ToolError("slots[\(i)]: '\(e.slot)' is not a slot of layout '\(layout.rawValue)'. Slots: \(layout.slots.map(\.id).joined(separator: ", "))")
+            }
+            guard seen.insert(e.slot).inserted else { throw ToolError("slots[\(i)]: duplicate slot '\(e.slot)'") }
+            guard (e.mediaRef != nil) != (e.clipId != nil) else {
+                throw ToolError("slots[\(i)]: provide exactly one of 'mediaRef' or 'clipId'")
+            }
+            if let cid = e.clipId, !seenClips.insert(cid).inserted {
+                throw ToolError("slots[\(i)]: clip '\(cid)' is assigned to more than one slot; each clip can fill only one.")
+            }
+            usesMedia = usesMedia || e.mediaRef != nil
+            usesClip = usesClip || e.clipId != nil
+            entries.append((slot, e, try resolveAnchor(e, path: "slots[\(i)]")))
+        }
+        let missing = Set(slotById.keys).subtracting(seen)
+        guard missing.isEmpty else {
+            throw ToolError("layout '\(layout.rawValue)' needs every slot filled. Missing: \(missing.sorted().joined(separator: ", "))")
+        }
+        guard !(usesMedia && usesClip) else {
+            throw ToolError("apply_layout: don't mix 'mediaRef' and 'clipId' — either place new clips (all mediaRef) or re-layout existing clips (all clipId).")
+        }
+
+        // Resolve sources up front so the mutation below can't fail partway.
+        let startFrame = input.startFrame ?? 0
+        let duration = input.durationFrames ?? 0
+        var assetBySlot: [String: MediaAsset] = [:]
+        var settingsNote: String?
+        if usesMedia {
+            guard startFrame >= 0 else { throw ToolError("startFrame must be >= 0 (got \(startFrame))") }
+            guard duration >= 1 else { throw ToolError("apply_layout placing new clips requires durationFrames >= 1.") }
+            for e in entries {
+                let a = try asset(e.entry.mediaRef!, editor: editor)
+                guard a.type == .video || a.type == .image else {
+                    throw ToolError("slot '\(e.slot.id)': asset \(e.entry.mediaRef!) is \(a.type.rawValue); layout slots take video or image.")
+                }
+                assetBySlot[e.slot.id] = a
+            }
+            settingsNote = applySettingsIfNeededForAgent(editor, assets: Array(assetBySlot.values))
+        } else {
+            // Layout shows every clip at once, so reject same-track overlaps (only the first renders)
+            // and clips that never share a frame.
+            var rangesByTrack: [String: [(slot: String, start: Int, end: Int)]] = [:]
+            var commonStart = Int.min, commonEnd = Int.max
+            for e in entries {
+                guard let loc = editor.findClip(id: e.entry.clipId!) else { throw ToolError("slot '\(e.slot.id)': clip not found: \(e.entry.clipId!)") }
+                let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                guard clip.mediaType == .video || clip.mediaType == .image else {
+                    throw ToolError("slot '\(e.slot.id)': clip \(e.entry.clipId!) is \(clip.mediaType.rawValue); layout applies to video/image clips.")
+                }
+                let trackId = editor.timeline.tracks[loc.trackIndex].id
+                let start = clip.startFrame, end = clip.startFrame + clip.durationFrames
+                for other in rangesByTrack[trackId] ?? [] where start < other.end && other.start < end {
+                    throw ToolError("slots '\(other.slot)' and '\(e.slot.id)' are clips on the same track whose times overlap; only the first would render. Move them to separate tracks (or place new clips with mediaRef) so every region shows.")
+                }
+                rangesByTrack[trackId, default: []].append((e.slot.id, start, end))
+                commonStart = max(commonStart, start); commonEnd = min(commonEnd, end)
+            }
+            if entries.count > 1, commonStart >= commonEnd {
+                throw ToolError("the selected clips never play at the same time, so no single frame shows every region. Overlap their timeline ranges (or place new clips with mediaRef) before laying them out.")
+            }
+        }
+
+        let tracksBefore = Set(editor.timeline.tracks.map(\.id))
+        var summaries: [String] = []
+
+        editor.withTimelineSwap(actionName: "Apply Layout (Agent)") {
+            var clipBySlot: [String: String] = [:]
+            if usesMedia {
+                // Insert lowest-z first so the highest-z slot (a PIP inset) lands on top (index 0).
+                var trackBySlot: [String: String] = [:]
+                for slot in layout.slots.sorted(by: { $0.z < $1.z }) {
+                    let idx = editor.insertTrack(at: 0, type: .video)
+                    trackBySlot[slot.id] = editor.timeline.tracks[idx].id
+                }
+                for e in entries {
+                    guard let tid = trackBySlot[e.slot.id], let asset = assetBySlot[e.slot.id],
+                          let tIdx = editor.timeline.tracks.firstIndex(where: { $0.id == tid }) else { continue }
+                    let ids = editor.placeClip(asset: asset, trackIndex: tIdx, startFrame: startFrame, durationFrames: duration)
+                    if let primary = ids.first {
+                        clipBySlot[e.slot.id] = primary
+                        summaries.append("\(e.slot.id) → \(primary)\(ids.count > 1 ? " (+audio \(ids[1]))" : "")")
+                    }
+                }
+            } else {
+                for e in entries {
+                    clipBySlot[e.slot.id] = e.entry.clipId!
+                    summaries.append("\(e.slot.id) → \(e.entry.clipId!)")
+                }
+            }
+
+            for e in entries {
+                guard let cid = clipBySlot[e.slot.id], let clip = editor.clipFor(id: cid),
+                      let loc = editor.findClip(id: cid) else { continue }
+                let p = editor.layoutPlacement(for: clip, in: e.slot.rect, fit: fit, anchorX: e.anchor.x, anchorY: e.anchor.y)
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].transform = p.transform
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].crop = p.crop
+                // Drop animation tracks; the renderer samples them over the static transform/crop.
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].positionTrack = nil
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].scaleTrack = nil
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].rotationTrack = nil
+                editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].cropTrack = nil
+            }
+        }
+
+        guard !summaries.isEmpty else { throw ToolError("apply_layout changed no clips.") }
+
+        var prefix = settingsNote.map { "\($0) " } ?? ""
+        let createdTracks = editor.timeline.tracks.enumerated()
+            .filter { !tracksBefore.contains($0.element.id) }
+            .map { "track \($0.offset) ('\(editor.timelineTrackDisplayLabel(at: $0.offset))', \($0.element.type.rawValue))" }
+        if !createdTracks.isEmpty { prefix += "Created \(createdTracks.joined(separator: ", ")). " }
+        let span = usesMedia ? " at frame \(startFrame) for \(duration)" : " on existing clips"
+        let tail = usesMedia ? "" : " Stacking follows current track order; reorder tracks if a PIP inset isn't on top."
+        return .ok("\(prefix)Applied '\(layout.rawValue)' layout (\(fit.rawValue))\(span): \(summaries.joined(separator: "; ")).\(tail)")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
@@ -103,7 +103,10 @@ extension ToolExecutor {
                 }
                 assetBySlot[e.slot.id] = a
             }
-            settingsNote = applySettingsIfNeededForAgent(editor, assets: Array(assetBySlot.values))
+            settingsNote = applySettingsIfNeededForAgent(
+                editor,
+                assets: layout.slots.compactMap { assetBySlot[$0.id] }
+            )
         } else {
             // Layout shows every clip at once, so reject same-track overlaps (only the first renders)
             // and clips that never share a frame.

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
@@ -20,14 +20,12 @@ fileprivate struct ApplyLayoutInput: DecodableToolArgs {
 
 extension ToolExecutor {
 
-    /// Named anchors → normalized (anchorX, anchorY); y grows downward so "top" is y 0.
     static let layoutAnchors: [String: (x: Double, y: Double)] = [
         "center": (0.5, 0.5),
         "top": (0.5, 0), "bottom": (0.5, 1), "left": (0, 0.5), "right": (1, 0.5),
         "top_left": (0, 0), "top_right": (1, 0), "bottom_left": (0, 1), "bottom_right": (1, 1),
     ]
 
-    /// Named `anchor` sets coarse framing; numeric `anchorX`/`anchorY` (0–1) override per axis.
     private func resolveAnchor(_ e: ApplyLayoutInput.SlotEntry, path: String) throws -> (x: Double, y: Double) {
         var anchor = Self.layoutAnchors["center"]!
         if let raw = e.anchor {
@@ -88,7 +86,6 @@ extension ToolExecutor {
             throw ToolError("apply_layout: don't mix 'mediaRef' and 'clipId' — either place new clips (all mediaRef) or re-layout existing clips (all clipId).")
         }
 
-        // Resolve sources up front so the mutation below can't fail partway.
         let startFrame = input.startFrame ?? 0
         let duration = input.durationFrames ?? 0
         var assetBySlot: [String: MediaAsset] = [:]
@@ -108,8 +105,6 @@ extension ToolExecutor {
                 assets: layout.slots.compactMap { assetBySlot[$0.id] }
             )
         } else {
-            // Layout shows every clip at once, so reject same-track overlaps (only the first renders)
-            // and clips that never share a frame.
             var rangesByTrack: [String: [(slot: String, start: Int, end: Int)]] = [:]
             var commonStart = Int.min, commonEnd = Int.max
             for e in entries {
@@ -137,7 +132,6 @@ extension ToolExecutor {
         editor.withTimelineSwap(actionName: "Apply Layout (Agent)") {
             var clipBySlot: [String: String] = [:]
             if usesMedia {
-                // Insert lowest-z first so the highest-z slot (a PIP inset) lands on top (index 0).
                 var trackBySlot: [String: String] = [:]
                 for slot in layout.slots.sorted(by: { $0.z < $1.z }) {
                     let idx = editor.insertTrack(at: 0, type: .video)
@@ -165,7 +159,6 @@ extension ToolExecutor {
                 let p = editor.layoutPlacement(for: clip, in: e.slot.rect, fit: fit, anchorX: e.anchor.x, anchorY: e.anchor.y)
                 editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].transform = p.transform
                 editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].crop = p.crop
-                // Drop animation tracks; the renderer samples them over the static transform/crop.
                 editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].positionTrack = nil
                 editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].scaleTrack = nil
                 editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex].rotationTrack = nil

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -87,6 +87,7 @@ final class ToolExecutor {
         case .removeClips:      return try removeClips(editor, args)
         case .removeTracks:     return try removeTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
+        case .applyLayout:      return try applyLayout(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Layout.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Layout.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension EditorViewModel {
+
+    /// Transform + crop placing `clip` into `rect` without distorting it: `.fill` covers the slot
+    /// (crops to its aspect), `.fit` letterboxes the source inside it. `anchorX`/`anchorY` (0–1)
+    /// bias which part survives — anchorY 0 keeps the top (a face).
+    func layoutPlacement(
+        for clip: Clip,
+        in rect: LayoutRect,
+        fit: LayoutFit,
+        anchorX: Double = 0.5,
+        anchorY: Double = 0.5
+    ) -> (transform: Transform, crop: Crop) {
+        let canvasAspect = Double(timeline.width) / Double(max(1, timeline.height))
+        let slotPixelAspect = rect.h > 0 ? (rect.w / rect.h) * canvasAspect : canvasAspect
+
+        switch fit {
+        case .fill:
+            // Renderer maps the whole frame into transform.w×h, so expand it by the crop's
+            // visible fraction (and shift by the inset) or the crop just floats in a stretched box.
+            let crop = cropFittingAspect(for: clip, targetPixelAspect: slotPixelAspect, anchorX: anchorX, anchorY: anchorY)
+            let vw = crop.visibleWidthFraction
+            let vh = crop.visibleHeightFraction
+            guard vw > 0, vh > 0 else {
+                return (Transform(topLeft: (rect.x, rect.y), width: rect.w, height: rect.h), crop)
+            }
+            let w = rect.w / vw
+            let h = rect.h / vh
+            let x = rect.x - crop.left * w
+            let y = rect.y - crop.top * h
+            return (Transform(topLeft: (x, y), width: w, height: h), crop)
+
+        case .fit:
+            guard let rel = mediaCanvasAspect(for: clip), rel > 0 else {
+                return (Transform(topLeft: (rect.x, rect.y), width: rect.w, height: rect.h), Crop())
+            }
+            var drawW = rect.w
+            var drawH = rect.h
+            if rel * rect.h <= rect.w {
+                drawH = rect.h
+                drawW = rel * rect.h
+            } else {
+                drawW = rect.w
+                drawH = rect.w / rel
+            }
+            let ax = min(1, max(0, anchorX))
+            let ay = min(1, max(0, anchorY))
+            let x = rect.x + (rect.w - drawW) * ax
+            let y = rect.y + (rect.h - drawH) * ay
+            return (Transform(topLeft: (x, y), width: drawW, height: drawH), Crop())
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Layout.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Layout.swift
@@ -2,9 +2,6 @@ import Foundation
 
 extension EditorViewModel {
 
-    /// Transform + crop placing `clip` into `rect` without distorting it: `.fill` covers the slot
-    /// (crops to its aspect), `.fit` letterboxes the source inside it. `anchorX`/`anchorY` (0–1)
-    /// bias which part survives — anchorY 0 keeps the top (a face).
     func layoutPlacement(
         for clip: Clip,
         in rect: LayoutRect,
@@ -17,8 +14,6 @@ extension EditorViewModel {
 
         switch fit {
         case .fill:
-            // Renderer maps the whole frame into transform.w×h, so expand it by the crop's
-            // visible fraction (and shift by the inset) or the crop just floats in a stretched box.
             let crop = cropFittingAspect(for: clip, targetPixelAspect: slotPixelAspect, anchorX: anchorX, anchorY: anchorY)
             let vw = crop.visibleWidthFraction
             let vh = crop.visibleHeightFraction

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -495,21 +495,29 @@ final class EditorViewModel {
         return mediaCanvasAspect(for: asset, canvasWidth: timeline.width, canvasHeight: timeline.height)
     }
 
-    /// Largest centered crop of `target` aspect inside the source.
-    func cropFittingAspect(for clip: Clip, targetPixelAspect target: Double) -> Crop {
+    /// Largest crop of `target` aspect inside the source. `anchorX`/`anchorY` (0–1) bias which
+    /// part survives on the cropped axis (0.5 centers; anchorY 0 keeps the top).
+    func cropFittingAspect(
+        for clip: Clip,
+        targetPixelAspect target: Double,
+        anchorX: Double = 0.5,
+        anchorY: Double = 0.5
+    ) -> Crop {
         guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
               let sw = asset.sourceWidth, let sh = asset.sourceHeight,
               sw > 0, sh > 0, target > 0 else { return Crop() }
         let sourceAspect = Double(sw) / Double(sh)
         if abs(sourceAspect - target) < 0.0001 { return Crop() }
+        let ax = min(1, max(0, anchorX))
+        let ay = min(1, max(0, anchorY))
         if sourceAspect > target {
-            let visibleWidthFrac = target / sourceAspect
-            let inset = (1 - visibleWidthFrac) / 2
-            return Crop(left: inset, top: 0, right: inset, bottom: 0)
+            let total = 1 - target / sourceAspect
+            let left = total * ax
+            return Crop(left: left, top: 0, right: total - left, bottom: 0)
         } else {
-            let visibleHeightFrac = sourceAspect / target
-            let inset = (1 - visibleHeightFrac) / 2
-            return Crop(left: 0, top: inset, right: 0, bottom: inset)
+            let total = 1 - sourceAspect / target
+            let top = total * ay
+            return Crop(left: 0, top: top, right: 0, bottom: total - top)
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -495,8 +495,6 @@ final class EditorViewModel {
         return mediaCanvasAspect(for: asset, canvasWidth: timeline.width, canvasHeight: timeline.height)
     }
 
-    /// Largest crop of `target` aspect inside the source. `anchorX`/`anchorY` (0–1) bias which
-    /// part survives on the cropped axis (0.5 centers; anchorY 0 keeps the top).
     func cropFittingAspect(
         for clip: Clip,
         targetPixelAspect target: Double,

--- a/Sources/PalmierPro/Models/VideoLayout.swift
+++ b/Sources/PalmierPro/Models/VideoLayout.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Normalized (0–1) top-left rectangle in canvas space (same coords as `Transform.topLeft`).
+struct LayoutRect: Equatable, Sendable {
+    var x: Double
+    var y: Double
+    var w: Double
+    var h: Double
+}
+
+/// A named region of a layout; higher `z` renders on top (a PIP inset).
+struct LayoutSlot: Equatable, Sendable {
+    let id: String
+    let rect: LayoutRect
+    var z: Int = 0
+}
+
+/// `fill` covers the slot (crops the source); `fit` letterboxes the source inside it.
+enum LayoutFit: String, Sendable {
+    case fill
+    case fit
+}
+
+/// Hardcoded multi-clip frame layouts; each names its slots.
+enum VideoLayout: String, CaseIterable, Sendable {
+    case full
+    case sideBySide = "side_by_side"
+    case topBottom = "top_bottom"
+    case pipBottomRight = "pip_bottom_right"
+    case pipBottomLeft = "pip_bottom_left"
+    case pipTopRight = "pip_top_right"
+    case pipTopLeft = "pip_top_left"
+    case grid2x2 = "grid_2x2"
+    case mainSidebar = "main_sidebar"
+    case threeUp = "three_up"
+
+    // A square normalized inset reads as the canvas aspect in pixels (same-aspect source = no crop).
+    private static let pipInset = 0.28
+    private static let pipMargin = 0.035
+
+    var slots: [LayoutSlot] {
+        switch self {
+        case .full:
+            return [LayoutSlot(id: "main", rect: LayoutRect(x: 0, y: 0, w: 1, h: 1))]
+
+        case .sideBySide:
+            return [
+                LayoutSlot(id: "left",  rect: LayoutRect(x: 0,   y: 0, w: 0.5, h: 1)),
+                LayoutSlot(id: "right", rect: LayoutRect(x: 0.5, y: 0, w: 0.5, h: 1)),
+            ]
+
+        case .topBottom:
+            return [
+                LayoutSlot(id: "top",    rect: LayoutRect(x: 0, y: 0,   w: 1, h: 0.5)),
+                LayoutSlot(id: "bottom", rect: LayoutRect(x: 0, y: 0.5, w: 1, h: 0.5)),
+            ]
+
+        case .pipBottomRight: return Self.pip(insetX: 1 - Self.pipMargin - Self.pipInset, insetY: 1 - Self.pipMargin - Self.pipInset)
+        case .pipBottomLeft:  return Self.pip(insetX: Self.pipMargin,                     insetY: 1 - Self.pipMargin - Self.pipInset)
+        case .pipTopRight:    return Self.pip(insetX: 1 - Self.pipMargin - Self.pipInset, insetY: Self.pipMargin)
+        case .pipTopLeft:     return Self.pip(insetX: Self.pipMargin,                     insetY: Self.pipMargin)
+
+        case .grid2x2:
+            return [
+                LayoutSlot(id: "top_left",     rect: LayoutRect(x: 0,   y: 0,   w: 0.5, h: 0.5)),
+                LayoutSlot(id: "top_right",    rect: LayoutRect(x: 0.5, y: 0,   w: 0.5, h: 0.5)),
+                LayoutSlot(id: "bottom_left",  rect: LayoutRect(x: 0,   y: 0.5, w: 0.5, h: 0.5)),
+                LayoutSlot(id: "bottom_right", rect: LayoutRect(x: 0.5, y: 0.5, w: 0.5, h: 0.5)),
+            ]
+
+        case .mainSidebar:
+            return [
+                LayoutSlot(id: "main",    rect: LayoutRect(x: 0,   y: 0, w: 0.7, h: 1)),
+                LayoutSlot(id: "sidebar", rect: LayoutRect(x: 0.7, y: 0, w: 0.3, h: 1)),
+            ]
+
+        case .threeUp:
+            let third = 1.0 / 3.0
+            return [
+                LayoutSlot(id: "left",   rect: LayoutRect(x: 0,         y: 0, w: third, h: 1)),
+                LayoutSlot(id: "center", rect: LayoutRect(x: third,     y: 0, w: third, h: 1)),
+                LayoutSlot(id: "right",  rect: LayoutRect(x: third * 2, y: 0, w: third, h: 1)),
+            ]
+        }
+    }
+
+    private static func pip(insetX: Double, insetY: Double) -> [LayoutSlot] {
+        [
+            LayoutSlot(id: "main",  rect: LayoutRect(x: 0, y: 0, w: 1, h: 1), z: 0),
+            LayoutSlot(id: "inset", rect: LayoutRect(x: insetX, y: insetY, w: pipInset, h: pipInset), z: 1),
+        ]
+    }
+}

--- a/Sources/PalmierPro/Models/VideoLayout.swift
+++ b/Sources/PalmierPro/Models/VideoLayout.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// Normalized (0–1) top-left rectangle in canvas space (same coords as `Transform.topLeft`).
 struct LayoutRect: Equatable, Sendable {
     var x: Double
     var y: Double
@@ -8,20 +7,17 @@ struct LayoutRect: Equatable, Sendable {
     var h: Double
 }
 
-/// A named region of a layout; higher `z` renders on top (a PIP inset).
 struct LayoutSlot: Equatable, Sendable {
     let id: String
     let rect: LayoutRect
     var z: Int = 0
 }
 
-/// `fill` covers the slot (crops the source); `fit` letterboxes the source inside it.
 enum LayoutFit: String, Sendable {
     case fill
     case fit
 }
 
-/// Hardcoded multi-clip frame layouts; each names its slots.
 enum VideoLayout: String, CaseIterable, Sendable {
     case full
     case sideBySide = "side_by_side"
@@ -34,7 +30,6 @@ enum VideoLayout: String, CaseIterable, Sendable {
     case mainSidebar = "main_sidebar"
     case threeUp = "three_up"
 
-    // A square normalized inset reads as the canvas aspect in pixels (same-aspect source = no crop).
     private static let pipInset = 0.28
     private static let pipMargin = 0.035
 

--- a/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
+++ b/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// Records action names; `registerTimelineSwap` names a swap only when it registers, so suppressed
+/// (nested) swaps leave no entry — letting a test count real swaps.
+private final class SpyUndoManager: UndoManager {
+    var actionNames: [String] = []
+    override func setActionName(_ actionName: String) {
+        actionNames.append(actionName)
+        super.setActionName(actionName)
+    }
+}
+
+@Suite("apply_layout")
+@MainActor
+struct ApplyLayoutTests {
+
+    private func approx(_ a: Double, _ b: Double, tol: Double = 1e-6) -> Bool { abs(a - b) < tol }
+
+    @discardableResult
+    private func videoAsset(_ h: ToolHarness, id: String, w: Int = 1920, ht: Int = 1080, hasAudio: Bool = false) -> MediaAsset {
+        let a = h.addAsset(id: id, type: .video, hasAudio: hasAudio)
+        a.sourceWidth = w
+        a.sourceHeight = ht
+        return a
+    }
+
+    /// Configured timeline at `w`×`h` with one pre-existing clip, so the agent path keeps the
+    /// canvas instead of adopting the first placed clip's resolution.
+    private func configured(_ w: Int, _ h: Int) -> ToolHarness {
+        var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "existing", start: 0, duration: 30)])])
+        t.width = w; t.height = h; t.settingsConfigured = true
+        return ToolHarness(timeline: t)
+    }
+
+    private func clips(_ h: ToolHarness, mediaRef: String) -> Clip? {
+        h.editor.timeline.tracks.flatMap(\.clips).first { $0.mediaRef == mediaRef }
+    }
+
+    private func clip(_ h: ToolHarness, id: String) -> Clip? {
+        h.editor.timeline.tracks.flatMap(\.clips).first { $0.id == id }
+    }
+
+    // MARK: Placement
+
+    @Test func sideBySideFillsWithoutStretch() async throws {
+        let h = ToolHarness() // 1920x1080
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side", "durationFrames": 120,
+            "slots": [["slot": "left", "mediaRef": "a"], ["slot": "right", "mediaRef": "b"]],
+        ])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.tracks.count == 2)
+        let left = clips(h, mediaRef: "a")!
+        let right = clips(h, mediaRef: "b")!
+        #expect(approx(left.transform.centerX, 0.25))
+        #expect(approx(right.transform.centerX, 0.75))
+        let canvasAspect = 1920.0 / 1080.0
+        for c in [left, right] {
+            #expect(approx(c.crop.left, 0.25))
+            #expect(approx(c.crop.right, 0.25))
+            // No stretch: drawn box keeps source aspect; visible crop exactly fills the slot.
+            #expect(approx((c.transform.width / c.transform.height) * canvasAspect, 16.0 / 9.0, tol: 1e-3))
+            #expect(approx(c.transform.width * c.crop.visibleWidthFraction, 0.5))
+            #expect(approx(c.transform.height * c.crop.visibleHeightFraction, 1.0))
+        }
+    }
+
+    @Test func pipInsetSitsOnTopOfMain() async throws {
+        let h = ToolHarness()
+        videoAsset(h, id: "screen"); videoAsset(h, id: "cam")
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "pip_bottom_right", "durationFrames": 90,
+            "slots": [["slot": "main", "mediaRef": "screen"], ["slot": "inset", "mediaRef": "cam"]],
+        ])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.tracks.count == 2)
+        var insetIdx = -1, mainIdx = -1
+        for (i, t) in h.editor.timeline.tracks.enumerated() {
+            for c in t.clips {
+                if approx(c.transform.width, 0.28) { insetIdx = i }
+                if approx(c.transform.width, 1.0) { mainIdx = i }
+            }
+        }
+        #expect(insetIdx >= 0 && mainIdx >= 0)
+        #expect(insetIdx < mainIdx) // lower index renders on top
+        let inset = clips(h, mediaRef: "cam")!
+        #expect(inset.transform.topLeft.x > 0.6 && inset.transform.topLeft.y > 0.6)
+    }
+
+    @Test func fitLetterboxesWithoutCropping() async throws {
+        let h = ToolHarness()
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "top_bottom", "durationFrames": 60, "fit": "fit",
+            "slots": [["slot": "top", "mediaRef": "a"], ["slot": "bottom", "mediaRef": "b"]],
+        ])
+        #expect(r.isError == false)
+        let canvasAspect = 1920.0 / 1080.0
+        for c in h.editor.timeline.tracks.flatMap(\.clips) {
+            #expect(approx(c.crop.left, 0) && approx(c.crop.top, 0))
+            #expect(approx((c.transform.width / c.transform.height) * canvasAspect, 16.0 / 9.0, tol: 1e-3))
+            #expect(c.transform.height <= 0.5 + 1e-6)
+        }
+    }
+
+    @Test func gridFillsFourSlots() async throws {
+        let h = ToolHarness()
+        for id in ["a", "b", "c", "d"] { videoAsset(h, id: id) }
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "grid_2x2", "durationFrames": 90,
+            "slots": [
+                ["slot": "top_left", "mediaRef": "a"], ["slot": "top_right", "mediaRef": "b"],
+                ["slot": "bottom_left", "mediaRef": "c"], ["slot": "bottom_right", "mediaRef": "d"],
+            ],
+        ])
+        #expect(r.isError == false)
+        let cs = h.editor.timeline.tracks.flatMap(\.clips)
+        #expect(cs.count == 4)
+        for c in cs { #expect(approx(c.transform.width, 0.5) && approx(c.transform.height, 0.5)) }
+    }
+
+    @Test func placementIsSingleUndoStep() async throws {
+        // Nested insertTrack/placeClip swaps must stay suppressed: one swap, one undo to revert.
+        let h = configured(1920, 1080)
+        for id in ["a", "b", "c", "d"] { videoAsset(h, id: id, hasAudio: true) }
+        let um = SpyUndoManager()
+        h.editor.undoManager = um
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "grid_2x2", "durationFrames": 90,
+            "slots": [
+                ["slot": "top_left", "mediaRef": "a"], ["slot": "top_right", "mediaRef": "b"],
+                ["slot": "bottom_left", "mediaRef": "c"], ["slot": "bottom_right", "mediaRef": "d"],
+            ],
+        ])
+        #expect(r.isError == false)
+        #expect(um.actionNames == ["Apply Layout (Agent)"]) // no leaked "Add Track" swaps
+
+        let tracksAfter = h.editor.timeline.tracks.count
+        #expect(tracksAfter > 1)
+        um.undo()
+        #expect(h.editor.timeline.tracks.count < tracksAfter)
+        #expect(h.editor.timeline.tracks.flatMap(\.clips).allSatisfy { $0.id == "existing" })
+        #expect(um.canUndo == false)
+    }
+
+    // MARK: Existing clips / single full
+
+    @Test func reLayoutsExistingClipsByClipId() async throws {
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60)]),
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "cb", mediaRef: "b", start: 0, duration: 60)]),
+        ])
+        let h = ToolHarness(timeline: timeline)
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let before = h.editor.timeline.tracks.count
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side",
+            "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
+        ])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.tracks.count == before) // no new tracks, timing untouched
+        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.25))
+        #expect(approx(clip(h, id: "cb")!.transform.centerX, 0.75))
+        #expect(clip(h, id: "ca")!.startFrame == 0)
+    }
+
+    @Test func reLayoutClearsAnimationTracks() async throws {
+        // Renderer samples keyframe tracks over static transform/crop, so re-layout must drop them.
+        var t = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60)]),
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "cb", mediaRef: "b", start: 0, duration: 60)]),
+        ])
+        t.width = 1920; t.height = 1080; t.settingsConfigured = true
+        let h = ToolHarness(timeline: t)
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        h.editor.timeline.tracks[0].clips[0].positionTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: AnimPair(a: 0, b: 0)),
+            Keyframe(frame: 60, value: AnimPair(a: 0.5, b: 0.5)),
+        ])
+        h.editor.timeline.tracks[0].clips[0].scaleTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: AnimPair(a: 1, b: 1)),
+            Keyframe(frame: 60, value: AnimPair(a: 0.5, b: 0.5)),
+        ])
+        h.editor.timeline.tracks[0].clips[0].cropTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: Crop()),
+            Keyframe(frame: 60, value: Crop(left: 0.5, top: 0, right: 0, bottom: 0)),
+        ])
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side",
+            "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
+        ])
+        #expect(r.isError == false)
+        let c = clip(h, id: "ca")!
+        #expect(c.positionTrack == nil && c.scaleTrack == nil && c.cropTrack == nil)
+        #expect(approx(c.transformAt(frame: 0).centerX, 0.25))
+        #expect(approx(c.transformAt(frame: 60).centerX, 0.25)) // static layout, not animated
+    }
+
+    @Test func reLayoutRejectsSameTrackOverlap() async throws {
+        // Overlapping clips on one track: compositor renders only the first, so reject.
+        var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60),
+            Fixtures.clip(id: "cb", mediaRef: "b", start: 30, duration: 60),
+        ])])
+        t.width = 1920; t.height = 1080; t.settingsConfigured = true
+        let h = ToolHarness(timeline: t)
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side",
+            "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
+        ])
+        #expect(r.isError)
+        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5)) // untouched
+    }
+
+    @Test func reLayoutRejectsClipsThatNeverCoincide() async throws {
+        // Disjoint in time on separate tracks: no playhead shows both, so reject.
+        var t = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60)]),
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "cb", mediaRef: "b", start: 120, duration: 60)]),
+        ])
+        t.width = 1920; t.height = 1080; t.settingsConfigured = true
+        let h = ToolHarness(timeline: t)
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side",
+            "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
+        ])
+        #expect(r.isError)
+        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5)) // untouched
+    }
+
+    @Test func fullRefitsSingleClipToCanvasAspect() async throws {
+        // Vertical project, one landscape clip → 'full' covers the frame (no stretch, no bars),
+        // anchorX biases the horizontal crop. No new tracks, timing untouched.
+        var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", mediaRef: "wide", start: 0, duration: 60)])])
+        t.width = 1080; t.height = 1920; t.settingsConfigured = true
+        let h = ToolHarness(timeline: t)
+        videoAsset(h, id: "wide", w: 1920, ht: 1080)
+        let before = h.editor.timeline.tracks.count
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "full", "slots": [["slot": "main", "clipId": "c1", "anchorX": 0.3]],
+        ])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.tracks.count == before)
+        let c = clip(h, id: "c1")!
+        #expect(approx(c.transform.width * c.crop.visibleWidthFraction, 1.0))
+        #expect(approx(c.transform.height * c.crop.visibleHeightFraction, 1.0))
+        #expect(approx((c.transform.width / c.transform.height) * (1080.0 / 1920.0), 16.0 / 9.0, tol: 1e-3))
+        #expect(approx(c.crop.top, 0)) // landscape into portrait crops the sides only
+        #expect(approx(c.crop.left, (c.crop.left + c.crop.right) * 0.3)) // anchorX bias
+    }
+
+    // MARK: Framing anchor
+
+    @Test func anchorBiasesCropContinuously() async throws {
+        // Portrait sources into wider slots crop top/bottom. Ordering must be strict:
+        // top (0) < partial nudge (anchorY 0.2) < center (even split); 'top' aligns to slot top.
+        let h = configured(1920, 1080)
+        for id in ["c", "p", "t"] { videoAsset(h, id: id, w: 1080, ht: 1920) }
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "three_up", "durationFrames": 60,
+            "slots": [
+                ["slot": "left", "mediaRef": "c"],
+                ["slot": "center", "mediaRef": "p", "anchorY": 0.2],
+                ["slot": "right", "mediaRef": "t", "anchor": "top"],
+            ],
+        ])
+        #expect(r.isError == false)
+        let center = clips(h, mediaRef: "c")!, partial = clips(h, mediaRef: "p")!, top = clips(h, mediaRef: "t")!
+        let total = center.crop.top + center.crop.bottom
+        #expect(total > 0.01)
+        #expect(approx(partial.crop.top, total * 0.2))
+        #expect(approx(top.crop.top, 0))
+        #expect(top.crop.top < partial.crop.top && partial.crop.top < center.crop.top)
+        #expect(approx(center.crop.top, center.crop.bottom))
+        #expect(approx(top.transform.topLeft.y, 0)) // kept-top region aligns to slot top
+    }
+
+    // MARK: Validation
+
+    @Test func rejectsInvalidInput() async {
+        let t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "cx", mediaRef: "a", start: 0, duration: 30)])])
+        let h = ToolHarness(timeline: t)
+        videoAsset(h, id: "a"); videoAsset(h, id: "b")
+        let bad: [(String, [String: Any])] = [
+            ("unknown layout", ["layout": "hexagon", "durationFrames": 30, "slots": [["slot": "left", "mediaRef": "a"]]]),
+            ("unknown slot", ["layout": "side_by_side", "durationFrames": 30, "slots": [["slot": "left", "mediaRef": "a"], ["slot": "mid", "mediaRef": "b"]]]),
+            ("missing slot", ["layout": "side_by_side", "durationFrames": 30, "slots": [["slot": "left", "mediaRef": "a"]]]),
+            ("mixed sources", ["layout": "side_by_side", "durationFrames": 30, "slots": [["slot": "left", "clipId": "cx"], ["slot": "right", "mediaRef": "b"]]]),
+            ("no duration", ["layout": "side_by_side", "slots": [["slot": "left", "mediaRef": "a"], ["slot": "right", "mediaRef": "b"]]]),
+            ("both source + clip", ["layout": "full", "durationFrames": 30, "slots": [["slot": "main", "mediaRef": "a", "clipId": "cx"]]]),
+            ("invalid anchor", ["layout": "full", "durationFrames": 30, "slots": [["slot": "main", "mediaRef": "a", "anchor": "diagonal"]]]),
+            ("anchor out of range", ["layout": "full", "durationFrames": 30, "slots": [["slot": "main", "mediaRef": "a", "anchorY": 1.5]]]),
+            ("duplicate clipId", ["layout": "side_by_side", "slots": [["slot": "left", "clipId": "cx"], ["slot": "right", "clipId": "cx"]]]),
+        ]
+        for (label, args) in bad {
+            let r = await h.runRaw("apply_layout", args: args)
+            #expect(r.isError, "expected error for: \(label)")
+        }
+    }
+}

--- a/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
+++ b/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
@@ -44,6 +44,20 @@ struct ApplyLayoutTests {
 
     // MARK: Placement
 
+    @Test func placementAdoptsLayoutSlotOrderForSettings() async throws {
+        // Unconfigured timeline: canvas follows the layout's canonical slot order, not input.slots order.
+        let h = ToolHarness()
+        videoAsset(h, id: "landscape", w: 1920, ht: 1080)
+        videoAsset(h, id: "portrait", w: 1080, ht: 1920)
+        let r = await h.runRaw("apply_layout", args: [
+            "layout": "side_by_side", "durationFrames": 60,
+            "slots": [["slot": "right", "mediaRef": "portrait"], ["slot": "left", "mediaRef": "landscape"]],
+        ])
+        #expect(r.isError == false)
+        #expect(h.editor.timeline.width == 1920)
+        #expect(h.editor.timeline.height == 1080)
+    }
+
     @Test func sideBySideFillsWithoutStretch() async throws {
         let h = ToolHarness() // 1920x1080
         videoAsset(h, id: "a"); videoAsset(h, id: "b")

--- a/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
+++ b/Tests/PalmierProTests/Agent/ApplyLayoutTests.swift
@@ -2,8 +2,6 @@ import Foundation
 import Testing
 @testable import PalmierPro
 
-/// Records action names; `registerTimelineSwap` names a swap only when it registers, so suppressed
-/// (nested) swaps leave no entry — letting a test count real swaps.
 private final class SpyUndoManager: UndoManager {
     var actionNames: [String] = []
     override func setActionName(_ actionName: String) {
@@ -26,8 +24,6 @@ struct ApplyLayoutTests {
         return a
     }
 
-    /// Configured timeline at `w`×`h` with one pre-existing clip, so the agent path keeps the
-    /// canvas instead of adopting the first placed clip's resolution.
     private func configured(_ w: Int, _ h: Int) -> ToolHarness {
         var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "existing", start: 0, duration: 30)])])
         t.width = w; t.height = h; t.settingsConfigured = true
@@ -42,10 +38,7 @@ struct ApplyLayoutTests {
         h.editor.timeline.tracks.flatMap(\.clips).first { $0.id == id }
     }
 
-    // MARK: Placement
-
     @Test func placementAdoptsLayoutSlotOrderForSettings() async throws {
-        // Unconfigured timeline: canvas follows the layout's canonical slot order, not input.slots order.
         let h = ToolHarness()
         videoAsset(h, id: "landscape", w: 1920, ht: 1080)
         videoAsset(h, id: "portrait", w: 1080, ht: 1920)
@@ -59,7 +52,7 @@ struct ApplyLayoutTests {
     }
 
     @Test func sideBySideFillsWithoutStretch() async throws {
-        let h = ToolHarness() // 1920x1080
+        let h = ToolHarness()
         videoAsset(h, id: "a"); videoAsset(h, id: "b")
         let r = await h.runRaw("apply_layout", args: [
             "layout": "side_by_side", "durationFrames": 120,
@@ -75,7 +68,6 @@ struct ApplyLayoutTests {
         for c in [left, right] {
             #expect(approx(c.crop.left, 0.25))
             #expect(approx(c.crop.right, 0.25))
-            // No stretch: drawn box keeps source aspect; visible crop exactly fills the slot.
             #expect(approx((c.transform.width / c.transform.height) * canvasAspect, 16.0 / 9.0, tol: 1e-3))
             #expect(approx(c.transform.width * c.crop.visibleWidthFraction, 0.5))
             #expect(approx(c.transform.height * c.crop.visibleHeightFraction, 1.0))
@@ -99,7 +91,7 @@ struct ApplyLayoutTests {
             }
         }
         #expect(insetIdx >= 0 && mainIdx >= 0)
-        #expect(insetIdx < mainIdx) // lower index renders on top
+        #expect(insetIdx < mainIdx)
         let inset = clips(h, mediaRef: "cam")!
         #expect(inset.transform.topLeft.x > 0.6 && inset.transform.topLeft.y > 0.6)
     }
@@ -137,7 +129,6 @@ struct ApplyLayoutTests {
     }
 
     @Test func placementIsSingleUndoStep() async throws {
-        // Nested insertTrack/placeClip swaps must stay suppressed: one swap, one undo to revert.
         let h = configured(1920, 1080)
         for id in ["a", "b", "c", "d"] { videoAsset(h, id: id, hasAudio: true) }
         let um = SpyUndoManager()
@@ -150,7 +141,7 @@ struct ApplyLayoutTests {
             ],
         ])
         #expect(r.isError == false)
-        #expect(um.actionNames == ["Apply Layout (Agent)"]) // no leaked "Add Track" swaps
+        #expect(um.actionNames == ["Apply Layout (Agent)"])
 
         let tracksAfter = h.editor.timeline.tracks.count
         #expect(tracksAfter > 1)
@@ -159,8 +150,6 @@ struct ApplyLayoutTests {
         #expect(h.editor.timeline.tracks.flatMap(\.clips).allSatisfy { $0.id == "existing" })
         #expect(um.canUndo == false)
     }
-
-    // MARK: Existing clips / single full
 
     @Test func reLayoutsExistingClipsByClipId() async throws {
         let timeline = Fixtures.timeline(tracks: [
@@ -175,14 +164,13 @@ struct ApplyLayoutTests {
             "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
         ])
         #expect(r.isError == false)
-        #expect(h.editor.timeline.tracks.count == before) // no new tracks, timing untouched
+        #expect(h.editor.timeline.tracks.count == before)
         #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.25))
         #expect(approx(clip(h, id: "cb")!.transform.centerX, 0.75))
         #expect(clip(h, id: "ca")!.startFrame == 0)
     }
 
     @Test func reLayoutClearsAnimationTracks() async throws {
-        // Renderer samples keyframe tracks over static transform/crop, so re-layout must drop them.
         var t = Fixtures.timeline(tracks: [
             Fixtures.videoTrack(clips: [Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60)]),
             Fixtures.videoTrack(clips: [Fixtures.clip(id: "cb", mediaRef: "b", start: 0, duration: 60)]),
@@ -210,11 +198,10 @@ struct ApplyLayoutTests {
         let c = clip(h, id: "ca")!
         #expect(c.positionTrack == nil && c.scaleTrack == nil && c.cropTrack == nil)
         #expect(approx(c.transformAt(frame: 0).centerX, 0.25))
-        #expect(approx(c.transformAt(frame: 60).centerX, 0.25)) // static layout, not animated
+        #expect(approx(c.transformAt(frame: 60).centerX, 0.25))
     }
 
     @Test func reLayoutRejectsSameTrackOverlap() async throws {
-        // Overlapping clips on one track: compositor renders only the first, so reject.
         var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [
             Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60),
             Fixtures.clip(id: "cb", mediaRef: "b", start: 30, duration: 60),
@@ -227,11 +214,10 @@ struct ApplyLayoutTests {
             "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
         ])
         #expect(r.isError)
-        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5)) // untouched
+        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5))
     }
 
     @Test func reLayoutRejectsClipsThatNeverCoincide() async throws {
-        // Disjoint in time on separate tracks: no playhead shows both, so reject.
         var t = Fixtures.timeline(tracks: [
             Fixtures.videoTrack(clips: [Fixtures.clip(id: "ca", mediaRef: "a", start: 0, duration: 60)]),
             Fixtures.videoTrack(clips: [Fixtures.clip(id: "cb", mediaRef: "b", start: 120, duration: 60)]),
@@ -244,12 +230,10 @@ struct ApplyLayoutTests {
             "slots": [["slot": "left", "clipId": "ca"], ["slot": "right", "clipId": "cb"]],
         ])
         #expect(r.isError)
-        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5)) // untouched
+        #expect(approx(clip(h, id: "ca")!.transform.centerX, 0.5))
     }
 
     @Test func fullRefitsSingleClipToCanvasAspect() async throws {
-        // Vertical project, one landscape clip → 'full' covers the frame (no stretch, no bars),
-        // anchorX biases the horizontal crop. No new tracks, timing untouched.
         var t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", mediaRef: "wide", start: 0, duration: 60)])])
         t.width = 1080; t.height = 1920; t.settingsConfigured = true
         let h = ToolHarness(timeline: t)
@@ -264,15 +248,11 @@ struct ApplyLayoutTests {
         #expect(approx(c.transform.width * c.crop.visibleWidthFraction, 1.0))
         #expect(approx(c.transform.height * c.crop.visibleHeightFraction, 1.0))
         #expect(approx((c.transform.width / c.transform.height) * (1080.0 / 1920.0), 16.0 / 9.0, tol: 1e-3))
-        #expect(approx(c.crop.top, 0)) // landscape into portrait crops the sides only
-        #expect(approx(c.crop.left, (c.crop.left + c.crop.right) * 0.3)) // anchorX bias
+        #expect(approx(c.crop.top, 0))
+        #expect(approx(c.crop.left, (c.crop.left + c.crop.right) * 0.3))
     }
 
-    // MARK: Framing anchor
-
     @Test func anchorBiasesCropContinuously() async throws {
-        // Portrait sources into wider slots crop top/bottom. Ordering must be strict:
-        // top (0) < partial nudge (anchorY 0.2) < center (even split); 'top' aligns to slot top.
         let h = configured(1920, 1080)
         for id in ["c", "p", "t"] { videoAsset(h, id: id, w: 1080, ht: 1920) }
         let r = await h.runRaw("apply_layout", args: [
@@ -291,10 +271,8 @@ struct ApplyLayoutTests {
         #expect(approx(top.crop.top, 0))
         #expect(top.crop.top < partial.crop.top && partial.crop.top < center.crop.top)
         #expect(approx(center.crop.top, center.crop.bottom))
-        #expect(approx(top.transform.topLeft.y, 0)) // kept-top region aligns to slot top
+        #expect(approx(top.transform.topLeft.y, 0))
     }
-
-    // MARK: Validation
 
     @Test func rejectsInvalidInput() async {
         let t = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(id: "cx", mediaRef: "a", start: 0, duration: 30)])])


### PR DESCRIPTION
Easier for the agent to crop video layouts and organize footage in common ways instead of trying to toggle x y positions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline edits (new tracks, transforms, crops, cleared motion keyframes) are user-visible and hard to reverse except via undo; logic is well-tested but touches core clip geometry.
> 
> **Overview**
> Adds an **`apply_layout`** agent/MCP tool so split-screen, PIP, grid, and similar compositions land in one undoable step instead of manual transforms and `inspect_timeline` alignment loops.
> 
> **Templates** live in new `VideoLayout` (e.g. `side_by_side`, `pip_*`, `grid_2x2`, `three_up`) with normalized slot rects and PIP z-order. **`layoutPlacement`** on `EditorViewModel` maps each clip to transform + crop: default **`fill`** cover-crops to the slot; **`fit`** letterboxes. **`cropFittingAspect`** now takes **`anchorX`/`anchorY`** (and named anchors) so framing isn’t always centered.
> 
> The executor supports **placement** (`mediaRef` + `startFrame`/`durationFrames`, one video track per slot, linked audio) or **re-layout** (`clipId` only, timing unchanged) with validation for full slots, no mixed modes, overlapping same-track clips, and non-overlapping play ranges. Re-layout clears position/scale/rotation/crop keyframe tracks. Agent instructions and tool schema document layouts and anchors; **`ApplyLayoutTests`** cover geometry, PIP stacking, undo, and errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1298be774f5426be9c15d50823bbb36c87eb88ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->