### PR TITLE
Audio Enhancer / Denoise

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "806aa29ab163d9ddd0a263c12468e03f6dc0cc679d156fc54fb46aeab0640103",
+  "originHash" : "b7674ff7f13087bc334a6d37850ef376159f261445a3824150ccb5f626730fb4",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "clerk-convex-swift",
       "kind" : "remoteSourceControl",
@@ -17,6 +26,15 @@
       "state" : {
         "revision" : "9b6c83e780c48af3a5cb8c40305674d9d8cb0fc6",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "compress-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/compress-nio.git",
+      "state" : {
+        "revision" : "e1caa19077dda4b00441142ef57da3db02acd466",
+        "version" : "1.4.2"
       }
     },
     {
@@ -38,12 +56,39 @@
       }
     },
     {
+      "identity" : "hummingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
+      "state" : {
+        "revision" : "3ae359b1bb1e72378ed43b59fdcd4d44cac5d7a4",
+        "version" : "2.16.0"
+      }
+    },
+    {
+      "identity" : "hummingbird-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird-websocket.git",
+      "state" : {
+        "revision" : "716c54294152c6d3301a6239a1d74db57cbcd6dc",
+        "version" : "2.6.0"
+      }
+    },
+    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios",
       "state" : {
         "revision" : "f4db77d7feacba0c2360b84a40c38a6ce8ff399d",
         "version" : "4.6.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "eb889e01b7267bc6d9c01fde91bc517b09506c2d",
+        "version" : "0.31.5"
       }
     },
     {
@@ -83,12 +128,48 @@
       }
     },
     {
+      "identity" : "speech-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soniqo/speech-swift",
+      "state" : {
+        "revision" : "7609977be837a6529bd04300c6b963e735300070",
+        "version" : "0.0.21"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
         "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
       }
     },
     {
@@ -101,6 +182,15 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "eaa10d47d19919979dd8df22ff4fd6349b1108d4",
+        "version" : "1.19.2"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -110,12 +200,48 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
         "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
         "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -146,6 +272,15 @@
       }
     },
     {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -155,12 +290,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
         "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -179,6 +377,24 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/swift-websocket.git",
+      "state" : {
+        "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "whisperkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/WhisperKit",
+      "state" : {
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/get-convex/convex-swift", from: "0.8.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.6.1"),
+        .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.21"),
     ],
     targets: [
         .executableTarget(
@@ -30,6 +31,7 @@ let package = Package(
                 .product(name: "ConvexMobile", package: "convex-swift"),
                 .product(name: "Tokenizers", package: "swift-transformers"),
                 .product(name: "Lottie", package: "lottie-ios"),
+                .product(name: "SpeechEnhancement", package: "speech-swift"),
             ],
             path: "Sources/PalmierPro",
             exclude: [

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -34,6 +34,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case searchMedia = "search_media"
     case applyColor = "apply_color"
     case applyEffect = "apply_effect"
+    case denoiseAudio = "denoise_audio"
     case inspectColor = "inspect_color"
     case listFolders = "list_folders"
     case createFolder = "create_folder"
@@ -783,6 +784,18 @@ enum ToolDefinitions {
                         ),
                     ],
                     "remove": ["type": "array", "items": ["type": "string"], "description": "Effect type ids to remove from the clips."],
+                ],
+                required: ["clipIds"]
+            )
+        ),
+        AgentTool(
+            name: .denoiseAudio,
+            description: "Remove background noise from audio clips using an on-device speech-enhancement model (DeepFilterNet3). strength is a dry/wet percentage: 0 leaves the audio untouched, 100 is fully denoised. Full strength can sound thin or over-gated on real-world recordings, so the default is 60. The bake runs in the background — the timeline updates automatically when it finishes; no need to poll. Pass enabled:false to turn denoise off. Undoable.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipIds": ["type": "array", "items": ["type": "string"], "description": "Audio clip ids from get_timeline."],
+                    "strength": ["type": "number", "description": "Dry/wet mix as a percentage, 0–100 (default 60). Lower it if voices sound thin or over-compressed."],
+                    "enabled": ["type": "boolean", "description": "Default true. false removes the denoise effect from the clips."],
                 ],
                 required: ["clipIds"]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Denoise.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Denoise.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension ToolExecutor {
+    fileprivate struct DenoiseAudioInput: DecodableToolArgs {
+        let clipIds: [String]
+        let strength: Double?
+        let enabled: Bool?
+        static let allowedKeys: Set<String> = ["clipIds", "strength", "enabled"]
+    }
+
+    func denoiseAudio(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: DenoiseAudioInput = try decodeToolArgs(args, path: "denoise_audio")
+        guard !input.clipIds.isEmpty else { throw ToolError("clipIds is empty.") }
+        if let s = input.strength, !(0...100).contains(s) {
+            throw ToolError("strength must be 0–100 (got \(s))")
+        }
+        for id in input.clipIds {
+            guard let clip = editor.clipFor(id: id) else { throw ToolError("Clip not found: \(id)") }
+            guard clip.mediaType == .audio else {
+                throw ToolError("Clip \(id) is a \(clip.mediaType.rawValue) clip; denoise_audio needs an audio clip.")
+            }
+        }
+
+        let enabled = input.enabled ?? true
+        let actionName = enabled ? "Denoise Audio (Agent)" : "Disable Denoise (Agent)"
+        withUndoGroup(editor, actionName: actionName) {
+            editor.setDenoise(
+                clipIds: Set(input.clipIds),
+                enabled: enabled,
+                amount: input.strength.map { $0 / 100 },
+                actionName: actionName
+            )
+        }
+        let count = input.clipIds.count
+        let noun = "clip\(count == 1 ? "" : "s")"
+        guard enabled else { return .ok("Disabled denoise on \(count) \(noun).") }
+        let pct = Int(((input.strength ?? Clip.defaultDenoiseAmount * 100)).rounded())
+        return .ok("Denoise enabled at \(pct)% on \(count) \(noun). The bake runs in the background; the preview picks it up automatically when it finishes.")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -74,6 +74,7 @@ extension ToolExecutor {
             if let error = service.error {
                 AppNotifications.exportFailed(name: name, reason: error)
             } else {
+                editor.syncDenoiseAfterExport()
                 let report = service.lastReport
                 let warningCount = (report?.offlineMediaRefs.count ?? 0) + (report?.unprocessableMediaRefs.count ?? 0)
                 AppNotifications.exportComplete(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -91,6 +91,7 @@ final class ToolExecutor {
         case .searchMedia:   return try await searchMedia(editor, args)
         case .applyColor:    return try applyColor(editor, args)
         case .applyEffect:   return try applyEffect(editor, args)
+        case .denoiseAudio:  return try denoiseAudio(editor, args)
         case .inspectColor:  return try await inspectColor(editor, args)
         case .addClips:         return try addClips(editor, args)
         case .insertClips:      return try insertClips(editor, args)

--- a/Sources/PalmierPro/Audio/AudioEnhancer.swift
+++ b/Sources/PalmierPro/Audio/AudioEnhancer.swift
@@ -45,15 +45,19 @@ enum AudioEnhancer {
     }
 
     static func cachedURL(for sourceURL: URL, mediaRef: String, amount: Double) -> URL? {
+        if percent(amount) == 0 { return sourceURL }
         let url = mixedOutputURL(for: sourceURL, mediaRef: mediaRef, amount: amount)
         return FileManager.default.fileExists(atPath: url.path) ? url : nil
     }
 
     // MARK: - Cache paths
 
+    private static func percent(_ amount: Double) -> Int {
+        Int((min(1, max(0, amount)) * 100).rounded())
+    }
+
     private static func mixedOutputURL(for sourceURL: URL, mediaRef: String, amount: Double) -> URL {
-        let pct = Int((min(1, max(0, amount)) * 100).rounded())
-        return cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_\(pct)_denoised.caf")
+        cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_\(percent(amount))_denoised.caf")
     }
 
     private static func cacheTag(for url: URL) -> String {

--- a/Sources/PalmierPro/Audio/AudioEnhancer.swift
+++ b/Sources/PalmierPro/Audio/AudioEnhancer.swift
@@ -1,0 +1,168 @@
+import AVFoundation
+import Accelerate
+import SpeechEnhancement
+
+/// Offline noise-removal bake for audio clips, via DeepFilterNet3 (Core ML, Neural Engine).
+/// Mirrors `AlphaVideoNormalizer`: cache-checked transcode keyed on source file identity.
+///
+/// The model's raw output ("wet") is cached once per source file, independent of the
+/// dry/wet `amount` — changing the Strength slider only re-mixes cached wet+dry PCM
+/// (cheap, no model inference), rather than re-running the model.
+enum AudioEnhancer {
+    static let cache = DiskCache(named: "EnhancedAudio")
+
+    enum EnhanceError: LocalizedError {
+        case noAudioTrack
+        case writeFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .noAudioTrack: "Source has no audio track"
+            case .writeFailed: "Could not write enhanced audio"
+            }
+        }
+    }
+
+    /// Model is expensive to load and its buffers aren't Sendable; keep both loading
+    /// and inference confined to this actor so the instance never crosses isolation domains.
+    private static let modelBox = ModelBox()
+
+    private actor ModelBox {
+        private var enhancer: SpeechEnhancer?
+
+        /// DeepFilterNet3 processes a single channel; internal streaming state resets
+        /// per call (`enhanceChunked` calls `resetState()` up front), so sequential
+        /// per-channel calls on one instance are safe.
+        func enhance(audio: [Float], sampleRate: Int) async throws -> [Float] {
+            if enhancer == nil { enhancer = try await SpeechEnhancer.fromPretrained() }
+            return try enhancer!.enhanceChunked(audio: audio, sampleRate: sampleRate)
+        }
+    }
+
+    private static var sampleRate: Double { Double(SpeechEnhancer.sampleRate) }
+
+    /// Returns the mixed (dry/wet) audio for `amount`, bakes if needed. `mediaRef` scopes the
+    /// cache key. `amount` is the dry/wet mix (0 = untouched, 1 = fully denoised) — DeepFilterNet3
+    /// at full strength tends to sound thin/over-gated on non-ideal input, so blending back some
+    /// of the original signal is the main lever for taming that.
+    static func enhancedAudio(for sourceURL: URL, mediaRef: String, amount: Double) async throws -> URL {
+        if let cached = cachedURL(for: sourceURL, mediaRef: mediaRef, amount: amount) { return cached }
+        let wet = try await wetChannels(for: sourceURL, mediaRef: mediaRef)
+        let dry = try await readChannels(from: sourceURL, channelCount: wet.count)
+        let w = Float(min(1, max(0, amount)))
+        let mixed = zip(dry, wet).map { dry, wet in
+            let n = min(dry.count, wet.count)
+            return vDSP.add(multiplication: (wet[0..<n], w), multiplication: (dry[0..<n], 1 - w))
+        }
+        let outputURL = mixedOutputURL(for: sourceURL, mediaRef: mediaRef, amount: amount)
+        try write(channels: mixed, to: outputURL)
+        return outputURL
+    }
+
+    /// Non-blocking cache check — never triggers a bake. Used by `CompositionBuilder` so
+    /// preview/export rebuilds don't stall on the model; falls back to the raw source until
+    /// the background bake (kicked off elsewhere) lands and triggers a rebuild.
+    static func cachedURL(for sourceURL: URL, mediaRef: String, amount: Double) -> URL? {
+        let url = mixedOutputURL(for: sourceURL, mediaRef: mediaRef, amount: amount)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    // MARK: - Cache paths
+
+    private static func mixedOutputURL(for sourceURL: URL, mediaRef: String, amount: Double) -> URL {
+        let pct = Int((min(1, max(0, amount)) * 100).rounded())
+        return cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_\(pct)_denoised.caf")
+    }
+
+    /// Cache key fragment that busts when the underlying file is replaced.
+    private static func cacheTag(for url: URL) -> String {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attrs?[.size] as? Int) ?? 0
+        let modified = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return "\(size)_\(Int(modified))"
+    }
+
+    // MARK: - Reading
+
+    /// Reads deinterleaved float PCM at the model's sample rate. When `channelCount` is nil,
+    /// it is probed from the file itself (capped at stereo — the model is mono per channel;
+    /// anything beyond L/R is downmixed by the reader).
+    private static func readChannels(from url: URL, channelCount: Int? = nil) async throws -> [[Float]] {
+        let count: Int
+        if let channelCount {
+            count = channelCount
+        } else {
+            let track = try await AVURLAsset(url: url).loadTracks(withMediaType: .audio).first
+            let desc = try await track?.load(.formatDescriptions).first
+            let channels = desc.flatMap { CMAudioFormatDescriptionGetStreamBasicDescription($0)?.pointee.mChannelsPerFrame } ?? 1
+            count = min(2, max(1, Int(channels)))
+        }
+        var channels = [[Float]](repeating: [], count: count)
+        try await AudioTrackReader.read(
+            from: url,
+            outputSettings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: count,
+                AVLinearPCMBitDepthKey: 32,
+                AVLinearPCMIsFloatKey: true,
+                AVLinearPCMIsNonInterleaved: true,
+            ]
+        ) { buffer in
+            guard let data = buffer.floatChannelData else { return }
+            for ch in 0..<count {
+                channels[ch].append(contentsOf: UnsafeBufferPointer(start: data[ch], count: Int(buffer.frameLength)))
+            }
+        }
+        return channels
+    }
+
+    /// Returns the model's raw (100% wet) output per channel, running inference only if not
+    /// already cached on disk for this source file.
+    private static func wetChannels(for sourceURL: URL, mediaRef: String) async throws -> [[Float]] {
+        let wetURL = cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_wet.caf")
+        if FileManager.default.fileExists(atPath: wetURL.path) {
+            let cached = try await readChannels(from: wetURL)
+            if cached.contains(where: { !$0.isEmpty }) { return cached }
+        }
+
+        let dryChannels = try await readChannels(from: sourceURL)
+        guard dryChannels.contains(where: { !$0.isEmpty }) else { throw EnhanceError.noAudioTrack }
+
+        var wet: [[Float]] = []
+        for dry in dryChannels {
+            wet.append(dry.isEmpty ? dry : try await modelBox.enhance(audio: dry, sampleRate: SpeechEnhancer.sampleRate))
+        }
+        try write(channels: wet, to: wetURL)
+        return wet
+    }
+
+    // MARK: - Writing
+
+    private static func write(channels: [[Float]], to outputURL: URL) throws {
+        guard let frameCount = channels.first?.count, frameCount > 0,
+              let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: AVAudioChannelCount(channels.count)),
+              let outBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))
+        else { throw EnhanceError.writeFailed }
+        outBuffer.frameLength = AVAudioFrameCount(frameCount)
+        for ch in channels.indices {
+            channels[ch].withUnsafeBufferPointer { src in
+                outBuffer.floatChannelData?[ch].update(from: src.baseAddress!, count: channels[ch].count)
+            }
+        }
+
+        let fm = FileManager.default
+        try? fm.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let tempURL = outputURL.deletingLastPathComponent().appendingPathComponent(".writing-\(UUID().uuidString).caf")
+        defer { try? fm.removeItem(at: tempURL) }
+        let file = try AVAudioFile(forWriting: tempURL, settings: format.settings)
+        try file.write(from: outBuffer)
+
+        guard !fm.fileExists(atPath: outputURL.path) else { return }
+        do {
+            try fm.moveItem(at: tempURL, to: outputURL)
+        } catch {
+            guard fm.fileExists(atPath: outputURL.path) else { throw error }
+        }
+    }
+}

--- a/Sources/PalmierPro/Audio/AudioEnhancer.swift
+++ b/Sources/PalmierPro/Audio/AudioEnhancer.swift
@@ -2,12 +2,6 @@ import AVFoundation
 import Accelerate
 import SpeechEnhancement
 
-/// Offline noise-removal bake for audio clips, via DeepFilterNet3 (Core ML, Neural Engine).
-/// Mirrors `AlphaVideoNormalizer`: cache-checked transcode keyed on source file identity.
-///
-/// The model's raw output ("wet") is cached once per source file, independent of the
-/// dry/wet `amount` — changing the Strength slider only re-mixes cached wet+dry PCM
-/// (cheap, no model inference), rather than re-running the model.
 enum AudioEnhancer {
     static let cache = DiskCache(named: "EnhancedAudio")
 
@@ -23,16 +17,11 @@ enum AudioEnhancer {
         }
     }
 
-    /// Model is expensive to load and its buffers aren't Sendable; keep both loading
-    /// and inference confined to this actor so the instance never crosses isolation domains.
     private static let modelBox = ModelBox()
 
     private actor ModelBox {
         private var enhancer: SpeechEnhancer?
 
-        /// DeepFilterNet3 processes a single channel; internal streaming state resets
-        /// per call (`enhanceChunked` calls `resetState()` up front), so sequential
-        /// per-channel calls on one instance are safe.
         func enhance(audio: [Float], sampleRate: Int) async throws -> [Float] {
             if enhancer == nil { enhancer = try await SpeechEnhancer.fromPretrained() }
             return try enhancer!.enhanceChunked(audio: audio, sampleRate: sampleRate)
@@ -41,10 +30,6 @@ enum AudioEnhancer {
 
     private static var sampleRate: Double { Double(SpeechEnhancer.sampleRate) }
 
-    /// Returns the mixed (dry/wet) audio for `amount`, bakes if needed. `mediaRef` scopes the
-    /// cache key. `amount` is the dry/wet mix (0 = untouched, 1 = fully denoised) — DeepFilterNet3
-    /// at full strength tends to sound thin/over-gated on non-ideal input, so blending back some
-    /// of the original signal is the main lever for taming that.
     static func enhancedAudio(for sourceURL: URL, mediaRef: String, amount: Double) async throws -> URL {
         if let cached = cachedURL(for: sourceURL, mediaRef: mediaRef, amount: amount) { return cached }
         let wet = try await wetChannels(for: sourceURL, mediaRef: mediaRef)
@@ -59,9 +44,6 @@ enum AudioEnhancer {
         return outputURL
     }
 
-    /// Non-blocking cache check — never triggers a bake. Used by `CompositionBuilder` so
-    /// preview/export rebuilds don't stall on the model; falls back to the raw source until
-    /// the background bake (kicked off elsewhere) lands and triggers a rebuild.
     static func cachedURL(for sourceURL: URL, mediaRef: String, amount: Double) -> URL? {
         let url = mixedOutputURL(for: sourceURL, mediaRef: mediaRef, amount: amount)
         return FileManager.default.fileExists(atPath: url.path) ? url : nil
@@ -74,7 +56,6 @@ enum AudioEnhancer {
         return cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_\(pct)_denoised.caf")
     }
 
-    /// Cache key fragment that busts when the underlying file is replaced.
     private static func cacheTag(for url: URL) -> String {
         let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
         let size = (attrs?[.size] as? Int) ?? 0
@@ -84,9 +65,6 @@ enum AudioEnhancer {
 
     // MARK: - Reading
 
-    /// Reads deinterleaved float PCM at the model's sample rate. When `channelCount` is nil,
-    /// it is probed from the file itself (capped at stereo — the model is mono per channel;
-    /// anything beyond L/R is downmixed by the reader).
     private static func readChannels(from url: URL, channelCount: Int? = nil) async throws -> [[Float]] {
         let count: Int
         if let channelCount {
@@ -117,8 +95,6 @@ enum AudioEnhancer {
         return channels
     }
 
-    /// Returns the model's raw (100% wet) output per channel, running inference only if not
-    /// already cached on disk for this source file.
     private static func wetChannels(for sourceURL: URL, mediaRef: String) async throws -> [[Float]] {
         let wetURL = cache.directory.appendingPathComponent("\(mediaRef)_\(cacheTag(for: sourceURL))_wet.caf")
         if FileManager.default.fileExists(atPath: wetURL.path) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -19,26 +19,48 @@ extension EditorViewModel {
         }
         guard enabled else { return }
         for id in clipIds {
-            if let live = clipFor(id: id) { enhanceAudioIfNeeded(for: live) }
+            guard let live = clipFor(id: id) else { continue }
+            // An explicit user/agent change is the retry gesture after a failed bake.
+            denoiseFailed.remove(live.mediaRef)
+            enhanceAudioIfNeeded(for: live)
+        }
+    }
+
+    /// Re-checks every denoise-enabled clip and bakes anything missing from the cache.
+    /// Cheap no-op when nothing is pending (one file-exists check per denoised clip), so it's
+    /// safe to call after any timeline change — project open, undo/redo, agent edits.
+    func enhancePendingDenoises() {
+        for track in timeline.tracks {
+            for clip in track.clips where clip.hasDenoiseEnabled {
+                enhanceAudioIfNeeded(for: clip)
+            }
         }
     }
 
     /// Kicks off the offline denoise bake for `clip`'s source if not already cached/in-flight.
     /// Fire-and-forget; `CompositionBuilder` picks up the cached result on next rebuild.
     func enhanceAudioIfNeeded(for clip: Clip) {
-        guard clip.hasDenoiseEnabled, !denoiseInFlight.contains(clip.mediaRef),
-              let url = mediaResolver.resolveURL(for: clip.mediaRef) else { return }
+        guard clip.hasDenoiseEnabled,
+              !denoiseInFlight.contains(clip.mediaRef), !denoiseFailed.contains(clip.mediaRef),
+              let url = mediaResolver.resolveURL(for: clip.mediaRef),
+              AudioEnhancer.cachedURL(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount) == nil
+        else { return }
         denoiseInFlight.insert(clip.mediaRef)
         let mediaRef = clip.mediaRef
         let amount = clip.denoiseAmount
         Task.detached(priority: .utility) { [weak self] in
+            var failed = false
             do {
                 _ = try await AudioEnhancer.enhancedAudio(for: url, mediaRef: mediaRef, amount: amount)
             } catch {
+                failed = true
                 Log.preview.error("denoise bake failed mediaRef=\(mediaRef): \(error.localizedDescription)")
             }
             await MainActor.run { [self] in
                 self?.denoiseInFlight.remove(mediaRef)
+                if failed { self?.denoiseFailed.insert(mediaRef) }
+                // Also rescans pending denoises: strength may have changed while this bake
+                // ran; the cache check above makes the rescan converge instead of looping.
                 self?.notifyTimelineChanged()
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension EditorViewModel {
+    /// Enables/disables denoise (optionally setting the dry/wet amount) on `clipIds` as one
+    /// undoable action, then kicks off any needed bakes. Shared by the inspector and agent tool.
+    func setDenoise(clipIds: Set<String>, enabled: Bool, amount: Double? = nil, actionName: String) {
+        let clamped = amount.map { min(1, max(0, $0)) }
+        mutateClips(ids: clipIds, actionName: actionName) { clip in
+            var stack = clip.effects ?? []
+            let current = stack.first { $0.type == Clip.denoiseEffectType }
+            stack.removeAll { $0.type == Clip.denoiseEffectType }
+            if enabled {
+                let value = clamped ?? current?.params["amount"]?.value ?? Clip.defaultDenoiseAmount
+                stack.append(Effect(type: Clip.denoiseEffectType, enabled: true, params: [
+                    "amount": EffectParam(value: value),
+                ]))
+            }
+            clip.effects = stack.isEmpty ? nil : stack
+        }
+        guard enabled else { return }
+        for id in clipIds {
+            if let live = clipFor(id: id) { enhanceAudioIfNeeded(for: live) }
+        }
+    }
+
+    /// Kicks off the offline denoise bake for `clip`'s source if not already cached/in-flight.
+    /// Fire-and-forget; `CompositionBuilder` picks up the cached result on next rebuild.
+    func enhanceAudioIfNeeded(for clip: Clip) {
+        guard clip.hasDenoiseEnabled, !denoiseInFlight.contains(clip.mediaRef),
+              let url = mediaResolver.resolveURL(for: clip.mediaRef) else { return }
+        denoiseInFlight.insert(clip.mediaRef)
+        let mediaRef = clip.mediaRef
+        let amount = clip.denoiseAmount
+        Task.detached(priority: .utility) { [weak self] in
+            do {
+                _ = try await AudioEnhancer.enhancedAudio(for: url, mediaRef: mediaRef, amount: amount)
+            } catch {
+                Log.preview.error("denoise bake failed mediaRef=\(mediaRef): \(error.localizedDescription)")
+            }
+            await MainActor.run { [self] in
+                self?.denoiseInFlight.remove(mediaRef)
+                self?.notifyTimelineChanged()
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -31,6 +31,23 @@ extension EditorViewModel {
         }
     }
 
+    /// Export can bake denoise caches the preview never got (failed bake, or a composition
+    /// built before the cache landed). Clear stale failure marks and rebuild so playback
+    /// matches the exported file.
+    func syncDenoiseAfterExport() {
+        var hasCached = false
+        for track in timeline.tracks {
+            for clip in track.clips where clip.hasDenoiseEnabled {
+                guard let url = mediaResolver.resolveURL(for: clip.mediaRef),
+                      AudioEnhancer.cachedURL(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount) != nil
+                else { continue }
+                denoiseFailed.remove(clip.mediaRef)
+                hasCached = true
+            }
+        }
+        if hasCached { videoEngine?.rebuild() }
+    }
+
     func enhanceAudioIfNeeded(for clip: Clip) {
         guard clip.hasDenoiseEnabled,
               !denoiseInFlight.contains(clip.mediaRef), !denoiseFailed.contains(clip.mediaRef),

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -50,8 +50,12 @@ extension EditorViewModel {
             }
             await MainActor.run { [self] in
                 self?.denoiseInFlight.remove(mediaRef)
-                if failed { self?.denoiseFailed.insert(mediaRef) }
-                self?.notifyTimelineChanged()
+                if failed {
+                    self?.denoiseFailed.insert(mediaRef)
+                } else {
+                    // Rebuild to pick up the baked audio without pausing active playback.
+                    self?.videoEngine?.rebuild()
+                }
             }
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 extension EditorViewModel {
-    /// Enables/disables denoise (optionally setting the dry/wet amount) on `clipIds` as one
-    /// undoable action, then kicks off any needed bakes. Shared by the inspector and agent tool.
     func setDenoise(clipIds: Set<String>, enabled: Bool, amount: Double? = nil, actionName: String) {
         let clamped = amount.map { min(1, max(0, $0)) }
         mutateClips(ids: clipIds, actionName: actionName) { clip in
@@ -20,15 +18,11 @@ extension EditorViewModel {
         guard enabled else { return }
         for id in clipIds {
             guard let live = clipFor(id: id) else { continue }
-            // An explicit user/agent change is the retry gesture after a failed bake.
             denoiseFailed.remove(live.mediaRef)
             enhanceAudioIfNeeded(for: live)
         }
     }
 
-    /// Re-checks every denoise-enabled clip and bakes anything missing from the cache.
-    /// Cheap no-op when nothing is pending (one file-exists check per denoised clip), so it's
-    /// safe to call after any timeline change — project open, undo/redo, agent edits.
     func enhancePendingDenoises() {
         for track in timeline.tracks {
             for clip in track.clips where clip.hasDenoiseEnabled {
@@ -37,8 +31,6 @@ extension EditorViewModel {
         }
     }
 
-    /// Kicks off the offline denoise bake for `clip`'s source if not already cached/in-flight.
-    /// Fire-and-forget; `CompositionBuilder` picks up the cached result on next rebuild.
     func enhanceAudioIfNeeded(for clip: Clip) {
         guard clip.hasDenoiseEnabled,
               !denoiseInFlight.contains(clip.mediaRef), !denoiseFailed.contains(clip.mediaRef),
@@ -59,8 +51,6 @@ extension EditorViewModel {
             await MainActor.run { [self] in
                 self?.denoiseInFlight.remove(mediaRef)
                 if failed { self?.denoiseFailed.insert(mediaRef) }
-                // Also rescans pending denoises: strength may have changed while this bake
-                // ran; the cache check above makes the rescan converge instead of looping.
                 self?.notifyTimelineChanged()
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -49,13 +49,17 @@ extension EditorViewModel {
                 Log.preview.error("denoise bake failed mediaRef=\(mediaRef): \(error.localizedDescription)")
             }
             await MainActor.run { [self] in
-                self?.denoiseInFlight.remove(mediaRef)
+                guard let self else { return }
+                self.denoiseInFlight.remove(mediaRef)
                 if failed {
-                    self?.denoiseFailed.insert(mediaRef)
+                    self.denoiseFailed.insert(mediaRef)
                 } else {
                     // Rebuild to pick up the baked audio without pausing active playback.
-                    self?.videoEngine?.rebuild()
+                    self.videoEngine?.rebuild()
                 }
+                // Bakes dedupe by mediaRef, so other clips needing a different
+                // strength mix may have been skipped while this one was in flight.
+                self.enhancePendingDenoises()
             }
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -30,6 +30,9 @@ final class EditorViewModel {
     var mediaManifest = MediaManifest()
     var generationLog = GenerationLog()
 
+    /// mediaRefs currently being baked by `AudioEnhancer`.
+    var denoiseInFlight: Set<String> = []
+
     // MARK: - Panel focus
 
     enum FocusedPanel: String {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -33,6 +33,10 @@ final class EditorViewModel {
     /// mediaRefs currently being baked by `AudioEnhancer`.
     var denoiseInFlight: Set<String> = []
 
+    /// mediaRefs whose last bake failed; skipped by the automatic rescan so a persistent
+    /// failure can't retry-loop. Cleared when the user changes the clip's denoise settings.
+    var denoiseFailed: Set<String> = []
+
     // MARK: - Panel focus
 
     enum FocusedPanel: String {
@@ -333,6 +337,9 @@ final class EditorViewModel {
 
     func notifyTimelineChanged(refreshVisuals: Bool = true) {
         guard undoManager?.isUndoRegistrationEnabled ?? true else { return }
+        // Undo/redo (and any other restore) can bring back denoise-enabled clips whose
+        // bake never ran or whose strength changed; cheap no-op when nothing is pending.
+        enhancePendingDenoises()
         pendingRebuildTask?.cancel()
         pendingRebuildTask = nil
         if isPlaying {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -30,11 +30,7 @@ final class EditorViewModel {
     var mediaManifest = MediaManifest()
     var generationLog = GenerationLog()
 
-    /// mediaRefs currently being baked by `AudioEnhancer`.
     var denoiseInFlight: Set<String> = []
-
-    /// mediaRefs whose last bake failed; skipped by the automatic rescan so a persistent
-    /// failure can't retry-loop. Cleared when the user changes the clip's denoise settings.
     var denoiseFailed: Set<String> = []
 
     // MARK: - Panel focus
@@ -337,8 +333,6 @@ final class EditorViewModel {
 
     func notifyTimelineChanged(refreshVisuals: Bool = true) {
         guard undoManager?.isUndoRegistrationEnabled ?? true else { return }
-        // Undo/redo (and any other restore) can bring back denoise-enabled clips whose
-        // bake never ran or whose strength changed; cheap no-op when nothing is pending.
         enhancePendingDenoises()
         pendingRebuildTask?.cancel()
         pendingRebuildTask = nil

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -233,6 +233,15 @@ final class ExportService {
         let renderSize = resolution.renderSize(for: timelineCanvas)
         let mediaURLs = resolver.expectedURLMap()
 
+        // CompositionBuilder only ever uses an already-cached denoise bake (so preview never
+        // blocks on the model); export can afford to wait, so bake anything still missing here.
+        for track in timeline.tracks {
+            for clip in track.clips where clip.hasDenoiseEnabled {
+                guard let url = mediaURLs[clip.mediaRef] else { continue }
+                _ = try? await AudioEnhancer.enhancedAudio(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount)
+            }
+        }
+
         let result = try await CompositionBuilder.build(
             timeline: timeline,
             resolveURL: { mediaURLs[$0] },

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -235,10 +235,11 @@ final class ExportService {
 
         // CompositionBuilder only ever uses an already-cached denoise bake (so preview never
         // blocks on the model); export can afford to wait, so bake anything still missing here.
+        // Failures abort the export — silently rendering un-denoised audio would be worse.
         for track in timeline.tracks {
             for clip in track.clips where clip.hasDenoiseEnabled {
                 guard let url = mediaURLs[clip.mediaRef] else { continue }
-                _ = try? await AudioEnhancer.enhancedAudio(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount)
+                _ = try await AudioEnhancer.enhancedAudio(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount)
             }
         }
 

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -233,9 +233,6 @@ final class ExportService {
         let renderSize = resolution.renderSize(for: timelineCanvas)
         let mediaURLs = resolver.expectedURLMap()
 
-        // CompositionBuilder only ever uses an already-cached denoise bake (so preview never
-        // blocks on the model); export can afford to wait, so bake anything still missing here.
-        // Failures abort the export — silently rendering un-denoised audio would be worse.
         for track in timeline.tracks {
             for clip in track.clips where clip.hasDenoiseEnabled {
                 guard let url = mediaURLs[clip.mediaRef] else { continue }

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -457,6 +457,7 @@ struct ExportView: View {
                     outputURL: url
                 )
                 if service.error == nil {
+                    editor.syncDenoiseAfterExport()
                     editor.showExportDialog = false
                 }
             }

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -19,6 +19,8 @@ extension InspectorView {
                         .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
                     fadeRow(label: "Fade Out", clips: audios, edge: .right)
                         .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
+                    denoiseRow(audios: audios)
+                        .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
                     if nonTextVisualClips.isEmpty {
                         speedSection(clips: audios)
                             .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
@@ -39,6 +41,7 @@ extension InspectorView {
                     volumeRow(audios: audios)
                     fadeRow(label: "Fade In", clips: audios, edge: .left)
                     fadeRow(label: "Fade Out", clips: audios, edge: .right)
+                    denoiseRow(audios: audios)
                 }
                 if nonTextVisualClips.isEmpty {
                     speedSection(clips: audios)
@@ -72,6 +75,71 @@ extension InspectorView {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func denoiseRow(audios: [Clip]) -> some View {
+        if !audios.isEmpty {
+            let allOn = audios.allSatisfy(\.hasDenoiseEnabled)
+            let baking = audios.contains { editor.denoiseInFlight.contains($0.mediaRef) }
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+                propertyRow(label: "Denoise") {
+                    Toggle("", isOn: Binding(
+                        get: { allOn },
+                        set: { enabled in
+                            editor.setDenoise(
+                                clipIds: Set(audios.map(\.id)),
+                                enabled: enabled,
+                                amount: enabled ? Clip.defaultDenoiseAmount : nil,
+                                actionName: enabled ? "Enable Denoise" : "Disable Denoise"
+                            )
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .labelsHidden()
+                }
+                .help("Removes background noise from this audio using an on-device model.")
+                if allOn {
+                    denoiseStrengthRow(audios: audios)
+                }
+                if baking {
+                    HStack(spacing: AppTheme.Spacing.xs) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Removing background noise…")
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .foregroundStyle(AppTheme.Text.mutedColor)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func denoiseStrengthRow(audios: [Clip]) -> some View {
+        propertyRow(label: "Strength") {
+            ScrubbableNumberField(
+                value: sharedClipValue(audios) { $0.denoiseAmount * 100 },
+                range: 0...100,
+                format: "%.0f",
+                valueSuffix: "%",
+                dragSensitivity: 0.5,
+                fieldWidth: 56
+                // No onChanged: this only persists (and re-mixes) once on commit, so
+                // dragging/scrubbing doesn't trigger a full preview rebuild per pixel
+                // (that swaps the player item and flashes black). The field still
+                // tracks the live value locally while dragging.
+            ) { percent in
+                editor.setDenoise(
+                    clipIds: Set(audios.map(\.id)),
+                    enabled: true,
+                    amount: percent / 100,
+                    actionName: "Change Denoise Strength"
+                )
+            }
+        }
+        .help("Blends denoised and original audio — lower this if voices sound thin or over-compressed.")
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -97,7 +97,6 @@ extension InspectorView {
                             editor.setDenoise(
                                 clipIds: Set(audios.map(\.id)),
                                 enabled: enabled,
-                                amount: enabled ? Clip.defaultDenoiseAmount : nil,
                                 actionName: enabled ? "Enable Denoise" : "Disable Denoise"
                             )
                         }

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -82,6 +82,7 @@ extension InspectorView {
         if !audios.isEmpty {
             let allOn = audios.allSatisfy(\.hasDenoiseEnabled)
             let baking = audios.contains { editor.denoiseInFlight.contains($0.mediaRef) }
+            let failed = allOn && !baking && audios.contains { editor.denoiseFailed.contains($0.mediaRef) }
             VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
                 propertyRow(label: "Denoise") {
                     Toggle("", isOn: Binding(
@@ -111,6 +112,10 @@ extension InspectorView {
                             .font(.system(size: AppTheme.FontSize.xs))
                             .foregroundStyle(AppTheme.Text.mutedColor)
                     }
+                } else if failed {
+                    Text("Denoise failed. Playback uses the original audio — adjust Strength to retry.")
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Status.errorColor)
                 }
             }
         }

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -131,10 +131,6 @@ extension InspectorView {
                 valueSuffix: "%",
                 dragSensitivity: 0.5,
                 fieldWidth: 56
-                // No onChanged: this only persists (and re-mixes) once on commit, so
-                // dragging/scrubbing doesn't trigger a full preview rebuild per pixel
-                // (that swaps the player item and flashes black). The field still
-                // tracks the live value locally while dragging.
             ) { percent in
                 editor.setDenoise(
                     clipIds: Set(audios.map(\.id)),

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -82,7 +82,13 @@ extension InspectorView {
         if !audios.isEmpty {
             let allOn = audios.allSatisfy(\.hasDenoiseEnabled)
             let baking = audios.contains { editor.denoiseInFlight.contains($0.mediaRef) }
-            let failed = allOn && !baking && audios.contains { editor.denoiseFailed.contains($0.mediaRef) }
+            let hasDenoisedCache: (Clip) -> Bool = { clip in
+                guard let url = editor.mediaResolver.resolveURL(for: clip.mediaRef) else { return false }
+                return AudioEnhancer.cachedURL(for: url, mediaRef: clip.mediaRef, amount: clip.denoiseAmount) != nil
+            }
+            let failed = allOn && !baking && audios.contains {
+                editor.denoiseFailed.contains($0.mediaRef) && !hasDenoisedCache($0)
+            }
             VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
                 propertyRow(label: "Denoise") {
                     Toggle("", isOn: Binding(

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -205,6 +205,21 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         return volume * kfGain * fadeMultiplier(at: frame)
     }
 
+    /// Whether the offline noise-removal bake should be applied to this clip's audio.
+    var hasDenoiseEnabled: Bool {
+        effects?.contains { $0.type == Clip.denoiseEffectType && $0.enabled } ?? false
+    }
+
+    /// Dry/wet mix for the denoise bake (0 = untouched, 1 = fully denoised).
+    var denoiseAmount: Double {
+        effects?.first { $0.type == Clip.denoiseEffectType }?.params["amount"]?.value ?? Clip.defaultDenoiseAmount
+    }
+
+    static let denoiseEffectType = "audio.denoise"
+    /// DeepFilterNet3 at full strength tends to sound thin/gated on real-world audio;
+    /// blending in some dry signal by default keeps it usable out of the box.
+    static let defaultDenoiseAmount: Double = 0.6
+
     func rawVolumeAt(frame: Int) -> Double {
         let kfGain: Double
         if let track = volumeTrack, track.isActive {

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -205,19 +205,15 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         return volume * kfGain * fadeMultiplier(at: frame)
     }
 
-    /// Whether the offline noise-removal bake should be applied to this clip's audio.
     var hasDenoiseEnabled: Bool {
         effects?.contains { $0.type == Clip.denoiseEffectType && $0.enabled } ?? false
     }
 
-    /// Dry/wet mix for the denoise bake (0 = untouched, 1 = fully denoised).
     var denoiseAmount: Double {
         effects?.first { $0.type == Clip.denoiseEffectType }?.params["amount"]?.value ?? Clip.defaultDenoiseAmount
     }
 
     static let denoiseEffectType = "audio.denoise"
-    /// DeepFilterNet3 at full strength tends to sound thin/gated on real-world audio;
-    /// blending in some dry signal by default keeps it usable out of the box.
     static let defaultDenoiseAmount: Double = 0.6
 
     func rawVolumeAt(frame: Int) -> Double {

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -284,6 +284,11 @@ enum CompositionBuilder {
             }
         } else if mediaType == .video {
             mediaURL = (try? await AlphaVideoNormalizer.premultipliedVideo(for: resolved, mediaRef: clip.mediaRef)) ?? resolved
+        } else if mediaType == .audio, clip.hasDenoiseEnabled {
+            // Never bake inline here — that would block this rebuild (and playback) on the
+            // model. Use the cached result if the background bake has already landed; the
+            // caller is responsible for kicking off that bake and rebuilding once it completes.
+            mediaURL = AudioEnhancer.cachedURL(for: resolved, mediaRef: clip.mediaRef, amount: clip.denoiseAmount) ?? resolved
         } else {
             mediaURL = resolved
         }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -285,9 +285,6 @@ enum CompositionBuilder {
         } else if mediaType == .video {
             mediaURL = (try? await AlphaVideoNormalizer.premultipliedVideo(for: resolved, mediaRef: clip.mediaRef)) ?? resolved
         } else if mediaType == .audio, clip.hasDenoiseEnabled {
-            // Never bake inline here — that would block this rebuild (and playback) on the
-            // model. Use the cached result if the background bake has already landed; the
-            // caller is responsible for kicking off that bake and rebuilding once it completes.
             mediaURL = AudioEnhancer.cachedURL(for: resolved, mediaRef: clip.mediaRef, amount: clip.denoiseAmount) ?? resolved
         } else {
             mediaURL = resolved

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -346,6 +346,8 @@ final class VideoProject: NSDocument {
             loadedManifest = nil
             restoreAssetsFromManifest()
         }
+        // Resume denoise bakes for clips saved with denoise enabled but no cached result.
+        editorViewModel.enhancePendingDenoises()
 
         let editorView = EditorView()
             .environment(editorViewModel)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -346,7 +346,6 @@ final class VideoProject: NSDocument {
             loadedManifest = nil
             restoreAssetsFromManifest()
         }
-        // Resume denoise bakes for clips saved with denoise enabled but no cached result.
         editorViewModel.enhancePendingDenoises()
 
         let editorView = EditorView()

--- a/Sources/PalmierPro/Utilities/TimeFormatting.swift
+++ b/Sources/PalmierPro/Utilities/TimeFormatting.swift
@@ -28,7 +28,7 @@ func secondsToFrame(seconds: Double, fps: Int) -> Int {
 
 extension Double {
     func rounded(toPlaces places: Int) -> Double {
-        let factor = pow(10.0, Double(places))
+        let factor = Foundation.pow(10.0, Double(places))
         return (self * factor).rounded() / factor
     }
 }


### PR DESCRIPTION
40% of lines is in package. 

See if you can hear the difference


https://github.com/user-attachments/assets/c14f206f-adf2-4528-900c-3a77fb1f2113


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview composition and export audio paths and adds a heavy on-device ML dependency; incorrect caching or bake timing could make preview differ from export until sync runs.
> 
> **Overview**
> Adds **on-device background-noise removal** for audio clips using **speech-swift** (DeepFilterNet3), wired through preview, export, the inspector, and the agent.
> 
> Clips store denoise as an **`audio.denoise` effect** with a dry/wet **strength** (default 60%). **`AudioEnhancer`** runs the model in the background, caches wet and mixed `.caf` files on disk, and mixes denoised vs original audio. The **Audio** inspector gets a Denoise toggle, strength scrubber, baking progress, and failure messaging. **`CompositionBuilder`** uses cached denoised files when building the preview; **export** awaits bakes for denoised clips and **`syncDenoiseAfterExport`** refreshes preview if export produced caches the UI missed.
> 
> The agent gains an undoable **`denoise_audio`** tool (`clipIds`, `strength` 0–100, `enabled`). Timeline changes trigger **`enhancePendingDenoises`** so bakes stay in sync. **`Package.resolved`** grows with transitive ML/server deps from **speech-swift**; **`TimeFormatting`** qualifies **`pow`** as **`Foundation.pow`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c4c8e4938495fb217bc5bb40730d321ab8fcf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->