### PR TITLE
[fix] limit transcription audio extraction concurrency

### DIFF
--- a/Sources/PalmierPro/Transcription/Transcription.swift
+++ b/Sources/PalmierPro/Transcription/Transcription.swift
@@ -93,6 +93,8 @@ enum TranscriptionError: LocalizedError {
 }
 
 enum Transcription {
+    private static let audioExtractionGate = AsyncSemaphore(value: 2)
+
     static func transcribeVideoAudio(videoURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
         let tempAudioURL = try await extractAudioTrack(from: videoURL, range: sourceRange)
         defer { try? FileManager.default.removeItem(at: tempAudioURL) }
@@ -238,6 +240,9 @@ enum Transcription {
     ) async throws -> URL {
         let outURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("palmier-stt-\(UUID().uuidString).\(fileExtension)")
+        try await audioExtractionGate.wait()
+        defer { Task { await audioExtractionGate.signal() } }
+
         Log.transcription.notice(
             "extract start video=\(videoURL.lastPathComponent)",
             telemetry: "Transcription audio extraction started",


### PR DESCRIPTION
without semaphore it can get stuck with many concurrency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency guard on transcription extraction; behavior unchanged except under parallel load, with possible added queueing delay.
> 
> **Overview**
> **Limits how many transcription audio extractions can run at once** by gating `extractAudioTrack` with a shared `AsyncSemaphore` (max **2** concurrent jobs), using the same pattern as waveform extraction in `MediaVisualCache`.
> 
> Each extraction **waits for a permit** before starting `AudioTrackReader` and **releases it in a `defer`** when finished, so many parallel transcribe calls no longer pile unbounded `AVAssetReader` work that could hang the pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0628e25b224c225413c842c7b255a0737438367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->