### PR TITLE
fix(captions): deterministic transcripts via single full-file cache path

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -463,10 +463,10 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addCaptions,
-            description: "Transcribes spoken audio and creates styled caption text clips. Omit clipIds to auto-pick speech; pass clipIds to caption specific audio/video clips. Per-word animations are timed from transcript.",
+            description: "Transcribes spoken audio and creates styled caption text clips. By default — clipIds omitted — captions the timeline's main spoken audio; prefer this, it's the most consistent. Only pass clipIds to caption a specific clip or part. Per-word animations are timed from transcript.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
-                    "clipIds": ["type": "array", "items": ["type": "string"], "description": "Audio/video clips to caption."],
+                    "clipIds": ["type": "array", "items": ["type": "string"], "description": "Optional. Scope captioning to these audio/video clips. Omit (default) to caption the timeline's main spoken audio."],
                     "language": ["type": "string", "description": "BCP-47 speech language."],
                     "centerX": ["type": "number", "description": "0-1 horizontal center."],
                     "centerY": ["type": "number", "description": "0-1 vertical center."],

--- a/Sources/PalmierPro/Settings/StoragePane.swift
+++ b/Sources/PalmierPro/Settings/StoragePane.swift
@@ -14,7 +14,7 @@ struct StoragePane: View {
                     Text("Cache")
                         .font(.system(size: AppTheme.FontSize.md))
                         .foregroundStyle(AppTheme.Text.primaryColor)
-                    Text("Saved playback previews, waveforms, and filmstrip thumbnails. Safe to clear; they'll rebuild as needed.")
+                    Text("Saved playback previews, waveforms, filmstrip thumbnails, and transcripts. Safe to clear; they'll rebuild as needed.")
                         .font(.system(size: AppTheme.FontSize.sm))
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
                         .fixedSize(horizontal: false, vertical: true)
@@ -99,7 +99,7 @@ struct StoragePane: View {
         }
     }
 
