### PR TITLE
[tutorial] add skills to tutorial

### DIFF
--- a/Sources/PalmierPro/Editor/Tour/TourController.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourController.swift
@@ -35,12 +35,14 @@ enum TourAnchorID: Hashable {
     case generation
     case smartSearch
     case screenshotButton
+    case skillsButton
     case timelineRuler
 
     var hostPanel: EditorViewModel.FocusedPanel {
         switch self {
         case .importButton, .generateButton, .generation, .smartSearch: return .media
         case .screenshotButton: return .preview
+        case .skillsButton: return .agent
         case .timelineRuler: return .timeline
         }
     }
@@ -153,6 +155,8 @@ final class TourController {
                      instruction: "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range."),
             TourStep(kind: .spotlight(.panel(.agent)), title: "AI agent",
                      instruction: "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key."),
+            TourStep(kind: .spotlight(.element(.skillsButton)), title: "Skills",
+                     instruction: "Open Skills to browse community playbooks, create your own, or add them to other agents."),
             TourStep(kind: .outro, title: "You're all set",
                      instruction: "Start creating, or explore these to get the most out of Palmier Pro."),
         ]

--- a/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
@@ -155,6 +155,7 @@ struct TourOverlay: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             VStack(spacing: 0) {
+                linkRow("Skills", "book.closed.fill") { SettingsWindowController.shared.show(tab: .skills) }
                 linkRow("MCP Setup", "puzzlepiece.extension.fill") { HelpWindowController.shared.show(tab: .mcp) }
                 linkRow("Keyboard Shortcuts", "keyboard") { HelpWindowController.shared.show(tab: .shortcuts) }
                 linkRow("Documentation", "book.fill") { NSWorkspace.shared.open(Self.docsURL, configuration: .init(), completionHandler: nil) }

--- a/Sources/PalmierPro/UI/ViewSkillsButton.swift
+++ b/Sources/PalmierPro/UI/ViewSkillsButton.swift
@@ -11,6 +11,7 @@ struct ViewSkillsButton: View {
         .buttonStyle(.plain)
         .focusable(false)
         .help("View Skills")
+        .tourAnchor(.skillsButton)
     }
 
     private func openSkills() {


### PR DESCRIPTION
## Summary
- Add a Skills spotlight step to the tutorial agent section.
- Add Skills as the first link in the tutorial ending card.
<img width="551" height="300" alt="Screenshot 2026-06-29 at 11 54 23 PM" src="https://github.com/user-attachments/assets/e6c703d6-b978-4cc7-8950-0f4887adfec4" />
<img width="686" height="376" alt="Screenshot 2026-06-29 at 11 54 40 PM" src="https://github.com/user-attachments/assets/a857e441-5eea-469a-9da6-ee6faca0c151" />

## Impact
Users can discover the Skills pane from the guided tour and from the final tutorial links.

## Validation
- swift build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tutorial copy and navigation only; no changes to agent, settings, or skills behavior beyond discovery links.
> 
> **Overview**
> The guided tour now highlights **Skills** so users can find community playbooks and custom skills from the agent area.
> 
> After the **AI agent** panel step, a new spotlight targets the agent header **Skills** button (via a new `skillsButton` tour anchor on `ViewSkillsButton`). The final **You're all set** card adds **Skills** as the first quick link, opening Settings on the Skills tab—same destination as the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c024960f9cb67e2b69654a18d5281b79a67d335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->