### PR TITLE
fix(agent): add_clips no longer changes project fps

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
@@ -95,24 +95,28 @@ extension ToolExecutor {
         return .ok("Updated: \(changes.joined(separator: ", ")). Now \(newWidth)×\(newHeight) @ \(newFPS)fps.")
     }
 
-    /// Mirrors the UI's first-clip settings check: auto-applies timeline settings to match
-    /// the first video asset when the timeline is empty or unconfigured.
-    /// Returns a note string if settings changed, nil otherwise.
+    /// Syncs timeline resolution with the first clip if needed; returns a note if changed, nil otherwise.
     func applySettingsIfNeededForAgent(_ editor: EditorViewModel, assets: [MediaAsset]) -> String? {
-        let prevFPS = editor.timeline.fps
         let prevWidth = editor.timeline.width
         let prevHeight = editor.timeline.height
 
-        switch editor.checkProjectSettings(for: assets) {
+        // adoptFPS: false — only resolution syncs, fps stays unchanged.
+        var notes: [String] = []
+        switch editor.checkProjectSettings(for: assets, adoptFPS: false) {
         case .proceed:
-            // checkProjectSettings silently auto-applied on the first-ever clip when !settingsConfigured
-            guard editor.timeline.fps != prevFPS
-                    || editor.timeline.width != prevWidth
-                    || editor.timeline.height != prevHeight else { return nil }
-            return "Set timeline to \(editor.timeline.width)×\(editor.timeline.height) @ \(editor.timeline.fps)fps to match clip."
-        case .mismatch(let fps, let width, let height):
-            editor.applyTimelineSettings(fps: fps, width: width, height: height)
-            return "Matched timeline to clip: \(width)×\(height) @ \(fps)fps."
+            if editor.timeline.width != prevWidth || editor.timeline.height != prevHeight {
+                notes.append("Set timeline to \(editor.timeline.width)×\(editor.timeline.height) to match clip.")
+            }
+        case .mismatch(_, let width, let height):
+            editor.applyTimelineSettings(fps: editor.timeline.fps, width: width, height: height)
+            notes.append("Matched timeline resolution to clip: \(width)×\(height).")
         }
+
+        if let clipFPS = assets.first(where: { $0.type == .video })?.sourceFPS.flatMap({ Int($0.rounded()) }),
+           clipFPS != editor.timeline.fps {
+            notes.append("Clip is \(clipFPS)fps but project is \(editor.timeline.fps)fps; clips placed at \(editor.timeline.fps)fps and frame counts are interpreted at \(editor.timeline.fps)fps. To conform, call set_project_settings then re-read get_timeline.")
+        }
+
+        return notes.isEmpty ? nil : notes.joined(separator: " ")
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -98,7 +98,7 @@ extension EditorViewModel {
         abs(transform.width - other.width) < 0.0001 && abs(transform.height - other.height) < 0.0001
     }
 
-    func checkProjectSettings(for assets: [MediaAsset]) -> ProjectSettingsAction {
+    func checkProjectSettings(for assets: [MediaAsset], adoptFPS: Bool = true) -> ProjectSettingsAction {
         guard let firstVideo = assets.first(where: { $0.type == .video }) else {
             return .proceed
         }
@@ -107,7 +107,7 @@ extension EditorViewModel {
 
         if !timeline.settingsConfigured {
             // First clip ever — auto-detect settings silently
-            let fps = firstVideo.sourceFPS.flatMap { Int($0.rounded()) } ?? timeline.fps
+            let fps = adoptFPS ? (firstVideo.sourceFPS.flatMap { Int($0.rounded()) } ?? timeline.fps) : timeline.fps
             let width = firstVideo.sourceWidth ?? timeline.width
             let height = firstVideo.sourceHeight ?? timeline.height
             applyTimelineSettings(fps: fps, width: width, height: height)
@@ -123,13 +123,13 @@ extension EditorViewModel {
         let clipWidth = firstVideo.sourceWidth
         let clipHeight = firstVideo.sourceHeight
 
-        let fpsMismatch = clipFPS != nil && clipFPS != timeline.fps
+        let fpsMismatch = adoptFPS && clipFPS != nil && clipFPS != timeline.fps
         let resMismatch = (clipWidth != nil && clipWidth != timeline.width) ||
                           (clipHeight != nil && clipHeight != timeline.height)
 
         if fpsMismatch || resMismatch {
             return .mismatch(
-                clipFPS: clipFPS ?? timeline.fps,
+                clipFPS: adoptFPS ? (clipFPS ?? timeline.fps) : timeline.fps,
                 clipWidth: clipWidth ?? timeline.width,
                 clipHeight: clipHeight ?? timeline.height
             )


### PR DESCRIPTION
## Problem

Placing a clip via `add_clips` (and `insert_clips` / `apply_layout`) silently adopted the source clip's fps onto the project. If the agent had already computed `startFrame` / `durationFrames` against the previous fps, that math was invalidated without warning — frame counts then meant a different wall-clock duration.

The mental model was inverted: the timeline should be the authority that clips conform to, not the reverse. fps should be a deliberate setting, not a side effect of dropping a clip.

## Fix

The agent placement path no longer mutates project fps:
- Clips are placed at the existing project fps, so prior frame math stays valid.
- Resolution still matches the clip (doesn't affect frame timing).
- When the source fps diverges, the response warns loudly and points to `set_project_settings` + re-read `get_timeline`.

Implemented via an `adoptFPS` flag on `checkProjectSettings` (defaults `true`). The UI first-import/auto-config and mismatch-prompt behavior is unchanged; only the agent path passes `adoptFPS: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared project-settings logic used by both UI and agent; incorrect `adoptFPS` wiring could affect first-import or mismatch behavior, though defaults preserve existing UI paths.
> 
> **Overview**
> Agent clip placement (`add_clips`, `insert_clips`, `apply_layout`) no longer silently adopts the source clip’s fps. **`checkProjectSettings`** gains an **`adoptFPS`** flag (default **`true`**); the UI import/mismatch flow is unchanged, while **`applySettingsIfNeededForAgent`** calls it with **`adoptFPS: false`**.
> 
> On mismatch, the agent still updates **resolution** only (fps is passed through unchanged). User-facing notes no longer claim fps was matched; if clip fps differs from the project, the tool response adds an explicit warning that frame math uses project fps and points to **`set_project_settings`** + **`get_timeline`** to conform deliberately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2bdda997ec48654f3c4f583564ac254cce8e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->