### PR TITLE
fix(mcp): stateful sessions so clients refresh tools after app updates

### DIFF
--- a/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
@@ -2,12 +2,23 @@ import Foundation
 import MCP
 import Network
 
-/// HTTP server for MCP. Each TCP connection gets its own `Server` + `Transport` pair.
+/// HTTP server for MCP. Each client session gets its own `Server` + stateful transport
 actor MCPHTTPServer {
 
     private let port: UInt16
     private let makeServer: @Sendable () async -> Server
     private nonisolated(unsafe) var listener: NWListener?
+
+    private struct Session {
+        let server: Server
+        let transport: StatefulHTTPServerTransport
+        var lastUsed: ContinuousClock.Instant
+    }
+
+    private var sessions: [String: Session] = [:]
+    private var fallback: (server: Server, transport: StatelessHTTPServerTransport)?
+    private static let sessionIdleLimit: Duration = .seconds(3600)
+    private static let sessionCountLimit = 32
 
     init(port: UInt16, makeServer: @escaping @Sendable () async -> Server) {
         self.port = port
@@ -29,7 +40,7 @@ actor MCPHTTPServer {
         listener?.newConnectionHandler = { [weak self] connection in
             guard let self else { return }
             connection.start(queue: .global(qos: .userInitiated))
-            Task { await self.handleConnection(connection) }
+            Task { await self.receive(on: connection) }
         }
 
         listener?.start(queue: .global(qos: .userInitiated))
@@ -38,41 +49,72 @@ actor MCPHTTPServer {
     func stop() {
         listener?.cancel()
         listener = nil
+        let closing = sessions.values.map(\.transport)
+        sessions.removeAll()
+        let fallbackTransport = fallback?.transport
+        fallback = nil
+        Task {
+            for transport in closing { await transport.disconnect() }
+            await fallbackTransport?.disconnect()
+        }
     }
 
     // MARK: - Connection
 
-    private func handleConnection(_ connection: NWConnection) async {
-        let pipeline = StandardValidationPipeline(validators: [
-            OriginValidator.localhost(port: Int(port)),
-            ContentTypeValidator(),
-            ProtocolVersionValidator(),
-        ])
-        let transport = StatelessHTTPServerTransport(validationPipeline: pipeline)
-        let server = await makeServer()
-        try? await server.start(transport: transport)
-        receive(on: connection, transport: transport)
-    }
-
-    private func receive(on connection: NWConnection, transport: StatelessHTTPServerTransport) {
+    private func receive(on connection: NWConnection, buffer: Data = Data()) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 1_048_576) { [weak self] data, _, _, error in
             guard let self, let data, !data.isEmpty, error == nil else {
                 connection.cancel(); return
             }
-            Task { await self.handle(data: data, connection: connection, transport: transport) }
+            var buffer = buffer
+            buffer.append(data)
+            Task { await self.process(buffer: buffer, connection: connection) }
         }
     }
 
-    private func handle(data: Data, connection: NWConnection, transport: StatelessHTTPServerTransport) async {
-        guard let request = parseHTTPRequest(data) else {
+    // A request body can span multiple TCP reads; accumulate until Content-Length is satisfied.
+    private func process(buffer: Data, connection: NWConnection) async {
+        switch framing(of: buffer) {
+        case .needMoreData:
+            receive(on: connection, buffer: buffer)
+        case .invalid:
             sendRaw("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: false)
-            return
+        case .complete:
+            guard let request = parseHTTPRequest(buffer) else {
+                sendRaw("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: false)
+                return
+            }
+            await handle(request: request, connection: connection)
         }
+    }
 
+    private enum Framing { case needMoreData, complete, invalid }
+
+    private nonisolated func framing(of data: Data) -> Framing {
+        guard data.count <= 16_777_216 else { return .invalid }
+        guard let headerEnd = data.range(of: Data("\r\n\r\n".utf8)) else {
+            return data.count > 65_536 ? .invalid : .needMoreData
+        }
+        guard let head = String(data: data[data.startIndex..<headerEnd.lowerBound], encoding: .utf8) else {
+            return .invalid
+        }
+        let contentLength = head.components(separatedBy: "\r\n").dropFirst().compactMap { line -> Int? in
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" else { return nil }
+            return Int(parts[1].trimmingCharacters(in: .whitespaces))
+        }.first ?? 0
+        let bodyBytes = data.distance(from: headerEnd.upperBound, to: data.endIndex)
+        return bodyBytes >= contentLength ? .complete : .needMoreData
+    }
+
+    // MARK: - Routing
+
+    private func handle(request: HTTPRequest, connection: NWConnection) async {
         if request.path == "/.well-known/oauth-protected-resource" {
             let body = "{\"resource\":\"http://127.0.0.1:\(port)\"}"
             sendRaw("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(body.utf8.count)\r\n\r\n\(body)", on: connection, keepAlive: true)
-            receive(on: connection, transport: transport)
+            receive(on: connection)
             return
         }
 
@@ -81,16 +123,101 @@ actor MCPHTTPServer {
             return
         }
 
-        if request.method.uppercased() == "GET" {
-            sendRaw("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n: connected\n\n", on: connection, keepAlive: true)
+        let response: HTTPResponse
+        if let claimed = request.header(HTTPHeaderName.sessionID) {
+            guard var session = sessions[claimed] else {
+                // Unknown/expired session → 404 per spec; the client re-initializes
+                // and refreshes its tool inventory.
+                sendRaw("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: true)
+                receive(on: connection)
+                return
+            }
+            session.lastUsed = .now
+            sessions[claimed] = session
+            response = await session.transport.handleRequest(request)
+            if request.method.uppercased() == "DELETE", response.statusCode == 200 {
+                sessions.removeValue(forKey: claimed)
+            }
+        } else if isInitialize(request) {
+            let transport = StatefulHTTPServerTransport(
+                validationPipeline: StandardValidationPipeline(validators: baseValidators() + [SessionValidator()])
+            )
+            let server = await makeServer()
+            try? await server.start(transport: transport)
+            response = await transport.handleRequest(request)
+            if let assigned = response.headers[HTTPHeaderName.sessionID] {
+                pruneIdleSessions()
+                sessions[assigned] = Session(server: server, transport: transport, lastUsed: .now)
+                Log.mcp.notice("session started id=\(assigned) total=\(self.sessions.count)")
+            } else {
+                await transport.disconnect()
+            }
+        } else {
+            // Sessionless clients (and plain curl) get simple request/response semantics.
+            response = await fallbackPair().transport.handleRequest(request)
+        }
+        writeResponse(response, on: connection)
+    }
+
+    private nonisolated func isInitialize(_ request: HTTPRequest) -> Bool {
+        guard request.method.uppercased() == "POST", let body = request.body,
+              let json = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any] else { return false }
+        return json["method"] as? String == "initialize"
+    }
+
+    private nonisolated func baseValidators() -> [any HTTPRequestValidator] {
+        [OriginValidator.localhost(port: Int(port)), ContentTypeValidator(), ProtocolVersionValidator()]
+    }
+
+    private func fallbackPair() async -> (server: Server, transport: StatelessHTTPServerTransport) {
+        if let fallback { return fallback }
+        let pipeline = StandardValidationPipeline(validators: baseValidators())
+        let pair = (server: await makeServer(), transport: StatelessHTTPServerTransport(validationPipeline: pipeline))
+        try? await pair.server.start(transport: pair.transport)
+        fallback = pair
+        return pair
+    }
+
+    // Evicted clients recover transparently: their next request gets 404 and they re-initialize.
+    private func pruneIdleSessions() {
+        let cutoff = ContinuousClock.now - Self.sessionIdleLimit
+        for (id, session) in sessions where session.lastUsed < cutoff {
+            evictSession(id: id)
+        }
+        while sessions.count >= Self.sessionCountLimit,
+              let oldest = sessions.min(by: { $0.value.lastUsed < $1.value.lastUsed }) {
+            evictSession(id: oldest.key)
+        }
+    }
+
+    private func evictSession(id: String) {
+        guard let session = sessions.removeValue(forKey: id) else { return }
+        Log.mcp.notice("session evicted id=\(id)")
+        Task { await session.transport.disconnect() }
+    }
+
+    // MARK: - Response writing
+
+    private func writeResponse(_ response: HTTPResponse, on connection: NWConnection) {
+        if case .stream(let stream, let headers) = response {
+            // SSE has no Content-Length; close the connection to delimit the body.
+            var head = "HTTP/1.1 200 OK\r\n"
+            for (k, v) in headers where k.lowercased() != "connection" { head += "\(k): \(v)\r\n" }
+            head += "Connection: close\r\n\r\n"
+            connection.send(content: head.data(using: .utf8), completion: .contentProcessed { _ in })
+            Task {
+                do {
+                    for try await chunk in stream {
+                        connection.send(content: chunk, completion: .contentProcessed { _ in })
+                    }
+                } catch {}
+                connection.send(content: nil, contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            }
             return
         }
 
-        let mcpResponse = await transport.handleRequest(request)
-        writeResponse(mcpResponse, on: connection, transport: transport)
-    }
-
-    private func writeResponse(_ response: HTTPResponse, on connection: NWConnection, transport: StatelessHTTPServerTransport) {
         var head = "HTTP/1.1 \(response.statusCode) \(statusText(response.statusCode))\r\n"
         for (k, v) in response.headers { head += "\(k): \(v)\r\n" }
         head += "Content-Length: \(response.bodyData?.count ?? 0)\r\nConnection: keep-alive\r\n\r\n"
@@ -99,7 +226,7 @@ actor MCPHTTPServer {
         if let bodyData = response.bodyData { responseData.append(bodyData) }
 
         connection.send(content: responseData, completion: .contentProcessed { _ in })
-        receive(on: connection, transport: transport)
+        receive(on: connection)
     }
 
     // MARK: - HTTP Parsing
@@ -139,7 +266,8 @@ actor MCPHTTPServer {
     private nonisolated func statusText(_ code: Int) -> String {
         switch code {
         case 200: "OK"; case 202: "Accepted"; case 400: "Bad Request"
-        case 404: "Not Found"; case 405: "Method Not Allowed"; case 500: "Internal Server Error"
+        case 404: "Not Found"; case 405: "Method Not Allowed"; case 409: "Conflict"
+        case 500: "Internal Server Error"
         default: "Unknown"
         }
     }

--- a/Sources/PalmierPro/Agent/MCP/MCPService.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPService.swift
@@ -33,7 +33,8 @@ final class MCPService {
     }
 
     func start() {
-        let httpServer = MCPHTTPServer(port: Self.port) { [weak self] in
+        let toolExecutor = self.toolExecutor
+        let httpServer = MCPHTTPServer(port: Self.port) {
             let server = Server(
                 name: "palmier-pro",
                 version: "1.0.0",
@@ -43,8 +44,8 @@ final class MCPService {
                     tools: .init(listChanged: false)
                 )
             )
-            await self?.registerTools(on: server)
-            await self?.registerResources(on: server)
+            await Self.registerTools(on: server, executor: toolExecutor)
+            await Self.registerResources(on: server)
             return server
         }
         self.httpServer = httpServer
@@ -69,7 +70,7 @@ final class MCPService {
         Log.mcp.notice("http server stopped")
     }
 
-    private func registerTools(on server: Server) async {
+    private nonisolated static func registerTools(on server: Server, executor: ToolExecutor) async {
         let tools: [Tool] = ToolDefinitions.mcpServer.map { def in
             Tool(name: def.name.rawValue, description: def.description, inputSchema: def.mcpSchemaValue)
         }
@@ -78,22 +79,19 @@ final class MCPService {
             .init(tools: tools)
         }
 
-        await server.withMethodHandler(CallTool.self) { [weak self] params in
-            guard let self else {
-                return ToolResult.error("Editor not available").toMCPResult()
-            }
-            return await self.dispatchCall(params)
+        await server.withMethodHandler(CallTool.self) { params in
+            await dispatchCall(params, executor: executor)
         }
     }
 
-    // Convert args inside the actor so the non-Sendable dict never crosses the hop.
-    private func dispatchCall(_ params: CallTool.Parameters) async -> CallTool.Result {
+    // Convert args on the main actor so the non-Sendable dict never crosses the hop.
+    private static func dispatchCall(_ params: CallTool.Parameters, executor: ToolExecutor) async -> CallTool.Result {
         let args = ToolArgsBridge.argsFromMCP(params.arguments ?? [:])
-        let result = await toolExecutor.execute(name: params.name, args: args)
+        let result = await executor.execute(name: params.name, args: args)
         return result.toMCPResult()
     }
 
-    private func registerResources(on server: Server) async {
+    private nonisolated static func registerResources(on server: Server) async {
         let resources = [
             Resource(
                 name: "Video Models",


### PR DESCRIPTION
## Summary
MCP clients cache the tool list at initialization and never re-fetch it. Because the server was fully stateless, an app update was invisible to connected clients — their tool calls kept succeeding against the new server, so they kept advertising the previous release's tool schema until the client itself was restarted.

This adopts the MCP Streamable HTTP session mechanism: sessions issued at `initialize` die with the app process, the next request from an old session gets 404, and per spec the client re-initializes — refreshing tools, instructions, and capabilities automatically.

## What changed
- **`MCPHTTPServer`**: each client session gets its own `Server` + SDK `StatefulHTTPServerTransport`, routed by `Mcp-Session-Id` through a registry. Unknown/expired session → 404 → client re-initializes. Sessionless clients fall back to a shared stateless transport, preserving current behavior.
- **Real SSE**: responses stream as server-sent events and the standalone GET stream now works (previously a stub) — the foundation for `notifications/progress` on long tool runs and `tools/list_changed`.
- **Request framing**: requests are accumulated until Content-Length is satisfied. Previously the first TCP read was parsed as the whole request, corrupting large tool-call bodies (e.g. big `add_captions` payloads). Bounds: 64KB headers, 16MB body.
- **`MCPService`**: server construction, `tools/list`, and resource registration are now `nonisolated`; only tool execution hops to the main actor. A busy main thread can no longer stall new MCP connections (the plumbing half of #58 — long-running main-actor work inside individual tools is tracked separately).
- **Session hygiene**: LRU cap of 32 concurrent sessions plus 1-hour idle pruning; evicted clients recover transparently via the same 404 → re-initialize path.

## Verification
- Protocol-level (curl): `initialize` returns `Mcp-Session-Id` over SSE; `tools/list`/`tools/call` in-session; stale session → 404; sessionless request → 200 JSON via fallback; standalone GET SSE stream; 202 for notifications; 200KB `tools/call` body frames correctly; 40 spam initializes trigger LRU eviction.
- End-to-end (Claude Code over Streamable HTTP): killed and relaunched the app while a client session was live — the next tool call recovered transparently (404 → re-initialize → fresh 45-tool inventory) and succeeded. Verified read tools (`get_projects`, `open_project`, `get_timeline`) and the mutation path (`split_clips` on a linked A/V pair, then `undo`).

Refs #58. Overlaps with the main-actor decoupling in #187; this PR lands a smaller version of that fix as part of the transport rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches localhost MCP connection handling, session lifecycle, and tool-dispatch wiring; mistakes could break clients or leave stale sessions, but scope stays on loopback and preserves a stateless fallback.
> 
> **Overview**
> Replaces the **one transport per TCP connection** model with **MCP Streamable HTTP sessions**: `initialize` spins up a dedicated `Server` + `StatefulHTTPServerTransport`, registers it by `Mcp-Session-Id`, and later requests route to that session. **Stale or unknown session IDs return 404** so clients re-initialize and pick up fresh tools/instructions after an app restart or eviction. Sessionless traffic still uses a shared **stateless fallback** transport.
> 
> **HTTP handling** now **buffers reads until `Content-Length` is complete** (with size limits), fixing corrupted large `tools/call` bodies. **SSE responses** stream on the wire instead of treating GET as a stub; stop tears down all session and fallback transports.
> 
> **`MCPService`** moves server factory registration (`registerTools` / `registerResources`) to **`nonisolated static`** helpers and passes `ToolExecutor` into the factory so new MCP connections are not blocked on the `@MainActor` service; tool execution still goes through the executor.
> 
> Session registry enforces **1h idle** and **32-session LRU** eviction with the same 404 → re-init recovery path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ab2f36598a87c298267043d6fc5aaed76d600e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->