### PR TITLE
Fix master audio issues

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -180,7 +180,7 @@ extension EditorViewModel {
         return rippleDeleteRangesOnTrack(trackIndex: anchorLoc.trackIndex, ranges: ranges)
     }
 
-    /// Deletes project-frame ranges from one track (spanning any clips) and closes the gaps; cuts linked A/V partners, shifts sync-locked tracks, refuses if any can't absorb.
+    /// Deletes project-frame ranges from one track (spanning any clips) and closes the gaps; cuts linked A/V partners and sync-locked tracks, refuses if any can't absorb.
     /// Tracks in `ignoreSyncLockTrackIndices` are treated as unlocked for this call only
     func rippleDeleteRangesOnTrack(trackIndex: Int, ranges: [FrameRange], ignoreSyncLockTrackIndices: Set<Int> = []) -> RippleRangesOutcome {
         guard timeline.tracks.indices.contains(trackIndex) else {
@@ -202,9 +202,11 @@ extension EditorViewModel {
                 if let l = findClip(id: pid) { clearTrackIds.insert(timeline.tracks[l.trackIndex].id) }
             }
         }
+        for track in timeline.tracks where track.syncLocked && !ignoredTrackIds.contains(track.id) {
+            clearTrackIds.insert(track.id)
+        }
 
-        // Refuse up front if a sync-locked follower can't absorb the shift. These tracks
-        // aren't cleared, so their clips are unchanged when the shift is applied below.
+        // Refuse up front if a sync-locked follower can't absorb the shift after clearing.
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
             guard !clearTrackIds.contains(track.id), track.syncLocked, !ignoredTrackIds.contains(track.id) else { continue }

--- a/Tests/PalmierProTests/Timeline/RippleDeleteRangesTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleDeleteRangesTests.swift
@@ -89,6 +89,18 @@ struct RippleDeleteRangesTests {
         #expect(starts(e.timeline.tracks[1]) == [110])
     }
 
+    @Test func syncLockedFollowerCutInSync() {
+        // Master audio spanning the same span as video gets the cut, not just a shift.
+        let v = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 100)])
+        let a = Fixtures.audioTrack(clips: [Fixtures.clip(id: "a1", start: 0, duration: 100)])
+        let e = editor([v, a])
+        let outcome = e.rippleDeleteRanges(anchorClipId: "c1", ranges: [FrameRange(start: 40, end: 50)])
+        guard case .ok(let report) = outcome else { Issue.record("expected .ok"); return }
+        #expect(report.clearedTracks == 2)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 40], [40, 90]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 40], [40, 90]])
+    }
+
     @Test func trackWideCutSpansMultipleClips() {
         // Two contiguous clips on one track; one call removes a range from each and closes both gaps.
         let track = Fixtures.videoTrack(clips: [
@@ -139,8 +151,8 @@ struct RippleDeleteRangesTests {
         #expect(s.contains([80, 130]))
     }
 
-    @Test func refusesWhenSyncLockedFollowerWouldCollide() {
-        // a2 would slide left onto a1 → whole edit refused, nothing moves.
+    @Test func syncLockedFollowerCutAvoidsShiftCollision() {
+        // a1 is trimmed by the cut so a2 can shift left without overlapping.
         let v = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 100)])
         let a = Fixtures.audioTrack(clips: [
             Fixtures.clip(id: "a1", start: 0, duration: 95),
@@ -148,9 +160,9 @@ struct RippleDeleteRangesTests {
         ])
         let e = editor([v, a])
         let outcome = e.rippleDeleteRanges(anchorClipId: "c1", ranges: [FrameRange(start: 40, end: 50)])
-        guard case .refused = outcome else { Issue.record("expected .refused"); return }
-        #expect(spans(e.timeline.tracks[0]) == [[0, 100]])
-        #expect(starts(e.timeline.tracks[1]) == [0, 100])
+        guard case .ok = outcome else { Issue.record("expected .ok"); return }
+        #expect(spans(e.timeline.tracks[0]) == [[0, 40], [40, 90]])
+        #expect(spans(e.timeline.tracks[1]) == [[0, 40], [40, 85], [90, 140]])
     }
 
     @Test func ignoreSyncLockedTracksLetsCutProceedAndLeavesThemInPlace() {


### PR DESCRIPTION
From X: https://x.com/MrDaveFoy/status/2070789489929138460?s=20

For “master on its own track + camera + screen, edits stay in sync”:

Place and align with sync_audio (master = reference).
Mute scratch on V1/V2.
Keep master on a sync-locked audio track.
Edit from video or master — ripple cuts now propagate to master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline ripple-delete behavior for all sync-locked tracks; mistakes could desync tracks or allow collisions, though behavior is covered by updated tests.
> 
> **Overview**
> **Ripple range deletes** now apply the same frame cuts to **sync-locked** tracks (e.g. master audio) as on the anchor video track, instead of only shifting clips that start after the removed span.
> 
> `rippleDeleteRangesOnTrack` adds every non-ignored sync-locked track to `clearTrackIds`, so `clearRegion` runs on those tracks and downstream ripple shifts are validated **after** that trimming. Edits from video or master therefore stay aligned when master lives on its own sync-locked audio track.
> 
> Tests cover aligned master/video getting matching spans, and a case that previously refused the edit now succeeds because the leading audio clip is trimmed by the cut so a later clip can ripple left without colliding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ef3b3aa973f3107950afa819e401029bed31b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->