### PR TITLE
free tier models

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 extension ToolExecutor {
+    private var canUsePaidModels: Bool { AccountService.shared.isPaid }
+    private func modelAvailable(paidOnly: Bool) -> Bool { canUsePaidModels || !paidOnly }
+
+    private func requirePlan(for modelId: String, paidOnly: Bool) throws {
+        if paidOnly && !canUsePaidModels {
+            throw ToolError(
+                "Model '\(modelId)' requires a paid plan. Pick a free model from list_models, "
+                + "or tell the user to subscribe."
+            )
+        }
+    }
+
     func generate(_ editor: EditorViewModel, _ args: [String: Any], type: ClipType) throws -> ToolResult {
         let prompt = try args.requireString("prompt")
         guard AccountService.shared.isSignedIn else {
@@ -11,12 +23,13 @@ extension ToolExecutor {
         }
         switch type {
         case .video:
-            guard let modelId = args.string("model") ?? VideoModelConfig.allModels.first?.id else {
+            guard let modelId = args.string("model") ?? VideoModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
                 throw ToolError("Model catalog not loaded yet. Try again in a moment.")
             }
             guard let model = VideoModelConfig.allModels.first(where: { $0.id == modelId }) else {
                 throw ToolError("Unknown model '\(modelId)'. Available: \(VideoModelConfig.allModels.map(\.id).joined(separator: ", "))")
             }
+            try requirePlan(for: model.id, paidOnly: model.paidOnly)
             return model.requiresSourceVideo
                 ? try generateVideoEdit(editor, args, prompt: prompt, model: model)
                 : try generateVideoText(editor, args, prompt: prompt, model: model)
@@ -151,12 +164,13 @@ extension ToolExecutor {
         _ editor: EditorViewModel, _ args: [String: Any], prompt: String
     ) throws -> ToolResult {
         guard !prompt.isEmpty else { throw ToolError("Empty prompt") }
-        guard let modelId = args.string("model") ?? ImageModelConfig.allModels.first?.id else {
+        guard let modelId = args.string("model") ?? ImageModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
             throw ToolError("Model catalog not loaded yet. Try again in a moment.")
         }
         guard let model = ImageModelConfig.allModels.first(where: { $0.id == modelId }) else {
             throw ToolError("Unknown model '\(modelId)'. Available: \(ImageModelConfig.allModels.map(\.id).joined(separator: ", "))")
         }
+        try requirePlan(for: model.id, paidOnly: model.paidOnly)
         let aspectRatio = args.string("aspectRatio") ?? model.aspectRatios.first ?? ""
         let resolution = args.string("resolution") ?? model.resolutions?.first
         let quality = args.string("quality") ?? model.qualities?.last
@@ -201,12 +215,13 @@ extension ToolExecutor {
         guard AccountService.shared.hasCredits else {
             throw ToolError("Out of credits. Tell the user to add credits or subscribe to keep generating.")
         }
-        guard let modelId = args.string("model") ?? AudioModelConfig.allModels.first?.id else {
+        guard let modelId = args.string("model") ?? AudioModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
             throw ToolError("Model catalog not loaded yet. Try again in a moment.")
         }
         guard let model = AudioModelConfig.allModels.first(where: { $0.id == modelId }) else {
             throw ToolError("Unknown model '\(modelId)'. Available: \(AudioModelConfig.allModels.map(\.id).joined(separator: ", "))")
         }
+        try requirePlan(for: model.id, paidOnly: model.paidOnly)
 
         let prompt = (args.string("prompt") ?? "").trimmingCharacters(in: .whitespaces)
         let acceptsVideo = model.inputs.contains(.video)
@@ -331,10 +346,11 @@ extension ToolExecutor {
                 let ids = available.map(\.id).joined(separator: ", ")
                 throw ToolError("Model '\(requested)' does not support \(asset.type.rawValue). Available: \(ids)")
             }
+            try requirePlan(for: match.id, paidOnly: match.paidOnly)
             model = match
         } else {
-            guard let first = available.first else {
-                throw ToolError("No upscaler available for \(asset.type.rawValue)")
+            guard let first = available.first(where: { modelAvailable(paidOnly: $0.paidOnly) }) else {
+                throw ToolError("No upscaler available for \(asset.type.rawValue) on the current plan.")
             }
             model = first
         }
@@ -375,16 +391,24 @@ extension ToolExecutor {
         let filter = args.string("type")
         var out: [[String: Any]] = []
         if filter == nil || filter == "video" {
-            out += VideoModelConfig.allModels.map { Self.videoModelInfo($0, includeType: true) }
+            out += VideoModelConfig.allModels
+                .filter { modelAvailable(paidOnly: $0.paidOnly) }
+                .map { Self.videoModelInfo($0, includeType: true) }
         }
         if filter == nil || filter == "image" {
-            out += ImageModelConfig.allModels.map { Self.imageModelInfo($0, includeType: true) }
+            out += ImageModelConfig.allModels
+                .filter { modelAvailable(paidOnly: $0.paidOnly) }
+                .map { Self.imageModelInfo($0, includeType: true) }
         }
         if filter == nil || filter == "audio" {
-            out += AudioModelConfig.allModels.map { Self.audioModelInfo($0) }
+            out += AudioModelConfig.allModels
+                .filter { modelAvailable(paidOnly: $0.paidOnly) }
+                .map { Self.audioModelInfo($0) }
         }
         if filter == nil || filter == "upscale" {
-            out += UpscaleModelConfig.allModels.map { Self.upscaleModelInfo($0) }
+            out += UpscaleModelConfig.allModels
+                .filter { modelAvailable(paidOnly: $0.paidOnly) }
+                .map { Self.upscaleModelInfo($0) }
         }
         let body: [String: Any] = [
             "models": out,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -13,6 +13,16 @@ extension ToolExecutor {
         }
     }
 
+    private func defaultModelId(_ ids: [(id: String, paidOnly: Bool)], kind: String) throws -> String {
+        guard !ids.isEmpty else {
+            throw ToolError("Model catalog not loaded yet. Try again in a moment.")
+        }
+        guard let match = ids.first(where: { modelAvailable(paidOnly: $0.paidOnly) }) else {
+            throw ToolError("No \(kind) model is available on the current plan. Tell the user to subscribe.")
+        }
+        return match.id
+    }
+
     func generate(_ editor: EditorViewModel, _ args: [String: Any], type: ClipType) throws -> ToolResult {
         let prompt = try args.requireString("prompt")
         guard AccountService.shared.isSignedIn else {
@@ -23,9 +33,8 @@ extension ToolExecutor {
         }
         switch type {
         case .video:
-            guard let modelId = args.string("model") ?? VideoModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
-                throw ToolError("Model catalog not loaded yet. Try again in a moment.")
-            }
+            let modelId = try args.string("model") ?? defaultModelId(
+                VideoModelConfig.allModels.map { (id: $0.id, paidOnly: $0.paidOnly) }, kind: "video")
             guard let model = VideoModelConfig.allModels.first(where: { $0.id == modelId }) else {
                 throw ToolError("Unknown model '\(modelId)'. Available: \(VideoModelConfig.allModels.map(\.id).joined(separator: ", "))")
             }
@@ -164,9 +173,8 @@ extension ToolExecutor {
         _ editor: EditorViewModel, _ args: [String: Any], prompt: String
     ) throws -> ToolResult {
         guard !prompt.isEmpty else { throw ToolError("Empty prompt") }
-        guard let modelId = args.string("model") ?? ImageModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
-            throw ToolError("Model catalog not loaded yet. Try again in a moment.")
-        }
+        let modelId = try args.string("model") ?? defaultModelId(
+            ImageModelConfig.allModels.map { (id: $0.id, paidOnly: $0.paidOnly) }, kind: "image")
         guard let model = ImageModelConfig.allModels.first(where: { $0.id == modelId }) else {
             throw ToolError("Unknown model '\(modelId)'. Available: \(ImageModelConfig.allModels.map(\.id).joined(separator: ", "))")
         }
@@ -215,9 +223,8 @@ extension ToolExecutor {
         guard AccountService.shared.hasCredits else {
             throw ToolError("Out of credits. Tell the user to add credits or subscribe to keep generating.")
         }
-        guard let modelId = args.string("model") ?? AudioModelConfig.allModels.first(where: { modelAvailable(paidOnly: $0.paidOnly) })?.id else {
-            throw ToolError("Model catalog not loaded yet. Try again in a moment.")
-        }
+        let modelId = try args.string("model") ?? defaultModelId(
+            AudioModelConfig.allModels.map { (id: $0.id, paidOnly: $0.paidOnly) }, kind: "audio")
         guard let model = AudioModelConfig.allModels.first(where: { $0.id == modelId }) else {
             throw ToolError("Unknown model '\(modelId)'. Available: \(AudioModelConfig.allModels.map(\.id).joined(separator: ", "))")
         }

--- a/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
@@ -61,6 +61,7 @@ struct AudioModelConfig: Identifiable, Sendable {
 
     var id: String { entry.id }
     var displayName: String { entry.displayName }
+    var paidOnly: Bool { entry.paidOnly }
 
     var category: Category {
         switch caps.category {

--- a/Sources/PalmierPro/Generation/Catalog/ImageModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ImageModelConfig.swift
@@ -38,6 +38,7 @@ struct ImageModelConfig: Identifiable, Sendable {
 
     var id: String { entry.id }
     var displayName: String { entry.displayName }
+    var paidOnly: Bool { entry.paidOnly }
     var creditsPerImage: [String: Double] { entry.creditsPerImage ?? [:] }
 
     var resolutions: [String]? { caps.resolutions }

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -122,6 +122,7 @@ struct CatalogEntry: Decodable, Sendable {
     let qualities: [String]?
     let audioPricing: AudioPricing?
     let creditsPerSecondUpscale: Double?
+    let paidOnly: Bool
 
     enum Kind: String, Decodable, Sendable { case video, image, audio, upscale }
     enum ResponseShape: String, Decodable, Sendable {
@@ -163,7 +164,7 @@ struct CatalogEntry: Decodable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id, kind, displayName, allowedEndpoints, responseShape, uiCapabilities
         case creditsPerSecond, audioDiscountRate, creditsPerImage, qualities
-        case audioPricing, creditsPerSecondUpscale
+        case audioPricing, creditsPerSecondUpscale, paidOnly
     }
 
     init(from decoder: Decoder) throws {
@@ -179,6 +180,7 @@ struct CatalogEntry: Decodable, Sendable {
         self.qualities = try c.decodeIfPresent([String].self, forKey: .qualities)
         self.audioPricing = try c.decodeIfPresent(AudioPricing.self, forKey: .audioPricing)
         self.creditsPerSecondUpscale = try c.decodeIfPresent(Double.self, forKey: .creditsPerSecondUpscale)
+        self.paidOnly = try c.decodeIfPresent(Bool.self, forKey: .paidOnly) ?? false
         switch self.kind {
         case .video:
             self.uiCapabilities = .video(try c.decode(VideoCaps.self, forKey: .uiCapabilities))

--- a/Sources/PalmierPro/Generation/Catalog/UpscaleModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/UpscaleModelConfig.swift
@@ -31,6 +31,7 @@ struct UpscaleModelConfig: Identifiable, Sendable {
 
     var id: String { entry.id }
     var displayName: String { entry.displayName }
+    var paidOnly: Bool { entry.paidOnly }
     var creditsPerSecond: Double { entry.creditsPerSecondUpscale ?? 0 }
 
     var speed: String { caps.speed }

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -13,6 +13,7 @@ struct VideoModelConfig: Identifiable, Sendable {
 
     var id: String { entry.id }
     var displayName: String { entry.displayName }
+    var paidOnly: Bool { entry.paidOnly }
     var creditsPerSecond: [String: Double] { entry.creditsPerSecond ?? [:] }
     var audioDiscountRate: [String: Double]? { entry.audioDiscountRate }
 

--- a/Sources/PalmierPro/Generation/Edit/AIEditMenu.swift
+++ b/Sources/PalmierPro/Generation/Edit/AIEditMenu.swift
@@ -15,7 +15,15 @@ struct AIEditMenu: View {
                 if availableActions.contains(.upscale) {
                     Menu("Upscale") {
                         ForEach(UpscaleModelConfig.models(for: asset.type)) { model in
-                            Button(model.displayName) { runUpscale(model) }
+                            if model.paidOnly && !AccountService.shared.isPaid {
+                                Button {
+                                    SettingsWindowController.shared.show(tab: .account)
+                                } label: {
+                                    Label("\(model.displayName) (Paid)", systemImage: "lock.fill")
+                                }
+                            } else {
+                                Button(model.displayName) { runUpscale(model) }
+                            }
                         }
                     }
                 }

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import Combine
+@preconcurrency import ConvexMobile
 
 /// Used by replace-clip callbacks so only the
 /// first successful asset of an N-image generation swaps the clip
@@ -304,6 +305,17 @@ final class GenerationService {
         }
     }
 
+    private func backendErrorMessage(_ error: Error) -> String {
+        struct Payload: Decodable { let code: String?; let message: String? }
+        if case let ClientError.ConvexError(data) = error,
+           let json = data.data(using: .utf8),
+           let payload = try? JSONDecoder().decode(Payload.self, from: json),
+           let message = payload.message {
+            return message
+        }
+        return error.localizedDescription
+    }
+
     private func updateGenerationMetadata(
         _ asset: MediaAsset,
         editor: EditorViewModel,
@@ -406,7 +418,7 @@ final class GenerationService {
                 projectId: editor.projectId,
             )
         } catch {
-            let message = error.localizedDescription
+            let message = backendErrorMessage(error)
             Log.generation.error("submit failed model=\(genInput.model) error=\(message)")
             for placeholder in placeholders {
                 updateGenerationMetadata(placeholder, editor: editor, status: .failed(message))

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -136,24 +136,35 @@ struct GenerationView: View {
     private var imageModel: ImageModelConfig { selectedModel(imageModels, at: selectedImageModelIndex) }
     private var audioModel: AudioModelConfig { selectedModel(audioModels, at: selectedAudioModelIndex) }
 
+    private var currentModelLocked: Bool {
+        guard !account.isPaid else { return false }
+        switch selectedType {
+        case .video: return videoModel.paidOnly
+        case .image: return imageModel.paidOnly
+        case .audio: return audioModel.paidOnly
+        }
+    }
+
     private func selectedModel<T>(_ models: [T], at index: Int) -> T {
         let safeIndex = models.indices.contains(index) ? index : models.startIndex
         return models[safeIndex]
     }
 
+    private func isAvailable(_ paidOnly: Bool) -> Bool { account.isPaid || !paidOnly }
+
     private var enabledVideoModels: [(index: Int, model: VideoModelConfig)] {
         videoModels.enumerated()
-            .filter { ModelPreferences.shared.isEnabled($0.element.id) }
+            .filter { ModelPreferences.shared.isEnabled($0.element.id) && isAvailable($0.element.paidOnly) }
             .map { (index: $0.offset, model: $0.element) }
     }
     private var enabledImageModels: [(index: Int, model: ImageModelConfig)] {
         imageModels.enumerated()
-            .filter { ModelPreferences.shared.isEnabled($0.element.id) }
+            .filter { ModelPreferences.shared.isEnabled($0.element.id) && isAvailable($0.element.paidOnly) }
             .map { (index: $0.offset, model: $0.element) }
     }
     private var enabledAudioModels: [(index: Int, model: AudioModelConfig)] {
         audioModels.enumerated()
-            .filter { ModelPreferences.shared.isEnabled($0.element.id) }
+            .filter { ModelPreferences.shared.isEnabled($0.element.id) && isAvailable($0.element.paidOnly) }
             .map { (index: $0.offset, model: $0.element) }
     }
     private var enabledAudioModelsByCategory: [AudioModelConfig.Category: [(index: Int, model: AudioModelConfig)]] {
@@ -167,17 +178,19 @@ struct GenerationView: View {
 
     private func normalizeModelSelection() {
         switch selectedType {
-        case .video: selectedVideoModelIndex = enabledIndex(selectedVideoModelIndex, in: videoModels.map(\.id))
-        case .image: selectedImageModelIndex = enabledIndex(selectedImageModelIndex, in: imageModels.map(\.id))
-        case .audio: selectedAudioModelIndex = enabledIndex(selectedAudioModelIndex, in: audioModels.map(\.id))
+        case .video:
+            if !enabledVideoModels.contains(where: { $0.index == selectedVideoModelIndex }) {
+                selectedVideoModelIndex = enabledVideoModels.first?.index ?? 0
+            }
+        case .image:
+            if !enabledImageModels.contains(where: { $0.index == selectedImageModelIndex }) {
+                selectedImageModelIndex = enabledImageModels.first?.index ?? 0
+            }
+        case .audio:
+            if !enabledAudioModels.contains(where: { $0.index == selectedAudioModelIndex }) {
+                selectedAudioModelIndex = enabledAudioModels.first?.index ?? 0
+            }
         }
-    }
-
-    /// Keeps an enabled selection untouched
-    private func enabledIndex(_ current: Int, in ids: [String]) -> Int {
-        let prefs = ModelPreferences.shared
-        if ids.indices.contains(current), prefs.isEnabled(ids[current]) { return current }
-        return ids.firstIndex { prefs.isEnabled($0) } ?? (ids.indices.contains(current) ? current : 0)
     }
 
     private var trimmedPrompt: String { prompt.trimmingCharacters(in: .whitespaces) }
@@ -567,6 +580,10 @@ struct GenerationView: View {
         }
         .onChange(of: editor.pendingPanelSeed?.asset.id) { _, _ in consumePendingPanelSeed() }
         .onChange(of: ModelPreferences.shared.disabledIds) { _, _ in
+            guard !isPopulatingPanel else { return }
+            normalizeModelSelection()
+        }
+        .onChange(of: account.isPaid) { _, _ in
             guard !isPopulatingPanel else { return }
             normalizeModelSelection()
         }
@@ -1576,6 +1593,10 @@ struct GenerationView: View {
     }
 
     private func submitGeneration() {
+        if currentModelLocked {
+            SettingsWindowController.shared.show(tab: .account)
+            return
+        }
         let audioDuration: Int = {
             guard selectedType == .audio else { return 0 }
             if audioModel.inputs.contains(.video) { return effectiveAudioVideoSeconds }

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -190,8 +190,9 @@ struct AIEditTab: View {
             for: asset,
             effectiveDurationOverride: effectiveDurationForAvailability
         )
-        let isEnabled = availability.isAvailable
-        let disabledReason = availability.reason
+        let paidBlocked = (action == .upscale || action == .edit) && !account.isPaid
+        let isEnabled = availability.isAvailable && !paidBlocked
+        let disabledReason = paidBlocked ? "Requires a paid plan" : availability.reason
 
         HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
             Image(systemName: icon)

--- a/Sources/PalmierPro/Settings/ModelsPane.swift
+++ b/Sources/PalmierPro/Settings/ModelsPane.swift
@@ -3,12 +3,14 @@ import SwiftUI
 struct ModelsPane: View {
     private var prefs = ModelPreferences.shared
     private var catalog = ModelCatalog.shared
+    private var account = AccountService.shared
 
     @State private var query = ""
 
     private struct Row: Identifiable {
         let id: String
         let displayName: String
+        let paidOnly: Bool
     }
 
     private struct Section: Identifiable {
@@ -17,18 +19,22 @@ struct ModelsPane: View {
         let rows: [Row]
     }
 
+    private func isLocked(_ row: Row) -> Bool { row.paidOnly && !account.isPaid }
+
     private var sections: [Section] {
         let q = query.trimmingCharacters(in: .whitespaces).lowercased()
-        func filtered(_ rows: [Row]) -> [Row] {
-            q.isEmpty ? rows : rows.filter { $0.displayName.lowercased().contains(q) }
+        func prepare(_ rows: [Row]) -> [Row] {
+            let matched = q.isEmpty ? rows : rows.filter { $0.displayName.lowercased().contains(q) }
+            // Available models first, locked (paid-only) ones grouped at the bottom.
+            return matched.filter { !isLocked($0) } + matched.filter { isLocked($0) }
         }
         return [
             Section(id: "image", title: "Image",
-                    rows: filtered(catalog.image.map { Row(id: $0.id, displayName: $0.displayName) })),
+                    rows: prepare(catalog.image.map { Row(id: $0.id, displayName: $0.displayName, paidOnly: $0.paidOnly) })),
             Section(id: "video", title: "Video",
-                    rows: filtered(catalog.video.map { Row(id: $0.id, displayName: $0.displayName) })),
+                    rows: prepare(catalog.video.map { Row(id: $0.id, displayName: $0.displayName, paidOnly: $0.paidOnly) })),
             Section(id: "audio", title: "Audio",
-                    rows: filtered(catalog.audio.map { Row(id: $0.id, displayName: $0.displayName) })),
+                    rows: prepare(catalog.audio.map { Row(id: $0.id, displayName: $0.displayName, paidOnly: $0.paidOnly) })),
         ].filter { !$0.rows.isEmpty }
     }
 
@@ -99,19 +105,28 @@ struct ModelsPane: View {
         }
     }
 
+    @ViewBuilder
     private func modelRow(_ row: Row) -> some View {
+        let locked = isLocked(row)
         HStack(spacing: AppTheme.Spacing.md) {
             Text(row.displayName)
                 .font(.system(size: AppTheme.FontSize.md))
-                .foregroundStyle(AppTheme.Text.primaryColor)
+                .foregroundStyle(locked ? AppTheme.Text.tertiaryColor : AppTheme.Text.primaryColor)
             Spacer(minLength: AppTheme.Spacing.lg)
-            Toggle("", isOn: Binding(
-                get: { prefs.isEnabled(row.id) },
-                set: { prefs.setEnabled(row.id, $0) }
-            ))
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .controlSize(.small)
+            if locked {
+                Button("Subscribe") {
+                    SettingsWindowController.shared.show(tab: .account)
+                }
+                .buttonStyle(.capsule(.secondary))
+            } else {
+                Toggle("", isOn: Binding(
+                    get: { prefs.isEnabled(row.id) },
+                    set: { prefs.setEnabled(row.id, $0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+            }
         }
         .padding(.vertical, AppTheme.Spacing.smMd)
     }

--- a/Sources/PalmierPro/Timeline/TimelineView+AIEditMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+AIEditMenu.swift
@@ -8,28 +8,30 @@ extension TimelineView {
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         let aiAllowed = editor.aiEditAllowed
+        let isPaid = AccountService.shared.isPaid
         for action in actions {
             switch action {
             case .upscale:
                 let models = editor.aiEditUpscaleModels(clipId: clipId)
                 guard !models.isEmpty else { continue }
-                let upscaleItem = NSMenuItem(title: "Upscale", action: nil, keyEquivalent: "")
+                let upscaleItem = NSMenuItem(title: isPaid ? "Upscale" : "Upscale (Paid)", action: nil, keyEquivalent: "")
+                upscaleItem.isEnabled = aiAllowed && isPaid
                 let modelsMenu = NSMenu()
                 modelsMenu.autoenablesItems = false
                 for model in models {
                     let item = NSMenuItem(title: model.displayName, action: #selector(performAIEditUpscale(_:)), keyEquivalent: "")
                     item.target = self
                     item.representedObject = ["clipId": clipId, "modelId": model.id]
-                    item.isEnabled = aiAllowed
+                    item.isEnabled = aiAllowed && isPaid
                     modelsMenu.addItem(item)
                 }
                 upscaleItem.submenu = modelsMenu
                 submenu.addItem(upscaleItem)
             case .edit:
-                let item = NSMenuItem(title: "Edit…", action: #selector(performAIEditEdit(_:)), keyEquivalent: "")
+                let item = NSMenuItem(title: isPaid ? "Edit…" : "Edit… (Paid)", action: #selector(performAIEditEdit(_:)), keyEquivalent: "")
                 item.target = self
                 item.representedObject = clipId
-                item.isEnabled = aiAllowed
+                item.isEnabled = aiAllowed && isPaid
                 submenu.addItem(item)
             case .generateMusic, .generateSFX:
                 let kind: VideoToAudioEditKind = action == .generateMusic ? .music : .sfx


### PR DESCRIPTION
let free users try some cheaper models.

1. list_tools return the available model
2. the model drop down only show the available model
3. the model setting disable the paid model to avoid confusion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing/plan gating across agent APIs and multiple UI entry points; inconsistent rules (per-model locks in some menus vs blanket upscale/edit block in inspector/timeline) could confuse users or miss edge cases if catalog and `AccountService.isPaid` drift.
> 
> **Overview**
> Introduces a **`paidOnly`** flag on catalog models (decoded from the backend, default `false`) and threads it through video/image/audio/upscale configs so the app can treat free vs paid plans differently.
> 
> **Agent tools** (`ToolExecutor`): `list_models` only returns models the current plan can use; generate/upscale default to the first allowed model, reject explicit paid model IDs on free accounts, and surface subscribe-oriented errors.
> 
> **Generation UI**: the model picker hides paid-only entries for free users, re-normalizes selection when plan or prefs change, and routes submit on a locked model to Account settings.
> 
> **Settings → Models**: paid-only rows are dimmed, sorted to the bottom, and show **Subscribe** instead of an enable toggle.
> 
> **AI Edit** surfaces diverge: context menus show lock/subscribe for paid upscale models (`AIEditMenu`); the timeline NSMenu and inspector **AI Edit** tab disable **Upscale** and **Edit** entirely for non-paid users (inspector copy: “Requires a paid plan”).
> 
> **GenerationService** parses Convex error payloads for clearer failed-submit messages when the backend enforces plan limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704ecd0510367a9a16ebf5a6df03274c41f1a7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->