### PR TITLE
feat(matte): add solid-color matte creation via toolbar and agent

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -151,6 +151,8 @@ enum AgentInstructions {
           create folders for unrelated concepts.
         - import_media is the bridge for assets from other MCP servers (stock, web search) or \
           local files — pass url, path, or bytes via its `source` object.
+        - create_matte adds a solid-color PNG to the library — pass `hex` (e.g. '#000000') and \
+          optional aspectRatio (defaults to Project / timeline size).
 
         # Audio generation
         - Two categories, distinguished by model (see list_models type='audio'):

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -26,6 +26,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case generateAudio = "generate_audio"
     case upscaleMedia = "upscale_media"
     case importMedia = "import_media"
+    case createMatte = "create_matte"
     case listModels = "list_models"
     case inspectMedia = "inspect_media"
     case getTranscript = "get_transcript"
@@ -588,6 +589,23 @@ enum ToolDefinitions {
                     "folderId": ["type": "string", "description": "Optional. Folder id (from list_folders or create_folder) to place the result in. Omit for the project root."],
                 ],
                 required: ["source"]
+            )
+        ),
+        AgentTool(
+            name: .createMatte,
+            description: "Creates a solid-color PNG matte in the media library.",
+            inputSchema: objectSchema(
+                properties: [
+                    "hex": ["type": "string", "description": "Hex color, e.g. '#000000' or '#FFFFFF'."],
+                    "aspectRatio": [
+                        "type": "string",
+                        "enum": ["Project", "16:9", "9:16", "1:1", "4:3", "9:14", "2.4:1"],
+                        "description": "Defaults to Project (timeline resolution). Other values use the project's short edge.",
+                    ],
+                    "name": ["type": "string"],
+                    "folderId": ["type": "string"],
+                ],
+                required: ["hex"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -322,6 +322,28 @@ extension ToolExecutor {
         default: return nil
         }
     }
+
+    func createMatte(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["hex", "aspectRatio", "name", "folderId"], path: "create_matte")
+        guard let hex = args.string("hex")?.trimmingCharacters(in: .whitespacesAndNewlines), !hex.isEmpty
+        else { throw ToolError("create_matte requires 'hex'.") }
+        let aspect: MatteAspect
+        if let raw = args.string("aspectRatio") {
+            guard let parsed = MatteAspect.parse(raw) else {
+                throw ToolError("create_matte: unknown aspectRatio '\(raw)'. Use one of \(MatteAspect.allCases.map(\.rawValue).joined(separator: ", ")).")
+            }
+            aspect = parsed
+        } else {
+            aspect = .project
+        }
+        let asset = try await editor.createMatte(
+            hex: hex,
+            aspect: aspect,
+            folderId: try resolveFolderId(args, editor: editor),
+            name: args.string("name")
+        )
+        return .ok(Self.jsonString(["mediaRef": asset.id, "name": asset.name]) ?? asset.id)
+    }
 }
 
 fileprivate final class ImportDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -104,6 +104,7 @@ final class ToolExecutor {
         case .generateAudio: return try await generateAudio(editor, args)
         case .upscaleMedia:  return try upscaleMedia(editor, args)
         case .importMedia:   return try await importMedia(editor, args)
+        case .createMatte:   return try await createMatte(editor, args)
         case .listModels:    return listModels(args)
         case .listFolders:   return listFolders(editor)
         case .createFolder:  return try createFolder(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Matte.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Matte.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension EditorViewModel {
+    func createMatte(
+        hex: String,
+        aspect: MatteAspect = .project,
+        folderId: String? = nil,
+        name: String? = nil
+    ) async throws -> MediaAsset {
+        guard let projectURL else { throw Matte.Error.noProject }
+        let d = aspect.pixelSize(timelineWidth: timeline.width, timelineHeight: timeline.height)
+        let dest = projectURL
+            .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+            .appendingPathComponent("matte-\(UUID().uuidString.prefix(8)).png")
+        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try Matte.png(hex: hex, width: d.width, height: d.height)
+        try await Task.detached(priority: .userInitiated) { try FileIO.writeData(data, to: dest) }.value
+        let asset = MediaAsset(
+            url: dest, type: .image,
+            name: name ?? (aspect == .project ? "Matte · \(d.width)×\(d.height)" : "Matte · \(aspect.rawValue)")
+        )
+        asset.folderId = folderId
+        importMediaAsset(asset)
+        await finalizeImportedAsset(asset)
+        onProjectCheckpointRequired?()
+        return asset
+    }
+}

--- a/Sources/PalmierPro/Media/Matte.swift
+++ b/Sources/PalmierPro/Media/Matte.swift
@@ -1,0 +1,119 @@
+import AppKit
+import Foundation
+import ImageIO
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum MatteAspect: String, CaseIterable, Identifiable {
+    case project = "Project", sixteenNine = "16:9", nineSixteen = "9:16"
+    case oneOne = "1:1", fourThree = "4:3", nineFourteen = "9:14", twoPointFourOne = "2.4:1"
+    var id: String { rawValue }
+
+    private var ratio: (Int, Int)? {
+        switch self {
+        case .project: nil
+        case .sixteenNine: (16, 9)
+        case .nineSixteen: (9, 16)
+        case .oneOne: (1, 1)
+        case .fourThree: (4, 3)
+        case .nineFourteen: (9, 14)
+        case .twoPointFourOne: (24, 10)
+        }
+    }
+
+    func pixelSize(timelineWidth w: Int, timelineHeight h: Int) -> (width: Int, height: Int) {
+        guard let (aw, ah) = ratio else { return Matte.even(w, h) }
+        return Matte.fit(short: min(w, h), aspectW: aw, aspectH: ah)
+    }
+
+    static func parse(_ raw: String?) -> MatteAspect? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        if raw.caseInsensitiveCompare("project") == .orderedSame { return .project }
+        return MatteAspect(rawValue: raw)
+    }
+}
+
+enum Matte {
+    enum Error: LocalizedError {
+        case renderFailed, noProject
+        var errorDescription: String? {
+            switch self {
+            case .renderFailed: "Couldn't render matte image."
+            case .noProject: "Open a project before creating a matte."
+            }
+        }
+    }
+
+    static func even(_ w: Int, _ h: Int) -> (width: Int, height: Int) {
+        (max(2, (max(2, w) / 2) * 2), max(2, (max(2, h) / 2) * 2))
+    }
+
+    static func fit(short edge: Int, aspectW: Int, aspectH: Int) -> (width: Int, height: Int) {
+        let e = max(2, edge)
+        let aw = Double(aspectW), ah = Double(aspectH)
+        if aw >= ah { return even(Int((Double(e) * aw / ah).rounded()), e) }
+        return even(e, Int((Double(e) * ah / aw).rounded()))
+    }
+
+    static func png(hex: String, width: Int, height: Int) throws -> Data {
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        if s.count == 3 { s = s.map { String(repeating: $0, count: 2) }.joined() }
+        guard s.count == 6, let v = UInt32(s, radix: 16) else { throw Error.renderFailed }
+        let (ew, eh) = even(width, height)
+        guard let ctx = CGContext(
+            data: nil, width: ew, height: eh, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { throw Error.renderFailed }
+        ctx.setFillColor(
+            red: CGFloat((v >> 16) & 0xFF) / 255,
+            green: CGFloat((v >> 8) & 0xFF) / 255,
+            blue: CGFloat(v & 0xFF) / 255,
+            alpha: 1
+        )
+        ctx.fill(CGRect(x: 0, y: 0, width: ew, height: eh))
+        guard let image = ctx.makeImage() else { throw Error.renderFailed }
+        let buf = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(buf, UTType.png.identifier as CFString, 1, nil) else {
+            throw Error.renderFailed
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else { throw Error.renderFailed }
+        return buf as Data
+    }
+}
+
+extension Color {
+    var matteHex: String {
+        let c = NSColor(self).usingColorSpace(.sRGB) ?? .black
+        return String(format: "#%02X%02X%02X", Int(c.redComponent * 255), Int(c.greenComponent * 255), Int(c.blueComponent * 255))
+    }
+}
+
+extension EditorViewModel {
+    func createMatte(
+        hex: String,
+        aspect: MatteAspect = .project,
+        folderId: String? = nil,
+        name: String? = nil
+    ) async throws -> MediaAsset {
+        guard let projectURL else { throw Matte.Error.noProject }
+        let d = aspect.pixelSize(timelineWidth: timeline.width, timelineHeight: timeline.height)
+        let dest = projectURL
+            .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+            .appendingPathComponent("matte-\(UUID().uuidString.prefix(8)).png")
+        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try Matte.png(hex: hex, width: d.width, height: d.height)
+        try await Task.detached(priority: .userInitiated) { try FileIO.writeData(data, to: dest) }.value
+        let asset = MediaAsset(
+            url: dest, type: .image,
+            name: name ?? (aspect == .project ? "Matte · \(d.width)×\(d.height)" : "Matte · \(aspect.rawValue)")
+        )
+        asset.folderId = folderId
+        importMediaAsset(asset)
+        await finalizeImportedAsset(asset)
+        onProjectCheckpointRequired?()
+        return asset
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MatteSheet.swift
+++ b/Sources/PalmierPro/MediaPanel/MatteSheet.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct MatteSheet: View {
+    @Environment(EditorViewModel.self) private var editor
+    @Binding var isPresented: Bool
+    @State private var color = Color.black
+    @State private var aspect = MatteAspect.project
+    @State private var isCreating = false
+    @State private var error: String?
+
+    private let controlWidth: CGFloat = 116
+
+    private var dims: (width: Int, height: Int) {
+        aspect.pixelSize(timelineWidth: editor.timeline.width, timelineHeight: editor.timeline.height)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+            row(icon: "paintpalette", label: "Color") {
+                ColorField(displayColor: color, onUserChange: { color = $0 }, supportsOpacity: false)
+            }
+            row(icon: "aspectratio", label: "Aspect") {
+                Picker("", selection: $aspect) {
+                    ForEach(MatteAspect.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .labelsHidden()
+            }
+            row(icon: "ruler", label: "Size") {
+                Text("\(dims.width) × \(dims.height)")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .monospacedDigit()
+            }
+            if let error {
+                Text(error)
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Status.errorColor)
+            }
+            Button(action: create) {
+                Text(isCreating ? "Creating…" : "Create Matte")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(AppTheme.Background.baseColor)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(RoundedRectangle(cornerRadius: AppTheme.Radius.sm).fill(AppTheme.Accent.primary))
+            }
+            .buttonStyle(.plain)
+            .disabled(isCreating)
+            .padding(.top, AppTheme.Spacing.xs)
+        }
+        .padding(AppTheme.Spacing.lgXl)
+        .frame(width: 280)
+    }
+
+    private func row<Control: View>(icon: String, label: String, @ViewBuilder control: () -> Control) -> some View {
+        HStack(spacing: AppTheme.Spacing.smMd) {
+            Image(systemName: icon)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .frame(width: AppTheme.IconSize.sm)
+            Text(label)
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+            Spacer(minLength: AppTheme.Spacing.md)
+            control()
+                .frame(width: controlWidth, alignment: .trailing)
+        }
+    }
+
+    private func create() {
+        error = nil
+        isCreating = true
+        Task {
+            defer { isCreating = false }
+            do {
+                _ = try await editor.createMatte(hex: color.matteHex, aspect: aspect, folderId: editor.mediaPanelCurrentFolderId)
+                isPresented = false
+            } catch {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Left-dock panel that hosts the Media and Captions tabs.
+/// Left-dock panel that hosts the Media, Captions, and Music tabs.
 struct MediaPanelView: View {
     @Environment(EditorViewModel.self) private var editor
     @State private var panelTab: PanelTab = .media

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -33,6 +33,7 @@ struct MediaTab: View {
     @State var marqueeSelection = MarqueeSelection()
 
     @State private var mediaPanelHeight: CGFloat = 600
+    @State private var showMatteSheet = false
 
     enum ViewMode: String, CaseIterable {
         case folder, flat, grouped
@@ -152,6 +153,9 @@ struct MediaTab: View {
         }
         .onChange(of: currentFolderId, initial: true) { _, folderId in
             editor.mediaPanelCurrentFolderId = folderId
+        }
+        .sheet(isPresented: $showMatteSheet) {
+            MatteSheet(isPresented: $showMatteSheet)
         }
     }
 
@@ -582,6 +586,9 @@ struct MediaTab: View {
         return toolbarMenuIcon(systemName: "ellipsis") {
             Button(action: createNewFolderInCurrent) {
                 Label("New Folder", systemImage: "folder.badge.plus")
+            }
+            Button { showMatteSheet = true } label: {
+                Label("Create Matte", systemImage: "square.fill")
             }
             if canOrganize {
                 Button(action: organizeWithAgent) {

--- a/Sources/PalmierPro/Models/Matte.swift
+++ b/Sources/PalmierPro/Models/Matte.swift
@@ -56,22 +56,14 @@ enum Matte {
     }
 
     static func png(hex: String, width: Int, height: Int) throws -> Data {
-        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if s.hasPrefix("#") { s.removeFirst() }
-        if s.count == 3 { s = s.map { String(repeating: $0, count: 2) }.joined() }
-        guard s.count == 6, let v = UInt32(s, radix: 16) else { throw Error.renderFailed }
+        guard let color = TextStyle.RGBA(hex: hex) else { throw Error.renderFailed }
         let (ew, eh) = even(width, height)
         guard let ctx = CGContext(
             data: nil, width: ew, height: eh, bitsPerComponent: 8, bytesPerRow: 0,
             space: CGColorSpaceCreateDeviceRGB(),
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ) else { throw Error.renderFailed }
-        ctx.setFillColor(
-            red: CGFloat((v >> 16) & 0xFF) / 255,
-            green: CGFloat((v >> 8) & 0xFF) / 255,
-            blue: CGFloat(v & 0xFF) / 255,
-            alpha: 1
-        )
+        ctx.setFillColor(red: CGFloat(color.r), green: CGFloat(color.g), blue: CGFloat(color.b), alpha: 1)
         ctx.fill(CGRect(x: 0, y: 0, width: ew, height: eh))
         guard let image = ctx.makeImage() else { throw Error.renderFailed }
         let buf = NSMutableData()
@@ -88,32 +80,5 @@ extension Color {
     var matteHex: String {
         let c = NSColor(self).usingColorSpace(.sRGB) ?? .black
         return String(format: "#%02X%02X%02X", Int(c.redComponent * 255), Int(c.greenComponent * 255), Int(c.blueComponent * 255))
-    }
-}
-
-extension EditorViewModel {
-    func createMatte(
-        hex: String,
-        aspect: MatteAspect = .project,
-        folderId: String? = nil,
-        name: String? = nil
-    ) async throws -> MediaAsset {
-        guard let projectURL else { throw Matte.Error.noProject }
-        let d = aspect.pixelSize(timelineWidth: timeline.width, timelineHeight: timeline.height)
-        let dest = projectURL
-            .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-            .appendingPathComponent("matte-\(UUID().uuidString.prefix(8)).png")
-        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
-        let data = try Matte.png(hex: hex, width: d.width, height: d.height)
-        try await Task.detached(priority: .userInitiated) { try FileIO.writeData(data, to: dest) }.value
-        let asset = MediaAsset(
-            url: dest, type: .image,
-            name: name ?? (aspect == .project ? "Matte · \(d.width)×\(d.height)" : "Matte · \(aspect.rawValue)")
-        )
-        asset.folderId = folderId
-        importMediaAsset(asset)
-        await finalizeImportedAsset(asset)
-        onProjectCheckpointRequired?()
-        return asset
     }
 }

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct ToolbarView: View {
     @Environment(EditorViewModel.self) var editor
-    @State private var showMatteSheet = false
 
     var body: some View {
         HStack(spacing: AppTheme.Spacing.md) {
@@ -38,7 +37,6 @@ struct ToolbarView: View {
             // Add content
             HStack(spacing: AppTheme.Spacing.md) {
                 textGlyphButton("T", help: "Add Text", action: { _ = editor.addTextClip() })
-                matteButton
             }
 
             Spacer()
@@ -70,21 +68,6 @@ struct ToolbarView: View {
         }
         .padding(.horizontal, AppTheme.Spacing.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var matteButton: some View {
-        Button { showMatteSheet = true } label: {
-            Image(systemName: "square.fill")
-                .font(.system(size: AppTheme.FontSize.md))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
-                .frame(width: 24, height: 24)
-                .hoverHighlight()
-        }
-        .buttonStyle(.plain)
-        .help("Create Matte")
-        .sheet(isPresented: $showMatteSheet) {
-            MatteSheet(isPresented: $showMatteSheet)
-        }
     }
 
     private func toolbarButton(_ systemName: String, help: String, action: @escaping () -> Void) -> some View {
@@ -172,87 +155,5 @@ struct ToolbarView: View {
         }
         .buttonStyle(.plain)
         .help(help)
-    }
-}
-
-private struct MatteSheet: View {
-    @Environment(EditorViewModel.self) private var editor
-    @Binding var isPresented: Bool
-    @State private var color = Color.black
-    @State private var aspect = MatteAspect.project
-    @State private var isCreating = false
-    @State private var error: String?
-
-    private var dims: (width: Int, height: Int) {
-        aspect.pixelSize(timelineWidth: editor.timeline.width, timelineHeight: editor.timeline.height)
-    }
-
-    private let controlWidth: CGFloat = 116
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
-            row(icon: "paintpalette", label: "Color") {
-                ColorField(displayColor: color, onUserChange: { color = $0 }, supportsOpacity: false)
-            }
-            row(icon: "aspectratio", label: "Aspect") {
-                Picker("", selection: $aspect) {
-                    ForEach(MatteAspect.allCases) { Text($0.rawValue).tag($0) }
-                }
-                .labelsHidden()
-            }
-            row(icon: "ruler", label: "Size") {
-                Text("\(dims.width) × \(dims.height)")
-                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .monospacedDigit()
-            }
-            if let error {
-                Text(error)
-                    .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(AppTheme.Status.errorColor)
-            }
-            Button(action: create) {
-                Text(isCreating ? "Creating…" : "Create Matte")
-                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.semibold))
-                    .foregroundStyle(AppTheme.Background.baseColor)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, AppTheme.Spacing.smMd)
-                    .background(RoundedRectangle(cornerRadius: AppTheme.Radius.sm).fill(AppTheme.Accent.primary))
-            }
-            .buttonStyle(.plain)
-            .disabled(isCreating)
-            .padding(.top, AppTheme.Spacing.xs)
-        }
-        .padding(AppTheme.Spacing.lgXl)
-        .frame(width: 280)
-    }
-
-    private func row<Control: View>(icon: String, label: String, @ViewBuilder control: () -> Control) -> some View {
-        HStack(spacing: AppTheme.Spacing.smMd) {
-            Image(systemName: icon)
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
-                .frame(width: AppTheme.IconSize.sm)
-            Text(label)
-                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
-                .foregroundStyle(AppTheme.Text.primaryColor)
-            Spacer(minLength: AppTheme.Spacing.md)
-            control()
-                .frame(width: controlWidth, alignment: .trailing)
-        }
-    }
-
-    private func create() {
-        error = nil
-        isCreating = true
-        Task {
-            defer { isCreating = false }
-            do {
-                _ = try await editor.createMatte(hex: color.matteHex, aspect: aspect, folderId: editor.mediaPanelCurrentFolderId)
-                isPresented = false
-            } catch {
-                self.error = error.localizedDescription
-            }
-        }
     }
 }

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -77,7 +77,7 @@ struct ToolbarView: View {
             Image(systemName: "square.fill")
                 .font(.system(size: AppTheme.FontSize.md))
                 .foregroundStyle(AppTheme.Text.secondaryColor)
-                .frame(width: 24, height: 24)
+                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
                 .hoverHighlight()
         }
         .buttonStyle(.plain)
@@ -187,8 +187,6 @@ private struct MatteSheet: View {
         aspect.pixelSize(timelineWidth: editor.timeline.width, timelineHeight: editor.timeline.height)
     }
 
-    private let controlWidth: CGFloat = 116
-
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
             row(icon: "paintpalette", label: "Color") {
@@ -224,7 +222,7 @@ private struct MatteSheet: View {
             .padding(.top, AppTheme.Spacing.xs)
         }
         .padding(AppTheme.Spacing.lgXl)
-        .frame(width: 280)
+        .frame(width: AppTheme.Matte.sheetWidth)
     }
 
     private func row<Control: View>(icon: String, label: String, @ViewBuilder control: () -> Control) -> some View {
@@ -238,7 +236,7 @@ private struct MatteSheet: View {
                 .foregroundStyle(AppTheme.Text.primaryColor)
             Spacer(minLength: AppTheme.Spacing.md)
             control()
-                .frame(width: controlWidth, alignment: .trailing)
+                .frame(width: AppTheme.Matte.controlWidth, alignment: .trailing)
         }
     }
 

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ToolbarView: View {
     @Environment(EditorViewModel.self) var editor
+    @State private var showMatteSheet = false
 
     var body: some View {
         HStack(spacing: AppTheme.Spacing.md) {
@@ -37,6 +38,7 @@ struct ToolbarView: View {
             // Add content
             HStack(spacing: AppTheme.Spacing.md) {
                 textGlyphButton("T", help: "Add Text", action: { _ = editor.addTextClip() })
+                matteButton
             }
 
             Spacer()
@@ -68,6 +70,21 @@ struct ToolbarView: View {
         }
         .padding(.horizontal, AppTheme.Spacing.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var matteButton: some View {
+        Button { showMatteSheet = true } label: {
+            Image(systemName: "square.fill")
+                .font(.system(size: AppTheme.FontSize.md))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .frame(width: 24, height: 24)
+                .hoverHighlight()
+        }
+        .buttonStyle(.plain)
+        .help("Create Matte")
+        .sheet(isPresented: $showMatteSheet) {
+            MatteSheet(isPresented: $showMatteSheet)
+        }
     }
 
     private func toolbarButton(_ systemName: String, help: String, action: @escaping () -> Void) -> some View {
@@ -156,5 +173,86 @@ struct ToolbarView: View {
         .buttonStyle(.plain)
         .help(help)
     }
+}
 
+private struct MatteSheet: View {
+    @Environment(EditorViewModel.self) private var editor
+    @Binding var isPresented: Bool
+    @State private var color = Color.black
+    @State private var aspect = MatteAspect.project
+    @State private var isCreating = false
+    @State private var error: String?
+
+    private var dims: (width: Int, height: Int) {
+        aspect.pixelSize(timelineWidth: editor.timeline.width, timelineHeight: editor.timeline.height)
+    }
+
+    private let controlWidth: CGFloat = 116
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.lg) {
+            row(icon: "paintpalette", label: "Color") {
+                ColorField(displayColor: color, onUserChange: { color = $0 }, supportsOpacity: false)
+            }
+            row(icon: "aspectratio", label: "Aspect") {
+                Picker("", selection: $aspect) {
+                    ForEach(MatteAspect.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .labelsHidden()
+            }
+            row(icon: "ruler", label: "Size") {
+                Text("\(dims.width) × \(dims.height)")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .monospacedDigit()
+            }
+            if let error {
+                Text(error)
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Status.errorColor)
+            }
+            Button(action: create) {
+                Text(isCreating ? "Creating…" : "Create Matte")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(AppTheme.Background.baseColor)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(RoundedRectangle(cornerRadius: AppTheme.Radius.sm).fill(AppTheme.Accent.primary))
+            }
+            .buttonStyle(.plain)
+            .disabled(isCreating)
+            .padding(.top, AppTheme.Spacing.xs)
+        }
+        .padding(AppTheme.Spacing.lgXl)
+        .frame(width: 280)
+    }
+
+    private func row<Control: View>(icon: String, label: String, @ViewBuilder control: () -> Control) -> some View {
+        HStack(spacing: AppTheme.Spacing.smMd) {
+            Image(systemName: icon)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .frame(width: AppTheme.IconSize.sm)
+            Text(label)
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+            Spacer(minLength: AppTheme.Spacing.md)
+            control()
+                .frame(width: controlWidth, alignment: .trailing)
+        }
+    }
+
+    private func create() {
+        error = nil
+        isCreating = true
+        Task {
+            defer { isCreating = false }
+            do {
+                _ = try await editor.createMatte(hex: color.matteHex, aspect: aspect, folderId: editor.mediaPanelCurrentFolderId)
+                isPresented = false
+            } catch {
+                self.error = error.localizedDescription
+            }
+        }
+    }
 }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -306,6 +306,11 @@ enum AppTheme {
         static let sheetHeight: CGFloat = 520
     }
 
+    enum Matte {
+        static let sheetWidth: CGFloat = 280
+        static let controlWidth: CGFloat = 116
+    }
+
     // MARK: - Shadows
 
     struct ShadowStyle {


### PR DESCRIPTION
Add a Matte type that renders a solid-color PNG (project resolution or aspect-ratio presets) into the media library. Expose it through a toolbar sheet with a color well, aspect picker, and size readout, plus a create_matte agent tool taking hex and aspectRatio. Remove the unused Assets media-panel tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local image generation and media-library writes only; no timeline mutation, billing, or security-sensitive paths.
> 
> **Overview**
> Adds **solid-color matte** support: a new `Matte` helper renders even-sized PNGs from a hex color at **project resolution** or preset aspect ratios (16:9, 9:16, 1:1, etc.), using the timeline short edge for non-project sizes.
> 
> **In the app**, `EditorViewModel.createMatte` writes `matte-*.png` into project media, registers the image like an import, and checkpoints the project. The Media tab **overflow menu** opens `MatteSheet` (color well, aspect picker, live pixel dimensions) and drops the asset into the **current media folder**.
> 
> **For the agent**, a new **`create_matte`** tool (`hex`, optional `aspectRatio`, `name`, `folderId`) is wired through `ToolExecutor` and documented in agent generation instructions. `AppTheme.Matte` defines sheet layout constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c73223e4c47a08a7f4f5943fd22fb0dc9334b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->