### PR TITLE
Use Apple tokenizer for display text

### DIFF
--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -383,21 +383,7 @@ enum TextFrameRenderer {
     }
 
     private static func words(in content: String) -> [(range: NSRange, text: String)] {
-        let ns = content as NSString
-        let ws = CharacterSet.whitespacesAndNewlines
-        // A surrogate half (emoji etc.) maps to no scalar — treat it as part of a word, not whitespace.
-        func isSpace(_ u: unichar) -> Bool { Unicode.Scalar(u).map(ws.contains) ?? false }
-        var result: [(NSRange, String)] = []
-        var i = 0
-        while i < ns.length {
-            while i < ns.length, isSpace(ns.character(at: i)) { i += 1 }
-            guard i < ns.length else { break }
-            let start = i
-            while i < ns.length, !isSpace(ns.character(at: i)) { i += 1 }
-            let r = NSRange(location: start, length: i - start)
-            result.append((r, ns.substring(with: r)))
-        }
-        return result
+        DisplayTextTokenizer.nsWordTokens(in: content)
     }
 
     // MARK: - Shared drawing

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -21,47 +21,54 @@ enum CaptionBuilder {
         words: [TranscriptionWord] = [],
         fits: (String) -> Bool,
         maxWords: Int? = nil,
-        minDuration: Double
+        minDuration: Double,
+        maxCharacters: Int? = nil
     ) -> [Phrase] {
-        // Only phrases that fit visually and within the word cap are accepted; else, keep splitting.
-        let pieces: [String]
-        if let limit = maxWords {
-            let cap = max(1, limit)
-            pieces = split(segment.text, fits: { fits($0) && wordCount($0) <= cap })
-        } else {
-            pieces = split(segment.text, fits: fits)
-        }
+        let pieces = split(
+            segment.text,
+            fits: { phraseFits($0, fits: fits, maxCharacters: maxCharacters, maxWords: maxWords) },
+            maxCharacters: maxCharacters
+        )
         let timed = time(pieces, segment: segment, words: words)
         return enforceMinDuration(timed, minDuration: minDuration)
     }
 