-    private nonisolated static let caches = [ImageVideoGenerator.cache, MediaVisualCache.diskCache]
+    private nonisolated static let caches = [ImageVideoGenerator.cache, MediaVisualCache.diskCache, DiskCache(directory: TranscriptCache.directory)]
 
     private var displayPath: String {
         DiskCache.rootDirectory.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")

--- a/Sources/PalmierPro/Settings/StoragePane.swift
+++ b/Sources/PalmierPro/Settings/StoragePane.swift
@@ -114,6 +114,7 @@ struct StoragePane: View {
         isClearing = true
         Task.detached {
             for cache in Self.caches { cache.clear() }
+            await TranscriptCache.shared.clearMemory()
             await MainActor.run { isClearing = false }
             await refresh()
         }

--- a/Sources/PalmierPro/Transcription/TranscriptCache.swift
+++ b/Sources/PalmierPro/Transcription/TranscriptCache.swift
@@ -2,7 +2,6 @@ import CryptoKit
 import Foundation
 
 /// Disk + memory cache for full-file transcripts, keyed by file identity so edits invalidate naturally.
-/// Only full transcripts are cached. Windowed requests are served by filtering a cached full transcript.
 actor TranscriptCache {
     static let shared = TranscriptCache()
 
@@ -16,20 +15,18 @@ actor TranscriptCache {
                 ? try await Transcription.transcribeVideoAudio(videoURL: url, preferredLocale: preferredLocale, sourceRange: range)
                 : try await Transcription.transcribe(fileURL: url, preferredLocale: preferredLocale, sourceRange: range)
         }
+        // Cache full transcripts only; windowed calls filter the cached result for consistency.
         let key = Self.key(for: url)
-        if let key, let full = cached(key) {
-            return range.map { Self.filter(full, to: $0) } ?? full
+        let full: TranscriptionResult
+        if let key, let cached = cached(key) {
+            full = cached
+        } else {
+            full = isVideo
+                ? try await Transcription.transcribeVideoAudio(videoURL: url)
+                : try await Transcription.transcribe(fileURL: url)
+            if let key { store(full, key: key) }
         }
-        if let range {
-            return isVideo
-                ? try await Transcription.transcribeVideoAudio(videoURL: url, sourceRange: range)
-                : try await Transcription.transcribe(fileURL: url, sourceRange: range)
-        }
-        let full = isVideo
-            ? try await Transcription.transcribeVideoAudio(videoURL: url)
-            : try await Transcription.transcribe(fileURL: url)
-        if let key { store(full, key: key) }
-        return full
+        return range.map { Self.filter(full, to: $0) } ?? full
     }
 
     static func filter(_ r: TranscriptionResult, to range: ClosedRange<Double>) -> TranscriptionResult {
@@ -65,7 +62,7 @@ actor TranscriptCache {
         memory[key] = result
     }
 
-    private static let directory = FileManager.default
+    static let directory = FileManager.default
         .urls(for: .cachesDirectory, in: .userDomainMask)[0]
         .appendingPathComponent("\(Log.subsystem)/Transcripts", isDirectory: true)
 

--- a/Sources/PalmierPro/Transcription/TranscriptCache.swift
+++ b/Sources/PalmierPro/Transcription/TranscriptCache.swift
@@ -62,6 +62,9 @@ actor TranscriptCache {
         memory[key] = result
     }
 
+    /// Drop in-memory entries so a disk clear isn't shadowed by the memory cache.
+    func clearMemory() { memory.removeAll() }
+
     static let directory = FileManager.default
         .urls(for: .cachesDirectory, in: .userDomainMask)[0]
         .appendingPathComponent("\(Log.subsystem)/Transcripts", isDirectory: true)

--- a/Sources/PalmierPro/Utilities/DiskCache.swift
+++ b/Sources/PalmierPro/Utilities/DiskCache.swift
@@ -8,7 +8,11 @@ struct DiskCache: Sendable {
     let directory: URL
 
     init(named name: String) {
-        directory = Self.rootDirectory.appendingPathComponent(name, isDirectory: true)
+        self.init(directory: Self.rootDirectory.appendingPathComponent(name, isDirectory: true))
+    }
+
+    init(directory: URL) {
+        self.directory = directory
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 


### PR DESCRIPTION
## Problem

Caption generation was non-deterministic. The same clip captioned twice could produce different word boundaries and timings depending on cache state.

`TranscriptCache` had two recognition bases:
- If a full-file transcript was already cached (by indexing / `get_transcript` / `inspect_media`), windowed requests **filtered** it — full-file recognition.
- If not cached, a windowed request transcribed just the padded clip window (and didn't cache it) — windowed recognition.

`SpeechTranscriber` places word boundaries differently given the whole file vs. a short window, and the windowed path also adds an extract-offset. So which basis a run hit — and thus where captions landed — depended on whether background indexing had populated the cache yet. This could even make tab-vs-tab generations differ.

## Fix

Single transcription path: always transcribe the whole file, cache it, and serve windowed requests by filtering that one result. Every caller (captions, `get_transcript`, `inspect_media`, indexing) now reads identical word timestamps for a given file → same clips and timing every run, regardless of order.

Also: **Settings → Clear cache** now wipes transcripts (previously untouched, with no UI to purge them), giving an escape hatch for stale entries cached before this change. Added `DiskCache(directory:)` and included `TranscriptCache.directory` in the swept/sized caches.

Trade-off: the first caption on a long source now transcribes the whole file instead of just the window — slower up front, cached after; indexing already does full-file transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transcription/caching behavior used by captions and search indexing; first caption on long media may do a full-file transcribe instead of a window, with a possible one-time perf hit until cached.
> 
> **Overview**
> **Caption timing is now consistent** by routing every cached transcript request through one path: transcribe the **whole file**, store it, and **filter** when a time window is requested. The old split between “filter a cached full transcript” vs “transcribe only the clip window” (different word boundaries) is removed, so captions, indexing, `get_transcript`, and `inspect_media` share the same word timestamps for a file.
> 
> **Settings → Clear cache** now includes **transcript** disk data in size and wipe, and clears the in-memory transcript cache so a disk clear isn’t shadowed. `DiskCache` gains `init(directory:)` so the transcript cache directory can be swept like other caches.
> 
> **Agent `add_captions`** tool text is updated to prefer omitting `clipIds` (main spoken audio) and only pass `clipIds` when scoping to a specific clip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c65ab06f8c7685ed2310bdd68737c01c4942bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->