### PR TITLE
docs: document macOS-only constraint for Cursor Cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,12 @@ Palmier Pro speaks like a quietly capable native Mac app for filmmakers: direct,
 confident. Prefer Apple HIG-style terseness over warmth. Never chatty or cute. Never marketing. When the
 product needs to ask for action, lead with the action verb; when it reports state, name the thing.
 
+## Cursor Cloud specific instructions
+
+This project **cannot be built, run, or tested on the Cursor Cloud VM**, which is Linux/x86_64. PalmierPro is a macOS-only GUI app: `Package.swift` pins `.macOS(.v26)` (Tahoe) on Apple Silicon, ~150 source files import Apple-only frameworks (`AppKit`, `SwiftUI`, `AVFoundation`, `Metal`, `Cocoa`), the SPM dependencies (`Sparkle`, `sentry-cocoa`, `clerk-ios`, `lottie-ios`) are Apple-platform-only, the `MetalCIKernelPlugin` build tool needs Apple's Metal toolchain, and `scripts/bundle.sh`/`scripts/dev.sh` rely on `codesign`, `install_name_tool`, `dsymutil`, `xcrun`, `hdiutil`, and `PlistBuddy`.
+
+Consequences for cloud agents:
+- `swift build` / `swift run` / `swift test` will fail on Linux even if a Swift toolchain is installed — `import AppKit` and the macOS-only packages do not resolve there. The test target depends on the main target, so nothing in `Tests/` is Linux-testable either.
+- There is no useful dependency install step for this repo on Linux; the startup update script is intentionally a no-op.
+- Lint/build/run/test must be done on a macOS 26 + Xcode 16 + Swift 6.2 machine using the commands in `CONTRIBUTING.md` (`swift build`, `swift run`, `swift test`, `./scripts/dev.sh`). Make code-only changes here and verify them on macOS.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Environment setup for the Cursor Cloud VM. PalmierPro is a **macOS-only GUI application** and cannot be built, run, or tested on the Linux/x86_64 Cloud VM. This PR documents that constraint so future cloud agents don't waste effort attempting an impossible build.

## Why it can't run on the Cloud VM

- `Package.swift` pins `.macOS(.v26)` (Tahoe) on Apple Silicon — no Linux platform.
- ~150 source files import Apple-only frameworks: `AppKit`, `SwiftUI`, `AVFoundation`, `Metal`, `Cocoa`.
- SPM dependencies are Apple-platform-only: `Sparkle`, `sentry-cocoa`, `clerk-ios`, `lottie-ios`.
- `MetalCIKernelPlugin` build tool requires Apple's Metal toolchain.
- `scripts/bundle.sh` / `scripts/dev.sh` depend on `codesign`, `install_name_tool`, `dsymutil`, `xcrun`, `hdiutil`, `PlistBuddy`.

The Cloud VM is Ubuntu 24.04 / x86_64 with no Swift, Xcode, or macOS frameworks. `swift build`/`run`/`test` fail on Linux even with a Swift toolchain installed, since `import AppKit` and the macOS-only packages don't resolve.

## Changes

- Add `## Cursor Cloud specific instructions` to `AGENTS.md` explaining the macOS-only constraint and pointing to `CONTRIBUTING.md` for the real (macOS) build/run/test commands.

The startup update script is intentionally a no-op (nothing to install on Linux).

## Testing

No build/run/test possible on this Linux VM (documented above). Lint/build/run/test must be performed on macOS 26 + Xcode 16 + Swift 6.2 via `swift build`, `swift run`, `swift test`, `./scripts/dev.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b026fbc7-bbf7-4e48-83f7-54d83af16471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b026fbc7-bbf7-4e48-83f7-54d83af16471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

