### PR TITLE
feat(mcp): project navigation tools (get/open/new project)

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -451,8 +451,14 @@ final class AgentService {
         }
     }
 
+    private func nextNonSystemIndex(after index: Int) -> Int {
+        var next = index + 1
+        while next < messages.count, messages[next].role == .system { next += 1 }
+        return next
+    }
+
     private func resolvedToolUseIds(afterAssistantAt index: Int) -> Set<String> {
-        let next = index + 1
+        let next = nextNonSystemIndex(after: index)
         guard next < messages.count, messages[next].role == .user else { return [] }
         return Set(messages[next].blocks.compactMap {
             if case let .toolResult(id, _, _) = $0 { return id }
@@ -471,7 +477,7 @@ final class AgentService {
             }
             guard !toolUseIds.isEmpty else { continue }
 
-            let next = i + 1
+            let next = nextNonSystemIndex(after: i)
             let nextIsToolResult = next < messages.count
                 && messages[next].role == .user
                 && messages[next].blocks.contains(where: {

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -320,6 +320,7 @@ final class AgentService {
     func postSystemNotice(_ text: String) {
         messages.append(AgentMessage(role: .system, blocks: [.text(text)]))
         syncMessagesIntoCurrentSession()
+        onSessionsChanged?()
     }
 
     func cancel() {

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -317,6 +317,11 @@ final class AgentService {
         kickOffStream()
     }
 
+    func postSystemNotice(_ text: String) {
+        messages.append(AgentMessage(role: .system, blocks: [.text(text)]))
+        syncMessagesIntoCurrentSession()
+    }
+
     func cancel() {
         currentTask?.cancel()
         currentTask = nil
@@ -355,7 +360,7 @@ final class AgentService {
 
             do {
                 let stream = client.stream(
-                    system: AgentInstructions.serverInstructions + SkillStore.shared.promptIndex,
+                    system: AgentInstructions.serverInstructions + AgentInstructions.skillsSection(SkillStore.shared.skillIndex),
                     tools: tools,
                     messages: apiMsgs
                 )
@@ -513,6 +518,7 @@ final class AgentService {
     private func apiMessages() async -> [AnthropicMessage] {
         var result: [AnthropicMessage] = []
         for msg in messages {
+            if msg.role == .system { continue }
             var content = msg.blocks.compactMap(Self.contentBlockJSON)
             if msg.role == .user, !msg.mentions.isEmpty {
                 let inlined = await inlineImageBlocks(for: msg.mentions)
@@ -602,7 +608,7 @@ final class AgentService {
 }
 
 struct AgentMessage: Identifiable, Codable {
-    enum Role: String, Codable { case user, assistant }
+    enum Role: String, Codable { case user, assistant, system }
     let id: UUID
     let role: Role
     var blocks: [AgentContentBlock]

--- a/Sources/PalmierPro/Agent/MCP/MCPService.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPService.swift
@@ -37,7 +37,7 @@ final class MCPService {
             let server = Server(
                 name: "palmier-pro",
                 version: "1.0.0",
-                instructions: AgentInstructions.serverInstructions,
+                instructions: AgentInstructions.serverInstructions + AgentInstructions.projectNavigation,
                 capabilities: .init(
                     resources: .init(subscribe: false, listChanged: false),
                     tools: .init(listChanged: false)
@@ -70,7 +70,7 @@ final class MCPService {
     }
 
     private func registerTools(on server: Server) async {
-        let tools: [Tool] = ToolDefinitions.all.map { def in
+        let tools: [Tool] = ToolDefinitions.mcpServer.map { def in
             Tool(name: def.name.rawValue, description: def.description, inputSchema: def.mcpSchemaValue)
         }
 

--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -10,6 +10,25 @@ struct AgentMessageView: View {
         switch message.role {
         case .user:   userBody
         case .assistant: assistantBody
+        case .system: systemBody
+        }
+    }
+
+    @ViewBuilder
+    private var systemBody: some View {
+        let texts = message.blocks.compactMap { block -> String? in
+            if case let .text(s) = block { return s }
+            return nil
+        }
+        if !texts.isEmpty {
+            HStack {
+                Spacer(minLength: 0)
+                Text(texts.joined(separator: "\n"))
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .multilineTextAlignment(.center)
+                Spacer(minLength: 0)
+            }
         }
     }
 

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -193,19 +193,9 @@ final class SkillStore {
 
     func body(for id: String) -> String? { bodyCache[id] }
 
-    /// The always-on index appended to the in-app assistant's system prompt: one line
-    /// per skill so the model knows what's available; full bodies load via read_skill.
-    var promptIndex: String {
-        guard !skills.isEmpty else { return "" }
-        let lines = skills.map { "- \($0.id): \($0.description)" }.joined(separator: "\n")
-        return """
-
-
-            # Skills
-            Playbooks for specific tasks. Before a task that matches one, call read_skill(id) \
-            to load its full procedure, then follow it.
-            \(lines)
-            """
+    /// One-line list of skills; full content loads on demand.
+    var skillIndex: String {
+        skills.map { "- \($0.id): \($0.description)" }.joined(separator: "\n")
     }
 
     func openFolder() {

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -207,8 +207,8 @@ enum AgentInstructions {
           Call this first when unsure what's available.
         - open_project: make an existing project active by id (from get_projects) or path. \
           Editing tools then target it.
-        - new_project: create and open a fresh project. Give it a name; it lands in the \
-          default location unless you pass a directory. Fails if that name already exists there.
+        - new_project: create and open a fresh project. Give it a name; it's created in the \
+          Palmier Pro folder. Fails if that name already exists there.
         Only one project is active at a time — opening or creating one switches the active \
         project, and the user sees the window change.
         """

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -196,4 +196,32 @@ enum AgentInstructions {
         - When the user is vague about aesthetic direction, ask one focused question instead \
           of guessing.
         """
+
+    /// MCP server only
+    static let projectNavigation: String = """
+
+        # Projects
+        These tools choose which project you edit — every other tool acts on the active \
+        project, and you may start with none open.
+        - get_projects: list known projects (id, name, path, whether open, which is active). \
+          Call this first when unsure what's available.
+        - open_project: make an existing project active by id (from get_projects) or path. \
+          Editing tools then target it.
+        - new_project: create and open a fresh project. Give it a name; it lands in the \
+          default location unless you pass a directory. Fails if that name already exists there.
+        Only one project is active at a time — opening or creating one switches the active \
+        project, and the user sees the window change.
+        """
+
+    /// In-app agent only
+    static func skillsSection(_ index: String) -> String {
+        guard !index.isEmpty else { return "" }
+        return """
+
+            # Skills
+            Playbooks for specific tasks. Before a task that matches one, call read_skill(id) \
+            to load its full procedure, then follow it.
+            \(index)
+            """
+    }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -898,7 +898,7 @@ enum ToolDefinitions {
     /// MCP server only
     static let getProjects = AgentTool(
         name: .getProjects,
-        description: "List the user's known projects, most recently opened first: each entry's id, name, path, whether it's currently open, and whether it's the active project (the one editing tools act on). Call this to discover what's available before open_project, or to find out which project is active. Takes no arguments.",
+        description: "List the user's known projects, most recently opened first: each entry's id, name, path, whether it's currently open, and whether it's the active project (the one editing tools act on). Also returns a top-level `active` (name, path) for the current project, which may not appear in the list. Call this to discover what's available before open_project, or to find out which project is active. Takes no arguments.",
         inputSchema: objectSchema()
     )
 

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -44,6 +44,9 @@ enum ToolName: String, CaseIterable, Sendable {
     case sendFeedback = "send_feedback"
     case setProjectSettings = "set_project_settings"
     case readSkill = "read_skill"
+    case getProjects = "get_projects"
+    case openProject = "open_project"
+    case newProject = "new_project"
 }
 
 struct AgentTool: @unchecked Sendable {
@@ -880,7 +883,7 @@ enum ToolDefinitions {
             .joined(separator: "\n")
     }
 
-    /// In-app assistant only. Not registered with the MCP server
+    /// In-app assistant only
     static let readSkill = AgentTool(
         name: .readSkill,
         description: "Load the full instructions for one of the skills listed under # Skills in your system prompt. Call this before starting a task that matches a skill's description, then follow the returned procedure. Pass the id exactly as listed.",
@@ -892,7 +895,36 @@ enum ToolDefinitions {
         )
     )
 
-    /// Tools for the in-app agent: every MCP tool plus read_skill.
+    /// MCP server only
+    static let getProjects = AgentTool(
+        name: .getProjects,
+        description: "List the user's known projects, most recently opened first: each entry's id, name, path, whether it's currently open, and whether it's the active project (the one editing tools act on). Call this to discover what's available before open_project, or to find out which project is active. Takes no arguments.",
+        inputSchema: objectSchema()
+    )
+
+    static let openProject = AgentTool(
+        name: .openProject,
+        description: "Open a project and make it the active one — every editing tool then acts on it. Identify it by `id` (from get_projects) or by `path` to a .palmier package. If it's already open, it's brought to front. Returns the now-active project and how many are open. The user sees the window change.",
+        inputSchema: objectSchema(
+            properties: [
+                "id": ["type": "string", "description": "Project id from get_projects. Provide this or path."],
+                "path": ["type": "string", "description": "Filesystem path to a .palmier package. Provide this or id."],
+            ]
+        )
+    )
+
+    static let newProject = AgentTool(
+        name: .newProject,
+        description: "Create a new empty project in the user's Palmier Pro folder and make it active. Fails if a project with that name already exists — pick another name. Returns the new project's name and path.",
+        inputSchema: objectSchema(
+            properties: [
+                "name": ["type": "string", "description": "Project name (without extension). Defaults to 'Untitled Project'."],
+            ]
+        )
+    )
+
+
+    static var mcpServer: [AgentTool] { all + [getProjects, openProject, newProject] }
     static var inAppAgent: [AgentTool] { all + [readSkill] }
 
     private static func textBoxTransformProperties() -> [String: [String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
@@ -22,7 +22,8 @@ extension ToolExecutor {
     private func getProjects() throws -> ToolResult {
         let openDocs = AppState.shared.openProjects
         let openURLs = Set(openDocs.compactMap { $0.fileURL?.standardizedFileURL })
-        let activeURL = AppState.shared.activeProject?.fileURL?.standardizedFileURL
+        let active = AppState.shared.activeProject
+        let activeURL = active?.fileURL?.standardizedFileURL
 
         // Only registered projects, sorted by most recently opened.
         let projects = ProjectRegistry.shared.sortedEntries.map { entry -> [String: Any] in
@@ -37,7 +38,10 @@ extension ToolExecutor {
             ]
         }
 
-        let payload: [String: Any] = ["openCount": openDocs.count, "projects": projects]
+        var payload: [String: Any] = ["openCount": openDocs.count, "projects": projects]
+        if let active {
+            payload["active"] = ["name": active.displayName ?? Project.defaultProjectName, "path": active.fileURL?.path ?? ""]
+        }
         return .ok(Self.jsonString(payload) ?? "{}")
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
@@ -20,7 +20,7 @@ extension ToolExecutor {
     }
 
     private func getProjects() throws -> ToolResult {
-        let openDocs = Self.openProjects()
+        let openDocs = AppState.shared.openProjects
         let openURLs = Set(openDocs.compactMap { $0.fileURL?.standardizedFileURL })
         let activeURL = AppState.shared.activeProject?.fileURL?.standardizedFileURL
 
@@ -48,7 +48,7 @@ extension ToolExecutor {
         }
         let doc = try await AppState.shared.openProjectAsync(at: url)
         notifyNowEditing(doc)
-        return .ok("Now editing “\(doc.displayName ?? Project.defaultProjectName)”. \(Self.openProjects().count) project(s) open.")
+        return .ok("Now editing “\(doc.displayName ?? Project.defaultProjectName)”. \(AppState.shared.openProjects.count) project(s) open.")
     }
 
     private func newProject(_ args: [String: Any]) async throws -> ToolResult {
@@ -74,9 +74,5 @@ extension ToolExecutor {
     private func notifyNowEditing(_ doc: VideoProject) {
         let name = doc.displayName ?? Project.defaultProjectName
         doc.editorViewModel.agentService.postSystemNotice("Now editing: \(name)")
-    }
-
-    private static func openProjects() -> [VideoProject] {
-        NSDocumentController.shared.documents.compactMap { $0 as? VideoProject }
     }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Projects.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+
+/// MCP server-only project navigation. Runs on AppState/ProjectRegistry before editor loads.
+extension ToolExecutor {
+
+    func runProjectTool(_ tool: ToolName, _ args: [String: Any]) async -> ToolResult {
+        do {
+            switch tool {
+            case .getProjects: return try getProjects()
+            case .openProject: return try await openProject(args)
+            case .newProject:  return try await newProject(args)
+            default:           return .error("Not a project tool: \(tool.rawValue)")
+            }
+        } catch let err as ToolError {
+            return .error(err.message)
+        } catch {
+            return .error(error.localizedDescription)
+        }
+    }
+
+    private func getProjects() throws -> ToolResult {
+        let openDocs = Self.openProjects()
+        let openURLs = Set(openDocs.compactMap { $0.fileURL?.standardizedFileURL })
+        let activeURL = AppState.shared.activeProject?.fileURL?.standardizedFileURL
+
+        // Only registered projects, sorted by most recently opened.
+        let projects = ProjectRegistry.shared.sortedEntries.map { entry -> [String: Any] in
+            let url = entry.url.standardizedFileURL
+            return [
+                "id": entry.id.uuidString,
+                "name": entry.name,
+                "path": entry.url.path,
+                "isOpen": openURLs.contains(url),
+                "isActive": activeURL == url,
+                "isAccessible": entry.isAccessible,
+            ]
+        }
+
+        let payload: [String: Any] = ["openCount": openDocs.count, "projects": projects]
+        return .ok(Self.jsonString(payload) ?? "{}")
+    }
+
+    private func openProject(_ args: [String: Any]) async throws -> ToolResult {
+        let url = try resolveProjectURL(args)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ToolError("No project at \(url.path).")
+        }
+        let doc = try await AppState.shared.openProjectAsync(at: url)
+        notifyNowEditing(doc)
+        return .ok("Now editing “\(doc.displayName ?? Project.defaultProjectName)”. \(Self.openProjects().count) project(s) open.")
+    }
+
+    private func newProject(_ args: [String: Any]) async throws -> ToolResult {
+        let name = args.string("name") ?? Project.defaultProjectName
+        let doc = try await AppState.shared.createProject(named: name)
+        notifyNowEditing(doc)
+        return .ok("Created and now editing “\(doc.displayName ?? name)” at \(doc.fileURL?.path ?? "").")
+    }
+
+    private func resolveProjectURL(_ args: [String: Any]) throws -> URL {
+        if let path = args.string("path"), !path.isEmpty {
+            return URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        }
+        if let id = args.string("id"), !id.isEmpty {
+            guard let entry = ProjectRegistry.shared.entries.first(where: { $0.id.uuidString == id }) else {
+                throw ToolError("No project with id \(id). Call get_projects for valid ids.")
+            }
+            return entry.url
+        }
+        throw ToolError("open_project needs an id (from get_projects) or a path.")
+    }
+
+    private func notifyNowEditing(_ doc: VideoProject) {
+        let name = doc.displayName ?? Project.defaultProjectName
+        doc.editorViewModel.agentService.postSystemNotice("Now editing: \(name)")
+    }
+
+    private static func openProjects() -> [VideoProject] {
+        NSDocumentController.shared.documents.compactMap { $0 as? VideoProject }
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -24,6 +24,15 @@ final class ToolExecutor {
         guard let tool = ToolName(rawValue: name) else {
             return .error("Unknown tool: \(name)")
         }
+
+        // project tools act on AppState before editor is available
+        switch tool {
+        case .getProjects, .openProject, .newProject:
+            return await runProjectTool(tool, args)
+        default:
+            break
+        }
+
         guard let editor else { return .error("Editor not available") }
         let before = editor.timeline
         let result: ToolResult
@@ -115,6 +124,8 @@ final class ToolExecutor {
         case .sendFeedback:  return try await sendFeedback(editor, args)
         case .setProjectSettings: return try setProjectSettings(editor, args)
         case .readSkill:     return readSkill(args)
+        case .getProjects, .openProject, .newProject:
+            return await runProjectTool(tool, args)
         }
     }
 

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -62,7 +62,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     @objc func newProject(_ sender: Any?) {
-        AppState.shared.createNewProject()
+        AppState.shared.createProjectInteractively()
     }
 
     @MainActor

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -171,6 +171,7 @@ final class AppState {
             }
         } catch {
             doc.close()
+            try? FileManager.default.removeItem(at: url)
             throw error
         }
         ProjectRegistry.shared.register(url)

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -162,6 +162,7 @@ final class AppState {
         guard !FileManager.default.fileExists(atPath: url.path) else {
             throw ProjectError.nameTaken(url)
         }
+        let previous = activeProject
         let doc = instantiateProject(at: url)
         do {
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
@@ -172,6 +173,7 @@ final class AppState {
         } catch {
             doc.close()
             try? FileManager.default.removeItem(at: url)
+            if let previous { showEditor(for: previous) }
             throw error
         }
         ProjectRegistry.shared.register(url)

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -26,6 +26,10 @@ final class AppState {
 
     private(set) var activeProject: VideoProject?
 
+    var openProjects: [VideoProject] {
+        NSDocumentController.shared.documents.compactMap { $0 as? VideoProject }
+    }
+
     private(set) var mcpService: MCPService?
 
     func startMCPService() {
@@ -115,7 +119,6 @@ final class AppState {
     }
 
     private func notificationTargetProject(assetId: String?, projectURL: URL?) -> VideoProject? {
-        let openProjects = NSDocumentController.shared.documents.compactMap { $0 as? VideoProject }
         if let projectURL {
             return openProjects.first { Self.sameFile($0.fileURL, projectURL) }
         }
@@ -145,24 +148,30 @@ final class AppState {
         return doc
     }
 
-    /// Creates a new project, errors if name exists in directory.
+    /// Creates a new project in the storage folder; errors if the name is invalid or already taken.
     @discardableResult
-    func createProject(named name: String, in directory: URL = Project.storageDirectory) async throws -> VideoProject {
+    func createProject(named name: String) async throws -> VideoProject {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let base = trimmed.isEmpty ? Project.defaultProjectName : trimmed
         guard !base.contains("/"), !base.contains("\\"), base != ".", base != ".." else {
             throw ProjectError.invalidName(base)
         }
+        let directory = Project.storageDirectory
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let url = directory.appendingPathComponent(base).appendingPathExtension(Project.fileExtension)
         guard !FileManager.default.fileExists(atPath: url.path) else {
             throw ProjectError.nameTaken(url)
         }
         let doc = instantiateProject(at: url)
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            doc.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
-                if let error { cont.resume(throwing: error) } else { cont.resume() }
+        do {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                doc.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
+                    if let error { cont.resume(throwing: error) } else { cont.resume() }
+                }
             }
+        } catch {
+            doc.close()
+            throw error
         }
         ProjectRegistry.shared.register(url)
         return doc
@@ -213,9 +222,7 @@ final class AppState {
     }
 
     private func showExistingProject(at url: URL, register: Bool, options: ProjectOpenOptions) -> VideoProject? {
-        if let existing = NSDocumentController.shared.documents
-            .compactMap({ $0 as? VideoProject })
-            .first(where: { Self.sameFile($0.fileURL, url) }) {
+        if let existing = openProjects.first(where: { Self.sameFile($0.fileURL, url) }) {
             showEditor(for: existing)
             if register { ProjectRegistry.shared.register(url) }
             apply(options, to: existing.editorViewModel)

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -5,6 +5,20 @@ struct ProjectOpenOptions {
     var startTutorial = false
 }
 
+enum ProjectError: LocalizedError {
+    case nameTaken(URL)
+    case invalidName(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .nameTaken(let url):
+            "A project named “\(url.deletingPathExtension().lastPathComponent)” already exists in that folder. Pick another name."
+        case .invalidName(let name):
+            "“\(name)” isn't a valid project name. Use a plain name without slashes or path components."
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class AppState {
@@ -120,20 +134,49 @@ final class AppState {
 
     // MARK: - Project lifecycle
 
-    func createNewProject() {
+    // Creates and displays a project at `url`; doesn't save or register.
+    private func instantiateProject(at url: URL) -> VideoProject {
+        let doc = VideoProject()
+        doc.fileURL = url
+        doc.fileType = VideoProject.typeIdentifier
+        doc.makeWindowControllers()
+        doc.showWindows()
+        NSDocumentController.shared.addDocument(doc)
+        return doc
+    }
+
+    /// Creates a new project, errors if name exists in directory.
+    @discardableResult
+    func createProject(named name: String, in directory: URL = Project.storageDirectory) async throws -> VideoProject {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.isEmpty ? Project.defaultProjectName : trimmed
+        guard !base.contains("/"), !base.contains("\\"), base != ".", base != ".." else {
+            throw ProjectError.invalidName(base)
+        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(base).appendingPathExtension(Project.fileExtension)
+        guard !FileManager.default.fileExists(atPath: url.path) else {
+            throw ProjectError.nameTaken(url)
+        }
+        let doc = instantiateProject(at: url)
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            doc.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            }
+        }
+        ProjectRegistry.shared.register(url)
+        return doc
+    }
+
+    func createProjectInteractively() {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [Self.projectContentType]
         panel.nameFieldStringValue = Project.defaultProjectName
         panel.directoryURL = Project.storageDirectory
         panel.title = "New Project"
-        panel.begin { response in
+        panel.begin { [self] response in
             guard response == .OK, let url = panel.url else { return }
-            let doc = VideoProject()
-            doc.fileURL = url
-            doc.fileType = VideoProject.typeIdentifier
-            doc.makeWindowControllers()
-            doc.showWindows()
-            NSDocumentController.shared.addDocument(doc)
+            let doc = instantiateProject(at: url)
             doc.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { _ in
                 ProjectRegistry.shared.register(url)
             }
@@ -151,7 +194,7 @@ final class AppState {
     }
 
     @discardableResult
-    private func openProjectAsync(at url: URL, register: Bool = true, options: ProjectOpenOptions = .init()) async throws -> VideoProject {
+    func openProjectAsync(at url: URL, register: Bool = true, options: ProjectOpenOptions = .init()) async throws -> VideoProject {
         let resolved = url.standardizedFileURL
         if let existing = showExistingProject(at: resolved, register: register, options: options) {
             return existing

--- a/Sources/PalmierPro/Project/HomeView.swift
+++ b/Sources/PalmierPro/Project/HomeView.swift
@@ -77,7 +77,7 @@ struct HomeView: View {
         return ScrollView {
             LazyVGrid(columns: columns, alignment: .leading, spacing: AppTheme.Spacing.xl) {
                 if entries.isEmpty {
-                    NewProjectCard(action: { AppState.shared.createNewProject() })
+                    NewProjectCard(action: { AppState.shared.createProjectInteractively() })
                 } else {
                     ForEach(entries) { entry in
                         ProjectCard(
@@ -189,7 +189,7 @@ private struct HomeSidebar: View {
                 SidebarRowButton(
                     label: "New Project",
                     systemImage: "plus",
-                    action: { AppState.shared.createNewProject() }
+                    action: { AppState.shared.createProjectInteractively() }
                 )
                 SidebarRowButton(
                     label: "Open Project",


### PR DESCRIPTION
closes #172 
3 new tools: `get_projects`, `open_project`, `new_project` for mcp server only, excluded from in-project agent.

limitation:
1. new_project can only create project in our default directory, as opposed being able to write anywhere in filesystem
2. open_project can only open one at a time, there is currently no concurrency support. opening a new one will close the old one


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces programmatic project open/create and active-project switching driven by external MCP clients; failures are partially mitigated by save rollback, but wrong project targeting could confuse users or leave partial state.
> 
> **Overview**
> Adds **MCP-only** project navigation: `get_projects`, `open_project`, and `new_project`. They are registered on `ToolDefinitions.mcpServer` and documented via `AgentInstructions.projectNavigation`; the in-app agent still uses `read_skill` only. `ToolExecutor` routes these tools through new `ToolExecutor+Projects` logic against `AppState` and `ProjectRegistry`, so they work **before** an editor is available (unlike timeline tools).
> 
> `get_projects` returns registered projects with open/active flags; `open_project` resolves by registry id or path and calls `openProjectAsync`; `new_project` creates in the default Palmier storage folder via new `createProject(named:)` with validation and rollback on save failure. UI entry points keep using `createProjectInteractively()` (renamed from `createNewProject()`).
> 
> When MCP switches projects, the active project’s agent chat gets a centered **system** notice (`postSystemNotice` / new `.system` role). Those messages are omitted from the API payload and skipped when pairing assistant tool uses with tool results.
> 
> Skills prompting is split: `SkillStore.skillIndex` supplies lines; `AgentInstructions.skillsSection` wraps them for the in-app agent only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa781567bc025348aee1358a807a0d4421e8abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->