-    private static func wordCount(_ text: String) -> Int {
-        text.split(whereSeparator: \.isWhitespace).count
+    private static func phraseFits(_ text: String, fits: (String) -> Bool, maxCharacters: Int?, maxWords: Int?) -> Bool {
+        guard fits(text) else { return false }
+        if let maxCharacters, visibleCharacterCount(text) > maxCharacters { return false }
+        if let maxWords, wordCount(text) > max(1, maxWords) { return false }
+        return true
     }
 
-    private static func split(_ text: String, fits: (String) -> Bool) -> [String] {
+    private static func wordCount(_ text: String) -> Int {
+        DisplayTextTokenizer.wordCount(text)
+    }
+
+    private static func split(_ text: String, fits: (String) -> Bool, maxCharacters: Int?) -> [String] {
         let t = text.trimmingCharacters(in: .whitespaces)
         guard !t.isEmpty else { return [] }
         if fits(t) { return [t] }
         let parts = breakOnce(t)
-        guard parts.count > 1 else { return [t] }   // a single over-long word: keep it
-        return parts.flatMap { split($0, fits: fits) }
+        guard parts.count > 1 else {
+            guard let maxCharacters, visibleCharacterCount(t) > maxCharacters else { return [t] }
+            return breakAtCharacterLimit(t, maxCharacters: maxCharacters)
+        }
+        return parts.flatMap { split($0, fits: fits, maxCharacters: maxCharacters) }
     }
 
-    /// Break once at the best boundary present: sentence, then clause, then midpoint word.
     private static func breakOnce(_ text: String) -> [String] {
-        breakOn(text, delimiters: ".!?") ?? breakOn(text, delimiters: ",;:") ?? breakAtMidWord(text)
+        breakOn(text, delimiters: ".!?。！？") ?? breakOn(text, delimiters: ",;:，、；：") ?? breakAtMidToken(text)
     }
 
-    /// Split after delimiters followed by a space, so "U.S." and "3.14" stay intact.
     private static func breakOn(_ text: String, delimiters: String) -> [String]? {
         let set = Set(delimiters)
+        let ascii = Set(".!?,;:")
         let chars = Array(text)
         var pieces: [String] = []
         var current = ""
         for (i, c) in chars.enumerated() {
             current.append(c)
-            let nextIsBreak = i + 1 >= chars.count || chars[i + 1] == " "
+            let nextIsBreak = i + 1 >= chars.count || chars[i + 1].isWhitespace || !ascii.contains(c)
             if set.contains(c), nextIsBreak {
                 let piece = current.trimmingCharacters(in: .whitespaces)
                 if !piece.isEmpty { pieces.append(piece) }
@@ -73,11 +80,36 @@ enum CaptionBuilder {
         return pieces.count > 1 ? pieces : nil
     }
 
-    private static func breakAtMidWord(_ text: String) -> [String] {
-        let words = text.split(separator: " ").map(String.init)
-        guard words.count > 1 else { return [text] }
-        let mid = words.count / 2
-        return [words[..<mid].joined(separator: " "), words[mid...].joined(separator: " ")]
+    private static func breakAtMidToken(_ text: String) -> [String] {
+        DisplayTextTokenizer.splitAtBalancedWordBoundary(text) ?? [text]
+    }
+
+    static func visibleCharacterCount(_ text: String) -> Int {
+        DisplayTextTokenizer.visibleCharacterCount(text)
+    }
+
+    private static func breakAtCharacterLimit(_ text: String, maxCharacters: Int) -> [String] {
+        if let pieces = DisplayTextTokenizer.splitByVisibleCharacterLimit(text, maxVisibleCharacters: maxCharacters) {
+            return pieces
+        }
+
+        var pieces: [String] = []
+        var current = ""
+        var count = 0
+        for character in text {
+            let increment = character.isWhitespace ? 0 : 1
+            if count > 0, count + increment > maxCharacters {
+                let piece = current.trimmingCharacters(in: .whitespaces)
+                if !piece.isEmpty { pieces.append(piece) }
+                current = ""
+                count = 0
+            }
+            current.append(character)
+            count += increment
+        }
+        let tail = current.trimmingCharacters(in: .whitespaces)
+        if !tail.isEmpty { pieces.append(tail) }
+        return pieces.isEmpty ? [text] : pieces
     }
 
     /// Time phrases from word runs by matching shared characters, so timing holds when

--- a/Sources/PalmierPro/Models/DisplayTextTokenizer.swift
+++ b/Sources/PalmierPro/Models/DisplayTextTokenizer.swift
@@ -1,0 +1,121 @@
+import Foundation
+import NaturalLanguage
+
+enum DisplayTextTokenizer {
+    struct Token: Equatable {
+        let range: Range<String.Index>
+        let text: String
+    }
+
+    static func wordTokens(in text: String) -> [Token] {
+        guard !text.isEmpty else { return [] }
+
+        let tokenizer = NLTokenizer(unit: .word)
+        tokenizer.string = text
+        var tokens: [Token] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let tokenText = String(text[range])
+            if containsWordCharacter(tokenText) {
+                tokens.append(Token(range: range, text: tokenText))
+            }
+            return true
+        }
+
+        return tokens.isEmpty ? fallbackWhitespaceTokens(in: text) : tokens
+    }
+
+    static func nsWordTokens(in text: String) -> [(range: NSRange, text: String)] {
+        wordTokens(in: text).map { token in
+            (NSRange(token.range, in: text), token.text)
+        }
+    }
+
+    static func wordCount(_ text: String) -> Int {
+        wordTokens(in: text).count
+    }
+
+    static func splitAtBalancedWordBoundary(_ text: String) -> [String]? {
+        let tokens = wordTokens(in: text)
+        guard tokens.count > 1 else { return nil }
+
+        let total = visibleCharacterCount(text)
+        guard total > 1 else { return nil }
+        let target = Double(total) / 2
+
+        let boundaries = tokens.dropFirst().map(\.range.lowerBound)
+        guard let boundary = boundaries.min(by: { lhs, rhs in
+            abs(Double(visibleCharacterCount(String(text[..<lhs]))) - target)
+                < abs(Double(visibleCharacterCount(String(text[..<rhs]))) - target)
+        }) else { return nil }
+
+        let left = String(text[..<boundary]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let right = String(text[boundary...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !left.isEmpty, !right.isEmpty else { return nil }
+        return [left, right]
+    }
+
+    static func splitByVisibleCharacterLimit(_ text: String, maxVisibleCharacters: Int) -> [String]? {
+        guard maxVisibleCharacters > 0 else { return nil }
+        let tokens = wordTokens(in: text)
+        guard !tokens.isEmpty else { return nil }
+
+        let boundaries = tokens.dropFirst().map(\.range.lowerBound) + [text.endIndex]
+        var pieces: [String] = []
+        var start = text.startIndex
+        var lastAccepted: String.Index?
+        var index = 0
+
+        while index < boundaries.count {
+            let boundary = boundaries[index]
+            let candidate = String(text[start..<boundary]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if candidate.isEmpty {
+                index += 1
+                continue
+            }
+
+            if visibleCharacterCount(candidate) <= maxVisibleCharacters || lastAccepted == nil {
+                lastAccepted = boundary
+                index += 1
+            } else if let accepted = lastAccepted {
+                let piece = String(text[start..<accepted]).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !piece.isEmpty { pieces.append(piece) }
+                start = accepted
+                lastAccepted = nil
+            }
+        }
+
+        let tail = String(text[start...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tail.isEmpty { pieces.append(tail) }
+        return pieces.isEmpty ? nil : pieces
+    }
+
+    static func visibleCharacterCount(_ text: String) -> Int {
+        text.reduce(0) { $0 + ($1.isWhitespace ? 0 : 1) }
+    }
+
+    private static func containsWordCharacter(_ text: String) -> Bool {
+        text.contains { $0.isLetter || $0.isNumber }
+    }
+
+    private static func fallbackWhitespaceTokens(in text: String) -> [Token] {
+        var tokens: [Token] = []
+        var i = text.startIndex
+
+        while i < text.endIndex {
+            while i < text.endIndex, text[i].isWhitespace {
+                i = text.index(after: i)
+            }
+            guard i < text.endIndex else { break }
+            let start = i
+            while i < text.endIndex, !text[i].isWhitespace {
+                i = text.index(after: i)
+            }
+            let tokenText = String(text[start..<i])
+            if containsWordCharacter(tokenText) {
+                tokens.append(Token(range: start..<i, text: tokenText))
+            }
+        }
+
+        return tokens
+    }
+}

--- a/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
@@ -66,6 +66,32 @@ struct CaptionBuilderTests {
         #expect(phrases.map(\.text) == ["supercalifragilistic"])
     }
 
+    @Test func splitsContinuousTextByMaxCharacters() {
+        let phrases = CaptionBuilder.phrases(
+            for: segment("这个输入不对生成字幕太长了", 0, 10),
+            fits: { CaptionBuilder.visibleCharacterCount($0) <= 10 },
+            minDuration: 0,
+            maxCharacters: 10
+        )
+        #expect(phrases.map(\.text) == ["这个输入不对", "生成字幕太长了"])
+        #expect(phrases.allSatisfy { CaptionBuilder.visibleCharacterCount($0.text) <= 10 })
+    }
+
+    @Test func splitsChineseAtTokenizerWordBoundaries() {
+        let phrases = CaptionBuilder.phrases(
+            for: segment("你好世界", 0, 4),
+            fits: { CaptionBuilder.visibleCharacterCount($0) <= 2 },
+            minDuration: 0,
+            maxCharacters: 2
+        )
+        #expect(phrases.map(\.text) == ["你好", "世界"])
+    }
+
+    @Test func respectsChinesePunctuationWithoutSpaces() {
+        let phrases = CaptionBuilder.phrases(for: segment("你好。世界", 0, 4), fits: { CaptionBuilder.visibleCharacterCount($0) <= 3 }, minDuration: 0)
+        #expect(phrases.map(\.text) == ["你好。", "世界"])
+    }
+
     private let clip = Clip(mediaRef: "m", startFrame: 30, durationFrames: 120)
 
     @Test func carriesWordTimingsAndAnimation() {

--- a/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
@@ -98,4 +98,10 @@ struct TextAnimationRenderTests {
             WordTiming(text: "NewYork", startFrame: 10, endFrame: 50),
         ])
     }
+
+    @Test func tokenizerFindsChineseAnimationTokens() {
+        let tokens = DisplayTextTokenizer.nsWordTokens(in: "你好世界").map(\.text)
+        #expect(tokens.count > 1)
+        #expect(tokens.joined() == "你好世界")
+    }
 }


### PR DESCRIPTION
## Summary
- Add a shared display text tokenizer backed by Apple NaturalLanguage.
- Use it for per-word text animation ranges instead of splitting only on whitespace.
- Use the same tokenization for caption splitting, including Chinese punctuation and character limits.

## Validation
- git diff --check
- swift test --filter 'CaptionBuilderTests|TextAnimationRenderTests'