### PR TITLE
sonnet 4.6 -> sonnet 5

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -46,7 +46,7 @@ final class AgentService {
 
     var availableModels: [AnthropicModel] {
         if hasApiKey { return AnthropicModel.allCases }
-        return AccountService.shared.isPaid ? [.sonnet46] : [.haiku45]
+        return AccountService.shared.isPaid ? [.sonnet5] : [.haiku45]
     }
 
     private func selectClient() -> (any AgentClient)? {
@@ -61,7 +61,7 @@ final class AgentService {
     var effectiveModel: AnthropicModel {
         let available = availableModels
         if available.contains(model) { return model }
-        return available.first ?? .sonnet46
+        return available.first ?? .sonnet5
     }
 
     var model: AnthropicModel = {
@@ -69,7 +69,7 @@ final class AgentService {
            let m = AnthropicModel(rawValue: raw) {
             return m
         }
-        return .sonnet46
+        return .sonnet5
     }() {
         didSet { UserDefaults.standard.set(model.rawValue, forKey: "agentModel") }
     }

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -3,13 +3,13 @@ import Foundation
 // MARK: - Shared value types
 
 enum AnthropicModel: String, CaseIterable, Sendable {
-    case sonnet46 = "claude-sonnet-4-6"
+    case sonnet5 = "claude-sonnet-5"
     case opus48 = "claude-opus-4-8"
     case haiku45 = "claude-haiku-4-5-20251001"
 
     var displayName: String {
         switch self {
-        case .sonnet46: "Sonnet 4.6"
+        case .sonnet5: "Sonnet 5"
         case .opus48: "Opus 4.8"
         case .haiku45: "Haiku 4.5"
         }


### PR DESCRIPTION
nuff said.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Straightforward model ID and enum rename with no auth or data-path changes; risk is mainly if the new model string is wrong or unavailable upstream.
> 
> **Overview**
> Updates the in-app agent to use **Claude Sonnet 5** (`claude-sonnet-5`) instead of Sonnet 4.6.
> 
> The `AnthropicModel` enum renames `sonnet46` to `sonnet5` with the new API model string and **Sonnet 5** display label. **AgentService** now uses `.sonnet5` for paid-plan availability, default/fallback model selection, and the persisted `agentModel` default when nothing is stored in UserDefaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79079a7054049869558e6390c6b83a7d38ea4f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->