### PR TITLE
feat(timeline): multiple timelines per project

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -16,8 +16,12 @@ enum AgentInstructions {
           speed, volume, and opacity.
         - Media assets live in a project library and are referenced by ID. They may be \
           user-imported or AI-generated.
-        - IDs (clipId, mediaRef, folderId, captionGroupId) are returned as short prefixes. \
-          Pass them back exactly as given — never pad, complete, or guess a longer form.
+        - A project can hold several timelines; exactly one is active and every read/edit \
+          tool targets it. get_timeline lists them when there is more than one; switch with \
+          set_active_timeline and re-read before editing. A timeline nested inside another \
+          appears as a clip with mediaType 'sequence' whose mediaRef is the child timelineId.
+        - IDs (clipId, mediaRef, folderId, captionGroupId, timelineId) are returned as short \
+          prefixes. Pass them back exactly as given — never pad, complete, or guess a longer form.
 
         # Always do
         - Call get_timeline once per session (or after an out-of-band change) for fps, tracks, \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -44,6 +44,9 @@ enum ToolName: String, CaseIterable, Sendable {
     case deleteFolder = "delete_folder"
     case sendFeedback = "send_feedback"
     case setProjectSettings = "set_project_settings"
+    case createTimeline = "create_timeline"
+    case setActiveTimeline = "set_active_timeline"
+    case duplicateTimeline = "duplicate_timeline"
     case readSkill = "read_skill"
     case getProjects = "get_projects"
     case openProject = "open_project"
@@ -874,6 +877,35 @@ enum ToolDefinitions {
                     "height": ["type": "integer", "description": "Canvas height in pixels. Use with width for an exact resolution. Mutually exclusive with aspectRatio."],
                     "aspectRatio": ["type": "string", "enum": ["16:9", "9:16", "1:1", "4:3", "2.4:1", "9:14"], "description": "Preset aspect ratio — sets both width and height from the preset, or combined with quality to pick a specific size. Mutually exclusive with width/height."],
                     "quality": ["type": "string", "enum": ["720p", "1080p", "2K", "4K"], "description": "Resolution quality preset — scales the short edge to the target while preserving the current (or specified) aspect ratio."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .createTimeline,
+            description: "Creates a new empty timeline in the project and switches to it — every read and edit tool now targets it. Settings (fps, resolution) are inherited from the previously active timeline. Returns the new timelineId. Undoable.\n\nUse timelines to organize a project: alternate versions, sections assembled separately, or reusable groups. A timeline can be placed inside another as a single clip (the user drops it from the media panel); it then appears as a clip with mediaType 'sequence' whose mediaRef is the timelineId.",
+            inputSchema: objectSchema(
+                properties: [
+                    "name": ["type": "string", "description": "Optional display name. Defaults to 'Timeline N'."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .setActiveTimeline,
+            description: "Switches the active timeline — the one every read and edit tool targets and the one the user sees. get_timeline lists the project's timelines (with timelineId) whenever there is more than one. Always re-read get_timeline after switching; clip and track ids from the previous timeline are no longer valid targets.\n\nTo edit the contents of a nested timeline (a clip with mediaType 'sequence'), switch to its mediaRef.",
+            inputSchema: objectSchema(
+                properties: [
+                    "timelineId": ["type": "string", "description": "Timeline id from get_timeline's timelines list (or a sequence clip's mediaRef)."],
+                ],
+                required: ["timelineId"]
+            )
+        ),
+        AgentTool(
+            name: .duplicateTimeline,
+            description: "Duplicates a timeline — the versioning primitive: copy, then edit the copy (\"a tighter cut\", \"a 9:16 version\") while the original stays intact. Copies all tracks, clips, and settings, switches to the copy, and returns its timelineId. Every clip and track id in the copy is NEW — re-read get_timeline before editing. Undoable.",
+            inputSchema: objectSchema(
+                properties: [
+                    "timelineId": ["type": "string", "description": "Timeline to duplicate. Defaults to the active timeline."],
+                    "name": ["type": "string", "description": "Optional name for the copy. Defaults to '<name> copy'."],
                 ]
             )
         ),

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -131,7 +131,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addClips,
-            description: "Places one or more media assets on the timeline as a single undoable action. Each entry's asset type must be compatible with its target track (video/image are interchangeable across video/image tracks; audio requires an audio track). When a video asset with audio is placed on a video track, a linked audio clip is automatically created on an audio track (an existing one if available, otherwise a new one). The whole batch is one undo step.\n\ntrackIndex is optional. Omit it on all entries and the tool auto-creates the needed tracks — one shared video track for visual entries and one shared audio track for audio entries (matches the captioning pattern in add_texts). To target existing tracks, set trackIndex on every entry. Mixing (some entries specify, others omit) is rejected — split into two calls.\n\nTracks work as layers: clips on the SAME track are sequential — if a new clip's range overlaps an existing clip on that track, the existing clip is trimmed/split/removed to make room, matching the UI's drag-onto-track overwrite behavior.",
+            description: "Places one or more media assets on the timeline as a single undoable action. Each entry's asset type must be compatible with its target track (video/image are interchangeable across video/image tracks; audio requires an audio track). When a video asset with audio is placed on a video track, a linked audio clip is automatically created on an audio track (an existing one if available, otherwise a new one). The whole batch is one undo step.\n\ntrackIndex is optional. Omit it on all entries and the tool auto-creates the needed tracks — one shared video track for visual entries and one shared audio track for audio entries (matches the captioning pattern in add_texts). To target existing tracks, set trackIndex on every entry. Mixing (some entries specify, others omit) is rejected — split into two calls.\n\nTracks work as layers: clips on the SAME track are sequential — if a new clip's range overlaps an existing clip on that track, the existing clip is trimmed/split/removed to make room, matching the UI's drag-onto-track overwrite behavior.\n\nNESTING: mediaRef may also be a timelineId — the timeline is placed as a single live nested clip (mediaType 'sequence'), with a linked audio clip when the child has audio. Duration defaults to the child's full length; trims and durationFrames work as for video. Cycles (a timeline containing itself) and empty timelines are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -156,7 +156,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .insertClips,
-            description: "Inserts one or more media assets at a single point and RIPPLES: every clip at or after atFrame is pushed right to open a gap, so nothing is overwritten. This is the non-destructive counterpart to add_clips (which clears the landing region, trimming/splitting/removing whatever's there). Use insert_clips to splice footage in without losing existing clips; use add_clips to fill empty space or deliberately overwrite.\n\nEntries are laid end-to-end starting at atFrame on the target track (entry[0] at atFrame, entry[1] immediately after, ...). The push equals the sum of the entries' durations and is applied to the target track, every sync-locked track, AND the audio track any auto-created linked audio lands on — so a clip and its linked audio stay aligned. As in add_clips, a video asset with audio spawns a linked audio clip. One undoable action; one bad entry rejects the whole call with no partial state.\n\ntrackIndex is required — ripple needs an existing track to push. For placement into empty space, use add_clips.",
+            description: "Inserts one or more media assets at a single point and RIPPLES: every clip at or after atFrame is pushed right to open a gap, so nothing is overwritten. This is the non-destructive counterpart to add_clips (which clears the landing region, trimming/splitting/removing whatever's there). Use insert_clips to splice footage in without losing existing clips; use add_clips to fill empty space or deliberately overwrite.\n\nEntries are laid end-to-end starting at atFrame on the target track (entry[0] at atFrame, entry[1] immediately after, ...). The push equals the sum of the entries' durations and is applied to the target track, every sync-locked track, AND the audio track any auto-created linked audio lands on — so a clip and its linked audio stay aligned. As in add_clips, a video asset with audio spawns a linked audio clip. One undoable action; one bad entry rejects the whole call with no partial state.\n\ntrackIndex is required — ripple needs an existing track to push. For placement into empty space, use add_clips.\n\nAs in add_clips, mediaRef may be a timelineId to splice in a nested timeline.",
             inputSchema: objectSchema(
                 properties: [
                     "trackIndex": ["type": "integer", "description": "Track index (0-based, from get_timeline) to insert into and ripple."],
@@ -678,7 +678,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .renameMedia,
-            description: "Renames media assets in the library. Pass either mediaRef/name for one asset or entries for multiple assets, not both. Undoable.",
+            description: "Renames media assets or timelines. mediaRef accepts either an asset id from get_media or a timelineId from get_timeline. Pass either mediaRef/name for one item or entries for multiple, not both. Undoable.",
             inputSchema: objectSchema(
                 properties: [
                     "mediaRef": ["type": "string", "description": "Media asset id from get_media."],
@@ -722,7 +722,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .deleteMedia,
-            description: "Deletes media assets from the library. Any clips referencing them are removed from the timeline in the same undoable action.",
+            description: "Deletes media assets or timelines. assetIds accepts asset ids from get_media and timelineIds from get_timeline. Deleting an asset removes any clips referencing it; deleting a timeline leaves nest clips referencing it rendering black (remove those clips too, or don't delete a timeline that's still nested). The last remaining timeline can't be deleted. Undoable.",
             inputSchema: objectSchema(
                 properties: [
                     "assetIds": [

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -506,6 +506,7 @@ enum ToolDefinitions {
                     "outputPath": ["type": "string", "description": "Optional. Absolute destination path. If omitted, a unique project-named file is written to ~/Downloads. If no extension is provided, the mode's extension is appended."],
                     "overwrite": ["type": "boolean", "description": "Optional. Default true, matching the UI save flow. false refuses when outputPath already exists."],
                     "fcpxmlTarget": ["type": "string", "enum": ["resolve", "fcp"], "description": "fcpxml mode only. Optional, default resolve. Davinci Resolve and Final Cut interpret crop and position values differently; pick the app the file will be imported into."],
+                    "timelineId": ["type": "string", "description": "Optional. Timeline to export (from get_timeline's timelines list). Defaults to the active timeline. Not valid for palmier mode, which packages every timeline."],
                 ]
             )
         ),

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -293,7 +293,7 @@ extension ToolExecutor {
                 reportTrack(idx)
             }
             let addedIds = allAdded
-            editor.undoManager?.registerUndo(withTarget: editor) { vm in
+            editor.registerTimelineUndo { vm in
                 vm.removeClips(ids: Set(addedIds))
             }
             return (createdTracks, summaries)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -182,7 +182,7 @@ extension ToolExecutor {
         var prepared: [(entry: AddClipsInput.Entry, asset: MediaAsset, trackId: String?)] = []
         prepared.reserveCapacity(input.entries.count)
         for (idx, entry) in input.entries.enumerated() {
-            let asset = try asset(entry.mediaRef, editor: editor)
+            let asset = try clipSource(entry.mediaRef, editor: editor, path: "entries[\(idx)]")
             var trackId: String? = nil
             if let ti = entry.trackIndex {
                 guard editor.timeline.tracks.indices.contains(ti) else {
@@ -206,7 +206,7 @@ extension ToolExecutor {
             throw ToolError("Mixed trackIndex: \(omittedCount) of \(prepared.count) entries omitted trackIndex. Either set it on every entry or omit it on every entry (to auto-create shared tracks).")
         }
 
-        let settingsNote = applySettingsIfNeededForAgent(editor, assets: prepared.map(\.asset))
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: prepared.map(\.asset).filter { $0.type != .sequence })
 
         var specs: [AddClipSpec] = []
         specs.reserveCapacity(prepared.count)
@@ -327,14 +327,14 @@ extension ToolExecutor {
         var resolvedAssets: [MediaAsset] = []
         resolvedAssets.reserveCapacity(input.entries.count)
         for (idx, entry) in input.entries.enumerated() {
-            let asset = try asset(entry.mediaRef, editor: editor)
+            let asset = try clipSource(entry.mediaRef, editor: editor, path: "entries[\(idx)]")
             guard asset.type.isCompatible(with: targetType) else {
                 throw ToolError("entries[\(idx)]: asset type \(asset.type.rawValue) is not compatible with \(targetType.rawValue) track at index \(input.trackIndex)")
             }
             resolvedAssets.append(asset)
         }
 
-        let settingsNote = applySettingsIfNeededForAgent(editor, assets: resolvedAssets)
+        let settingsNote = applySettingsIfNeededForAgent(editor, assets: resolvedAssets.filter { $0.type != .sequence })
 
         var specs: [EditorViewModel.RippleInsertSpec] = []
         specs.reserveCapacity(input.entries.count)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -584,13 +584,17 @@ extension ToolExecutor {
             if let v = trimStartFrame { clip.trimStartFrame = v; changed.append("trimStartFrame") }
             if let v = trimEndFrame   { clip.trimEndFrame   = v; changed.append("trimEndFrame") }
             if let v = speed {
-                if durationFrames == nil, v > 0 {
-                    let sourceConsumed = Double(clip.durationFrames) * clip.speed
-                    clip.setDuration(max(1, safeInt((sourceConsumed / v).rounded()) ?? clip.durationFrames))
-                    changed.append("durationFrames")
+                if clip.sourceClipType == .sequence {
+                    changed.append("speed skipped (nested timelines don't support retiming)")
+                } else {
+                    if durationFrames == nil, v > 0 {
+                        let sourceConsumed = Double(clip.durationFrames) * clip.speed
+                        clip.setDuration(max(1, safeInt((sourceConsumed / v).rounded()) ?? clip.durationFrames))
+                        changed.append("durationFrames")
+                    }
+                    clip.speed = v
+                    changed.append("speed")
                 }
-                clip.speed = v
-                changed.append("speed")
             }
             // Setting a scalar clears any existing keyframe track on the same property.
             if let v = volume         { clip.volume  = v; clip.volumeTrack  = nil; changed.append("volume") }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -584,7 +584,7 @@ extension ToolExecutor {
             if let v = trimStartFrame { clip.trimStartFrame = v; changed.append("trimStartFrame") }
             if let v = trimEndFrame   { clip.trimEndFrame   = v; changed.append("trimEndFrame") }
             if let v = speed {
-                if clip.sourceClipType == .sequence {
+                if !clip.supportsRetiming {
                     changed.append("speed skipped (nested timelines don't support retiming)")
                 } else {
                     if durationFrames == nil, v > 0 {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -109,16 +109,24 @@ extension ToolExecutor {
             }
         }
         do {
-            try await XMLExporter.export(timeline: editor.timeline, resolver: editor.mediaResolver, outputURL: outputURL)
+            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
+            try await XMLExporter.export(
+                timeline: editor.timeline, resolver: editor.mediaResolver,
+                resolveTimeline: { timelinesById[$0] }, outputURL: outputURL
+            )
         } catch {
             throw ToolError("export_project: XML export failed: \(error.localizedDescription)")
         }
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: XML export failed")
         }
-        let nestCount = editor.timeline.tracks.flatMap(\.clips).count { $0.sourceClipType == .sequence }
-        let warnings: [String] = nestCount > 0
-            ? ["\(nestCount) nested timeline clip(s) were not exported — XML nesting support is not available yet."]
+        // Nests export as nested sequences; only unresolvable/empty children drop.
+        let droppedNests = editor.timeline.tracks.flatMap(\.clips).count {
+            $0.sourceClipType == .sequence && $0.mediaType != .audio
+                && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
+        }
+        let warnings: [String] = droppedNests > 0
+            ? ["\(droppedNests) nested timeline clip(s) were skipped — their timelines are empty or missing."]
             : []
         return try jsonResult([
             "status": "exported",
@@ -142,16 +150,24 @@ extension ToolExecutor {
             }
         }
         do {
-            try await FCPXMLExporter.export(timeline: editor.timeline, resolver: editor.mediaResolver, outputURL: outputURL)
+            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
+            try await FCPXMLExporter.export(
+                timeline: editor.timeline, resolver: editor.mediaResolver,
+                resolveTimeline: { timelinesById[$0] }, outputURL: outputURL
+            )
         } catch {
             throw ToolError("export_project: FCPXML export failed: \(error.localizedDescription)")
         }
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: FCPXML export failed")
         }
-        let nestCount = editor.timeline.tracks.flatMap(\.clips).count { $0.sourceClipType == .sequence }
-        let warnings: [String] = nestCount > 0
-            ? ["\(nestCount) nested timeline clip(s) were not exported — XML nesting support is not available yet."]
+        // Nests export as compound clips; only unresolvable/empty children drop.
+        let droppedNests = editor.timeline.tracks.flatMap(\.clips).count {
+            $0.sourceClipType == .sequence && ($0.mediaType != .audio)
+                && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
+        }
+        let warnings: [String] = droppedNests > 0
+            ? ["\(droppedNests) nested timeline clip(s) were skipped — their timelines are empty or missing."]
             : []
         return try jsonResult([
             "status": "exported",

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -58,6 +58,7 @@ extension ToolExecutor {
         let resolver = editor.mediaResolver
         let missingMediaRefs = editor.missingMediaRefs
         let name = outputURL.lastPathComponent
+        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
 
         Task { @MainActor in
             defer { ExportCoordinator.endExport() }
@@ -65,6 +66,7 @@ extension ToolExecutor {
             await service.export(
                 timeline: timeline,
                 resolver: resolver,
+                resolveTimeline: { timelinesById[$0] },
                 format: format,
                 resolution: resolution,
                 missingMediaRefs: missingMediaRefs,
@@ -114,6 +116,10 @@ extension ToolExecutor {
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: XML export failed")
         }
+        let nestCount = editor.timeline.tracks.flatMap(\.clips).count { $0.sourceClipType == .sequence }
+        let warnings: [String] = nestCount > 0
+            ? ["\(nestCount) nested timeline clip(s) were not exported — XML nesting support is not available yet."]
+            : []
         return try jsonResult([
             "status": "exported",
             "mode": ExportProjectMode.xml.rawValue,
@@ -123,7 +129,7 @@ extension ToolExecutor {
             "durationFrames": editor.timeline.totalFrames,
             "durationSeconds": Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)),
             "fps": editor.timeline.fps,
-            "warnings": [],
+            "warnings": warnings,
         ])
     }
 
@@ -143,6 +149,10 @@ extension ToolExecutor {
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: FCPXML export failed")
         }
+        let nestCount = editor.timeline.tracks.flatMap(\.clips).count { $0.sourceClipType == .sequence }
+        let warnings: [String] = nestCount > 0
+            ? ["\(nestCount) nested timeline clip(s) were not exported — XML nesting support is not available yet."]
+            : []
         return try jsonResult([
             "status": "exported",
             "mode": ExportProjectMode.fcpxml.rawValue,
@@ -152,7 +162,7 @@ extension ToolExecutor {
             "durationFrames": editor.timeline.totalFrames,
             "durationSeconds": Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)),
             "fps": editor.timeline.fps,
-            "warnings": [],
+            "warnings": warnings,
         ])
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -164,7 +164,7 @@ extension ToolExecutor {
 
         let service = ExportService()
         guard let report = await service.exportPalmierProject(
-            timeline: editor.timeline,
+            projectFile: editor.projectFileSnapshot(),
             manifest: editor.mediaManifest,
             generationLog: editor.generationLog,
             sourceProjectURL: editor.projectURL,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -18,6 +18,19 @@ extension ToolExecutor {
         let format = try mode == .video ? ExportFormat.videoCodec(named: input.codec) : nil
         let resolution = try mode == .video ? ExportResolution.exportPreset(named: input.resolution) : .matchTimeline
 
+        let timeline: Timeline
+        if let id = input.timelineId {
+            guard mode != .palmier else {
+                throw ToolError("export_project: timelineId doesn't apply to palmier mode — the package carries every timeline")
+            }
+            guard let t = editor.timeline(for: id) else {
+                throw ToolError("export_project: no timeline with id '\(id)'. get_timeline lists the project's timelines.")
+            }
+            timeline = t
+        } else {
+            timeline = editor.timeline
+        }
+
         let outputURL = try exportDestination(
             outputPath: input.outputPath,
             mode: mode,
@@ -31,12 +44,12 @@ extension ToolExecutor {
             guard let format else {
                 throw ToolError("export_project: codec is required for video mode")
             }
-            guard editor.timeline.totalFrames > 0 else {
+            guard timeline.totalFrames > 0 else {
                 throw ToolError("export_project: timeline is empty")
             }
-            return try exportVideo(editor, format: format, resolution: resolution, outputURL: outputURL)
+            return try exportVideo(editor, timeline: timeline, format: format, resolution: resolution, outputURL: outputURL)
         case .xml:
-            return try await exportXML(editor, outputURL: outputURL)
+            return try await exportXML(editor, timeline: timeline, outputURL: outputURL)
         case .fcpxml:
             let target: FCPXMLTarget
             if let raw = input.fcpxmlTarget {
@@ -47,7 +60,7 @@ extension ToolExecutor {
             } else {
                 target = .default
             }
-            return try await exportFCPXML(editor, target: target, outputURL: outputURL)
+            return try await exportFCPXML(editor, timeline: timeline, target: target, outputURL: outputURL)
         case .palmier:
             return try await exportPalmier(editor, outputURL: outputURL)
         }
@@ -55,6 +68,7 @@ extension ToolExecutor {
 
     private func exportVideo(
         _ editor: EditorViewModel,
+        timeline: Timeline,
         format: ExportFormat,
         resolution: ExportResolution,
         outputURL: URL
@@ -63,7 +77,6 @@ extension ToolExecutor {
             throw ToolError("export_project: Another export is already in progress.")
         }
 
-        let timeline = editor.timeline
         let resolver = editor.mediaResolver
         let missingMediaRefs = editor.missingMediaRefs
         let name = outputURL.lastPathComponent
@@ -102,14 +115,15 @@ extension ToolExecutor {
             "path": outputURL.path,
             "codec": format.displayName,
             "resolution": resolution.rawValue,
-            "durationFrames": editor.timeline.totalFrames,
-            "durationSeconds": Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)),
-            "fps": editor.timeline.fps,
+            "timeline": timeline.name,
+            "durationFrames": timeline.totalFrames,
+            "durationSeconds": Double(timeline.totalFrames) / Double(max(1, timeline.fps)),
+            "fps": timeline.fps,
             "note": "Rendering in the background. A system notification will report completion or failure.",
         ])
     }
 
-    private func exportXML(_ editor: EditorViewModel, outputURL: URL) async throws -> ToolResult {
+    private func exportXML(_ editor: EditorViewModel, timeline: Timeline, outputURL: URL) async throws -> ToolResult {
         if FileManager.default.fileExists(atPath: outputURL.path) {
             do {
                 try FileManager.default.removeItem(at: outputURL)
@@ -120,7 +134,7 @@ extension ToolExecutor {
         do {
             let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             try await XMLExporter.export(
-                timeline: editor.timeline, resolver: editor.mediaResolver,
+                timeline: timeline, resolver: editor.mediaResolver,
                 resolveTimeline: { timelinesById[$0] }, outputURL: outputURL
             )
         } catch {
@@ -130,7 +144,7 @@ extension ToolExecutor {
             throw ToolError("export_project: XML export failed")
         }
         // Nests export as nested sequences; only unresolvable/empty children drop.
-        let droppedNests = editor.timeline.tracks.flatMap(\.clips).count {
+        let droppedNests = timeline.tracks.flatMap(\.clips).count {
             $0.sourceClipType == .sequence && $0.mediaType != .audio
                 && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
         }
@@ -141,16 +155,17 @@ extension ToolExecutor {
             "status": "exported",
             "mode": ExportProjectMode.xml.rawValue,
             "path": outputURL.path,
-            "width": editor.timeline.width,
-            "height": editor.timeline.height,
-            "durationFrames": editor.timeline.totalFrames,
-            "durationSeconds": Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)),
-            "fps": editor.timeline.fps,
+            "timeline": timeline.name,
+            "width": timeline.width,
+            "height": timeline.height,
+            "durationFrames": timeline.totalFrames,
+            "durationSeconds": Double(timeline.totalFrames) / Double(max(1, timeline.fps)),
+            "fps": timeline.fps,
             "warnings": warnings,
         ])
     }
 
-    private func exportFCPXML(_ editor: EditorViewModel, target: FCPXMLTarget, outputURL: URL) async throws -> ToolResult {
+    private func exportFCPXML(_ editor: EditorViewModel, timeline: Timeline, target: FCPXMLTarget, outputURL: URL) async throws -> ToolResult {
         if FileManager.default.fileExists(atPath: outputURL.path) {
             do {
                 try FileManager.default.removeItem(at: outputURL)
@@ -161,7 +176,7 @@ extension ToolExecutor {
         do {
             let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             try await FCPXMLExporter.export(
-                timeline: editor.timeline, resolver: editor.mediaResolver,
+                timeline: timeline, resolver: editor.mediaResolver,
                 resolveTimeline: { timelinesById[$0] }, target: target, outputURL: outputURL
             )
         } catch {
@@ -171,7 +186,7 @@ extension ToolExecutor {
             throw ToolError("export_project: FCPXML export failed")
         }
         // Nests export as compound clips; only unresolvable/empty children drop.
-        let droppedNests = editor.timeline.tracks.flatMap(\.clips).count {
+        let droppedNests = timeline.tracks.flatMap(\.clips).count {
             $0.sourceClipType == .sequence && ($0.mediaType != .audio)
                 && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
         }
@@ -182,11 +197,12 @@ extension ToolExecutor {
             "status": "exported",
             "mode": ExportProjectMode.fcpxml.rawValue,
             "path": outputURL.path,
-            "width": editor.timeline.width,
-            "height": editor.timeline.height,
-            "durationFrames": editor.timeline.totalFrames,
-            "durationSeconds": Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps)),
-            "fps": editor.timeline.fps,
+            "timeline": timeline.name,
+            "width": timeline.width,
+            "height": timeline.height,
+            "durationFrames": timeline.totalFrames,
+            "durationSeconds": Double(timeline.totalFrames) / Double(max(1, timeline.fps)),
+            "fps": timeline.fps,
             "warnings": warnings,
         ])
     }
@@ -313,7 +329,7 @@ extension ToolExecutor {
 }
 
 private struct ExportProjectArgs: DecodableToolArgs {
-    static let allowedKeys: Set<String> = ["mode", "codec", "resolution", "outputPath", "overwrite", "fcpxmlTarget"]
+    static let allowedKeys: Set<String> = ["mode", "codec", "resolution", "outputPath", "overwrite", "fcpxmlTarget", "timelineId"]
 
     var mode: String?
     var codec: String?
@@ -321,6 +337,7 @@ private struct ExportProjectArgs: DecodableToolArgs {
     var outputPath: String?
     var overwrite: Bool?
     var fcpxmlTarget: String?
+    var timelineId: String?
 }
 
 private enum ExportProjectMode: String {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Export.swift
@@ -80,7 +80,7 @@ extension ToolExecutor {
         let resolver = editor.mediaResolver
         let missingMediaRefs = editor.missingMediaRefs
         let name = outputURL.lastPathComponent
-        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
+        let resolveTimeline = editor.timelineResolver()
 
         Task { @MainActor in
             defer { ExportCoordinator.endExport() }
@@ -88,7 +88,7 @@ extension ToolExecutor {
             await service.export(
                 timeline: timeline,
                 resolver: resolver,
-                resolveTimeline: { timelinesById[$0] },
+                resolveTimeline: resolveTimeline,
                 format: format,
                 resolution: resolution,
                 missingMediaRefs: missingMediaRefs,
@@ -132,10 +132,9 @@ extension ToolExecutor {
             }
         }
         do {
-            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             try await XMLExporter.export(
                 timeline: timeline, resolver: editor.mediaResolver,
-                resolveTimeline: { timelinesById[$0] }, outputURL: outputURL
+                resolveTimeline: editor.timelineResolver(), outputURL: outputURL
             )
         } catch {
             throw ToolError("export_project: XML export failed: \(error.localizedDescription)")
@@ -143,14 +142,7 @@ extension ToolExecutor {
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: XML export failed")
         }
-        // Nests export as nested sequences; only unresolvable/empty children drop.
-        let droppedNests = timeline.tracks.flatMap(\.clips).count {
-            $0.sourceClipType == .sequence && $0.mediaType != .audio
-                && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
-        }
-        let warnings: [String] = droppedNests > 0
-            ? ["\(droppedNests) nested timeline clip(s) were skipped — their timelines are empty or missing."]
-            : []
+        let warnings = nestExportWarnings(editor, timeline: timeline)
         return try jsonResult([
             "status": "exported",
             "mode": ExportProjectMode.xml.rawValue,
@@ -174,10 +166,9 @@ extension ToolExecutor {
             }
         }
         do {
-            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             try await FCPXMLExporter.export(
                 timeline: timeline, resolver: editor.mediaResolver,
-                resolveTimeline: { timelinesById[$0] }, target: target, outputURL: outputURL
+                resolveTimeline: editor.timelineResolver(), target: target, outputURL: outputURL
             )
         } catch {
             throw ToolError("export_project: FCPXML export failed: \(error.localizedDescription)")
@@ -185,14 +176,7 @@ extension ToolExecutor {
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw ToolError("export_project: FCPXML export failed")
         }
-        // Nests export as compound clips; only unresolvable/empty children drop.
-        let droppedNests = timeline.tracks.flatMap(\.clips).count {
-            $0.sourceClipType == .sequence && ($0.mediaType != .audio)
-                && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
-        }
-        let warnings: [String] = droppedNests > 0
-            ? ["\(droppedNests) nested timeline clip(s) were skipped — their timelines are empty or missing."]
-            : []
+        let warnings = nestExportWarnings(editor, timeline: timeline)
         return try jsonResult([
             "status": "exported",
             "mode": ExportProjectMode.fcpxml.rawValue,
@@ -205,6 +189,15 @@ extension ToolExecutor {
             "fps": timeline.fps,
             "warnings": warnings,
         ])
+    }
+
+    private func nestExportWarnings(_ editor: EditorViewModel, timeline: Timeline) -> [String] {
+        let dropped = timeline.tracks.flatMap(\.clips).count {
+            $0.sourceClipType == .sequence && $0.mediaType != .audio
+                && (editor.timeline(for: $0.mediaRef)?.totalFrames ?? 0) == 0
+        }
+        guard dropped > 0 else { return [] }
+        return ["\(dropped) nested timeline clip(s) were skipped — their timelines are empty or missing."]
     }
 
     private func exportPalmier(_ editor: EditorViewModel, outputURL: URL) async throws -> ToolResult {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Folders.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Folders.swift
@@ -72,7 +72,11 @@ extension ToolExecutor {
         let (specs, isBatch) = try parseRenameMediaSpecs(args, editor: editor)
         withUndoGroup(editor, actionName: specs.count == 1 ? "Rename Asset" : "Rename Assets") {
             for spec in specs {
-                editor.renameMediaAsset(id: spec.mediaRef, name: spec.name)
+                if editor.timeline(for: spec.mediaRef) != nil {
+                    editor.renameTimeline(spec.mediaRef, to: spec.name)
+                } else {
+                    editor.renameMediaAsset(id: spec.mediaRef, name: spec.name)
+                }
             }
         }
         if !isBatch, let spec = specs.first {
@@ -97,13 +101,22 @@ extension ToolExecutor {
     func deleteMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let assetIds = args.stringArray("assetIds")
         guard !assetIds.isEmpty else { throw ToolError("assetIds is required") }
-        for id in assetIds {
+        let timelineIds = assetIds.filter { id in editor.timelines.contains { $0.id == id } }
+        for id in assetIds where !timelineIds.contains(id) {
             guard editor.mediaAssets.contains(where: { $0.id == id }) else {
-                throw ToolError("Media asset not found: \(id)")
+                throw ToolError("Media asset or timeline not found: \(id)")
             }
         }
-        editor.deleteMediaAssets(ids: Set(assetIds))
-        return .ok("Deleted \(assetIds.count) asset(s). Any clips referencing them were removed from the timeline.")
+        guard timelineIds.count < editor.timelines.count else {
+            throw ToolError("Can't delete every timeline — the project needs at least one.")
+        }
+        let mediaIds = Set(assetIds).subtracting(timelineIds)
+        if !mediaIds.isEmpty { editor.deleteMediaAssets(ids: mediaIds) }
+        for id in timelineIds { editor.deleteTimeline(id) }
+        var notes: [String] = []
+        if !mediaIds.isEmpty { notes.append("Deleted \(mediaIds.count) asset(s); clips referencing them were removed.") }
+        if !timelineIds.isEmpty { notes.append("Deleted \(timelineIds.count) timeline(s); nest clips referencing them will render black.") }
+        return .ok(notes.joined(separator: " "))
     }
 
     func deleteFolder(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
@@ -159,14 +172,20 @@ extension ToolExecutor {
                 try validateUnknownKeys(entry, allowed: Self.renameMediaEntryAllowedKeys, path: path)
                 let mediaRef = try entry.requireString("mediaRef")
                 let name = try entry.requireString("name")
-                _ = try asset(mediaRef, editor: editor)
+                try requireAssetOrTimeline(mediaRef, editor: editor)
                 return RenameMediaSpec(mediaRef: mediaRef, name: name)
             }, true)
         }
         let mediaRef = try args.requireString("mediaRef")
         let name = try args.requireString("name")
-        _ = try asset(mediaRef, editor: editor)
+        try requireAssetOrTimeline(mediaRef, editor: editor)
         return ([RenameMediaSpec(mediaRef: mediaRef, name: name)], false)
+    }
+
+    private func requireAssetOrTimeline(_ id: String, editor: EditorViewModel) throws {
+        guard editor.mediaAssets.contains(where: { $0.id == id }) || editor.timeline(for: id) != nil else {
+            throw ToolError("Media asset or timeline not found: \(id)")
+        }
     }
 
     private func parseRenameFolderSpecs(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Folders.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Folders.swift
@@ -99,7 +99,8 @@ extension ToolExecutor {
     }
 
     func deleteMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
-        let assetIds = args.stringArray("assetIds")
+        var seen: Set<String> = []
+        let assetIds = args.stringArray("assetIds").filter { seen.insert($0).inserted }
         guard !assetIds.isEmpty else { throw ToolError("assetIds is required") }
         let timelineIds = assetIds.filter { id in editor.timelines.contains { $0.id == id } }
         for id in assetIds where !timelineIds.contains(id) {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -32,6 +32,8 @@ extension ToolExecutor {
             throw ToolError("Out of credits. Tell the user to add credits or subscribe to keep generating.")
         }
         switch type {
+        case .sequence:
+            throw ToolError("Cannot generate a sequence. Sequences are timelines.")
         case .video:
             let modelId = try args.string("model") ?? defaultModelId(
                 VideoModelConfig.allModels.map { (id: $0.id, paidOnly: $0.paidOnly) }, kind: "video")
@@ -255,8 +257,10 @@ extension ToolExecutor {
             guard start >= 0, end > start else {
                 throw ToolError("videoSourceEndFrame must be greater than videoSourceStartFrame (>= 0).")
             }
+            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             let mp4 = try await TimelineRenderer.render(
                 timeline: editor.timeline, resolver: editor.mediaResolver,
+                resolveTimeline: { timelinesById[$0] },
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: start, frameCount: end - start,
                 shortSide: 360, includeAudio: false

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -257,10 +257,9 @@ extension ToolExecutor {
             guard start >= 0, end > start else {
                 throw ToolError("videoSourceEndFrame must be greater than videoSourceStartFrame (>= 0).")
             }
-            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             let mp4 = try await TimelineRenderer.render(
                 timeline: editor.timeline, resolver: editor.mediaResolver,
-                resolveTimeline: { timelinesById[$0] },
+                resolveTimeline: editor.timelineResolver(),
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: start, frameCount: end - start,
                 shortSide: 360, includeAudio: false

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
@@ -39,9 +39,11 @@ extension ToolExecutor {
         let canvas = CGSize(width: timeline.width, height: timeline.height)
         let renderSize = Self.fit(canvas, longestEdge: Self.inspectTimelineMaxDimension)
         let mediaURLs = editor.mediaResolver.expectedURLMap()
+        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
         let composition = try await CompositionBuilder.build(
             timeline: timeline,
             resolveURL: { mediaURLs[$0] },
+            resolveTimeline: { timelinesById[$0] },
             missingMediaRefs: editor.missingMediaRefs,
             renderSize: canvas
         )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+InspectTimeline.swift
@@ -39,11 +39,10 @@ extension ToolExecutor {
         let canvas = CGSize(width: timeline.width, height: timeline.height)
         let renderSize = Self.fit(canvas, longestEdge: Self.inspectTimelineMaxDimension)
         let mediaURLs = editor.mediaResolver.expectedURLMap()
-        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
         let composition = try await CompositionBuilder.build(
             timeline: timeline,
             resolveURL: { mediaURLs[$0] },
-            resolveTimeline: { timelinesById[$0] },
+            resolveTimeline: editor.timelineResolver(),
             missingMediaRefs: editor.missingMediaRefs,
             renderSize: canvas
         )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
@@ -11,7 +11,7 @@ extension ToolExecutor {
         "clipId", "sourceClipId", "referenceClipId", "targetClipId",
         "mediaRef", "startFrameMediaRef", "endFrameMediaRef",
         "sourceVideoMediaRef", "videoSourceMediaRef",
-        "folderId", "parentFolderId", "captionGroupId",
+        "folderId", "parentFolderId", "captionGroupId", "timelineId",
     ]
     private static let arrayIdKeys: Set<String> = [
         "clipIds", "targetClipIds", "assetIds", "folderIds",
@@ -23,6 +23,7 @@ extension ToolExecutor {
     /// prefix is distinct across the whole set, so anything we emit resolves to exactly one id.
     func currentIdUniverse(_ editor: EditorViewModel) -> Set<String> {
         var ids = Set<String>()
+        for timeline in editor.timelines { ids.insert(timeline.id) }
         for track in editor.timeline.tracks {
             ids.insert(track.id)
             for clip in track.clips {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -232,7 +232,7 @@ extension ToolExecutor {
                 throw ToolError("Failed to place any text clips")
             }
 
-            editor.undoManager?.registerUndo(withTarget: editor) { vm in
+            editor.registerTimelineUndo { vm in
                 vm.removeClips(ids: Set(ids))
             }
             return (ids, createdTrackInfo, resolvedSpecs)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -35,7 +35,6 @@ extension ToolExecutor {
             }
             dict["tracks"] = tracks
         }
-        dict.removeValue(forKey: "viewState")
         dict["totalFrames"] = editor.timeline.totalFrames
         if let window {
             dict["window"] = [window.lowerBound, min(window.upperBound, editor.timeline.totalFrames)]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -35,16 +35,58 @@ extension ToolExecutor {
             }
             dict["tracks"] = tracks
         }
+        dict.removeValue(forKey: "viewState")
         dict["totalFrames"] = editor.timeline.totalFrames
         if let window {
             dict["window"] = [window.lowerBound, min(window.upperBound, editor.timeline.totalFrames)]
         }
         dict["currentFrame"] = editor.currentFrame
         dict["canGenerate"] = AccountService.shared.isSignedIn && AccountService.shared.hasCredits
+        if editor.timelines.count > 1 {
+            dict["timelines"] = editor.timelines.map { t -> [String: Any] in
+                var entry: [String: Any] = ["timelineId": t.id, "name": t.name]
+                if t.id == editor.activeTimelineId { entry["active"] = true }
+                return entry
+            }
+        }
         guard let json = Self.jsonString(roundJSONFloatingPointNumbers(dict, toPlaces: 3)) else {
             throw ToolError("Failed to encode timeline")
         }
         return .ok(json)
+    }
+
+    func createTimeline(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["name"], path: "create_timeline")
+        let id = editor.createTimeline(name: args.string("name"))
+        let name = editor.timeline(for: id)?.name ?? ""
+        return .ok("Created and switched to timeline \"\(name)\" (timelineId \(id)). It is empty; all edit tools now target it.")
+    }
+
+    func setActiveTimeline(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["timelineId"], path: "set_active_timeline")
+        guard let id = args.string("timelineId") else { throw ToolError("timelineId is required") }
+        guard let target = editor.timeline(for: id) else {
+            throw ToolError("No timeline with id '\(id)'. get_timeline lists the project's timelines.")
+        }
+        guard editor.activeTimelineId != target.id else {
+            return .ok("\"\(target.name)\" is already the active timeline.")
+        }
+        editor.activateTimeline(target.id)
+        return .ok("Active timeline: \"\(target.name)\" (\(target.totalFrames) frames, \(target.fps) fps). Re-read get_timeline before editing.")
+    }
+
+    func duplicateTimeline(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["timelineId", "name"], path: "duplicate_timeline")
+        let sourceId = args.string("timelineId") ?? editor.activeTimelineId
+        guard let source = editor.timeline(for: sourceId) else {
+            throw ToolError("No timeline with id '\(sourceId)'. get_timeline lists the project's timelines.")
+        }
+        guard let newId = editor.duplicateTimeline(sourceId) else {
+            throw ToolError("Couldn't duplicate \"\(source.name)\".")
+        }
+        if let name = args.string("name") { editor.renameTimeline(newId, to: name) }
+        let copy = editor.timeline(for: newId)
+        return .ok("Duplicated \"\(source.name)\" as \"\(copy?.name ?? "")\" (timelineId \(newId)) and switched to it. Clip and track ids in the copy are new — re-read get_timeline before editing.")
     }
 
     private static let trackDefaults: [String: Any] = ["muted": false, "hidden": false, "syncLocked": true]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -295,6 +295,7 @@ extension ToolExecutor {
         case .audio: return try await readAudio(editor: editor, asset: asset, args: args, mapping: mapping, preferredLocale: preferredLocale)
         case .lottie: return try await readLottie(asset: asset, args: args)
         case .text: throw ToolError("Text clips are not stored as media assets.")
+        case .sequence: throw ToolError("Sequences are timelines, not media assets. Use get_timeline.")
         }
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -47,7 +47,8 @@ final class ToolExecutor {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
             result = try await run(tool, editor, resolved)
             // Record any edit that actually changed the timeline so `undo` can revert it.
-            if tool != .undo, !result.isError, editor.timeline != before,
+            // A timeline switch changes `editor.timeline` without registering an undo.
+            if tool != .undo, tool != .setActiveTimeline, !result.isError, editor.timeline != before,
                let actionName = editor.undoManager?.undoActionName {
                 agentUndoStack.append(actionName)
             }
@@ -125,6 +126,9 @@ final class ToolExecutor {
         case .deleteFolder:  return try deleteFolder(editor, args)
         case .sendFeedback:  return try await sendFeedback(editor, args)
         case .setProjectSettings: return try setProjectSettings(editor, args)
+        case .createTimeline:     return try createTimeline(editor, args)
+        case .setActiveTimeline:  return try setActiveTimeline(editor, args)
+        case .duplicateTimeline:  return try duplicateTimeline(editor, args)
         case .readSkill:     return readSkill(args)
         case .getProjects, .openProject, .newProject:
             return await runProjectTool(tool, args)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -46,8 +46,7 @@ final class ToolExecutor {
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
             result = try await run(tool, editor, resolved)
-            // Record any edit that actually changed the timeline so `undo` can revert it.
-            // A timeline switch changes `editor.timeline` without registering an undo.
+            // Register undo only if the timeline actually changed
             if tool != .undo, tool != .setActiveTimeline, !result.isError, editor.timeline != before,
                let actionName = editor.undoManager?.undoActionName {
                 agentUndoStack.append(actionName)
@@ -169,6 +168,31 @@ final class ToolExecutor {
             throw ToolError("\(label) not found: \(id)")
         }
         return asset
+    }
+
+    /// Media asset, or a synthetic stand-in when `id` names a timeline (nest insertion).
+    func clipSource(_ id: String, editor: EditorViewModel, path: String) throws -> MediaAsset {
+        if let existing = editor.mediaAssets.first(where: { $0.id == id }) { return existing }
+        guard let child = editor.timeline(for: id) else {
+            throw ToolError("\(path): media asset or timeline not found: \(id)")
+        }
+        guard child.totalFrames > 0 else {
+            throw ToolError("\(path): timeline \"\(child.name)\" is empty — add clips to it before nesting it.")
+        }
+        guard !editor.wouldCreateNestCycle(nesting: child.id, into: editor.activeTimelineId) else {
+            throw ToolError("\(path): can't nest \"\(child.name)\" here — it would contain itself.")
+        }
+        let stand = MediaAsset(
+            id: child.id,
+            url: URL(fileURLWithPath: "/dev/null"),
+            type: .sequence,
+            name: child.name,
+            duration: Double(child.totalFrames) / Double(editor.timeline.fps)
+        )
+        stand.sourceWidth = child.width
+        stand.sourceHeight = child.height
+        stand.hasAudio = child.tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
+        return stand
     }
 
     func resolveFolderId(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -35,7 +35,7 @@ final class ToolExecutor {
         }
 
         guard let editor else { return .error("Editor not available") }
-        let before = editor.timeline
+        let before = editor.timelines
         let result: ToolResult
         let started = ContinuousClock.now
         Log.agent.notice(
@@ -46,8 +46,7 @@ final class ToolExecutor {
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
             result = try await run(tool, editor, resolved)
-            // Register undo only if the timeline actually changed
-            if tool != .undo, tool != .setActiveTimeline, !result.isError, editor.timeline != before,
+            if tool != .undo, tool != .setActiveTimeline, !result.isError, editor.timelines != before,
                let actionName = editor.undoManager?.undoActionName {
                 agentUndoStack.append(actionName)
             }
@@ -62,7 +61,7 @@ final class ToolExecutor {
         let payload: Telemetry.Payload = [
             "tool": tool.rawValue,
             "durationSeconds": elapsed,
-            "timelineChanged": editor.timeline != before
+            "timelineChanged": editor.timelines != before
         ]
         if result.isError {
             Log.agent.warning(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -176,11 +176,8 @@ final class ToolExecutor {
         guard let child = editor.timeline(for: id) else {
             throw ToolError("\(path): media asset or timeline not found: \(id)")
         }
-        guard child.totalFrames > 0 else {
-            throw ToolError("\(path): timeline \"\(child.name)\" is empty — add clips to it before nesting it.")
-        }
-        guard !editor.wouldCreateNestCycle(nesting: child.id, into: editor.activeTimelineId) else {
-            throw ToolError("\(path): can't nest \"\(child.name)\" here — it would contain itself.")
+        if let reason = editor.nestBlockReason(childId: id) {
+            throw ToolError("\(path): \(reason)")
         }
         let stand = MediaAsset(
             id: child.id,
@@ -191,7 +188,7 @@ final class ToolExecutor {
         )
         stand.sourceWidth = child.width
         stand.sourceHeight = child.height
-        stand.hasAudio = child.tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
+        stand.hasAudio = child.hasAudioClips
         return stand
     }
 

--- a/Sources/PalmierPro/Compositing/CompositorInstruction.swift
+++ b/Sources/PalmierPro/Compositing/CompositorInstruction.swift
@@ -5,6 +5,8 @@ struct LayerPlan: Sendable {
     enum Source: Sendable {
         case track(CMPersistentTrackID)
         case text
+        /// Nested timeline: children composite into a `canvas`-sized unit, then the nest clip's pipeline applies.
+        case group(children: [LayerPlan], canvas: CGSize)
     }
     let source: Source
     let clip: Clip
@@ -14,6 +16,15 @@ struct LayerPlan: Sendable {
     var trackID: CMPersistentTrackID? {
         if case .track(let id) = source { return id }
         return nil
+    }
+
+    func collectTrackIDs(into ids: inout [CMPersistentTrackID]) {
+        switch source {
+        case .track(let id): ids.append(id)
+        case .text: break
+        case .group(let children, _):
+            for child in children { child.collectTrackIDs(into: &ids) }
+        }
     }
 }
 
@@ -34,10 +45,11 @@ final class CompositorInstruction: NSObject, AVVideoCompositionInstructionProtoc
         self.layers = layers
         self.renderSize = renderSize
         self.fps = fps
+        var all: [CMPersistentTrackID] = []
+        for layer in layers { layer.collectTrackIDs(into: &all) }
         var seen = Set<CMPersistentTrackID>()
-        self.requiredSourceTrackIDs = layers.compactMap {
-            guard let id = $0.trackID else { return nil }  // text layers need no decoded source
-            return seen.insert(id).inserted ? NSNumber(value: id) : nil
+        self.requiredSourceTrackIDs = all.compactMap {
+            seen.insert($0).inserted ? NSNumber(value: $0) : nil
         }
         super.init()
     }

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -15,8 +15,27 @@ enum FrameRenderer {
         let renderRect = CGRect(origin: .zero, size: instruction.renderSize)
         let frame = Int((compositionTime.seconds * Double(instruction.fps)).rounded())
 
-        var accum = CIImage(color: .black).cropped(to: renderRect)
-        for layer in instruction.layers {
+        let base = CIImage(color: .black).cropped(to: renderRect)
+        let accum = composite(
+            layers: instruction.layers, over: base, frame: frame,
+            renderSize: instruction.renderSize, sourceFrame: sourceFrame, gateByClipRange: false
+        )
+        context.render(accum, to: output, bounds: renderRect, colorSpace: nil)
+        tag709(output)
+    }
+
+    /// Bottom→top layer stack; `gateByClipRange` skips group children outside `frame`.
+    private static func composite(
+        layers: [LayerPlan],
+        over background: CIImage,
+        frame: Int,
+        renderSize: CGSize,
+        sourceFrame: (CMPersistentTrackID) -> CVPixelBuffer?,
+        gateByClipRange: Bool
+    ) -> CIImage {
+        var accum = background
+        for layer in layers {
+            if gateByClipRange, !layer.clip.contains(timelineFrame: frame) { continue }
             let mode = layer.clip.blendMode ?? .normal
             // Source-over bakes opacity into alpha; blend modes apply it as a fade of
             // the blend RESULT (Photoshop/Premiere semantics), so don't bake it there.
@@ -26,10 +45,13 @@ enum FrameRenderer {
             case .track(let id):
                 guard let buffer = sourceFrame(id) else { continue }
                 image = composedLayer(layer, buffer: buffer, frame: frame,
-                                      renderSize: instruction.renderSize, bakeOpacity: isNormal)
+                                      renderSize: renderSize, bakeOpacity: isNormal)
             case .text:
-                image = composedTextLayer(layer, frame: frame, renderSize: instruction.renderSize,
+                image = composedTextLayer(layer, frame: frame, renderSize: renderSize,
                                           bakeOpacity: isNormal)
+            case .group(let children, let canvas):
+                image = composedGroupLayer(layer, children: children, canvas: canvas, frame: frame,
+                                           renderSize: renderSize, sourceFrame: sourceFrame, bakeOpacity: isNormal)
             }
             guard let image else { continue }
             if isNormal {
@@ -39,8 +61,31 @@ enum FrameRenderer {
                 accum = blend(image, over: accum, filter: mode.ciFilterName!, opacity: opacity)
             }
         }
-        context.render(accum, to: output, bounds: renderRect, colorSpace: nil)
-        tag709(output)
+        return accum
+    }
+
+    /// Children composite at the child canvas; the nest clip's pipeline runs on the result.
+    private static func composedGroupLayer(
+        _ layer: LayerPlan,
+        children: [LayerPlan],
+        canvas: CGSize,
+        frame: Int,
+        renderSize: CGSize,
+        sourceFrame: (CMPersistentTrackID) -> CVPixelBuffer?,
+        bakeOpacity: Bool
+    ) -> CIImage? {
+        let alpha = min(1.0, max(0.0, layer.clip.opacityAt(frame: frame)))
+        guard alpha > 0, canvas.width > 0, canvas.height > 0 else { return nil }
+        let canvasRect = CGRect(origin: .zero, size: canvas)
+        let base = CIImage(color: .black).cropped(to: canvasRect)
+        let intermediate = composite(
+            layers: children, over: base, frame: frame,
+            renderSize: canvas, sourceFrame: sourceFrame, gateByClipRange: true
+        )
+        return applyClipPipeline(
+            image: intermediate, srcHeight: canvas.height, layer: layer, frame: frame,
+            renderSize: renderSize, alpha: alpha, bakeOpacity: bakeOpacity
+        )
     }
 
     /// Blend `image` over `background`, then fade the blend to background by `opacity`.
@@ -73,15 +118,30 @@ enum FrameRenderer {
         renderSize: CGSize,
         bakeOpacity: Bool = true
     ) -> CIImage? {
-        let clip = layer.clip
-        let alpha = min(1.0, max(0.0, clip.opacityAt(frame: frame)))
+        let alpha = min(1.0, max(0.0, layer.clip.opacityAt(frame: frame)))
         guard alpha > 0 else { return nil }
 
         // Undo premultiplied alpha to avoid dark edges.
-
-        var image = CIImage(cvPixelBuffer: buffer, options: [.colorSpace: NSNull()])
+        let image = CIImage(cvPixelBuffer: buffer, options: [.colorSpace: NSNull()])
             .unpremultiplyingAlpha()
-        let srcHeight = CGFloat(CVPixelBufferGetHeight(buffer))
+        return applyClipPipeline(
+            image: image, srcHeight: CGFloat(CVPixelBufferGetHeight(buffer)), layer: layer,
+            frame: frame, renderSize: renderSize, alpha: alpha, bakeOpacity: bakeOpacity
+        )
+    }
+
+    /// Crop → effects → transform → opacity, sampled from `layer.clip` at `frame`.
+    private static func applyClipPipeline(
+        image input: CIImage,
+        srcHeight: CGFloat,
+        layer: LayerPlan,
+        frame: Int,
+        renderSize: CGSize,
+        alpha: Double,
+        bakeOpacity: Bool
+    ) -> CIImage? {
+        let clip = layer.clip
+        var image = input
 
         let crop = clip.cropAt(frame: frame)
         if !crop.isIdentity {

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -70,7 +70,12 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private lazy var agentHC: NSViewController     = makeHosting(AgentPanelView(), panel: .agent)
     private lazy var timelineHC: NSViewController  = makeHosting(
         VStack(spacing: 0) {
-            ToolbarView().frame(height: Layout.toolbarHeight)
+            TimelineTabBar()
+            ToolbarView()
+                .frame(height: Layout.toolbarHeight)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(AppTheme.Border.primaryColor).frame(height: AppTheme.BorderWidth.thin)
+                }
             TimelineContainerView()
         },
         panel: .timeline

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -74,13 +74,18 @@ final class EditorWindowController: NSWindowController {
             return true
 
         case 51: // Delete/Backspace
-            if !editorViewModel.selectedFolderIds.isEmpty || !editorViewModel.selectedMediaAssetIds.isEmpty {
+            if !editorViewModel.selectedFolderIds.isEmpty || !editorViewModel.selectedMediaAssetIds.isEmpty
+                || !editorViewModel.selectedTimelineIds.isEmpty {
                 if !editorViewModel.selectedFolderIds.isEmpty {
                     editorViewModel.deleteFolders(ids: editorViewModel.selectedFolderIds)
                 }
                 if !editorViewModel.selectedMediaAssetIds.isEmpty {
                     editorViewModel.deleteSelectedMediaAssets()
                 }
+                for id in editorViewModel.selectedTimelineIds {
+                    editorViewModel.deleteTimeline(id)
+                }
+                editorViewModel.selectedTimelineIds.removeAll()
             } else if shift {
                 if editorViewModel.selectedGap != nil {
                     editorViewModel.rippleDeleteSelectedGap()

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -199,7 +199,11 @@ final class EditorWindowController: NSWindowController {
             if let panel = EditorViewModel.FocusedPanel(accessibilityID: v.accessibilityIdentifier()) {
                 editorViewModel.focusedPanel = panel
                 if panel == .media { editorViewModel.selectedClipIds.removeAll() }
-                if panel == .timeline { editorViewModel.selectedMediaAssetIds.removeAll() }
+                if panel == .timeline {
+                    editorViewModel.selectedMediaAssetIds.removeAll()
+                    editorViewModel.selectedTimelineIds.removeAll()
+                    editorViewModel.selectedFolderIds.removeAll()
+                }
                 return
             }
             view = v.superview

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -6,6 +6,7 @@ final class EditorWindowController: NSWindowController {
     let editorViewModel: EditorViewModel
     private nonisolated(unsafe) var keyMonitor: Any?
     private nonisolated(unsafe) var mouseMonitor: Any?
+    private nonisolated(unsafe) var endEditingObserver: Any?
 
     init(editorViewModel: EditorViewModel, window: NSWindow) {
         self.editorViewModel = editorViewModel
@@ -18,6 +19,7 @@ final class EditorWindowController: NSWindowController {
     deinit {
         if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
         if let mouseMonitor { NSEvent.removeMonitor(mouseMonitor) }
+        if let endEditingObserver { NotificationCenter.default.removeObserver(endEditingObserver) }
     }
 
     func installKeyMonitor() {
@@ -32,6 +34,17 @@ final class EditorWindowController: NSWindowController {
             self.resignStaleFocus(hitView: hitView)
             self.handlePanelClick(hitView: hitView)
             return event
+        }
+
+        endEditingObserver = NotificationCenter.default.addObserver(
+            forName: NSText.didEndEditingNotification, object: nil, queue: .main
+        ) { [weak self] note in
+            nonisolated(unsafe) let object = note.object
+            MainActor.assumeIsolated {
+                guard let self, let editor = object as? NSTextView,
+                      editor.window === self.window, let storage = editor.textStorage else { return }
+                self.editorViewModel.undoManager?.removeAllActions(withTarget: storage)
+            }
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -114,9 +114,13 @@ extension EditorViewModel {
 
     @discardableResult
     func generateCaptions(for request: CaptionRequest) async throws -> [String] {
+        let owningTimelineId = activeTimelineId
         var targets = resolvedCaptionTargets(for: request)
         guard !targets.isEmpty else { throw CaptionError.noSource }
         let results = try await transcribe(targets, request: request)
+
+        guard timeline(for: owningTimelineId) != nil else { return [] }
+        if activeTimelineId != owningTimelineId { activateTimeline(owningTimelineId) }
 
         if request.autoDetect {
             guard let winner = dominantSpeechTrack(targets, results) else { return [] }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -164,7 +164,7 @@ extension EditorViewModel {
         timeline.tracks[loc.trackIndex].clips.append(right)
         sortClips(trackIndex: loc.trackIndex)
 
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.removeClipInternal(id: right.id)
             if let newLoc = vm.findClip(id: left.id) {
                 vm.timeline.tracks[newLoc.trackIndex].clips[newLoc.clipIndex] = clip
@@ -240,7 +240,7 @@ extension EditorViewModel {
     }
 
     func registerTimelineSwap(undoState: Timeline, redoState: Timeline, actionName: String) {
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.timeline = undoState
             vm.notifyTimelineChanged()
             vm.registerTimelineSwap(undoState: redoState, redoState: undoState, actionName: actionName)
@@ -321,7 +321,7 @@ extension EditorViewModel {
         redoTarget: [(id: String, clip: Clip)],
         actionName: String
     ) {
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             for entry in undoTarget {
                 if let loc = vm.findClip(id: entry.id) {
                     vm.timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = entry.clip
@@ -558,7 +558,7 @@ extension EditorViewModel {
 
     /// Bidirectional undo/redo for a single clip's property change.
     fileprivate func registerClipPropertySwap(clipId: String, undoTarget: Clip, redoTarget: Clip) {
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             if let loc = vm.findClip(id: clipId) {
                 vm.timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = undoTarget
             }
@@ -624,7 +624,7 @@ extension EditorViewModel {
             }
         }
 
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             for id in targetIds {
                 if let l = vm.findClip(id: id) {
                     vm.timeline.tracks[l.trackIndex].clips[l.clipIndex].mediaRef = oldMediaRef
@@ -683,17 +683,7 @@ extension EditorViewModel {
         guard mediaAssets.contains(where: { ids.contains($0.id) }) else { return }
 
         let before = mediaLibraryUndoSnapshot()
-        let clipIdsToRemove = Set(timeline.tracks
-            .flatMap(\.clips)
-            .filter { ids.contains($0.mediaRef) }
-            .map(\.id))
-        if !clipIdsToRemove.isEmpty {
-            selectedClipIds.subtract(clipIdsToRemove)
-            for i in timeline.tracks.indices {
-                timeline.tracks[i].clips.removeAll { clipIdsToRemove.contains($0.id) }
-            }
-            pruneEmptyTracks()
-        }
+        let clipIdsToRemove = removeClipsReferencingAssets(ids)
 
         mediaAssets.removeAll { ids.contains($0.id) }
         mediaManifest.entries.removeAll { ids.contains($0.id) }
@@ -701,7 +691,7 @@ extension EditorViewModel {
         for id in ids { closePreviewTab(id: PreviewTab.mediaAssetTabId(for: id)) }
         selectedMediaAssetIds.removeAll()
 
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.restoreMediaLibraryUndoSnapshot(before, actionName: "Delete Media")
             vm.selectedMediaAssetIds.removeAll()
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -185,16 +185,9 @@ extension EditorViewModel {
         if leftKfs.last?.frame != splitOffset {
             leftKfs.append(Keyframe(frame: splitOffset, value: boundary))
         }
-        var rightKfs = track.keyframes
-            .filter { $0.frame >= splitOffset }
-            .map { Keyframe(frame: $0.frame - splitOffset, value: $0.value, interpolationOut: $0.interpolationOut) }
-        if rightKfs.first?.frame != 0 {
-            let interp = track.keyframes.last { $0.frame < splitOffset }?.interpolationOut ?? .smooth
-            rightKfs.insert(Keyframe(frame: 0, value: boundary, interpolationOut: interp), at: 0)
-        }
         return (
             leftKfs.isEmpty ? nil : KeyframeTrack(keyframes: leftKfs),
-            rightKfs.isEmpty ? nil : KeyframeTrack(keyframes: rightKfs)
+            track.rebased(by: splitOffset, fallback: fallback)
         )
     }
 
@@ -215,6 +208,8 @@ extension EditorViewModel {
 
     func applyClipSpeed(clipId: String, newSpeed: Double) {
         guard let loc = findClip(id: clipId) else { return }
+        // Nest playback doesn't support retiming yet.
+        guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].sourceClipType != .sequence else { return }
         if preDragTimeline == nil {
             preDragTimeline = timeline
         }
@@ -228,6 +223,7 @@ extension EditorViewModel {
         let before: Timeline = preDragTimeline ?? timeline
         for id in ids {
             guard let loc = findClip(id: id) else { continue }
+            guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].sourceClipType != .sequence else { continue }
             if timeline.tracks[loc.trackIndex].clips[loc.clipIndex].speed != newSpeed {
                 setClipSpeed(at: loc, newSpeed: newSpeed)
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -208,8 +208,7 @@ extension EditorViewModel {
 
     func applyClipSpeed(clipId: String, newSpeed: Double) {
         guard let loc = findClip(id: clipId) else { return }
-        // Nest playback doesn't support retiming yet.
-        guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].sourceClipType != .sequence else { return }
+        guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].supportsRetiming else { return }
         if preDragTimeline == nil {
             preDragTimeline = timeline
         }
@@ -223,7 +222,7 @@ extension EditorViewModel {
         let before: Timeline = preDragTimeline ?? timeline
         for id in ids {
             guard let loc = findClip(id: id) else { continue }
-            guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].sourceClipType != .sequence else { continue }
+            guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].supportsRetiming else { continue }
             if timeline.tracks[loc.trackIndex].clips[loc.clipIndex].speed != newSpeed {
                 setClipSpeed(at: loc, newSpeed: newSpeed)
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
@@ -72,6 +72,12 @@ extension EditorViewModel {
             guard timeline.tracks.indices.contains(dstTrack) else { continue }
             let trackType = timeline.tracks[dstTrack].type
             guard trackType.isCompatible(with: entry.clip.mediaType) else { continue }
+            // A pasted nest must not make this timeline contain itself.
+            if entry.clip.sourceClipType == .sequence,
+               wouldCreateNestCycle(nesting: entry.clip.mediaRef, into: activeTimelineId) {
+                mediaPanelToast = "Can't paste \"\(clipDisplayLabel(for: entry.clip))\" here — it would nest this timeline inside itself."
+                continue
+            }
             placements.append(ClonePlacement(
                 source: entry.clip,
                 trackId: timeline.tracks[dstTrack].id,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
@@ -134,7 +134,7 @@ private extension EditorViewModel {
         for p in placements {
             if let g = p.source.linkGroupId { groupCounts[g, default: 0] += 1 }
         }
-        var groupRemap: [String: String] = [:]
+        var groups: [String: String] = [:]
 
         var newIds: [String] = []
         withTimelineSwap(actionName: actionName) {
@@ -146,17 +146,9 @@ private extension EditorViewModel {
             for p in placements {
                 guard let ti = timeline.tracks.firstIndex(where: { $0.id == p.trackId }) else { continue }
                 var clone = p.source
-                clone.id = UUID().uuidString
                 clone.startFrame = p.dstStart
-                if let oldGroup = p.source.linkGroupId, (groupCounts[oldGroup] ?? 0) > 1 {
-                    if let mapped = groupRemap[oldGroup] {
-                        clone.linkGroupId = mapped
-                    } else {
-                        let new = UUID().uuidString
-                        groupRemap[oldGroup] = new
-                        clone.linkGroupId = new
-                    }
-                } else {
+                clone.freshenIds(groups: &groups)
+                if let oldGroup = p.source.linkGroupId, (groupCounts[oldGroup] ?? 0) <= 1 {
                     clone.linkGroupId = nil
                 }
                 timeline.tracks[ti].clips.append(clone)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -32,13 +32,6 @@ extension EditorViewModel {
             .map(\.id))
     }
 
-    private func clipIdsReferencingAssets(_ assetIds: Set<String>) -> Set<String> {
-        Set(timeline.tracks
-            .flatMap(\.clips)
-            .filter { assetIds.contains($0.mediaRef) }
-            .map(\.id))
-    }
-
     // MARK: - Mutations
 
     @discardableResult
@@ -71,15 +64,7 @@ extension EditorViewModel {
 
         let before = mediaLibraryUndoSnapshot()
         let assetIdsToDelete = assetIds(inFolderIds: allFolderIds)
-        let clipIdsToRemove = clipIdsReferencingAssets(assetIdsToDelete)
-
-        if !clipIdsToRemove.isEmpty {
-            selectedClipIds.subtract(clipIdsToRemove)
-            for i in timeline.tracks.indices {
-                timeline.tracks[i].clips.removeAll { clipIdsToRemove.contains($0.id) }
-            }
-            pruneEmptyTracks()
-        }
+        let clipIdsToRemove = removeClipsReferencingAssets(assetIdsToDelete)
 
         mediaAssets.removeAll { assetIdsToDelete.contains($0.id) }
         mediaManifest.entries.removeAll { assetIdsToDelete.contains($0.id) }
@@ -169,7 +154,9 @@ extension EditorViewModel {
 
     func mediaLibraryUndoSnapshot() -> MediaLibraryUndoSnapshot {
         MediaLibraryUndoSnapshot(
-            timeline: timeline,
+            timelines: timelines,
+            activeTimelineId: activeTimelineId,
+            openTimelineIds: openTimelineIds,
             mediaManifest: mediaManifest,
             mediaAssets: mediaAssets,
             selectedClipIds: selectedClipIds,
@@ -183,7 +170,9 @@ extension EditorViewModel {
 
     func restoreMediaLibraryUndoSnapshot(_ snapshot: MediaLibraryUndoSnapshot, actionName: String) {
         let redo = mediaLibraryUndoSnapshot()
-        timeline = snapshot.timeline
+        timelines = snapshot.timelines
+        activeTimelineId = snapshot.activeTimelineId
+        openTimelineIds = snapshot.openTimelineIds
         mediaManifest = snapshot.mediaManifest
         mediaAssets = snapshot.mediaAssets
         selectedClipIds = snapshot.selectedClipIds
@@ -203,7 +192,9 @@ extension EditorViewModel {
 }
 
 struct MediaLibraryUndoSnapshot {
-    let timeline: Timeline
+    let timelines: [Timeline]
+    let activeTimelineId: String
+    let openTimelineIds: [String]
     let mediaManifest: MediaManifest
     let mediaAssets: [MediaAsset]
     let selectedClipIds: Set<String>

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -194,8 +194,10 @@ extension EditorViewModel {
     func restoreMediaLibraryUndoSnapshot(_ snapshot: MediaLibraryUndoSnapshot, actionName: String) {
         let redo = mediaLibraryUndoSnapshot()
         timelines = snapshot.timelines
-        activeTimelineId = snapshot.activeTimelineId
         openTimelineIds = snapshot.openTimelineIds
+        if activeTimelineId != snapshot.activeTimelineId {
+            activateTimeline(snapshot.activeTimelineId)
+        }
         mediaManifest = snapshot.mediaManifest
         mediaAssets = snapshot.mediaAssets
         selectedClipIds = snapshot.selectedClipIds

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -194,6 +194,7 @@ extension EditorViewModel {
     func restoreMediaLibraryUndoSnapshot(_ snapshot: MediaLibraryUndoSnapshot, actionName: String) {
         let redo = mediaLibraryUndoSnapshot()
         timelines = snapshot.timelines
+        timelineRenderRevision &+= 1
         openTimelineIds = snapshot.openTimelineIds
         if activeTimelineId != snapshot.activeTimelineId {
             activateTimeline(snapshot.activeTimelineId)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -194,7 +194,6 @@ extension EditorViewModel {
     func restoreMediaLibraryUndoSnapshot(_ snapshot: MediaLibraryUndoSnapshot, actionName: String) {
         let redo = mediaLibraryUndoSnapshot()
         timelines = snapshot.timelines
-        timelineRenderRevision &+= 1
         openTimelineIds = snapshot.openTimelineIds
         if activeTimelineId != snapshot.activeTimelineId {
             activateTimeline(snapshot.activeTimelineId)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -66,6 +66,11 @@ extension EditorViewModel {
         let assetIdsToDelete = assetIds(inFolderIds: allFolderIds)
         let clipIdsToRemove = removeClipsReferencingAssets(assetIdsToDelete)
 
+        // Timelines are never cascade-deleted with their folder; reparent to root.
+        for i in timelines.indices where timelines[i].folderId.map(allFolderIds.contains) == true {
+            timelines[i].folderId = nil
+        }
+
         mediaAssets.removeAll { assetIdsToDelete.contains($0.id) }
         mediaManifest.entries.removeAll { assetIdsToDelete.contains($0.id) }
         mediaManifest.folders.removeAll { allFolderIds.contains($0.id) }
@@ -80,6 +85,24 @@ extension EditorViewModel {
         if !clipIdsToRemove.isEmpty {
             notifyTimelineChanged()
         }
+    }
+
+    func moveTimelinesToFolder(timelineIds: Set<String>, folderId: String?) {
+        guard !timelineIds.isEmpty else { return }
+        var changes: [ParentChange] = []
+        for id in timelineIds {
+            guard let t = timeline(for: id), t.folderId != folderId else { continue }
+            changes.append((id, folderId))
+        }
+        guard !changes.isEmpty else { return }
+        applyParentChanges(
+            changes, actionName: "Move to Folder",
+            get: { vm, id in vm.timeline(for: id)?.folderId },
+            set: { vm, id, value in
+                guard let i = vm.timelines.firstIndex(where: { $0.id == id }) else { return }
+                vm.timelines[i].folderId = value
+            }
+        )
     }
 
     func moveAssetsToFolder(assetIds: Set<String>, folderId: String?) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
@@ -47,23 +47,20 @@ extension EditorViewModel {
         return clipId
     }
 
+    // Generation completes asynchronously — the placeholder may live on a background timeline.
     func finalizeGeneratingClip(placeholderId: String, asset: MediaAsset) {
-        guard let loc = findClipLocationByMediaRef(placeholderId) else { return }
-        let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: timeline.fps))
-        undoManager?.disableUndoRegistration()
-        timeline.tracks[loc.trackIndex].clips[loc.clipIndex].durationFrames = realFrames
-        timeline.tracks[loc.trackIndex].clips[loc.clipIndex].trimStartFrame = 0
-        timeline.tracks[loc.trackIndex].clips[loc.clipIndex].trimEndFrame = 0
-        undoManager?.enableUndoRegistration()
-        notifyTimelineChanged()
-    }
-
-    private func findClipLocationByMediaRef(_ mediaRef: String) -> ClipLocation? {
-        for ti in timeline.tracks.indices {
-            if let ci = timeline.tracks[ti].clips.firstIndex(where: { $0.mediaRef == mediaRef }) {
-                return ClipLocation(trackIndex: ti, clipIndex: ci)
+        for i in timelines.indices {
+            for ti in timelines[i].tracks.indices {
+                guard let ci = timelines[i].tracks[ti].clips.firstIndex(where: { $0.mediaRef == placeholderId }) else { continue }
+                let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: timelines[i].fps))
+                undoManager?.disableUndoRegistration()
+                timelines[i].tracks[ti].clips[ci].durationFrames = realFrames
+                timelines[i].tracks[ti].clips[ci].trimStartFrame = 0
+                timelines[i].tracks[ti].clips[ci].trimEndFrame = 0
+                undoManager?.enableUndoRegistration()
+                if timelines[i].id == activeTimelineId { notifyTimelineChanged() }
+                return
             }
         }
-        return nil
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
@@ -68,7 +68,6 @@ extension EditorViewModel {
         // Rebuild when a touched timeline is visible from the active one, including through nests.
         if touched.contains(activeTimelineId)
             || timeline.reachableTimelines(resolve: timeline(for:)).contains(where: { touched.contains($0.id) }) {
-            timelineRenderRevision &+= 1
             notifyTimelineChanged()
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
@@ -47,20 +47,29 @@ extension EditorViewModel {
         return clipId
     }
 
-    // Generation completes asynchronously — the placeholder may live on a background timeline.
+    // Patch all timelines with placeholders for this asset.
     func finalizeGeneratingClip(placeholderId: String, asset: MediaAsset) {
+        var touched: Set<String> = []
+        undoManager?.disableUndoRegistration()
         for i in timelines.indices {
+            let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: timelines[i].fps))
             for ti in timelines[i].tracks.indices {
-                guard let ci = timelines[i].tracks[ti].clips.firstIndex(where: { $0.mediaRef == placeholderId }) else { continue }
-                let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: timelines[i].fps))
-                undoManager?.disableUndoRegistration()
-                timelines[i].tracks[ti].clips[ci].durationFrames = realFrames
-                timelines[i].tracks[ti].clips[ci].trimStartFrame = 0
-                timelines[i].tracks[ti].clips[ci].trimEndFrame = 0
-                undoManager?.enableUndoRegistration()
-                if timelines[i].id == activeTimelineId { notifyTimelineChanged() }
-                return
+                for ci in timelines[i].tracks[ti].clips.indices
+                where timelines[i].tracks[ti].clips[ci].mediaRef == placeholderId {
+                    timelines[i].tracks[ti].clips[ci].durationFrames = realFrames
+                    timelines[i].tracks[ti].clips[ci].trimStartFrame = 0
+                    timelines[i].tracks[ti].clips[ci].trimEndFrame = 0
+                    touched.insert(timelines[i].id)
+                }
             }
+        }
+        undoManager?.enableUndoRegistration()
+        guard !touched.isEmpty else { return }
+        // Rebuild when a touched timeline is visible from the active one, including through nests.
+        if touched.contains(activeTimelineId)
+            || timeline.reachableTimelines(resolve: timeline(for:)).contains(where: { touched.contains($0.id) }) {
+            timelineRenderRevision &+= 1
+            notifyTimelineChanged()
         }
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -3,6 +3,7 @@ import AVFoundation
 
 enum MediaPanelItemKey {
     static let folderPrefix = "folder-"
+    static let timelinePrefix = "timeline-"
 
     static func folder(_ id: String) -> String {
         folderPrefix + id
@@ -11,6 +12,15 @@ enum MediaPanelItemKey {
     static func folderId(from key: String) -> String? {
         guard key.hasPrefix(folderPrefix) else { return nil }
         return String(key.dropFirst(folderPrefix.count))
+    }
+
+    static func timeline(_ id: String) -> String {
+        timelinePrefix + id
+    }
+
+    static func timelineId(from key: String) -> String? {
+        guard key.hasPrefix(timelinePrefix) else { return nil }
+        return String(key.dropFirst(timelinePrefix.count))
     }
 }
 
@@ -438,6 +448,7 @@ extension EditorViewModel {
     private func mediaPanelSelectedKeys() -> Set<String> {
         var keys = selectedMediaAssetIds
         keys.formUnion(selectedFolderIds.map(MediaPanelItemKey.folder))
+        keys.formUnion(selectedTimelineIds.map(MediaPanelItemKey.timeline))
         return keys
     }
 
@@ -446,6 +457,15 @@ extension EditorViewModel {
             guard folder(id: folderId) != nil else { return }
             mediaPanelScrollTarget = key
             selectedFolderIds = [folderId]
+            selectedMediaAssetIds.removeAll()
+            selectedTimelineIds.removeAll()
+            return
+        }
+        if let timelineId = MediaPanelItemKey.timelineId(from: key) {
+            guard timeline(for: timelineId) != nil else { return }
+            mediaPanelScrollTarget = key
+            selectedTimelineIds = [timelineId]
+            selectedFolderIds.removeAll()
             selectedMediaAssetIds.removeAll()
             return
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -154,6 +154,13 @@ extension EditorViewModel {
         }
     }
 
+    func timelineIdsFromDragPayload(_ payload: String) -> [String] {
+        payload.split(separator: "\n").compactMap { line in
+            guard let id = MediaTab.timelineId(fromDragString: String(line)) else { return nil }
+            return timeline(for: id)?.id
+        }
+    }
+
     /// Source-second ranges carried by search-moment drags, keyed by asset id.
     func segmentsFromDragPayload(_ payload: String) -> [String: ClosedRange<Double>] {
         var segments: [String: ClosedRange<Double>] = [:]
@@ -365,6 +372,9 @@ extension EditorViewModel {
         if let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }), asset.isGenerating {
             return asset.name
         }
+        if clip.sourceClipType == .sequence, let nested = timeline(for: clip.mediaRef) {
+            return nested.name
+        }
         return mediaResolver.displayName(for: clip.mediaRef)
     }
 
@@ -403,7 +413,10 @@ extension EditorViewModel {
     }
 
     func isClipMediaOffline(_ clip: Clip) -> Bool {
-        clip.mediaType != .text && isMediaOffline(clip.mediaRef)
+        if clip.sourceClipType == .sequence {
+            return timeline(for: clip.mediaRef) == nil
+        }
+        return clip.mediaType != .text && isMediaOffline(clip.mediaRef)
     }
 
     func isClipMediaGenerating(_ clip: Clip) -> Bool {
@@ -593,7 +606,7 @@ extension EditorViewModel {
             mediaVisualCache.generateWaveform(for: asset)
         case .image:
             mediaVisualCache.generateImageThumbnail(for: asset)
-        case .text, .lottie:
+        case .text, .lottie, .sequence:
             break
         }
         refreshPreviewForFinalizedAsset(asset)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -626,8 +626,8 @@ extension EditorViewModel {
     }
 
     private func refreshPreviewForFinalizedAsset(_ asset: MediaAsset) {
-        let usedOnTimeline = timeline.tracks.contains { track in
-            track.clips.contains { $0.mediaRef == asset.id }
+        let usedOnTimeline = ([timeline] + timeline.reachableTimelines(resolve: timeline(for:))).contains { t in
+            t.tracks.contains { $0.clips.contains { $0.mediaRef == asset.id } }
         }
         if usedOnTimeline {
             timelineRenderRevision &+= 1

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
@@ -71,6 +71,7 @@ extension EditorViewModel {
                 return c
             })
         }
+        child.regenerateIds()
 
         timelines.append(child)
         registerRemoveUndo(for: child.id, actionName: "Nest Clips")
@@ -79,10 +80,20 @@ extension EditorViewModel {
             for i in timeline.tracks.indices {
                 timeline.tracks[i].clips.removeAll { ids.contains($0.id) }
             }
+            let span = start..<(start + duration)
+            var videoIdx = lanes.first { $0.type != .audio }?.index
+            var audioIdx = lanes.first { $0.type == .audio }?.index
+            if let vi = videoIdx, trackOverlaps(vi, span: span) {
+                let inserted = insertTrack(at: vi, type: .video)
+                videoIdx = inserted
+                if let ai = audioIdx, ai >= inserted { audioIdx = ai + 1 }
+            }
+            if let ai = audioIdx, trackOverlaps(ai, span: span) {
+                audioIdx = insertTrack(at: ai + 1, type: .audio)
+            }
             let carriers = insertNestCarriers(
                 for: child, start: start, duration: duration,
-                videoIdx: lanes.first { $0.type != .audio }?.index,
-                audioIdx: lanes.first { $0.type == .audio }?.index
+                videoIdx: videoIdx, audioIdx: audioIdx
             )
             pruneEmptyTracks()
             selectedClipIds = carriers
@@ -149,6 +160,10 @@ extension EditorViewModel {
             || audioCarrier.map({ $0.fadeInFrames > 0 || $0.fadeOutFrames > 0 || $0.volumeTrack != nil }) == true {
             mediaPanelToast = "Nest settings discarded. Undo to restore."
         }
+    }
+
+    private func trackOverlaps(_ idx: Int, span: Range<Int>) -> Bool {
+        timeline.tracks[idx].clips.contains { $0.startFrame < span.upperBound && $0.endFrame > span.lowerBound }
     }
 
     /// Group-level looks that have no per-clip equivalent after decompose.

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
@@ -9,6 +9,11 @@ extension EditorViewModel {
         return child.reachableTimelines(resolve: timeline(for:)).contains { $0.id == hostId }
     }
 
+    func isVisibleFromActive(_ id: String) -> Bool {
+        id == activeTimelineId
+            || timeline.reachableTimelines(resolve: timeline(for:)).contains { $0.id == id }
+    }
+
     /// Why `childId` can't nest into the active timeline, or nil if it can.
     func nestBlockReason(childId: String) -> String? {
         guard let child = timeline(for: childId) else { return nil }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// Nested timelines: eligibility, carrier insertion, and decompose.
+extension EditorViewModel {
+
+    func wouldCreateNestCycle(nesting childId: String, into hostId: String) -> Bool {
+        if childId == hostId { return true }
+        guard let child = timeline(for: childId) else { return false }
+        return child.reachableTimelines(resolve: timeline(for:)).contains { $0.id == hostId }
+    }
+
+    /// Why `childId` can't nest into the active timeline, or nil if it can.
+    func nestBlockReason(childId: String) -> String? {
+        guard let child = timeline(for: childId) else { return nil }
+        if child.totalFrames == 0 {
+            return "\"\(child.name)\" is empty. Add clips before nesting it."
+        }
+        if wouldCreateNestCycle(nesting: childId, into: activeTimelineId) {
+            return "Can't nest \"\(child.name)\" — it would contain itself."
+        }
+        return nil
+    }
+
+    /// Drops `childId` into the active timeline as a single nested clip.
+    @discardableResult
+    func nestTimeline(_ childId: String, cursor: TrackDropTarget, atFrame frame: Int) -> Bool {
+        guard let child = timeline(for: childId) else { return false }
+        if let reason = nestBlockReason(childId: childId) {
+            mediaPanelToast = MediaPanelToast(message: reason)
+            return false
+        }
+
+        let duration = child.totalFrames
+        let startFrame = max(0, frame)
+
+        withTimelineSwap(actionName: "Nest Timeline") {
+            var videoTarget = cursor
+            if case .existingTrack(let idx) = cursor,
+               !(timeline.tracks.indices.contains(idx) && timeline.tracks[idx].type == .video) {
+                videoTarget = .newTrackAt(0)
+            }
+            let videoIdx = materializeTrackIndex(target: videoTarget, type: .video)
+            let audioIdx = child.hasAudioClips ? resolveOrCreateAudioTrack(startFrame: startFrame, duration: duration) : nil
+            insertNestCarriers(for: child, start: startFrame, duration: duration, videoIdx: videoIdx, audioIdx: audioIdx)
+        }
+        return true
+    }
+
+    func nestSelectedClips() {
+        let ids = selectedClipIds
+        var lanes: [(index: Int, type: ClipType, clips: [Clip])] = []
+        for (i, track) in timeline.tracks.enumerated() {
+            let picked = track.clips.filter { ids.contains($0.id) }
+            if !picked.isEmpty { lanes.append((i, track.type, picked)) }
+        }
+        guard !lanes.isEmpty else { return }
+
+        let all = lanes.flatMap(\.clips)
+        let start = all.map(\.startFrame).min()!
+        let duration = all.map(\.endFrame).max()! - start
+
+        var child = Timeline(name: uniqueName({ "Nest \($0)" }, startingAt: 1))
+        child.fps = timeline.fps
+        child.width = timeline.width
+        child.height = timeline.height
+        child.settingsConfigured = timeline.settingsConfigured
+        child.tracks = lanes.map { lane in
+            Track(type: lane.type, clips: lane.clips.map { clip in
+                var c = clip
+                c.startFrame -= start
+                return c
+            })
+        }
+
+        timelines.append(child)
+        registerRemoveUndo(for: child.id, actionName: "Nest Clips")
+        selectedClipIds = []
+        withTimelineSwap(actionName: "Nest Clips") {
+            for i in timeline.tracks.indices {
+                timeline.tracks[i].clips.removeAll { ids.contains($0.id) }
+            }
+            let carriers = insertNestCarriers(
+                for: child, start: start, duration: duration,
+                videoIdx: lanes.first { $0.type != .audio }?.index,
+                audioIdx: lanes.first { $0.type == .audio }?.index
+            )
+            pruneEmptyTracks()
+            selectedClipIds = carriers
+        }
+        openTimelineIds.append(child.id)
+        timelineTabRenameRequest = child.id
+    }
+
+    /// Replaces a nest clip (and its linked audio) with the child's clips remapped in place
+    func decomposeNest(clipId: String) {
+        guard let loc = findClip(id: clipId) else { return }
+        let clicked = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard clicked.sourceClipType == .sequence, let child = timeline(for: clicked.mediaRef) else { return }
+
+        var videoCarrier: Clip?
+        var audioCarrier: Clip?
+        let group = expandToLinkGroup([clicked.id])
+        for id in group {
+            guard let l = findClip(id: id) else { continue }
+            let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
+            guard c.sourceClipType == .sequence, c.mediaRef == clicked.mediaRef else { continue }
+            if c.mediaType == .audio { audioCarrier = c } else { videoCarrier = c }
+        }
+        selectedClipIds.subtract(group)
+
+        var groups: [String: String] = [:]
+        func freshen(_ clip: Clip, volumeScale: Double = 1) -> Clip {
+            var c = clip
+            c.freshenIds(groups: &groups)
+            c.volume *= volumeScale
+            return c
+        }
+
+        // Top lane reuses the carrier's track; later lanes reuse free-span tracks below before inserting new ones.
+        func place(lanes: [[Clip]], carrier: Clip, type: ClipType, volumeScale: Double) {
+            guard let l = findClip(id: carrier.id) else { return }
+            let span = carrier.startFrame..<carrier.endFrame
+            timeline.tracks[l.trackIndex].clips.remove(at: l.clipIndex)
+            var idx = l.trackIndex
+            for lane in lanes {
+                let free = timeline.tracks.indices.contains(idx)
+                    && timeline.tracks[idx].type == type
+                    && !timeline.tracks[idx].clips.contains { $0.startFrame < span.upperBound && $0.endFrame > span.lowerBound }
+                if !free { idx = insertTrack(at: idx, type: type) }
+                timeline.tracks[idx].clips.append(contentsOf: lane.map { freshen($0, volumeScale: volumeScale) })
+                sortClips(trackIndex: idx)
+                idx += 1
+            }
+        }
+
+        withTimelineSwap(actionName: "Decompose Nested Timeline") {
+            if let carrier = videoCarrier {
+                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: true).videoTracks
+                place(lanes: lanes, carrier: carrier, type: .video, volumeScale: 1)
+            }
+            if let carrier = audioCarrier {
+                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: false).audioTracks
+                place(lanes: lanes, carrier: carrier, type: .audio, volumeScale: carrier.volume)
+            }
+            pruneEmptyTracks()
+        }
+
+        if videoCarrier.map({ carrierHasGroupLook($0, child: child) }) == true
+            || audioCarrier.map({ $0.fadeInFrames > 0 || $0.fadeOutFrames > 0 || $0.volumeTrack != nil }) == true {
+            mediaPanelToast = "Nest settings discarded. Undo to restore."
+        }
+    }
+
+    /// Group-level looks that have no per-clip equivalent after decompose.
+    private func carrierHasGroupLook(_ clip: Clip, child: Timeline) -> Bool {
+        clip.opacity != 1 || clip.crop != Crop() || clip.effects?.isEmpty == false
+            || clip.fadeInFrames > 0 || clip.fadeOutFrames > 0 || clip.blendMode != nil
+            || clip.opacityTrack != nil || clip.positionTrack != nil || clip.scaleTrack != nil
+            || clip.rotationTrack != nil || clip.cropTrack != nil
+            || clip.transform != fitTransform(sourceWidth: child.width, sourceHeight: child.height)
+    }
+
+    /// Inserts linked `.sequence` carrier clips on already-resolved tracks, clearing their span.
+    @discardableResult
+    private func insertNestCarriers(for child: Timeline, start: Int, duration: Int, videoIdx: Int?, audioIdx: Int?) -> Set<String> {
+        let linkGroupId = videoIdx != nil && audioIdx != nil ? UUID().uuidString : nil
+        var carrierIds: Set<String> = []
+        if let vi = videoIdx {
+            clearRegion(trackIndex: vi, start: start, end: start + duration, prune: false)
+            var clip = Clip(
+                mediaRef: child.id,
+                mediaType: .sequence,
+                sourceClipType: .sequence,
+                startFrame: start,
+                durationFrames: duration,
+                transform: fitTransform(sourceWidth: child.width, sourceHeight: child.height)
+            )
+            clip.linkGroupId = linkGroupId
+            timeline.tracks[vi].clips.append(clip)
+            sortClips(trackIndex: vi)
+            carrierIds.insert(clip.id)
+        }
+        if let ai = audioIdx {
+            clearRegion(trackIndex: ai, start: start, end: start + duration, prune: false)
+            var clip = Clip(
+                mediaRef: child.id,
+                mediaType: .audio,
+                sourceClipType: .sequence,
+                startFrame: start,
+                durationFrames: duration
+            )
+            clip.linkGroupId = linkGroupId
+            timeline.tracks[ai].clips.append(clip)
+            sortClips(trackIndex: ai)
+            carrierIds.insert(clip.id)
+        }
+        return carrierIds
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
@@ -30,6 +30,7 @@ extension EditorViewModel {
     }
 
     func selectMediaAsset(_ asset: MediaAsset, atSourceFrame frame: Int = 0) {
+        selectedTimelineIds.removeAll()
         openPreviewTab(for: asset, atSourceFrame: frame)
         syncSelectionToActiveTab()
         showMediaPanelMediaTab()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -147,7 +147,6 @@ extension EditorViewModel {
 
 extension Timeline {
     mutating func rescaleFrames(by scale: Double) {
-        viewState.playheadFrame = Int((Double(viewState.playheadFrame) * scale).rounded())
         for ti in tracks.indices {
             let clipIndices = tracks[ti].clips.indices.sorted {
                 tracks[ti].clips[$0].startFrame < tracks[ti].clips[$1].startFrame

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -83,7 +83,6 @@ extension EditorViewModel {
             }
         }
         undoManager?.setActionName("Change Project Settings")
-        timelineRenderRevision &+= 1
         notifyTimelineChanged()
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -83,6 +83,7 @@ extension EditorViewModel {
             }
         }
         undoManager?.setActionName("Change Project Settings")
+        timelineRenderRevision &+= 1
         notifyTimelineChanged()
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -20,34 +20,19 @@ extension EditorViewModel {
         let prevFPS = timeline.fps
         let prevWidth = timeline.width
         let prevHeight = timeline.height
-        let prevConfigured = timeline.settingsConfigured
 
-        // Rescale all frame-based values when FPS changes
+        // FPS is project-wide: rescale frame-based values in every timeline.
         if fps != prevFPS && prevFPS > 0 && fps > 0 {
             let scale = Double(fps) / Double(prevFPS)
             currentFrame = Int((Double(currentFrame) * scale).rounded())
             sourcePlayheadFrame = Int((Double(sourcePlayheadFrame) * scale).rounded())
-            for ti in timeline.tracks.indices {
-                let clipIndices = timeline.tracks[ti].clips.indices.sorted {
-                    timeline.tracks[ti].clips[$0].startFrame < timeline.tracks[ti].clips[$1].startFrame
-                }
-                var previousEnd: Int?
-                for ci in clipIndices {
-                    var clip = timeline.tracks[ti].clips[ci]
-                    let scaledStart = Int((Double(clip.startFrame) * scale).rounded())
-                    let scaledEnd = Int((Double(clip.endFrame) * scale).rounded())
-                    clip.startFrame = max(scaledStart, previousEnd ?? scaledStart)
-                    clip.durationFrames = max(1, scaledEnd - clip.startFrame)
-                    clip.trimStartFrame = Int((Double(clip.trimStartFrame) * scale).rounded())
-                    clip.trimEndFrame = Int((Double(clip.trimEndFrame) * scale).rounded())
-                    clip.rescaleKeyframes(by: scale)
-                    clip.fadeInFrames = Int((Double(clip.fadeInFrames) * scale).rounded())
-                    clip.fadeOutFrames = Int((Double(clip.fadeOutFrames) * scale).rounded())
-                    clip.clampKeyframesToDuration()
-                    clip.clampFadesToDuration()
-                    timeline.tracks[ti].clips[ci] = clip
-                    previousEnd = clip.endFrame
-                }
+            for i in timelines.indices {
+                timelines[i].rescaleFrames(by: scale)
+            }
+            liveViewStates = liveViewStates.mapValues { vs in
+                var vs = vs
+                vs.playheadFrame = Int((Double(vs.playheadFrame) * scale).rounded())
+                return vs
             }
         }
 
@@ -82,13 +67,20 @@ extension EditorViewModel {
             }
         }
 
-        timeline.fps = fps
+        let prevConfiguredById = timelines.map { ($0.id, $0.settingsConfigured) }
+        for i in timelines.indices {
+            timelines[i].fps = fps
+            timelines[i].settingsConfigured = true
+        }
         timeline.width = width
         timeline.height = height
-        timeline.settingsConfigured = true
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.applyTimelineSettings(fps: prevFPS, width: prevWidth, height: prevHeight)
-            vm.timeline.settingsConfigured = prevConfigured
+            for (id, configured) in prevConfiguredById {
+                if let i = vm.timelines.firstIndex(where: { $0.id == id }) {
+                    vm.timelines[i].settingsConfigured = configured
+                }
+            }
         }
         undoManager?.setActionName("Change Project Settings")
         notifyTimelineChanged()
@@ -149,6 +141,34 @@ extension EditorViewModel {
                 clipWidth: clipWidth,
                 clipHeight: clipHeight
             )
+        }
+    }
+}
+
+extension Timeline {
+    mutating func rescaleFrames(by scale: Double) {
+        viewState.playheadFrame = Int((Double(viewState.playheadFrame) * scale).rounded())
+        for ti in tracks.indices {
+            let clipIndices = tracks[ti].clips.indices.sorted {
+                tracks[ti].clips[$0].startFrame < tracks[ti].clips[$1].startFrame
+            }
+            var previousEnd: Int?
+            for ci in clipIndices {
+                var clip = tracks[ti].clips[ci]
+                let scaledStart = Int((Double(clip.startFrame) * scale).rounded())
+                let scaledEnd = Int((Double(clip.endFrame) * scale).rounded())
+                clip.startFrame = max(scaledStart, previousEnd ?? scaledStart)
+                clip.durationFrames = max(1, scaledEnd - clip.startFrame)
+                clip.trimStartFrame = Int((Double(clip.trimStartFrame) * scale).rounded())
+                clip.trimEndFrame = Int((Double(clip.trimEndFrame) * scale).rounded())
+                clip.rescaleKeyframes(by: scale)
+                clip.fadeInFrames = Int((Double(clip.fadeInFrames) * scale).rounded())
+                clip.fadeOutFrames = Int((Double(clip.fadeOutFrames) * scale).rounded())
+                clip.clampKeyframesToDuration()
+                clip.clampFadesToDuration()
+                tracks[ti].clips[ci] = clip
+                previousEnd = clip.endFrame
+            }
         }
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -41,15 +41,17 @@ extension EditorViewModel {
             for ti in timeline.tracks.indices {
                 for ci in timeline.tracks[ti].clips.indices {
                     var clip = timeline.tracks[ti].clips[ci]
-                    guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
-                          let oldAspect = mediaCanvasAspect(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight),
-                          let newAspect = mediaCanvasAspect(for: asset, canvasWidth: width, canvasHeight: height) else { continue }
+                    guard let dims = sourceDimensions(for: clip),
+                          prevWidth > 0, prevHeight > 0, width > 0, height > 0 else { continue }
+                    let sourceAspect = Double(dims.width) / Double(dims.height)
+                    let oldAspect = sourceAspect / (Double(prevWidth) / Double(prevHeight))
+                    let newAspect = sourceAspect / (Double(width) / Double(height))
 
                     let scaleAnimated = clip.scaleTrack?.isActive ?? false
-                    let oldFit = fitTransform(for: asset, canvasWidth: prevWidth, canvasHeight: prevHeight)
+                    let oldFit = fitTransform(sourceWidth: dims.width, sourceHeight: dims.height, canvasWidth: prevWidth, canvasHeight: prevHeight)
                     if !scaleAnimated,
                        transformScale(clip.transform, matches: oldFit) {
-                        let newFit = fitTransform(for: asset, canvasWidth: width, canvasHeight: height)
+                        let newFit = fitTransform(sourceWidth: dims.width, sourceHeight: dims.height, canvasWidth: width, canvasHeight: height)
                         clip.transform.width = newFit.width
                         clip.transform.height = newFit.height
                     } else {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -98,10 +98,11 @@ extension EditorViewModel {
         }
 
         let timelineIsEmpty = timeline.tracks.allSatisfy { $0.clips.isEmpty }
+        let canAdoptFPS = adoptFPS && timelines.allSatisfy { $0.tracks.allSatisfy { $0.clips.isEmpty } }
 
         if !timeline.settingsConfigured {
             // First clip ever — auto-detect settings silently
-            let fps = adoptFPS ? (firstVideo.sourceFPS.flatMap { Int($0.rounded()) } ?? timeline.fps) : timeline.fps
+            let fps = canAdoptFPS ? (firstVideo.sourceFPS.flatMap { Int($0.rounded()) } ?? timeline.fps) : timeline.fps
             let width = firstVideo.sourceWidth ?? timeline.width
             let height = firstVideo.sourceHeight ?? timeline.height
             applyTimelineSettings(fps: fps, width: width, height: height)
@@ -117,13 +118,13 @@ extension EditorViewModel {
         let clipWidth = firstVideo.sourceWidth
         let clipHeight = firstVideo.sourceHeight
 
-        let fpsMismatch = adoptFPS && clipFPS != nil && clipFPS != timeline.fps
+        let fpsMismatch = canAdoptFPS && clipFPS != nil && clipFPS != timeline.fps
         let resMismatch = (clipWidth != nil && clipWidth != timeline.width) ||
                           (clipHeight != nil && clipHeight != timeline.height)
 
         if fpsMismatch || resMismatch {
             return .mismatch(
-                clipFPS: adoptFPS ? (clipFPS ?? timeline.fps) : timeline.fps,
+                clipFPS: canAdoptFPS ? (clipFPS ?? timeline.fps) : timeline.fps,
                 clipWidth: clipWidth ?? timeline.width,
                 clipHeight: clipHeight ?? timeline.height
             )

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -454,7 +454,7 @@ extension EditorViewModel {
 
         sortClips(trackIndex: ti)
 
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.trimClipInternal(clipId: clipId, trimStartFrame: prevStart, trimEndFrame: prevEnd)
         }
         undoManager?.endUndoGrouping()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -387,7 +387,9 @@ extension EditorViewModel {
             // Pin the linked-audio destination before pushing so it ripples too; otherwise the
             // auto-created audio partner would land on an un-pushed track and overlap.
             let targetIsVideo = timeline.tracks[trackIndex].type == .video
-            let needsLinkedAudio = targetIsVideo && specs.contains { $0.asset.type == .video && $0.asset.hasAudio }
+            let needsLinkedAudio = targetIsVideo && specs.contains {
+                $0.asset.hasAudio && ($0.asset.type == .video || $0.asset.type == .sequence)
+            }
             let linkedAudioTrackIndex: Int? = needsLinkedAudio
                 ? (timeline.tracks.firstIndex { $0.type == .audio } ?? insertTrack(at: timeline.tracks.count, type: .audio))
                 : nil

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -79,12 +79,14 @@ extension EditorViewModel {
         let timeline = self.timeline
         let resolver = mediaResolver
         let missingMediaRefs = self.missingMediaRefs
+        let timelinesById = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
 
         Task { @MainActor [weak self] in
             do {
                 let tempURL = try await TimelineRenderer.render(
                     timeline: timeline,
                     resolver: resolver,
+                    resolveTimeline: { timelinesById[$0] },
                     missingMediaRefs: missingMediaRefs,
                     startFrame: startFrame,
                     frameCount: frameCount,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -79,14 +79,14 @@ extension EditorViewModel {
         let timeline = self.timeline
         let resolver = mediaResolver
         let missingMediaRefs = self.missingMediaRefs
-        let timelinesById = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
+        let resolveTimeline = timelineResolver()
 
         Task { @MainActor [weak self] in
             do {
                 let tempURL = try await TimelineRenderer.render(
                     timeline: timeline,
                     resolver: resolver,
-                    resolveTimeline: { timelinesById[$0] },
+                    resolveTimeline: resolveTimeline,
                     missingMediaRefs: missingMediaRefs,
                     startFrame: startFrame,
                     frameCount: frameCount,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -16,6 +16,7 @@ extension EditorViewModel {
     func applyProjectFile(_ file: ProjectFile) {
         guard !file.timelines.isEmpty else { return }
         timelines = file.timelines
+        timelineRenderRevision &+= 1
         liveViewStates = file.viewStates ?? [:]
         let ids = Set(file.timelines.map(\.id))
         activeTimelineId = file.activeTimelineId.flatMap { ids.contains($0) ? $0 : nil }
@@ -66,6 +67,7 @@ extension EditorViewModel {
         clearTimelineScopedState()
         activeTimelineId = id
         if !openTimelineIds.contains(id) { openTimelineIds.append(id) }
+        timelineRenderRevision &+= 1
         restoreActiveViewState()
         // refreshVisuals would apply the new timeline to the old track mappings — rebuild alone is correct.
         notifyTimelineChanged(refreshVisuals: false)
@@ -216,6 +218,7 @@ extension EditorViewModel {
             }
             if touched { timelines[i].tracks.removeAll(where: \.clips.isEmpty) }
         }
+        if !removed.isEmpty { timelineRenderRevision &+= 1 }
         selectedClipIds.subtract(removed)
         return removed
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+/// Multiple timelines per project: switching, per-timeline view state, and CRUD.
+extension EditorViewModel {
+
+    func timeline(for id: String) -> Timeline? {
+        timelines.first { $0.id == id }
+    }
+
+    func applyProjectFile(_ file: ProjectFile) {
+        guard !file.timelines.isEmpty else { return }
+        timelines = file.timelines
+        liveViewStates = Dictionary(uniqueKeysWithValues: file.timelines.map { ($0.id, $0.viewState) })
+        let ids = Set(file.timelines.map(\.id))
+        activeTimelineId = file.activeTimelineId.flatMap { ids.contains($0) ? $0 : nil }
+            ?? file.timelines[0].id
+        openTimelineIds = (file.openTimelineIds ?? []).filter { ids.contains($0) }
+        if !openTimelineIds.contains(activeTimelineId) {
+            openTimelineIds.append(activeTimelineId)
+        }
+        restoreActiveViewState()
+    }
+
+    /// Snapshot for save/export: timelines with live view state merged in.
+    func projectFileSnapshot() -> ProjectFile {
+        stashActiveViewState()
+        var merged = timelines
+        for i in merged.indices {
+            if let vs = liveViewStates[merged[i].id] { merged[i].viewState = vs }
+        }
+        return ProjectFile(timelines: merged, activeTimelineId: activeTimelineId, openTimelineIds: openTimelineIds)
+    }
+
+    func stashActiveViewState() {
+        liveViewStates[activeTimelineId] = TimelineViewState(
+            playheadFrame: currentFrame,
+            zoomScale: zoomScale,
+            scrollOffsetX: timelineScrollOffsetX
+        )
+    }
+
+    func viewState(for id: String) -> TimelineViewState {
+        liveViewStates[id] ?? timeline(for: id)?.viewState ?? TimelineViewState()
+    }
+
+    func restoreActiveViewState() {
+        let vs = viewState(for: activeTimelineId)
+        zoomScale = vs.zoomScale
+        currentFrame = min(max(0, vs.playheadFrame), max(0, timeline.totalFrames))
+        timelineScrollRestoreX = vs.scrollOffsetX
+    }
+
+    func activateTimeline(_ id: String) {
+        guard id != activeTimelineId, timelines.contains(where: { $0.id == id }) else { return }
+        revertInFlightDrag()
+        stashActiveViewState()
+        if isPlaying { pause() }
+        clearTimelineScopedState()
+        activeTimelineId = id
+        if !openTimelineIds.contains(id) { openTimelineIds.append(id) }
+        restoreActiveViewState()
+        notifyTimelineChanged()
+        seekToFrame(currentFrame)
+    }
+
+    /// A switch mid-gesture would orphan live mutations with no undo — put the clips back first.
+    private func revertInFlightDrag() {
+        if let preDrag = preDragTimeline {
+            timeline = preDrag
+        } else {
+            for (id, before) in dragBefore {
+                guard let loc = findClip(id: id) else { continue }
+                timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = before
+            }
+        }
+    }
+
+    private func clearTimelineScopedState() {
+        selectedClipIds = []
+        selectedGap = nil
+        selectedTimelineRange = nil
+        pendingSwapClipId = nil
+        dragBefore = [:]
+        preDragTimeline = nil
+    }
+
+    /// registerUndo that re-activates the owning timeline before applying.
+    func registerTimelineUndo(_ handler: @escaping @MainActor (EditorViewModel) -> Void) {
+        let tid = activeTimelineId
+        undoManager?.registerUndo(withTarget: self) { vm in
+            if vm.activeTimelineId != tid, vm.timelines.contains(where: { $0.id == tid }) {
+                vm.activateTimeline(tid)
+            }
+            handler(vm)
+        }
+    }
+
+    // MARK: - CRUD
+
+    @discardableResult
+    func createTimeline(name: String? = nil, activate: Bool = true) -> String {
+        let active = timeline
+        var t = Timeline(name: name ?? nextTimelineName())
+        t.fps = active.fps
+        t.width = active.width
+        t.height = active.height
+        t.settingsConfigured = active.settingsConfigured
+        timelines.append(t)
+        registerRemoveUndo(for: t.id, actionName: "New Timeline")
+        if activate { activateTimeline(t.id) }
+        return t.id
+    }
+
+    @discardableResult
+    func duplicateTimeline(_ id: String, activate: Bool = true) -> String? {
+        guard var copy = timeline(for: id) else { return nil }
+        copy.id = UUID().uuidString
+        copy.name = duplicateName(for: copy.name)
+        copy.viewState = viewState(for: id)
+        copy.regenerateIds()
+        timelines.append(copy)
+        liveViewStates[copy.id] = copy.viewState
+        registerRemoveUndo(for: copy.id, actionName: "Duplicate Timeline")
+        if activate { activateTimeline(copy.id) }
+        return copy.id
+    }
+
+    func renameTimeline(_ id: String, to name: String) {
+        guard let i = timelines.firstIndex(where: { $0.id == id }) else { return }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, timelines[i].name != trimmed else { return }
+        let previous = timelines[i].name
+        timelines[i].name = trimmed
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.renameTimeline(id, to: previous)
+        }
+        undoManager?.setActionName("Rename Timeline")
+    }
+
+    func deleteTimeline(_ id: String) {
+        guard timelines.count > 1,
+              let index = timelines.firstIndex(where: { $0.id == id }) else { return }
+        let openIndex = openTimelineIds.firstIndex(of: id)
+        let wasActive = activeTimelineId == id
+        if wasActive {
+            let fallback = openTimelineIds.first { $0 != id }
+                ?? timelines.first { $0.id != id }!.id
+            activateTimeline(fallback)
+        }
+        var removed = timelines[index]
+        removed.viewState = viewState(for: id)
+        timelines.remove(at: index)
+        if let openIndex { openTimelineIds.remove(at: openIndex) }
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.reinsertTimeline(removed, at: index, openAt: openIndex, reactivate: wasActive)
+        }
+        undoManager?.setActionName("Delete Timeline")
+    }
+
+    func closeTimelineTab(_ id: String) {
+        guard openTimelineIds.count > 1,
+              let index = openTimelineIds.firstIndex(of: id) else { return }
+        if activeTimelineId == id {
+            activateTimeline(openTimelineIds[index == 0 ? 1 : index - 1])
+        }
+        openTimelineIds.remove(at: index)
+    }
+
+    func closeOtherTimelineTabs(keeping id: String) {
+        guard openTimelineIds.contains(id) else { return }
+        activateTimeline(id)
+        openTimelineIds = [id]
+    }
+
+    private func reinsertTimeline(_ t: Timeline, at index: Int, openAt openIndex: Int?, reactivate: Bool) {
+        timelines.insert(t, at: min(index, timelines.count))
+        liveViewStates[t.id] = t.viewState
+        if let openIndex {
+            openTimelineIds.insert(t.id, at: min(openIndex, openTimelineIds.count))
+        }
+        if reactivate { activateTimeline(t.id) }
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.deleteTimeline(t.id)
+        }
+    }
+
+    private func registerRemoveUndo(for id: String, actionName: String) {
+        undoManager?.registerUndo(withTarget: self) { vm in
+            vm.deleteTimeline(id)
+        }
+        undoManager?.setActionName(actionName)
+    }
+
+    /// Removes every clip referencing `assetIds` from every timeline; prunes emptied tracks.
+    @discardableResult
+    func removeClipsReferencingAssets(_ assetIds: Set<String>) -> Set<String> {
+        var removed: Set<String> = []
+        for i in timelines.indices {
+            var touched = false
+            for t in timelines[i].tracks.indices {
+                for clip in timelines[i].tracks[t].clips where assetIds.contains(clip.mediaRef) {
+                    removed.insert(clip.id)
+                    touched = true
+                }
+                if touched {
+                    timelines[i].tracks[t].clips.removeAll { assetIds.contains($0.mediaRef) }
+                }
+            }
+            if touched { timelines[i].tracks.removeAll(where: \.clips.isEmpty) }
+        }
+        selectedClipIds.subtract(removed)
+        return removed
+    }
+
+    // MARK: - Naming
+
+    func nextTimelineName() -> String {
+        uniqueName({ "Timeline \($0)" }, startingAt: timelines.count + 1)
+    }
+
+    private func duplicateName(for name: String) -> String {
+        uniqueName({ $0 == 1 ? "\(name) copy" : "\(name) copy \($0)" }, startingAt: 1)
+    }
+
+    private func uniqueName(_ candidate: (Int) -> String, startingAt start: Int) -> String {
+        let used = Set(timelines.map(\.name))
+        var n = start
+        while used.contains(candidate(n)) { n += 1 }
+        return candidate(n)
+    }
+}
+
+extension Timeline {
+    /// Fresh track/clip/group ids for a duplicated timeline so ids stay unique project-wide.
+    mutating func regenerateIds() {
+        var groupMap: [String: String] = [:]
+        func remap(_ old: String?) -> String? {
+            guard let old else { return nil }
+            if let new = groupMap[old] { return new }
+            let new = UUID().uuidString
+            groupMap[old] = new
+            return new
+        }
+        for ti in tracks.indices {
+            tracks[ti].id = UUID().uuidString
+            for ci in tracks[ti].clips.indices {
+                tracks[ti].clips[ci].id = UUID().uuidString
+                tracks[ti].clips[ci].linkGroupId = remap(tracks[ti].clips[ci].linkGroupId)
+                tracks[ti].clips[ci].captionGroupId = remap(tracks[ti].clips[ci].captionGroupId)
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -16,7 +16,6 @@ extension EditorViewModel {
     func applyProjectFile(_ file: ProjectFile) {
         guard !file.timelines.isEmpty else { return }
         timelines = file.timelines
-        timelineRenderRevision &+= 1
         liveViewStates = file.viewStates ?? [:]
         let ids = Set(file.timelines.map(\.id))
         activeTimelineId = file.activeTimelineId.flatMap { ids.contains($0) ? $0 : nil }
@@ -142,7 +141,6 @@ extension EditorViewModel {
         guard !trimmed.isEmpty, timelines[i].name != trimmed else { return }
         let previous = timelines[i].name
         timelines[i].name = trimmed
-        if isVisibleFromActive(id) { timelineRenderRevision &+= 1 }
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.renameTimeline(id, to: previous)
         }
@@ -175,7 +173,6 @@ extension EditorViewModel {
         }
         undoManager?.setActionName("Delete Timeline")
         if wasNestedInActive {
-            timelineRenderRevision &+= 1
             notifyTimelineChanged(refreshVisuals: false)
         }
     }
@@ -208,7 +205,6 @@ extension EditorViewModel {
         if reactivate {
             activateTimeline(t.id)
         } else if isVisibleFromActive(t.id) {
-            timelineRenderRevision &+= 1
             notifyTimelineChanged(refreshVisuals: false)
         }
         undoManager?.registerUndo(withTarget: self) { vm in
@@ -238,7 +234,6 @@ extension EditorViewModel {
             }
             if touched { timelines[i].tracks.removeAll(where: \.clips.isEmpty) }
         }
-        if !removed.isEmpty { timelineRenderRevision &+= 1 }
         selectedClipIds.subtract(removed)
         return removed
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -16,7 +16,7 @@ extension EditorViewModel {
     func applyProjectFile(_ file: ProjectFile) {
         guard !file.timelines.isEmpty else { return }
         timelines = file.timelines
-        liveViewStates = Dictionary(uniqueKeysWithValues: file.timelines.map { ($0.id, $0.viewState) })
+        liveViewStates = file.viewStates ?? [:]
         let ids = Set(file.timelines.map(\.id))
         activeTimelineId = file.activeTimelineId.flatMap { ids.contains($0) ? $0 : nil }
             ?? file.timelines[0].id
@@ -27,14 +27,16 @@ extension EditorViewModel {
         restoreActiveViewState()
     }
 
-    /// Snapshot for save/export: timelines with live view state merged in.
+    /// Snapshot for save/export; view states pruned to timelines that still exist.
     func projectFileSnapshot() -> ProjectFile {
         stashActiveViewState()
-        var merged = timelines
-        for i in merged.indices {
-            if let vs = liveViewStates[merged[i].id] { merged[i].viewState = vs }
-        }
-        return ProjectFile(timelines: merged, activeTimelineId: activeTimelineId, openTimelineIds: openTimelineIds)
+        let ids = Set(timelines.map(\.id))
+        return ProjectFile(
+            timelines: timelines,
+            activeTimelineId: activeTimelineId,
+            openTimelineIds: openTimelineIds,
+            viewStates: liveViewStates.filter { ids.contains($0.key) }
+        )
     }
 
     func stashActiveViewState() {
@@ -46,7 +48,7 @@ extension EditorViewModel {
     }
 
     func viewState(for id: String) -> TimelineViewState {
-        liveViewStates[id] ?? timeline(for: id)?.viewState ?? TimelineViewState()
+        liveViewStates[id] ?? TimelineViewState()
     }
 
     func restoreActiveViewState() {
@@ -122,10 +124,9 @@ extension EditorViewModel {
         guard var copy = timeline(for: id) else { return nil }
         copy.id = UUID().uuidString
         copy.name = duplicateName(for: copy.name)
-        copy.viewState = viewState(for: id)
         copy.regenerateIds()
         timelines.append(copy)
-        liveViewStates[copy.id] = copy.viewState
+        liveViewStates[copy.id] = viewState(for: id)
         registerRemoveUndo(for: copy.id, actionName: "Duplicate Timeline")
         if activate { activateTimeline(copy.id) }
         return copy.id
@@ -153,12 +154,13 @@ extension EditorViewModel {
                 ?? timelines.first { $0.id != id }!.id
             activateTimeline(fallback)
         }
-        var removed = timelines[index]
-        removed.viewState = viewState(for: id)
+        let removed = timelines[index]
+        let removedViewState = viewState(for: id)
         timelines.remove(at: index)
+        liveViewStates.removeValue(forKey: id)
         if let openIndex { openTimelineIds.remove(at: openIndex) }
         undoManager?.registerUndo(withTarget: self) { vm in
-            vm.reinsertTimeline(removed, at: index, openAt: openIndex, reactivate: wasActive)
+            vm.reinsertTimeline(removed, viewState: removedViewState, at: index, openAt: openIndex, reactivate: wasActive)
         }
         undoManager?.setActionName("Delete Timeline")
     }
@@ -178,9 +180,9 @@ extension EditorViewModel {
         openTimelineIds = [id]
     }
 
-    private func reinsertTimeline(_ t: Timeline, at index: Int, openAt openIndex: Int?, reactivate: Bool) {
+    private func reinsertTimeline(_ t: Timeline, viewState: TimelineViewState, at index: Int, openAt openIndex: Int?, reactivate: Bool) {
         timelines.insert(t, at: min(index, timelines.count))
-        liveViewStates[t.id] = t.viewState
+        liveViewStates[t.id] = viewState
         if let openIndex {
             openTimelineIds.insert(t.id, at: min(openIndex, openTimelineIds.count))
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -251,38 +251,93 @@ extension EditorViewModel {
                 videoTarget = .newTrackAt(0)
             }
             let videoIdx = materializeTrackIndex(target: videoTarget, type: .video)
-            clearRegion(trackIndex: videoIdx, start: startFrame, end: startFrame + duration)
-
             let hasAudio = child.tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
-            let linkGroupId: String? = hasAudio ? UUID().uuidString : nil
+            let audioIdx = hasAudio ? resolveOrCreateAudioTrack(startFrame: startFrame, duration: duration) : nil
+            insertNestCarriers(for: child, start: startFrame, duration: duration, videoIdx: videoIdx, audioIdx: audioIdx)
+        }
+        return true
+    }
 
+    func nestSelectedClips() {
+        let ids = selectedClipIds
+        var lanes: [(index: Int, type: ClipType, clips: [Clip])] = []
+        for (i, track) in timeline.tracks.enumerated() {
+            let picked = track.clips.filter { ids.contains($0.id) }
+            if !picked.isEmpty { lanes.append((i, track.type, picked)) }
+        }
+        guard !lanes.isEmpty else { return }
+
+        let all = lanes.flatMap(\.clips)
+        let start = all.map(\.startFrame).min()!
+        let duration = all.map(\.endFrame).max()! - start
+
+        var child = Timeline(name: uniqueName({ "Nest \($0)" }, startingAt: 1))
+        child.fps = timeline.fps
+        child.width = timeline.width
+        child.height = timeline.height
+        child.settingsConfigured = timeline.settingsConfigured
+        child.tracks = lanes.map { lane in
+            Track(type: lane.type, clips: lane.clips.map { clip in
+                var c = clip
+                c.startFrame -= start
+                return c
+            })
+        }
+
+        timelines.append(child)
+        registerRemoveUndo(for: child.id, actionName: "Nest Clips")
+        selectedClipIds = []
+        withTimelineSwap(actionName: "Nest Clips") {
+            for i in timeline.tracks.indices {
+                timeline.tracks[i].clips.removeAll { ids.contains($0.id) }
+            }
+            let carriers = insertNestCarriers(
+                for: child, start: start, duration: duration,
+                videoIdx: lanes.first { $0.type != .audio }?.index,
+                audioIdx: lanes.first { $0.type == .audio }?.index
+            )
+            pruneEmptyTracks()
+            selectedClipIds = carriers
+        }
+        openTimelineIds.append(child.id)
+        timelineTabRenameRequest = child.id
+    }
+
+    /// Inserts linked `.sequence` carrier clips on already-resolved tracks, clearing their span.
+    @discardableResult
+    private func insertNestCarriers(for child: Timeline, start: Int, duration: Int, videoIdx: Int?, audioIdx: Int?) -> Set<String> {
+        let linkGroupId = videoIdx != nil && audioIdx != nil ? UUID().uuidString : nil
+        var carrierIds: Set<String> = []
+        if let vi = videoIdx {
+            clearRegion(trackIndex: vi, start: start, end: start + duration, prune: false)
             var clip = Clip(
-                mediaRef: childId,
+                mediaRef: child.id,
                 mediaType: .sequence,
                 sourceClipType: .sequence,
-                startFrame: startFrame,
+                startFrame: start,
                 durationFrames: duration,
                 transform: fitTransform(sourceWidth: child.width, sourceHeight: child.height)
             )
             clip.linkGroupId = linkGroupId
-            timeline.tracks[videoIdx].clips.append(clip)
-            sortClips(trackIndex: videoIdx)
-
-            if let linkGroupId {
-                let audioIdx = resolveOrCreateAudioTrack(startFrame: startFrame, duration: duration)
-                var audioClip = Clip(
-                    mediaRef: childId,
-                    mediaType: .audio,
-                    sourceClipType: .sequence,
-                    startFrame: startFrame,
-                    durationFrames: duration
-                )
-                audioClip.linkGroupId = linkGroupId
-                timeline.tracks[audioIdx].clips.append(audioClip)
-                sortClips(trackIndex: audioIdx)
-            }
+            timeline.tracks[vi].clips.append(clip)
+            sortClips(trackIndex: vi)
+            carrierIds.insert(clip.id)
         }
-        return true
+        if let ai = audioIdx {
+            clearRegion(trackIndex: ai, start: start, end: start + duration, prune: false)
+            var clip = Clip(
+                mediaRef: child.id,
+                mediaType: .audio,
+                sourceClipType: .sequence,
+                startFrame: start,
+                durationFrames: duration
+            )
+            clip.linkGroupId = linkGroupId
+            timeline.tracks[ai].clips.append(clip)
+            sortClips(trackIndex: ai)
+            carrierIds.insert(clip.id)
+        }
+        return carrierIds
     }
 
     // MARK: - Naming

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -67,7 +67,8 @@ extension EditorViewModel {
         activeTimelineId = id
         if !openTimelineIds.contains(id) { openTimelineIds.append(id) }
         restoreActiveViewState()
-        notifyTimelineChanged()
+        // refreshVisuals would apply the new timeline to the old track mappings — rebuild alone is correct.
+        notifyTimelineChanged(refreshVisuals: false)
         seekToFrame(currentFrame)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -212,6 +212,79 @@ extension EditorViewModel {
         return removed
     }
 
+    // MARK: - Nesting
+
+    func wouldCreateNestCycle(nesting childId: String, into hostId: String) -> Bool {
+        if childId == hostId { return true }
+        var visited: Set<String> = []
+        var frontier = [childId]
+        while let current = frontier.popLast() {
+            guard visited.insert(current).inserted else { continue }
+            guard let t = timeline(for: current) else { continue }
+            let ids = t.nestedTimelineIds
+            if ids.contains(hostId) { return true }
+            frontier.append(contentsOf: ids)
+        }
+        return false
+    }
+
+    /// Drops `childId` into the active timeline as a single nested clip.
+    @discardableResult
+    func nestTimeline(_ childId: String, cursor: TrackDropTarget, atFrame frame: Int) -> Bool {
+        guard let child = timeline(for: childId) else { return false }
+        guard child.totalFrames > 0 else {
+            mediaPanelToast = "\"\(child.name)\" is empty. Add clips before nesting it."
+            return false
+        }
+        guard !wouldCreateNestCycle(nesting: childId, into: activeTimelineId) else {
+            mediaPanelToast = "Can't nest \"\(child.name)\" — it would contain itself."
+            return false
+        }
+
+        let duration = child.totalFrames
+        let startFrame = max(0, frame)
+
+        withTimelineSwap(actionName: "Nest Timeline") {
+            var videoTarget = cursor
+            if case .existingTrack(let idx) = cursor,
+               !(timeline.tracks.indices.contains(idx) && timeline.tracks[idx].type == .video) {
+                videoTarget = .newTrackAt(0)
+            }
+            let videoIdx = materializeTrackIndex(target: videoTarget, type: .video)
+            clearRegion(trackIndex: videoIdx, start: startFrame, end: startFrame + duration)
+
+            let hasAudio = child.tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
+            let linkGroupId: String? = hasAudio ? UUID().uuidString : nil
+
+            var clip = Clip(
+                mediaRef: childId,
+                mediaType: .sequence,
+                sourceClipType: .sequence,
+                startFrame: startFrame,
+                durationFrames: duration,
+                transform: fitTransform(sourceWidth: child.width, sourceHeight: child.height)
+            )
+            clip.linkGroupId = linkGroupId
+            timeline.tracks[videoIdx].clips.append(clip)
+            sortClips(trackIndex: videoIdx)
+
+            if let linkGroupId {
+                let audioIdx = resolveOrCreateAudioTrack(startFrame: startFrame, duration: duration)
+                var audioClip = Clip(
+                    mediaRef: childId,
+                    mediaType: .audio,
+                    sourceClipType: .sequence,
+                    startFrame: startFrame,
+                    durationFrames: duration
+                )
+                audioClip.linkGroupId = linkGroupId
+                timeline.tracks[audioIdx].clips.append(audioClip)
+                sortClips(trackIndex: audioIdx)
+            }
+        }
+        return true
+    }
+
     // MARK: - Naming
 
     func nextTimelineName() -> String {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -303,6 +303,85 @@ extension EditorViewModel {
         timelineTabRenameRequest = child.id
     }
 
+    /// Replaces a nest clip (and its linked audio) with the child's clips remapped in place
+    func decomposeNest(clipId: String) {
+        guard let loc = findClip(id: clipId) else { return }
+        let clicked = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        guard clicked.sourceClipType == .sequence, let child = timeline(for: clicked.mediaRef) else { return }
+
+        var videoCarrier: Clip?
+        var audioCarrier: Clip?
+        let group = expandToLinkGroup([clicked.id])
+        for id in group {
+            guard let l = findClip(id: id) else { continue }
+            let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
+            guard c.sourceClipType == .sequence, c.mediaRef == clicked.mediaRef else { continue }
+            if c.mediaType == .audio { audioCarrier = c } else { videoCarrier = c }
+        }
+        selectedClipIds.subtract(group)
+
+        var groupMap: [String: String] = [:]
+        func remapGroup(_ old: String?) -> String? {
+            guard let old else { return nil }
+            if let new = groupMap[old] { return new }
+            let new = UUID().uuidString
+            groupMap[old] = new
+            return new
+        }
+        func freshen(_ clip: Clip, volumeScale: Double = 1) -> Clip {
+            var c = clip
+            c.id = UUID().uuidString
+            c.linkGroupId = remapGroup(c.linkGroupId)
+            c.captionGroupId = remapGroup(c.captionGroupId)
+            c.volume *= volumeScale
+            return c
+        }
+
+        // Top lane lands on the carrier's track; further lanes walk downward, reusing any
+        // track whose span is free (compose vacated exactly these) before inserting new ones.
+        func place(lanes: [[Clip]], carrier: Clip, type: ClipType, volumeScale: Double) {
+            guard let l = findClip(id: carrier.id) else { return }
+            let span = carrier.startFrame..<carrier.endFrame
+            timeline.tracks[l.trackIndex].clips.remove(at: l.clipIndex)
+            var idx = l.trackIndex
+            for lane in lanes {
+                let free = timeline.tracks.indices.contains(idx)
+                    && timeline.tracks[idx].type == type
+                    && !timeline.tracks[idx].clips.contains { $0.startFrame < span.upperBound && $0.endFrame > span.lowerBound }
+                if !free { idx = insertTrack(at: idx, type: type) }
+                timeline.tracks[idx].clips.append(contentsOf: lane.map { freshen($0, volumeScale: volumeScale) })
+                sortClips(trackIndex: idx)
+                idx += 1
+            }
+        }
+
+        withTimelineSwap(actionName: "Decompose Nested Timeline") {
+            if let carrier = videoCarrier {
+                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: true).videoTracks
+                place(lanes: lanes, carrier: carrier, type: .video, volumeScale: 1)
+            }
+            if let carrier = audioCarrier {
+                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: false).audioTracks
+                place(lanes: lanes, carrier: carrier, type: .audio, volumeScale: carrier.volume)
+            }
+            pruneEmptyTracks()
+        }
+
+        if videoCarrier.map({ carrierHasGroupLook($0, child: child) }) == true
+            || audioCarrier.map({ $0.fadeInFrames > 0 || $0.fadeOutFrames > 0 || $0.volumeTrack != nil }) == true {
+            mediaPanelToast = "Nest settings discarded. Undo to restore."
+        }
+    }
+
+    /// Group-level looks that have no per-clip equivalent after decompose.
+    private func carrierHasGroupLook(_ clip: Clip, child: Timeline) -> Bool {
+        clip.opacity != 1 || clip.crop != Crop() || clip.effects?.isEmpty == false
+            || clip.fadeInFrames > 0 || clip.fadeOutFrames > 0 || clip.blendMode != nil
+            || clip.opacityTrack != nil || clip.positionTrack != nil || clip.scaleTrack != nil
+            || clip.rotationTrack != nil || clip.cropTrack != nil
+            || clip.transform != fitTransform(sourceWidth: child.width, sourceHeight: child.height)
+    }
+
     /// Inserts linked `.sequence` carrier clips on already-resolved tracks, clearing their span.
     @discardableResult
     private func insertNestCarriers(for child: Timeline, start: Int, duration: Int, videoIdx: Int?, audioIdx: Int?) -> Set<String> {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -129,6 +129,7 @@ extension EditorViewModel {
         copy.name = duplicateName(for: copy.name)
         copy.regenerateIds()
         timelines.append(copy)
+        stashActiveViewState()
         liveViewStates[copy.id] = viewState(for: id)
         registerRemoveUndo(for: copy.id, actionName: "Duplicate Timeline")
         if activate { activateTimeline(copy.id) }
@@ -141,6 +142,7 @@ extension EditorViewModel {
         guard !trimmed.isEmpty, timelines[i].name != trimmed else { return }
         let previous = timelines[i].name
         timelines[i].name = trimmed
+        if isVisibleFromActive(id) { timelineRenderRevision &+= 1 }
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.renameTimeline(id, to: previous)
         }
@@ -148,8 +150,11 @@ extension EditorViewModel {
     }
 
     func deleteTimeline(_ id: String) {
-        guard timelines.count > 1,
-              let index = timelines.firstIndex(where: { $0.id == id }) else { return }
+        guard let index = timelines.firstIndex(where: { $0.id == id }) else { return }
+        guard timelines.count > 1 else {
+            mediaPanelToast = "Can't delete every timeline — the project needs at least one."
+            return
+        }
         let openIndex = openTimelineIds.firstIndex(of: id)
         let wasActive = activeTimelineId == id
         if wasActive {
@@ -159,14 +164,20 @@ extension EditorViewModel {
         }
         let removed = timelines[index]
         let removedViewState = viewState(for: id)
+        let wasNestedInActive = isVisibleFromActive(id)
         timelines.remove(at: index)
         liveViewStates.removeValue(forKey: id)
         selectedTimelineIds.remove(id)
+        videoEngine?.evictComposition(for: id)
         if let openIndex { openTimelineIds.remove(at: openIndex) }
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.reinsertTimeline(removed, viewState: removedViewState, at: index, openAt: openIndex, reactivate: wasActive)
         }
         undoManager?.setActionName("Delete Timeline")
+        if wasNestedInActive {
+            timelineRenderRevision &+= 1
+            notifyTimelineChanged(refreshVisuals: false)
+        }
     }
 
     func closeTimelineTab(_ id: String) {
@@ -176,11 +187,15 @@ extension EditorViewModel {
             activateTimeline(openTimelineIds[index == 0 ? 1 : index - 1])
         }
         openTimelineIds.remove(at: index)
+        videoEngine?.evictComposition(for: id)
     }
 
     func closeOtherTimelineTabs(keeping id: String) {
         guard openTimelineIds.contains(id) else { return }
         activateTimeline(id)
+        for closed in openTimelineIds where closed != id {
+            videoEngine?.evictComposition(for: closed)
+        }
         openTimelineIds = [id]
     }
 
@@ -190,7 +205,12 @@ extension EditorViewModel {
         if let openIndex {
             openTimelineIds.insert(t.id, at: min(openIndex, openTimelineIds.count))
         }
-        if reactivate { activateTimeline(t.id) }
+        if reactivate {
+            activateTimeline(t.id)
+        } else if isVisibleFromActive(t.id) {
+            timelineRenderRevision &+= 1
+            notifyTimelineChanged(refreshVisuals: false)
+        }
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.deleteTimeline(t.id)
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -158,6 +158,7 @@ extension EditorViewModel {
         let removedViewState = viewState(for: id)
         timelines.remove(at: index)
         liveViewStates.removeValue(forKey: id)
+        selectedTimelineIds.remove(id)
         if let openIndex { openTimelineIds.remove(at: openIndex) }
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.reinsertTimeline(removed, viewState: removedViewState, at: index, openAt: openIndex, reactivate: wasActive)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -7,6 +7,12 @@ extension EditorViewModel {
         timelines.first { $0.id == id }
     }
 
+    /// Sendable snapshot for render/export paths that resolve nested timelines off-main.
+    func timelineResolver() -> @Sendable (String) -> Timeline? {
+        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
+        return { byId[$0] }
+    }
+
     func applyProjectFile(_ file: ProjectFile) {
         guard !file.timelines.isEmpty else { return }
         timelines = file.timelines
@@ -184,7 +190,7 @@ extension EditorViewModel {
         }
     }
 
-    private func registerRemoveUndo(for id: String, actionName: String) {
+    func registerRemoveUndo(for id: String, actionName: String) {
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.deleteTimeline(id)
         }
@@ -198,225 +204,16 @@ extension EditorViewModel {
         for i in timelines.indices {
             var touched = false
             for t in timelines[i].tracks.indices {
-                for clip in timelines[i].tracks[t].clips where assetIds.contains(clip.mediaRef) {
-                    removed.insert(clip.id)
-                    touched = true
-                }
-                if touched {
-                    timelines[i].tracks[t].clips.removeAll { assetIds.contains($0.mediaRef) }
-                }
+                let hits = timelines[i].tracks[t].clips.filter { assetIds.contains($0.mediaRef) }
+                guard !hits.isEmpty else { continue }
+                removed.formUnion(hits.map(\.id))
+                timelines[i].tracks[t].clips.removeAll { assetIds.contains($0.mediaRef) }
+                touched = true
             }
             if touched { timelines[i].tracks.removeAll(where: \.clips.isEmpty) }
         }
         selectedClipIds.subtract(removed)
         return removed
-    }
-
-    // MARK: - Nesting
-
-    func wouldCreateNestCycle(nesting childId: String, into hostId: String) -> Bool {
-        if childId == hostId { return true }
-        var visited: Set<String> = []
-        var frontier = [childId]
-        while let current = frontier.popLast() {
-            guard visited.insert(current).inserted else { continue }
-            guard let t = timeline(for: current) else { continue }
-            let ids = t.nestedTimelineIds
-            if ids.contains(hostId) { return true }
-            frontier.append(contentsOf: ids)
-        }
-        return false
-    }
-
-    /// Drops `childId` into the active timeline as a single nested clip.
-    @discardableResult
-    func nestTimeline(_ childId: String, cursor: TrackDropTarget, atFrame frame: Int) -> Bool {
-        guard let child = timeline(for: childId) else { return false }
-        guard child.totalFrames > 0 else {
-            mediaPanelToast = "\"\(child.name)\" is empty. Add clips before nesting it."
-            return false
-        }
-        guard !wouldCreateNestCycle(nesting: childId, into: activeTimelineId) else {
-            mediaPanelToast = "Can't nest \"\(child.name)\" — it would contain itself."
-            return false
-        }
-
-        let duration = child.totalFrames
-        let startFrame = max(0, frame)
-
-        withTimelineSwap(actionName: "Nest Timeline") {
-            var videoTarget = cursor
-            if case .existingTrack(let idx) = cursor,
-               !(timeline.tracks.indices.contains(idx) && timeline.tracks[idx].type == .video) {
-                videoTarget = .newTrackAt(0)
-            }
-            let videoIdx = materializeTrackIndex(target: videoTarget, type: .video)
-            let hasAudio = child.tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
-            let audioIdx = hasAudio ? resolveOrCreateAudioTrack(startFrame: startFrame, duration: duration) : nil
-            insertNestCarriers(for: child, start: startFrame, duration: duration, videoIdx: videoIdx, audioIdx: audioIdx)
-        }
-        return true
-    }
-
-    func nestSelectedClips() {
-        let ids = selectedClipIds
-        var lanes: [(index: Int, type: ClipType, clips: [Clip])] = []
-        for (i, track) in timeline.tracks.enumerated() {
-            let picked = track.clips.filter { ids.contains($0.id) }
-            if !picked.isEmpty { lanes.append((i, track.type, picked)) }
-        }
-        guard !lanes.isEmpty else { return }
-
-        let all = lanes.flatMap(\.clips)
-        let start = all.map(\.startFrame).min()!
-        let duration = all.map(\.endFrame).max()! - start
-
-        var child = Timeline(name: uniqueName({ "Nest \($0)" }, startingAt: 1))
-        child.fps = timeline.fps
-        child.width = timeline.width
-        child.height = timeline.height
-        child.settingsConfigured = timeline.settingsConfigured
-        child.tracks = lanes.map { lane in
-            Track(type: lane.type, clips: lane.clips.map { clip in
-                var c = clip
-                c.startFrame -= start
-                return c
-            })
-        }
-
-        timelines.append(child)
-        registerRemoveUndo(for: child.id, actionName: "Nest Clips")
-        selectedClipIds = []
-        withTimelineSwap(actionName: "Nest Clips") {
-            for i in timeline.tracks.indices {
-                timeline.tracks[i].clips.removeAll { ids.contains($0.id) }
-            }
-            let carriers = insertNestCarriers(
-                for: child, start: start, duration: duration,
-                videoIdx: lanes.first { $0.type != .audio }?.index,
-                audioIdx: lanes.first { $0.type == .audio }?.index
-            )
-            pruneEmptyTracks()
-            selectedClipIds = carriers
-        }
-        openTimelineIds.append(child.id)
-        timelineTabRenameRequest = child.id
-    }
-
-    /// Replaces a nest clip (and its linked audio) with the child's clips remapped in place
-    func decomposeNest(clipId: String) {
-        guard let loc = findClip(id: clipId) else { return }
-        let clicked = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        guard clicked.sourceClipType == .sequence, let child = timeline(for: clicked.mediaRef) else { return }
-
-        var videoCarrier: Clip?
-        var audioCarrier: Clip?
-        let group = expandToLinkGroup([clicked.id])
-        for id in group {
-            guard let l = findClip(id: id) else { continue }
-            let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
-            guard c.sourceClipType == .sequence, c.mediaRef == clicked.mediaRef else { continue }
-            if c.mediaType == .audio { audioCarrier = c } else { videoCarrier = c }
-        }
-        selectedClipIds.subtract(group)
-
-        var groupMap: [String: String] = [:]
-        func remapGroup(_ old: String?) -> String? {
-            guard let old else { return nil }
-            if let new = groupMap[old] { return new }
-            let new = UUID().uuidString
-            groupMap[old] = new
-            return new
-        }
-        func freshen(_ clip: Clip, volumeScale: Double = 1) -> Clip {
-            var c = clip
-            c.id = UUID().uuidString
-            c.linkGroupId = remapGroup(c.linkGroupId)
-            c.captionGroupId = remapGroup(c.captionGroupId)
-            c.volume *= volumeScale
-            return c
-        }
-
-        // Top lane lands on the carrier's track; further lanes walk downward, reusing any
-        // track whose span is free (compose vacated exactly these) before inserting new ones.
-        func place(lanes: [[Clip]], carrier: Clip, type: ClipType, volumeScale: Double) {
-            guard let l = findClip(id: carrier.id) else { return }
-            let span = carrier.startFrame..<carrier.endFrame
-            timeline.tracks[l.trackIndex].clips.remove(at: l.clipIndex)
-            var idx = l.trackIndex
-            for lane in lanes {
-                let free = timeline.tracks.indices.contains(idx)
-                    && timeline.tracks[idx].type == type
-                    && !timeline.tracks[idx].clips.contains { $0.startFrame < span.upperBound && $0.endFrame > span.lowerBound }
-                if !free { idx = insertTrack(at: idx, type: type) }
-                timeline.tracks[idx].clips.append(contentsOf: lane.map { freshen($0, volumeScale: volumeScale) })
-                sortClips(trackIndex: idx)
-                idx += 1
-            }
-        }
-
-        withTimelineSwap(actionName: "Decompose Nested Timeline") {
-            if let carrier = videoCarrier {
-                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: true).videoTracks
-                place(lanes: lanes, carrier: carrier, type: .video, volumeScale: 1)
-            }
-            if let carrier = audioCarrier {
-                let lanes = NestFlattener.flatten(carrier: carrier, child: child, visual: false).audioTracks
-                place(lanes: lanes, carrier: carrier, type: .audio, volumeScale: carrier.volume)
-            }
-            pruneEmptyTracks()
-        }
-
-        if videoCarrier.map({ carrierHasGroupLook($0, child: child) }) == true
-            || audioCarrier.map({ $0.fadeInFrames > 0 || $0.fadeOutFrames > 0 || $0.volumeTrack != nil }) == true {
-            mediaPanelToast = "Nest settings discarded. Undo to restore."
-        }
-    }
-
-    /// Group-level looks that have no per-clip equivalent after decompose.
-    private func carrierHasGroupLook(_ clip: Clip, child: Timeline) -> Bool {
-        clip.opacity != 1 || clip.crop != Crop() || clip.effects?.isEmpty == false
-            || clip.fadeInFrames > 0 || clip.fadeOutFrames > 0 || clip.blendMode != nil
-            || clip.opacityTrack != nil || clip.positionTrack != nil || clip.scaleTrack != nil
-            || clip.rotationTrack != nil || clip.cropTrack != nil
-            || clip.transform != fitTransform(sourceWidth: child.width, sourceHeight: child.height)
-    }
-
-    /// Inserts linked `.sequence` carrier clips on already-resolved tracks, clearing their span.
-    @discardableResult
-    private func insertNestCarriers(for child: Timeline, start: Int, duration: Int, videoIdx: Int?, audioIdx: Int?) -> Set<String> {
-        let linkGroupId = videoIdx != nil && audioIdx != nil ? UUID().uuidString : nil
-        var carrierIds: Set<String> = []
-        if let vi = videoIdx {
-            clearRegion(trackIndex: vi, start: start, end: start + duration, prune: false)
-            var clip = Clip(
-                mediaRef: child.id,
-                mediaType: .sequence,
-                sourceClipType: .sequence,
-                startFrame: start,
-                durationFrames: duration,
-                transform: fitTransform(sourceWidth: child.width, sourceHeight: child.height)
-            )
-            clip.linkGroupId = linkGroupId
-            timeline.tracks[vi].clips.append(clip)
-            sortClips(trackIndex: vi)
-            carrierIds.insert(clip.id)
-        }
-        if let ai = audioIdx {
-            clearRegion(trackIndex: ai, start: start, end: start + duration, prune: false)
-            var clip = Clip(
-                mediaRef: child.id,
-                mediaType: .audio,
-                sourceClipType: .sequence,
-                startFrame: start,
-                durationFrames: duration
-            )
-            clip.linkGroupId = linkGroupId
-            timeline.tracks[ai].clips.append(clip)
-            sortClips(trackIndex: ai)
-            carrierIds.insert(clip.id)
-        }
-        return carrierIds
     }
 
     // MARK: - Naming
@@ -429,7 +226,7 @@ extension EditorViewModel {
         uniqueName({ $0 == 1 ? "\(name) copy" : "\(name) copy \($0)" }, startingAt: 1)
     }
 
-    private func uniqueName(_ candidate: (Int) -> String, startingAt start: Int) -> String {
+    func uniqueName(_ candidate: (Int) -> String, startingAt start: Int) -> String {
         let used = Set(timelines.map(\.name))
         var n = start
         while used.contains(candidate(n)) { n += 1 }
@@ -440,20 +237,11 @@ extension EditorViewModel {
 extension Timeline {
     /// Fresh track/clip/group ids for a duplicated timeline so ids stay unique project-wide.
     mutating func regenerateIds() {
-        var groupMap: [String: String] = [:]
-        func remap(_ old: String?) -> String? {
-            guard let old else { return nil }
-            if let new = groupMap[old] { return new }
-            let new = UUID().uuidString
-            groupMap[old] = new
-            return new
-        }
+        var groups: [String: String] = [:]
         for ti in tracks.indices {
             tracks[ti].id = UUID().uuidString
             for ci in tracks[ti].clips.indices {
-                tracks[ti].clips[ci].id = UUID().uuidString
-                tracks[ti].clips[ci].linkGroupId = remap(tracks[ti].clips[ci].linkGroupId)
-                tracks[ti].clips[ci].captionGroupId = remap(tracks[ti].clips[ci].captionGroupId)
+                tracks[ti].clips[ci].freshenIds(groups: &groups)
             }
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -108,7 +108,7 @@ extension EditorViewModel {
         guard timeline.tracks.indices.contains(trackIndex) else { return }
         let was = timeline.tracks[trackIndex][keyPath: keyPath]
         timeline.tracks[trackIndex][keyPath: keyPath].toggle()
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.timeline.tracks[trackIndex][keyPath: keyPath] = was
         }
         undoManager?.setActionName(was ? offName : onName)
@@ -121,7 +121,7 @@ extension EditorViewModel {
         guard timeline.tracks.indices.contains(trackIndex) else { return }
         let prev = timeline.tracks[trackIndex].displayHeight
         timeline.tracks[trackIndex].displayHeight = max(TrackSize.minHeight, min(TrackSize.maxHeight, height))
-        undoManager?.registerUndo(withTarget: self) { vm in
+        registerTimelineUndo { vm in
             vm.setTrackHeight(trackIndex: trackIndex, height: prev)
         }
         undoManager?.setActionName("Resize Track")

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -37,7 +37,7 @@ extension EditorViewModel {
         let z = zones
         let bounded = max(0, min(requested, z.trackCount))
         switch type {
-        case .video, .image, .text, .lottie:
+        case .video, .image, .text, .lottie, .sequence:
             // Visual tracks must come at or before the first audio track.
             return min(bounded, z.firstAudioIndex)
         case .audio:

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -540,10 +540,24 @@ final class EditorViewModel {
         return (Double(sw) / Double(sh)) / canvasAspect
     }
 
+    /// Source pixel dimensions for a clip: asset dims, or the child timeline's for nest carriers.
+    func sourceDimensions(for clip: Clip) -> (width: Int, height: Int)? {
+        if let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
+           let sw = asset.sourceWidth, let sh = asset.sourceHeight, sw > 0, sh > 0 {
+            return (sw, sh)
+        }
+        if clip.sourceClipType == .sequence, let child = timeline(for: clip.mediaRef),
+           child.width > 0, child.height > 0 {
+            return (child.width, child.height)
+        }
+        return nil
+    }
+
     /// Source aspect ratio relative to canvas; nil when source dimensions are unknown.
     func mediaCanvasAspect(for clip: Clip) -> Double? {
-        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { return nil }
-        return mediaCanvasAspect(for: asset, canvasWidth: timeline.width, canvasHeight: timeline.height)
+        guard let dims = sourceDimensions(for: clip), timeline.width > 0, timeline.height > 0 else { return nil }
+        let canvasAspect = Double(timeline.width) / Double(timeline.height)
+        return (Double(dims.width) / Double(dims.height)) / canvasAspect
     }
 
     func cropFittingAspect(
@@ -552,10 +566,8 @@ final class EditorViewModel {
         anchorX: Double = 0.5,
         anchorY: Double = 0.5
     ) -> Crop {
-        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }),
-              let sw = asset.sourceWidth, let sh = asset.sourceHeight,
-              sw > 0, sh > 0, target > 0 else { return Crop() }
-        let sourceAspect = Double(sw) / Double(sh)
+        guard let dims = sourceDimensions(for: clip), target > 0 else { return Crop() }
+        let sourceAspect = Double(dims.width) / Double(dims.height)
         if abs(sourceAspect - target) < 0.0001 { return Crop() }
         let ax = min(1, max(0, anchorX))
         let ay = min(1, max(0, anchorY))

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -24,9 +24,7 @@ final class EditorViewModel {
 
     // MARK: - Persisted state (synced with VideoProject)
 
-    var timelines: [Timeline] {
-        didSet { timelineRenderRevision &+= 1 }
-    }
+    var timelines: [Timeline]
     var activeTimelineId: String
     var openTimelineIds: [String]
     @ObservationIgnored var liveViewStates: [String: TimelineViewState] = [:]
@@ -46,9 +44,11 @@ final class EditorViewModel {
             }
             activeTimelineId = newValue.id
             if !openTimelineIds.contains(newValue.id) { openTimelineIds.append(newValue.id) }
+            timelineRenderRevision &+= 1
         }
         _modify {
             let i = timelines.firstIndex(where: { $0.id == activeTimelineId }) ?? 0
+            defer { timelineRenderRevision &+= 1 }
             yield &timelines[i]
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -24,8 +24,32 @@ final class EditorViewModel {
 
     // MARK: - Persisted state (synced with VideoProject)
 
-    var timeline = Timeline() {
+    var timelines: [Timeline] {
         didSet { timelineRenderRevision &+= 1 }
+    }
+    var activeTimelineId: String
+    var openTimelineIds: [String]
+    @ObservationIgnored var liveViewStates: [String: TimelineViewState] = [:]
+
+    /// Active-timeline proxy; assignment routes by id and activates so undo lands on its timeline.
+    var timeline: Timeline {
+        get { timelines.first(where: { $0.id == activeTimelineId }) ?? timelines[0] }
+        set {
+            if let i = timelines.firstIndex(where: { $0.id == newValue.id }) {
+                timelines[i] = newValue
+            } else {
+                let i = timelines.firstIndex(where: { $0.id == activeTimelineId }) ?? 0
+                let oldId = timelines[i].id
+                timelines[i] = newValue
+                openTimelineIds = openTimelineIds.map { $0 == oldId ? newValue.id : $0 }
+            }
+            activeTimelineId = newValue.id
+            if !openTimelineIds.contains(newValue.id) { openTimelineIds.append(newValue.id) }
+        }
+        _modify {
+            let i = timelines.firstIndex(where: { $0.id == activeTimelineId }) ?? 0
+            yield &timelines[i]
+        }
     }
     var mediaManifest = MediaManifest()
     var generationLog = GenerationLog()
@@ -74,6 +98,9 @@ final class EditorViewModel {
     var canvasOffset: CGSize = .zero
     var timelineVisibleWidth: Double = 0
     var timelineRenderRevision: Int = 0
+    /// Live horizontal scroll of the timeline panel, mirrored from AppKit for view-state stash.
+    @ObservationIgnored var timelineScrollOffsetX: Double = 0
+    var timelineScrollRestoreX: Double?
     var isScrubbing: Bool = false
     var toolMode: ToolMode = .pointer
     var showExportDialog: Bool = false
@@ -180,6 +207,10 @@ final class EditorViewModel {
     }
 
     init() {
+        let first = Timeline()
+        timelines = [first]
+        activeTimelineId = first.id
+        openTimelineIds = [first.id]
         mediaResolver = MediaResolver(
             manifest: { [weak self] in self?.mediaManifest ?? MediaManifest() },
             projectURL: { [weak self] in self?.projectURL }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -24,7 +24,9 @@ final class EditorViewModel {
 
     // MARK: - Persisted state (synced with VideoProject)
 
-    var timelines: [Timeline]
+    var timelines: [Timeline] {
+        didSet { timelineRenderRevision &+= 1 }
+    }
     var activeTimelineId: String
     var openTimelineIds: [String]
     @ObservationIgnored var liveViewStates: [String: TimelineViewState] = [:]
@@ -44,11 +46,9 @@ final class EditorViewModel {
             }
             activeTimelineId = newValue.id
             if !openTimelineIds.contains(newValue.id) { openTimelineIds.append(newValue.id) }
-            timelineRenderRevision &+= 1
         }
         _modify {
             let i = timelines.firstIndex(where: { $0.id == activeTimelineId }) ?? 0
-            defer { timelineRenderRevision &+= 1 }
             yield &timelines[i]
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -30,6 +30,7 @@ final class EditorViewModel {
     var activeTimelineId: String
     var openTimelineIds: [String]
     @ObservationIgnored var liveViewStates: [String: TimelineViewState] = [:]
+    var timelineTabRenameRequest: String?
 
     /// Active-timeline proxy; assignment routes by id and activates so undo lands on its timeline.
     var timeline: Timeline {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -87,6 +87,7 @@ final class EditorViewModel {
     var selectedTimelineRange: TimelineRangeSelection?
     var selectedMediaAssetIds: Set<String> = []
     var selectedFolderIds: Set<String> = []
+    var selectedTimelineIds: Set<String> = []
     var pendingSwapClipId: String?
     var clipClipboard: [ClipClipboardEntry] = []
     var zoomScale: Double = Defaults.pixelsPerFrame

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -509,10 +509,18 @@ final class EditorViewModel {
     }
 
     func fitTransform(for asset: MediaAsset, canvasWidth: Int, canvasHeight: Int) -> Transform {
-        guard let relativeAspect = mediaCanvasAspect(for: asset, canvasWidth: canvasWidth, canvasHeight: canvasHeight) else {
-            return Transform()
-        }
+        guard let sw = asset.sourceWidth, let sh = asset.sourceHeight else { return Transform() }
+        return fitTransform(sourceWidth: sw, sourceHeight: sh, canvasWidth: canvasWidth, canvasHeight: canvasHeight)
+    }
+
+    func fitTransform(sourceWidth: Int, sourceHeight: Int) -> Transform {
+        fitTransform(sourceWidth: sourceWidth, sourceHeight: sourceHeight, canvasWidth: timeline.width, canvasHeight: timeline.height)
+    }
+
+    func fitTransform(sourceWidth: Int, sourceHeight: Int, canvasWidth: Int, canvasHeight: Int) -> Transform {
+        guard sourceWidth > 0, sourceHeight > 0, canvasWidth > 0, canvasHeight > 0 else { return Transform() }
         let canvasAspect = Double(canvasWidth) / Double(canvasHeight)
+        let relativeAspect = (Double(sourceWidth) / Double(sourceHeight)) / canvasAspect
         let sourceAspect = relativeAspect * canvasAspect
         if abs(canvasAspect - sourceAspect) < Defaults.aspectTolerance {
             return Transform()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -401,7 +401,8 @@ final class EditorViewModel {
     ) -> [String] {
         guard timeline.tracks.indices.contains(trackIndex) else { return [] }
         let targetIsVideo = timeline.tracks[trackIndex].type == .video
-        let shouldLink = addLinkedAudio && targetIsVideo && asset.type == .video && asset.hasAudio
+        let shouldLink = addLinkedAudio && targetIsVideo && asset.hasAudio
+            && (asset.type == .video || asset.type == .sequence)
         let linkGroupId: String? = shouldLink ? UUID().uuidString : nil
         let trimStart = sourceSegment.map { secondsToFrame(seconds: $0.lowerBound, fps: timeline.fps) } ?? 0
         let totalSourceFrames = secondsToFrame(seconds: asset.duration, fps: timeline.fps)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -506,8 +506,8 @@ final class EditorViewModel {
     }
 
     func fitTransform(for clip: Clip) -> Transform {
-        guard let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { return Transform() }
-        return fitTransform(for: asset)
+        guard let dims = sourceDimensions(for: clip) else { return Transform() }
+        return fitTransform(sourceWidth: dims.width, sourceHeight: dims.height)
     }
 
     func fitTransform(for asset: MediaAsset, canvasWidth: Int, canvasHeight: Int) -> Transform {

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -55,9 +55,9 @@ final class ExportService {
             )
             do {
                 if format == .xml {
-                    try await XMLExporter.export(timeline: timeline, resolver: resolver, outputURL: outputURL)
+                    try await XMLExporter.export(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline, outputURL: outputURL)
                 } else {
-                    try await FCPXMLExporter.export(timeline: timeline, resolver: resolver, version: fcpxmlVersion, outputURL: outputURL)
+                    try await FCPXMLExporter.export(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline, version: fcpxmlVersion, outputURL: outputURL)
                 }
                 progress = 1.0
                 Log.export.notice("export ok format=\(name)", telemetry: "Export finished", data: ["format": name])

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -32,6 +32,7 @@ final class ExportService {
     func export(
         timeline: Timeline,
         resolver: MediaResolver,
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         format: ExportFormat,
         resolution: ExportResolution,
         fcpxmlVersion: FCPXMLVersion = .default,
@@ -91,7 +92,7 @@ final class ExportService {
 
         do {
             let prepared = try await makeExportSession(
-                timeline: timeline, resolver: resolver,
+                timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline,
                 format: format, resolution: resolution,
                 missingMediaRefs: missingMediaRefs
             )
@@ -225,6 +226,7 @@ final class ExportService {
     private func makeExportSession(
         timeline: Timeline,
         resolver: MediaResolver,
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         format: ExportFormat,
         resolution: ExportResolution,
         missingMediaRefs: Set<String>
@@ -236,6 +238,7 @@ final class ExportService {
         let result = try await CompositionBuilder.build(
             timeline: timeline,
             resolveURL: { mediaURLs[$0] },
+            resolveTimeline: resolveTimeline,
             missingMediaRefs: missingMediaRefs,
             renderSize: renderSize
         )

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -157,7 +157,7 @@ final class ExportService {
     /// Writes a self-contained `.palmier` bundle (all media collected internally).
     @discardableResult
     func exportPalmierProject(
-        timeline: Timeline,
+        projectFile: ProjectFile,
         manifest: MediaManifest,
         generationLog: GenerationLog,
         sourceProjectURL: URL?,
@@ -180,15 +180,15 @@ final class ExportService {
                 "palmier export start url=\(outputURL.lastPathComponent)",
                 telemetry: "Palmier project export started",
                 data: [
-                    "tracks": timeline.tracks.count,
-                    "clips": timeline.tracks.reduce(0) { $0 + $1.clips.count },
+                    "timelines": projectFile.timelines.count,
+                    "clips": projectFile.timelines.reduce(0) { $0 + $1.tracks.reduce(0) { $0 + $1.clips.count } },
                     "media": manifest.entries.count,
                     "generationLogEntries": generationLog.entries.count
                 ]
             )
             let report = try await Task.detached(priority: .userInitiated) {
                 try PalmierProjectExporter.export(
-                    timeline: timeline, manifest: manifest, generationLog: generationLog,
+                    projectFile: projectFile, manifest: manifest, generationLog: generationLog,
                     sourceProjectURL: sourceProjectURL, to: outputURL,
                     progress: { p in Task { @MainActor in self.progress = p } }
                 )

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -32,7 +32,7 @@ final class ExportService {
     func export(
         timeline: Timeline,
         resolver: MediaResolver,
-        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
+        resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
         format: ExportFormat,
         resolution: ExportResolution,
         fcpxmlVersion: FCPXMLVersion = .default,
@@ -226,7 +226,7 @@ final class ExportService {
     private func makeExportSession(
         timeline: Timeline,
         resolver: MediaResolver,
-        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
+        resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
         format: ExportFormat,
         resolution: ExportResolution,
         missingMediaRefs: Set<String>

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -447,9 +447,11 @@ struct ExportView: View {
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             Task {
+                let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
                 await service.export(
                     timeline: editor.timeline,
                     resolver: editor.mediaResolver,
+                    resolveTimeline: { timelinesById[$0] },
                     format: format,
                     resolution: resolution,
                     fcpxmlVersion: fcpxmlVersion,

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -474,7 +474,7 @@ struct ExportView: View {
             guard response == .OK, let url = panel.url else { return }
             Task {
                 let report = await service.exportPalmierProject(
-                    timeline: editor.timeline,
+                    projectFile: editor.projectFileSnapshot(),
                     manifest: editor.mediaManifest,
                     generationLog: editor.generationLog,
                     sourceProjectURL: editor.projectURL,

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -62,6 +62,11 @@ struct ExportView: View {
     @State private var resolution: ExportResolution = .matchTimeline
     @State private var palmierResult: String?
     @State private var palmierSummary: (collect: Int, missing: Int, bytes: Int64) = (0, 0, 0)
+    @State private var selectedTimelineId: String?
+
+    private var exportTimeline: Timeline {
+        selectedTimelineId.flatMap { editor.timeline(for: $0) } ?? editor.timeline
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -74,6 +79,7 @@ struct ExportView: View {
                 .background(.ultraThinMaterial)
         }
         .task {
+            selectedTimelineId = editor.activeTimelineId
             palmierSummary = computePalmierSummary()
         }
     }
@@ -99,6 +105,20 @@ struct ExportView: View {
                     destinationPicker
 
                     Divider().opacity(AppTheme.Opacity.moderate)
+
+                    if editor.timelines.count > 1, destination != .palmierProject {
+                        settingRow(label: "Timeline") {
+                            Picker("", selection: $selectedTimelineId) {
+                                ForEach(editor.timelines) { timeline in
+                                    Text(timeline.name).tag(timeline.id as String?)
+                                }
+                            }
+                            .labelsHidden()
+                            .fixedSize()
+                        }
+
+                        Divider().opacity(AppTheme.Opacity.moderate)
+                    }
 
                     switch destination {
                     case .video:
@@ -191,7 +211,7 @@ struct ExportView: View {
             Divider().opacity(AppTheme.Opacity.moderate)
 
             settingRow(label: "Frame Rate") {
-                Text("\(editor.timeline.fps) fps")
+                Text("\(exportTimeline.fps) fps")
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
             }
         }
@@ -270,7 +290,7 @@ struct ExportView: View {
 
     private var bottomBar: some View {
         HStack {
-            let duration = formatTimecode(frame: editor.timeline.totalFrames, fps: editor.timeline.fps)
+            let duration = formatTimecode(frame: exportTimeline.totalFrames, fps: exportTimeline.fps)
             HStack(spacing: AppTheme.Spacing.lg) {
                 HStack(spacing: AppTheme.Spacing.xs) {
                     Image(systemName: "clock")
@@ -282,11 +302,11 @@ struct ExportView: View {
                         Image(systemName: "doc")
                         Text("~\(estimatedFileSize)")
                     }
-                    let out = resolution.renderSize(for: CGSize(width: editor.timeline.width, height: editor.timeline.height))
+                    let out = resolution.renderSize(for: CGSize(width: exportTimeline.width, height: exportTimeline.height))
                     Text("\(Int(out.width))×\(Int(out.height))")
                     Text(codec.containerLabel)
                 case .timeline:
-                    Text("\(editor.timeline.width)×\(editor.timeline.height)")
+                    Text("\(exportTimeline.width)×\(exportTimeline.height)")
                     Text(timelineFormat.extensionLabel)
                 case .palmierProject:
                     HStack(spacing: AppTheme.Spacing.xs) {
@@ -403,9 +423,9 @@ struct ExportView: View {
     }
 
     private var estimatedFileSize: String {
-        let seconds = Double(editor.timeline.totalFrames) / Double(max(1, editor.timeline.fps))
+        let seconds = Double(exportTimeline.totalFrames) / Double(max(1, exportTimeline.fps))
         // Bitrate scales with output pixel area, so any resolution (incl. 2K / native) is covered.
-        let out = resolution.renderSize(for: CGSize(width: editor.timeline.width, height: editor.timeline.height))
+        let out = resolution.renderSize(for: CGSize(width: exportTimeline.width, height: exportTimeline.height))
         let megapixels = Double(out.width * out.height) / 1_000_000
         let bytesPerSecPerMP: Double = switch codec {
         case .h264:   0.63e6
@@ -455,14 +475,14 @@ struct ExportView: View {
             .mpeg4Movie
         }
         panel.allowedContentTypes = [contentType]
-        panel.nameFieldStringValue = "export.\(format.fileExtension)"
+        panel.nameFieldStringValue = "\(exportTimeline.name).\(format.fileExtension)"
 
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             Task {
                 let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
                 await service.export(
-                    timeline: editor.timeline,
+                    timeline: exportTimeline,
                     resolver: editor.mediaResolver,
                     resolveTimeline: { timelinesById[$0] },
                     format: format,

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -480,11 +480,10 @@ struct ExportView: View {
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             Task {
-                let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
                 await service.export(
                     timeline: exportTimeline,
                     resolver: editor.mediaResolver,
-                    resolveTimeline: { timelinesById[$0] },
+                    resolveTimeline: editor.timelineResolver(),
                     format: format,
                     resolution: resolution,
                     fcpxmlVersion: fcpxmlVersion,

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -46,7 +46,8 @@ enum FCPXMLVersion: String, CaseIterable, Identifiable, Sendable {
 /// What transports: clip placement/trims, speed, lane order, enabled state; text + font/face/
 /// size/color/alignment; position/scale/rotation/flip (+ position/scale/rotation keyframes);
 /// crop; opacity (+ keyframes); static volume; source start timecode, so Resolve doesn't flag a
-/// mismatch against the media's embedded timecode.
+/// mismatch against the media's embedded timecode; nested timelines as compound clips
+/// (`<media><sequence>` resource + `<ref-clip>` carrier, recursive; unresolvable/empty children drop).
 ///
 /// What does NOT: keyframed audio volume and audio fades (Resolve drops both itself); text
 /// background/border boxes (no FCPXML form); crop keyframes; title rotation/scale; color &
@@ -55,24 +56,46 @@ enum FCPXMLVersion: String, CaseIterable, Identifiable, Sendable {
 /// Reference: https://developer.apple.com/documentation/professional-video-applications/fcpxml-reference
 enum FCPXMLExporter {
     static func export(timeline: Timeline, resolver: MediaResolver,
+                       resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
                        version: FCPXMLVersion = .default, outputURL: URL) async throws {
-        let mediaRefs = Set(timeline.tracks.flatMap { $0.clips.map(\.mediaRef) })
+        // Media refs across the parent and every reachable nested timeline.
+        var mediaRefs: Set<String> = []
+        var queue = [timeline]
+        var visited: Set<String> = []
+        var i = 0
+        while i < queue.count {
+            let t = queue[i]
+            i += 1
+            guard visited.insert(t.id).inserted else { continue }
+            for clip in t.tracks.flatMap(\.clips) {
+                if clip.sourceClipType == .sequence {
+                    if let child = resolveTimeline(clip.mediaRef) { queue.append(child) }
+                } else {
+                    mediaRefs.insert(clip.mediaRef)
+                }
+            }
+        }
         let timecodes = await SourceTimecodeReader.cache(mediaRefs: mediaRefs, urls: resolver.expectedURLMap())
-        let xml = render(timeline: timeline, resolver: resolver, version: version, startTimecodes: timecodes)
+        let xml = render(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline,
+                         version: version, startTimecodes: timecodes)
         guard let data = xml.data(using: .utf8) else { throw ExportError.xmlEncodingFailed }
         try data.write(to: outputURL)
     }
 
     /// Build the document from an explicit timecode map. Split out so tests can inject embedded
     /// timecodes without a `tmcd`-carrying media file on disk.
-    static func render(timeline: Timeline, resolver: MediaResolver, version: FCPXMLVersion = .default,
+    static func render(timeline: Timeline, resolver: MediaResolver,
+                       resolveTimeline: @escaping (String) -> Timeline? = { _ in nil },
+                       version: FCPXMLVersion = .default,
                        startTimecodes: [String: SourceTimecode] = [:]) -> String {
-        Builder(timeline: timeline, resolver: resolver, version: version, startTimecodes: startTimecodes).build()
+        Builder(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline,
+                version: version, startTimecodes: startTimecodes).build()
     }
 
     private final class Builder {
         private let timeline: Timeline
         private let resolver: MediaResolver
+        private let resolveTimeline: (String) -> Timeline?
         private let version: FCPXMLVersion
         private let startTimecodes: [String: SourceTimecode]
         private let fps: Int
@@ -86,6 +109,9 @@ enum FCPXMLExporter {
         // A synced A/V pair collapses into one ref-clip; the audio partner is dropped, its volume kept.
         private var linkedAudioForVideo: [String: Clip] = [:]
         private var redundantAudioClipIds: Set<String> = []
+        // Nested timelines, discovery order; each becomes a <media><sequence> compound resource.
+        private var nests: [(mediaId: String, timeline: Timeline)] = []
+        private var nestIndex: [String: String] = [:]
 
         private struct EmittableClip {
             let clip: Clip
@@ -108,10 +134,11 @@ enum FCPXMLExporter {
             let startTimecodeFrames: Int
         }
 
-        init(timeline: Timeline, resolver: MediaResolver, version: FCPXMLVersion,
-             startTimecodes: [String: SourceTimecode]) {
+        init(timeline: Timeline, resolver: MediaResolver, resolveTimeline: @escaping (String) -> Timeline?,
+             version: FCPXMLVersion, startTimecodes: [String: SourceTimecode]) {
             self.timeline = timeline
             self.resolver = resolver
+            self.resolveTimeline = resolveTimeline
             self.version = version
             self.startTimecodes = startTimecodes
             self.fps = max(1, timeline.fps)
@@ -120,15 +147,37 @@ enum FCPXMLExporter {
         }
 
         func build() -> String {
-            let clips = emittableClips()
-            collectResources(from: clips)
-            indexLinkedPairs(clips)
-            let hasTitles = clips.contains { $0.clip.mediaType == .text }
+            collectNests()
+            let clips = emittableClips(of: timeline)
+            let nestedClips = nests.flatMap { emittableClips(of: $0.timeline) }
+            collectResources(from: clips + nestedClips)
+            indexLinkedPairs(clips + nestedClips)
+            let hasTitles = (clips + nestedClips).contains { $0.clip.mediaType == .text }
             let root = FCPXMLNode(name: "fcpxml", attributes: [("version", version.rawValue)], children: [
                 resourcesNode(hasTitles: hasTitles),
                 libraryNode(clips: clips),
             ])
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
+        }
+
+        /// Breadth-first over reachable child timelines; unresolvable or empty children stay
+        /// out of `nestIndex`, so their carriers are dropped by `isEmittable`.
+        private func collectNests() {
+            var queue = [(t: timeline, depth: 0)]
+            var i = 0
+            while i < queue.count {
+                let (t, depth) = queue[i]
+                i += 1
+                guard depth < NestFlattener.maxDepth else { continue }
+                for clip in t.tracks.flatMap(\.clips) where clip.sourceClipType == .sequence {
+                    guard nestIndex[clip.mediaRef] == nil,
+                          let child = resolveTimeline(clip.mediaRef), child.totalFrames > 0 else { continue }
+                    let mediaId = "nest\(nests.count + 1)"
+                    nestIndex[clip.mediaRef] = mediaId
+                    nests.append((mediaId, child))
+                    queue.append((child, depth + 1))
+                }
+            }
         }
 
         // Video + audio with matching linkGroup, source, timing, and enabled state are a synced pair
@@ -137,7 +186,7 @@ enum FCPXMLExporter {
             for item in clips {
                 guard let group = item.clip.linkGroupId else { continue }
                 switch item.clip.mediaType {
-                case .video, .image: byGroup[group, default: ([], [])].videos.append(item)
+                case .video, .image, .sequence: byGroup[group, default: ([], [])].videos.append(item)
                 case .audio: byGroup[group, default: ([], [])].audios.append(item)
                 default: break
                 }
@@ -177,7 +226,50 @@ enum FCPXMLExporter {
             children += resources.compactMap(formatNode)
             children += resources.map(assetNode)
             children += resources.compactMap(compoundClipNode)
+            children += nests.compactMap(nestFormatNode)
+            children += nests.map(nestMediaNode)
             return FCPXMLNode(name: "resources", children: children)
+        }
+
+        private func nestFormatId(_ nest: (mediaId: String, timeline: Timeline)) -> String {
+            nest.timeline.width == seqWidth && nest.timeline.height == seqHeight
+                ? sequenceFormatId : "\(nest.mediaId)Format"
+        }
+
+        private func nestFormatNode(_ nest: (mediaId: String, timeline: Timeline)) -> FCPXMLNode? {
+            let formatId = nestFormatId(nest)
+            guard formatId != sequenceFormatId else { return nil }
+            return FCPXMLNode(name: "format", attributes: [
+                ("id", formatId),
+                ("name", sequenceFormatName(width: nest.timeline.width, height: nest.timeline.height, fps: Double(fps))),
+                ("frameDuration", frameDuration(forFPS: Double(fps))),
+                ("width", "\(nest.timeline.width)"),
+                ("height", "\(nest.timeline.height)"),
+                ("colorSpace", "1-1-1 (Rec. 709)"),
+            ])
+        }
+
+        /// A nested timeline as a compound-clip resource: same gap-with-lanes shape as the project.
+        private func nestMediaNode(_ nest: (mediaId: String, timeline: Timeline)) -> FCPXMLNode {
+            let duration = time(frames: nest.timeline.totalFrames)
+            let gap = FCPXMLNode(name: "gap", attributes: [
+                ("name", "Timeline"),
+                ("offset", "0s"),
+                ("start", "0s"),
+                ("duration", duration),
+            ], children: storyNodes(for: emittableClips(of: nest.timeline)))
+            let sequence = FCPXMLNode(name: "sequence", attributes: [
+                ("format", nestFormatId(nest)),
+                ("duration", duration),
+                ("tcStart", "0s"),
+                ("tcFormat", "NDF"),
+                ("audioLayout", "stereo"),
+                ("audioRate", "48k"),
+            ], children: [FCPXMLNode(name: "spine", children: [gap])])
+            return FCPXMLNode(name: "media", attributes: [
+                ("id", nest.mediaId),
+                ("name", nest.timeline.name),
+            ], children: [sequence])
         }
 
         private func compoundClipNode(for resource: MediaResource) -> FCPXMLNode? {
@@ -246,7 +338,7 @@ enum FCPXMLExporter {
                   ])
                 : FCPXMLNode(name: "spine")
 
-            return FCPXMLNode(name: "project", attributes: [("name", "Timeline Export")], children: [
+            return FCPXMLNode(name: "project", attributes: [("name", timeline.name)], children: [
                 FCPXMLNode(name: "sequence", attributes: [
                     ("format", sequenceFormatId),
                     ("duration", duration),
@@ -279,6 +371,39 @@ enum FCPXMLExporter {
 
         private func assetClipNode(for item: EmittableClip) -> FCPXMLNode? {
             let clip = item.clip
+
+            // Nested timeline → <ref-clip> over its compound-clip media resource.
+            if clip.sourceClipType == .sequence {
+                guard let mediaId = nestIndex[clip.mediaRef],
+                      let child = resolveTimeline(clip.mediaRef) else { return nil }
+                // A frozen carrier can outlive the child's current length; clamp to content.
+                let duration = min(clip.durationFrames, max(0, child.totalFrames - clip.trimStartFrame))
+                guard duration > 0 else { return nil }
+                var attrs: [(String, String)] = [
+                    ("ref", mediaId),
+                    ("name", child.name),
+                    ("lane", "\(item.lane)"),
+                    ("offset", time(frames: clip.startFrame)),
+                    ("start", time(frames: clip.trimStartFrame)),
+                    ("duration", time(frames: duration)),
+                    ("enabled", item.enabled ? "1" : "0"),
+                ]
+                if clip.mediaType == .audio {
+                    attrs.append(("srcEnable", "audio"))
+                    return FCPXMLNode(name: "ref-clip", attributes: attrs,
+                                      children: [volumeNode(for: clip)].compactMap { $0 })
+                }
+                let linkedAudio = linkedAudioForVideo[clip.id]
+                if linkedAudio == nil { attrs.append(("srcEnable", "video")) }
+                return FCPXMLNode(name: "ref-clip", attributes: attrs, children: [
+                    FCPXMLNode(name: "adjust-conform", attributes: [("type", "fit")]),
+                    cropNode(for: clip),
+                    transformNode(for: clip),
+                    blendNode(for: clip),
+                    linkedAudio.flatMap(volumeNode),
+                ].compactMap { $0 })
+            }
+
             guard let i = resourceIndex[clip.mediaRef] else { return nil }
             let resource = resources[i]
 
@@ -654,7 +779,7 @@ enum FCPXMLExporter {
             return max(manifestFrames, clip.sourceDurationFrames)
         }
 
-        private func emittableClips() -> [EmittableClip] {
+        private func emittableClips(of timeline: Timeline) -> [EmittableClip] {
             let visualTrackCount = timeline.tracks.filter { $0.type.isVisual }.count
             var visualOrdinal = 0
             var audioOrdinal = 0
@@ -684,8 +809,8 @@ enum FCPXMLExporter {
 
         private func isEmittable(_ clip: Clip) -> Bool {
             guard clip.durationFrames > 0 else { return false }
-            // Nested timelines await ref-clip support; excluded with a warning at export.
-            guard clip.sourceClipType != .sequence else { return false }
+            // Nest carriers emit when their child timeline resolved to a compound resource.
+            if clip.sourceClipType == .sequence { return nestIndex[clip.mediaRef] != nil }
             switch clip.mediaType {
             case .text:
                 return clip.textContent?.isEmpty == false

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -269,7 +269,7 @@ enum FCPXMLExporter {
                     switch item.clip.mediaType {
                     case .text:
                         return titleNode(for: item)
-                    case .audio, .video, .image:
+                    case .audio, .video, .image, .sequence:
                         return assetClipNode(for: item)
                     case .lottie:
                         return nil
@@ -684,10 +684,12 @@ enum FCPXMLExporter {
 
         private func isEmittable(_ clip: Clip) -> Bool {
             guard clip.durationFrames > 0 else { return false }
+            // Nested timelines await ref-clip support; excluded with a warning at export.
+            guard clip.sourceClipType != .sequence else { return false }
             switch clip.mediaType {
             case .text:
                 return clip.textContent?.isEmpty == false
-            case .lottie:
+            case .lottie, .sequence:
                 return false
             case .audio, .video, .image:
                 return resolver.resolveURL(for: clip.mediaRef) != nil

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -185,23 +185,15 @@ enum FCPXMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
         }
 
-        /// Breadth-first over reachable child timelines; unresolvable or empty children stay
-        /// out of `nestIndex`, so their carriers are dropped by `isEmittable`.
+        /// Unresolvable or empty children stay out of `nestIndex`, so `isEmittable` drops their carriers.
         private func collectNests() {
-            var queue = [(t: timeline, depth: 0)]
-            var i = 0
-            while i < queue.count {
-                let (t, depth) = queue[i]
-                i += 1
-                guard depth < NestFlattener.maxDepth else { continue }
-                for clip in t.tracks.flatMap(\.clips) where clip.sourceClipType == .sequence {
-                    guard nestIndex[clip.mediaRef] == nil,
-                          let child = resolveTimeline(clip.mediaRef), child.totalFrames > 0 else { continue }
-                    let mediaId = "nest\(nests.count + 1)"
-                    nestIndex[clip.mediaRef] = mediaId
-                    nests.append((mediaId, child))
-                    queue.append((child, depth + 1))
-                }
+            let reachable = timeline.reachableTimelines(
+                resolve: resolveTimeline, maxDepth: NestFlattener.maxDepth, include: { $0.totalFrames > 0 }
+            )
+            for child in reachable {
+                let mediaId = "nest\(nests.count + 1)"
+                nestIndex[child.id] = mediaId
+                nests.append((mediaId, child))
             }
         }
 

--- a/Sources/PalmierPro/Export/PalmierProjectExporter.swift
+++ b/Sources/PalmierPro/Export/PalmierProjectExporter.swift
@@ -19,7 +19,7 @@ enum PalmierProjectExporter {
 
     @discardableResult
     static func export(
-        timeline: Timeline,
+        projectFile: ProjectFile,
         manifest: MediaManifest,
         generationLog: GenerationLog,
         sourceProjectURL: URL?,
@@ -70,7 +70,7 @@ enum PalmierProjectExporter {
         newManifest.entries = newEntries
 
         let encoder = JSONEncoder()
-        try encoder.encode(timeline).write(to: staging.appendingPathComponent(Project.timelineFilename))
+        try encoder.encode(projectFile).write(to: staging.appendingPathComponent(Project.timelineFilename))
         try encoder.encode(newManifest).write(to: staging.appendingPathComponent(Project.manifestFilename))
         try encoder.encode(generationLog).write(to: staging.appendingPathComponent(Project.generationLogFilename))
 

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -107,6 +107,7 @@ enum XMLExporter {
         private let fps: Int
         private let seqWidth: Int
         private let seqHeight: Int
+        private var curSeqWidth: Int
 
         /// Files already emitted in full; repeat references collapse to `<file id="..."/>`.
         private var emittedFiles: Set<FileKey> = []
@@ -130,6 +131,7 @@ enum XMLExporter {
             self.fps = timeline.fps
             self.seqWidth = timeline.width
             self.seqHeight = timeline.height
+            self.curSeqWidth = timeline.width
             self.startFrameCache = startFrameCache
         }
 
@@ -149,11 +151,14 @@ enum XMLExporter {
         private func sequenceNode(id: String, timeline: Timeline) -> XMLNode {
             let savedAddresses = clipAddresses
             let savedGroups = clipsByLinkGroup
+            let savedSeqWidth = curSeqWidth
             clipAddresses = [:]
             clipsByLinkGroup = [:]
+            curSeqWidth = timeline.width
             defer {
                 clipAddresses = savedAddresses
                 clipsByLinkGroup = savedGroups
+                curSeqWidth = savedSeqWidth
             }
 
             // FCP XML orders video tracks bottom→top; our model stores them top→bottom.
@@ -438,8 +443,9 @@ enum XMLExporter {
         /// Basic Motion: scale, rotation, center — keyframed, or static (defaults omitted).
         private func motionFilter(_ clip: Clip) -> XMLNode? {
             let sourceWidth = resolver.entry(for: clip.mediaRef)?.sourceWidth ?? 0
+            // Scale is relative to the sequence being emitted — a nested child's canvas, not the root's.
             func scalePct(_ width: Double) -> Double {
-                sourceWidth > 0 ? (Double(seqWidth) / Double(sourceWidth)) * width * 100 : width * 100
+                sourceWidth > 0 ? (Double(curSeqWidth) / Double(sourceWidth)) * width * 100 : width * 100
             }
 
             // FCP7 center uses normalized coordinates (0 = center), not pixels.

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -23,6 +23,9 @@ import Foundation
 /// - Fade in/out → single-sided transition (Cross Dissolve for video, Cross Fade for audio)
 /// - Linked A/V clips → reciprocal `<link>` blocks
 /// - Source frame rate → per-file NTSC flag (29.97/23.976/59.94 → ntsc TRUE)
+/// - Nested timelines → nested `<sequence>` inside the carrier clipitem (full definition on
+///   first use, id reference after — Premiere's own convention); recursive, frozen carriers
+///   clamp to the child's length, empty/missing children drop
 ///
 /// What does NOT transport:
 /// - Text overlays. FCPXML supports this, not XMEML.
@@ -38,15 +41,42 @@ import Foundation
 
 enum XMLExporter {
 
-    static func export(timeline: Timeline, resolver: MediaResolver, outputURL: URL) async throws {
-        let startFrameCache = await sourceTimecodeCache(timeline: timeline, resolver: resolver)
-        let xml = Builder(timeline: timeline, resolver: resolver, startFrameCache: startFrameCache).build()
+    static func export(timeline: Timeline, resolver: MediaResolver,
+                       resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
+                       outputURL: URL) async throws {
+        let startFrameCache = await sourceTimecodeCache(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline)
+        let xml = render(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline, startFrameCache: startFrameCache)
         guard let data = xml.data(using: .utf8) else { throw ExportError.xmlEncodingFailed }
         try data.write(to: outputURL)
     }
 
-    private static func sourceTimecodeCache(timeline: Timeline, resolver: MediaResolver) async -> [String: SourceTimecode] {
-        let mediaRefs = Set(timeline.tracks.flatMap { $0.clips.map(\.mediaRef) })
+    /// Split out so tests can build the document synchronously.
+    static func render(timeline: Timeline, resolver: MediaResolver,
+                       resolveTimeline: @escaping (String) -> Timeline? = { _ in nil },
+                       startFrameCache: [String: SourceTimecode] = [:]) -> String {
+        Builder(timeline: timeline, resolver: resolver, resolveTimeline: resolveTimeline,
+                startFrameCache: startFrameCache).build()
+    }
+
+    private static func sourceTimecodeCache(
+        timeline: Timeline, resolver: MediaResolver, resolveTimeline: (String) -> Timeline?
+    ) async -> [String: SourceTimecode] {
+        var mediaRefs: Set<String> = []
+        var queue = [timeline]
+        var visited: Set<String> = []
+        var i = 0
+        while i < queue.count {
+            let t = queue[i]
+            i += 1
+            guard visited.insert(t.id).inserted else { continue }
+            for clip in t.tracks.flatMap(\.clips) {
+                if clip.sourceClipType == .sequence {
+                    if let child = resolveTimeline(clip.mediaRef) { queue.append(child) }
+                } else {
+                    mediaRefs.insert(clip.mediaRef)
+                }
+            }
+        }
         return await SourceTimecodeReader.cache(mediaRefs: mediaRefs, urls: resolver.expectedURLMap())
     }
 
@@ -83,6 +113,7 @@ enum XMLExporter {
     private final class Builder {
         private let timeline: Timeline
         private let resolver: MediaResolver
+        private let resolveTimeline: (String) -> Timeline?
         private let fps: Int
         private let seqWidth: Int
         private let seqHeight: Int
@@ -93,13 +124,19 @@ enum XMLExporter {
         private var clipAddresses: [String: ClipAddress] = [:]
         private var clipsByLinkGroup: [String: [Clip]] = [:]
         private let startFrameCache: [String: SourceTimecode]
+        /// Child timeline id -> XMEML sequence id; first carrier embeds the full definition,
+        /// later carriers reference it (Premiere's own nested-sequence convention).
+        private var sequenceIds: [String: String] = [:]
+        private var emittedSequences: Set<String> = []
 
         private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
         private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
 
-        init(timeline: Timeline, resolver: MediaResolver, startFrameCache: [String: SourceTimecode]) {
+        init(timeline: Timeline, resolver: MediaResolver, resolveTimeline: @escaping (String) -> Timeline?,
+             startFrameCache: [String: SourceTimecode]) {
             self.timeline = timeline
             self.resolver = resolver
+            self.resolveTimeline = resolveTimeline
             self.fps = timeline.fps
             self.seqWidth = timeline.width
             self.seqHeight = timeline.height
@@ -109,6 +146,26 @@ enum XMLExporter {
         // MARK: - Document shell
 
         func build() -> String {
+            sequenceIds[timeline.id] = "sequence-1"
+            emittedSequences.insert(timeline.id)
+            let root = el("xmeml", attrs: [("version", "4")], [
+                sequenceNode(id: "sequence-1", timeline: timeline),
+            ])
+            return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE xmeml>\n" + renderXML(root, indent: 0)
+        }
+
+        /// One timeline as a <sequence>; used for the root and, recursively, nested timelines.
+        /// Link/address state is per-sequence, so it stacks around the recursive build.
+        private func sequenceNode(id: String, timeline: Timeline) -> XMLNode {
+            let savedAddresses = clipAddresses
+            let savedGroups = clipsByLinkGroup
+            clipAddresses = [:]
+            clipsByLinkGroup = [:]
+            defer {
+                clipAddresses = savedAddresses
+                clipsByLinkGroup = savedGroups
+            }
+
             // FCP XML orders video tracks bottom→top; our model stores them top→bottom.
             let videoTracks = Array(timeline.tracks.filter { $0.type.isVisual }.reversed())
             let audioTracks = timeline.tracks.filter { $0.type == .audio }
@@ -117,24 +174,21 @@ enum XMLExporter {
 
             indexAddresses(sortedVideo, isAudio: false)
             indexAddresses(sortedAudio, isAudio: true)
-            indexLinkGroups()
+            indexLinkGroups(timeline)
 
             let videoTrackNodes = zip(videoTracks, sortedVideo).map { trackNode($0, sortedClips: $1, isAudio: false) }
             let audioTrackNodes = zip(audioTracks, sortedAudio).map { trackNode($0, sortedClips: $1, isAudio: true) }
 
-            let root = el("xmeml", attrs: [("version", "4")], [
-                el("sequence", attrs: [("id", "sequence-1")], [
-                    leaf("name", "Timeline Export"),
-                    leaf("duration", timeline.totalFrames),
-                    rate(fps),
-                    timecodeNode(),
-                    el("media", [
-                        el("video", [videoFormatNode()] + videoTrackNodes),
-                        el("audio", [leaf("numOutputChannels", 2), audioFormatNode(), audioOutputsNode()] + audioTrackNodes),
-                    ]),
+            return el("sequence", attrs: [("id", id)], [
+                leaf("name", timeline.name),
+                leaf("duration", timeline.totalFrames),
+                rate(fps),
+                timecodeNode(),
+                el("media", [
+                    el("video", [videoFormatNode()] + videoTrackNodes),
+                    el("audio", [leaf("numOutputChannels", 2), audioFormatNode(), audioOutputsNode()] + audioTrackNodes),
                 ]),
             ])
-            return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE xmeml>\n" + render(root, indent: 0)
         }
 
         private func timecodeNode() -> XMLNode {
@@ -186,6 +240,7 @@ enum XMLExporter {
         }
 
         private func clipItemNode(_ clip: Clip, isAudio: Bool) -> XMLNode {
+            if clip.sourceClipType == .sequence { return nestClipItemNode(clip, isAudio: isAudio) }
             let sourceDuration = sourceDurationFrames(for: clip.mediaRef) ?? clip.sourceDurationFrames
             // in/out are source-frame offsets, so they span sourceFramesConsumed (Time Remap handles rate).
             let inPoint = clip.trimStartFrame
@@ -204,6 +259,39 @@ enum XMLExporter {
                 fileNode(for: clip.mediaRef, isAudio: isAudio),
             ]
             if let remap = timeRemapFilter(speed: clip.speed, isAudio: isAudio) { children.append(remap) }
+            children += isAudio ? volumeFilters(clip) : videoFilters(clip)
+            children += linkNodes(for: clip)
+            return el("clipitem", attrs: [("id", "clipitem-\(clip.id)")], children)
+        }
+
+        /// Nest carrier: a clipitem over the child <sequence> — full definition on first use,
+        /// id reference after. The frozen carrier is clamped to the child's current length.
+        private func nestClipItemNode(_ clip: Clip, isAudio: Bool) -> XMLNode {
+            let child = resolveTimeline(clip.mediaRef)!  // sortEmittable guarantees resolution
+            let seqId = sequenceIds[clip.mediaRef] ?? {
+                let id = "sequence-\(sequenceIds.count + 1)"
+                sequenceIds[clip.mediaRef] = id
+                return id
+            }()
+            let sequence = emittedSequences.insert(clip.mediaRef).inserted
+                ? sequenceNode(id: seqId, timeline: child)
+                : el("sequence", attrs: [("id", seqId)])
+
+            let inPoint = clip.trimStartFrame
+            let outPoint = min(inPoint + clip.durationFrames, child.totalFrames)
+
+            var children: [XMLNode] = [
+                leaf("masterclipid", masterclipId(for: clip, isAudio: isAudio)),
+                leaf("name", child.name),
+                bool("enabled", true),
+                leaf("duration", child.totalFrames),
+                rate(fps),
+                leaf("start", clip.startFrame),
+                leaf("end", clip.startFrame + (outPoint - inPoint)),
+                leaf("in", inPoint),
+                leaf("out", outPoint),
+                sequence,
+            ]
             children += isAudio ? volumeFilters(clip) : videoFilters(clip)
             children += linkNodes(for: clip)
             return el("clipitem", attrs: [("id", "clipitem-\(clip.id)")], children)
@@ -435,7 +523,11 @@ enum XMLExporter {
         /// Drops unresolvable clips so track builders and `<link>` indices agree.
         private func sortEmittable(_ track: Track) -> [Clip] {
             track.clips
-                .filter { $0.sourceClipType != .sequence && resolver.resolveURL(for: $0.mediaRef) != nil }
+                .filter { clip in
+                    clip.sourceClipType == .sequence
+                        ? (resolveTimeline(clip.mediaRef)?.totalFrames ?? 0) > 0
+                        : resolver.resolveURL(for: clip.mediaRef) != nil
+                }
                 .sorted { $0.startFrame < $1.startFrame }
         }
 
@@ -447,7 +539,7 @@ enum XMLExporter {
             }
         }
 
-        private func indexLinkGroups() {
+        private func indexLinkGroups(_ timeline: Timeline) {
             for track in timeline.tracks {
                 for clip in track.clips {
                     guard let group = clip.linkGroupId else { continue }
@@ -537,14 +629,14 @@ private func leaf(_ name: String, _ value: String) -> XMLNode { XMLNode(name: na
 private func leaf(_ name: String, _ value: Int) -> XMLNode { XMLNode(name: name, text: String(value)) }
 private func bool(_ name: String, _ value: Bool) -> XMLNode { XMLNode(name: name, text: value ? "TRUE" : "FALSE") }
 
-private func render(_ node: XMLNode, indent: Int) -> String {
+private func renderXML(_ node: XMLNode, indent: Int) -> String {
     let pad = String(repeating: " ", count: indent)
     let attrs = node.attributes.map { " \($0.0)=\"\(escapeXML($0.1))\"" }.joined()
     if let text = node.text {
         return "\(pad)<\(node.name)\(attrs)>\(escapeXML(text))</\(node.name)>"
     }
     guard !node.children.isEmpty else { return "\(pad)<\(node.name)\(attrs)/>" }
-    let inner = node.children.map { render($0, indent: indent + 2) }.joined(separator: "\n")
+    let inner = node.children.map { renderXML($0, indent: indent + 2) }.joined(separator: "\n")
     return "\(pad)<\(node.name)\(attrs)>\n\(inner)\n\(pad)</\(node.name)>"
 }
 

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -435,7 +435,7 @@ enum XMLExporter {
         /// Drops unresolvable clips so track builders and `<link>` indices agree.
         private func sortEmittable(_ track: Track) -> [Clip] {
             track.clips
-                .filter { resolver.resolveURL(for: $0.mediaRef) != nil }
+                .filter { $0.sourceClipType != .sequence && resolver.resolveURL(for: $0.mediaRef) != nil }
                 .sorted { $0.startFrame < $1.startFrame }
         }
 

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -175,7 +175,7 @@ enum XMLExporter {
                 rate(fps),
                 timecodeNode(),
                 el("media", [
-                    el("video", [videoFormatNode()] + videoTrackNodes),
+                    el("video", [videoFormatNode(width: timeline.width, height: timeline.height)] + videoTrackNodes),
                     el("audio", [leaf("numOutputChannels", 2), audioFormatNode(), audioOutputsNode()] + audioTrackNodes),
                 ]),
             ])
@@ -191,10 +191,10 @@ enum XMLExporter {
             ])
         }
 
-        private func videoFormatNode() -> XMLNode {
+        private func videoFormatNode(width: Int, height: Int) -> XMLNode {
             el("format", [el("samplecharacteristics", [
-                leaf("width", seqWidth),
-                leaf("height", seqHeight),
+                leaf("width", width),
+                leaf("height", height),
                 bool("anamorphic", false),
                 leaf("pixelaspectratio", "square"),
                 leaf("fielddominance", "none"),
@@ -514,8 +514,9 @@ enum XMLExporter {
         private func sortEmittable(_ track: Track) -> [Clip] {
             track.clips
                 .filter { clip in
+                    // A frozen carrier trimmed past the child's current length would emit out < in.
                     clip.sourceClipType == .sequence
-                        ? (resolveTimeline(clip.mediaRef)?.totalFrames ?? 0) > 0
+                        ? clip.trimStartFrame < (resolveTimeline(clip.mediaRef)?.totalFrames ?? 0)
                         : resolver.resolveURL(for: clip.mediaRef) != nil
                 }
                 .sorted { $0.startFrame < $1.startFrame }

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -62,19 +62,9 @@ enum XMLExporter {
         timeline: Timeline, resolver: MediaResolver, resolveTimeline: (String) -> Timeline?
     ) async -> [String: SourceTimecode] {
         var mediaRefs: Set<String> = []
-        var queue = [timeline]
-        var visited: Set<String> = []
-        var i = 0
-        while i < queue.count {
-            let t = queue[i]
-            i += 1
-            guard visited.insert(t.id).inserted else { continue }
-            for clip in t.tracks.flatMap(\.clips) {
-                if clip.sourceClipType == .sequence {
-                    if let child = resolveTimeline(clip.mediaRef) { queue.append(child) }
-                } else {
-                    mediaRefs.insert(clip.mediaRef)
-                }
+        for t in [timeline] + timeline.reachableTimelines(resolve: resolveTimeline) {
+            for clip in t.tracks.flatMap(\.clips) where clip.sourceClipType != .sequence {
+                mediaRefs.insert(clip.mediaRef)
             }
         }
         return await SourceTimecodeReader.cache(mediaRefs: mediaRefs, urls: resolver.expectedURLMap())

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -17,7 +17,7 @@ enum EditAction {
         case .image: candidates = [.upscale, .edit, .rerun, .createVideo]
         case .video: candidates = [.upscale, .edit, .generateMusic, .generateSFX, .rerun]
         case .audio, .text: candidates = [.upscale, .edit, .rerun]
-        case .lottie: candidates = []
+        case .lottie, .sequence: candidates = []
         }
         return candidates.filter {
             $0.availability(for: asset, effectiveDurationOverride: effectiveDurationOverride).isAvailable
@@ -65,6 +65,8 @@ enum EditAction {
                 return .disabled(reason: "Edit doesn't support text")
             case .lottie:
                 return .disabled(reason: "Edit doesn't support Lottie")
+            case .sequence:
+                return .disabled(reason: "Edit doesn't support sequences")
             }
             if asset.isGenerating {
                 return .disabled(reason: "Generation in progress")

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter.swift
@@ -296,7 +296,7 @@ enum EditSubmitter {
         case .image:
             guard let m = ImageModelConfig.nanoBananaPro else { return nil }
             modelId = m.id
-        case .audio, .text, .lottie:
+        case .audio, .text, .lottie, .sequence:
             return nil
         }
         var stored = GenerationInput(prompt: "", model: modelId, duration: 0, aspectRatio: "", resolution: nil)

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -392,6 +392,7 @@ final class GenerationService {
             case .audio: return "audio/mpeg"
             case .text: return "application/octet-stream"
             case .lottie: return "application/json"
+            case .sequence: return "video/mp4"
             }
         }
     }

--- a/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
@@ -34,9 +34,11 @@ struct MusicGenerationSubmission {
         var videoURL: String?
         if mode == .videoToMusic {
             onPhase(.exporting)
+            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             let mp4 = try await TimelineRenderer.render(
                 timeline: editor.timeline,
                 resolver: editor.mediaResolver,
+                resolveTimeline: { timelinesById[$0] },
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: source.startFrame,
                 frameCount: source.frameCount,

--- a/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
@@ -34,11 +34,10 @@ struct MusicGenerationSubmission {
         var videoURL: String?
         if mode == .videoToMusic {
             onPhase(.exporting)
-            let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
             let mp4 = try await TimelineRenderer.render(
                 timeline: editor.timeline,
                 resolver: editor.mediaResolver,
-                resolveTimeline: { timelinesById[$0] },
+                resolveTimeline: editor.timelineResolver(),
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: source.startFrame,
                 frameCount: source.frameCount,

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -983,7 +983,7 @@ struct GenerationView: View {
             case .image: assets = refImages
             case .video: assets = refVideos
             case .audio: assets = refAudios
-            case .text, .lottie: assets = []
+            case .text, .lottie, .sequence: assets = []
             }
             let noun = tagNoun(for: type)
             return assets.enumerated().map {
@@ -997,7 +997,7 @@ struct GenerationView: View {
         case .image: videoModel.maxReferenceImages
         case .video: videoModel.maxReferenceVideos
         case .audio: videoModel.maxReferenceAudios
-        case .text, .lottie: 0
+        case .text, .lottie, .sequence: 0
         }
     }
 
@@ -1006,7 +1006,7 @@ struct GenerationView: View {
         case .image: refImages.count
         case .video: refVideos.count
         case .audio: refAudios.count
-        case .text, .lottie: 0
+        case .text, .lottie, .sequence: 0
         }
     }
 
@@ -1018,6 +1018,7 @@ struct GenerationView: View {
         case .audio: "Audio"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .sequence: "Sequence"
         }
     }
 
@@ -1033,7 +1034,7 @@ struct GenerationView: View {
         case .image: selection.imageRefs.append(asset)
         case .video: selection.videoRefs.append(asset)
         case .audio: selection.audioRefs.append(asset)
-        case .text, .lottie:
+        case .text, .lottie, .sequence:
             let supported = ClipType.allCases.filter { refCap(for: $0) > 0 }.map(\.rawValue).joined(separator: " and ")
             flashDropError("\(videoModel.displayName) only accepts \(supported) references.")
             return
@@ -1046,7 +1047,7 @@ struct GenerationView: View {
         case .image: refImages.append(asset)
         case .video: refVideos.append(asset)
         case .audio: refAudios.append(asset)
-        case .text, .lottie: break
+        case .text, .lottie, .sequence: break
         }
     }
 
@@ -1084,7 +1085,7 @@ struct GenerationView: View {
         case .image: refImages.removeAll { $0.id == id }
         case .video: refVideos.removeAll { $0.id == id }
         case .audio: refAudios.removeAll { $0.id == id }
-        case .text, .lottie: break
+        case .text, .lottie, .sequence: break
         }
     }
 
@@ -1097,7 +1098,7 @@ struct GenerationView: View {
     private var refCounterLabel: String {
         let total = totalRefCount
         if let cap = videoModel.maxTotalReferences {
-            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot" } }
+            let shortLabel: (ClipType) -> String = { switch $0 { case .image: "img"; case .video: "vid"; case .audio: "aud"; case .text: "txt"; case .lottie: "lot"; case .sequence: "seq" } }
             let parts = ClipType.allCases
                 .filter { refCap(for: $0) > 0 }
                 .map { "\(refCount(for: $0)) \(shortLabel($0))" }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -382,7 +382,7 @@ struct InspectorView: View {
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
                     transformSection(clips: clips)
-                    speedSection(clips: clips + selectedAudioClips)
+                    speedSection(clips: (clips + selectedAudioClips).filter { $0.sourceClipType != .sequence })
                         .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -394,7 +394,7 @@ struct InspectorView: View {
             }
         } else {
             transformSection(clips: clips)
-            speedSection(clips: clips + selectedAudioClips)
+            speedSection(clips: (clips + selectedAudioClips).filter { $0.sourceClipType != .sequence })
         }
 
         keyframesToggleBar(enabled: single != nil)

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -382,7 +382,7 @@ struct InspectorView: View {
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
                     transformSection(clips: clips)
-                    speedSection(clips: (clips + selectedAudioClips).filter { $0.sourceClipType != .sequence })
+                    speedSection(clips: (clips + selectedAudioClips).filter(\.supportsRetiming))
                         .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -394,7 +394,7 @@ struct InspectorView: View {
             }
         } else {
             transformSection(clips: clips)
-            speedSection(clips: (clips + selectedAudioClips).filter { $0.sourceClipType != .sequence })
+            speedSection(clips: (clips + selectedAudioClips).filter(\.supportsRetiming))
         }
 
         keyframesToggleBar(enabled: single != nil)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -191,7 +191,7 @@ struct AssetThumbnailView: View {
     @ViewBuilder
     private var durationOverlay: some View {
         if showsDurationBadge {
-            durationBadge.padding(AppTheme.Spacing.xs)
+            durationBadge
         }
     }
 
@@ -225,11 +225,8 @@ struct AssetThumbnailView: View {
     private var durationBadge: some View {
         Text(formatDuration(asset.duration))
             .font(.system(size: AppTheme.FontSize.xxs, weight: .medium))
-            .foregroundStyle(.white)
             .monospacedDigit()
-            .padding(.horizontal, AppTheme.Spacing.sm)
-            .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(.ultraThinMaterial, in: .capsule)
+            .tileBadge()
     }
 
     private func failedThumbnail(error: String) -> some View {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -6,8 +6,6 @@ struct AssetThumbnailView: View {
 
     @Environment(EditorViewModel.self) var editor
     @State private var isRenaming = false
-    @FocusState private var isRenameFieldFocused: Bool
-    @State private var renameDraft = ""
     @State private var isHovering = false
 
     var body: some View {
@@ -37,16 +35,16 @@ struct AssetThumbnailView: View {
 
             ZStack(alignment: .leading) {
                 if isRenaming {
-                    TextField("Name", text: $renameDraft)
-                        .font(.system(size: AppTheme.FontSize.xs))
-                        .textFieldStyle(.plain)
-                        .lineLimit(1)
-                        .focused($isRenameFieldFocused)
-                        .onSubmit { commitRename() }
-                        .onChange(of: isRenameFieldFocused) { _, focused in
-                            if !focused { commitRename() }
-                        }
-                        .onExitCommand { isRenaming = false }
+                    InlineRenameField(
+                        originalName: asset.name,
+                        placeholder: "Name",
+                        font: .system(size: AppTheme.FontSize.xs),
+                        onCommit: { name in
+                            editor.renameMediaAsset(id: asset.id, name: name)
+                            isRenaming = false
+                        },
+                        onCancel: { isRenaming = false }
+                    )
                 } else {
                     Text(asset.name)
                         .font(.system(size: AppTheme.FontSize.xs))
@@ -320,18 +318,7 @@ struct AssetThumbnailView: View {
     }
 
     private func beginRename() {
-        renameDraft = asset.name
         isRenaming = true
-        isRenameFieldFocused = true
-    }
-
-    private func commitRename() {
-        guard isRenaming else { return }
-        let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty && trimmed != asset.name {
-            editor.renameMediaAsset(id: asset.id, name: trimmed)
-        }
-        isRenaming = false
     }
 
     private func handleTap() {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
@@ -45,12 +45,8 @@ struct FolderTileView: View {
                 Spacer()
                 Text("\(childCount)")
                     .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
-                    .foregroundStyle(.white)
                     .monospacedDigit()
-                    .padding(.horizontal, AppTheme.Spacing.sm)
-                    .padding(.vertical, AppTheme.Spacing.xxs)
-                    .background(.ultraThinMaterial, in: .capsule)
-                    .padding(AppTheme.Spacing.xs)
+                    .tileBadge()
             }
             Spacer()
         }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
@@ -11,137 +11,48 @@ struct FolderTileView: View {
     let onCommitRename: (String) -> Void
     let onCancelRename: () -> Void
     let onDelete: () -> Void
-    let shouldAutoFocus: Bool
-    let onAutoFocusConsumed: () -> Void
-
-    @State private var renameDraft: String = ""
-    @FocusState private var isRenameFieldFocused: Bool
-    @State private var lastClickTime: Date?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
-            ZStack {
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
-                Image(systemName: "folder.fill")
-                    .font(.system(size: AppTheme.FontSize.display, weight: .light))
-                    .foregroundStyle(AppTheme.Accent.primary.opacity(0.85))
-                if childCount > 0 {
-                    VStack {
-                        HStack {
-                            Spacer()
-                            Text("\(childCount)")
-                                .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
-                                .foregroundStyle(.white)
-                                .monospacedDigit()
-                                .padding(.horizontal, AppTheme.Spacing.sm)
-                                .padding(.vertical, AppTheme.Spacing.xxs)
-                                .background(.ultraThinMaterial, in: .capsule)
-                                .padding(AppTheme.Spacing.xs)
-                        }
-                        Spacer()
-                    }
-                }
+        MediaTileScaffold(
+            name: folder.name,
+            isSelected: isSelected,
+            isDropHover: isDropHover,
+            isRenaming: $isRenaming,
+            onTap: onTap,
+            onOpen: onOpen,
+            onCommitRename: onCommitRename,
+            onCancelRename: onCancelRename
+        ) {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
+            Image(systemName: "folder.fill")
+                .font(.system(size: AppTheme.FontSize.display, weight: AppTheme.FontWeight.light))
+                .foregroundStyle(AppTheme.Accent.primary.opacity(0.85))
+            if childCount > 0 {
+                countBadge
             }
-            .aspectRatio(16.0 / 9.0, contentMode: .fit)
-            .overlay(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(
-                        borderColor,
-                        lineWidth: borderWidth
-                    )
-            )
-            .contentShape(Rectangle())
-
-            ZStack(alignment: .leading) {
-                if isRenaming {
-                    TextField("Folder", text: $renameDraft)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
-                        .textFieldStyle(.plain)
-                        .lineLimit(1)
-                        .focused($isRenameFieldFocused)
-                        .onSubmit { commit() }
-                        .onChange(of: isRenameFieldFocused) { _, focused in
-                            if !focused { commit() }
-                        }
-                        .onExitCommand { onCancelRename() }
-                } else {
-                    Text(folder.name)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .foregroundStyle(AppTheme.Text.primaryColor)
-                }
-            }
-            .padding(.horizontal, AppTheme.Spacing.xs)
-            .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
-            )
-        }
-        .frame(maxWidth: .infinity)
-        .contentShape(Rectangle())
-        .onTapGesture { handleClick() }
-        .contextMenu { contextMenuItems }
-        .onAppear {
-            if shouldAutoFocus {
-                renameDraft = folder.name
-                isRenameFieldFocused = true
-                onAutoFocusConsumed()
-            }
-        }
-        .onChange(of: isRenaming) { _, newValue in
-            if newValue {
-                renameDraft = folder.name
-                DispatchQueue.main.async { isRenameFieldFocused = true }
-            }
+        } menuItems: {
+            Button("Open") { onOpen() }
+            Button("Rename") { isRenaming = true }
+            Divider()
+            Button("Delete", role: .destructive) { onDelete() }
         }
     }
 
-    private var borderColor: Color {
-        if isDropHover { return AppTheme.Accent.primary.opacity(0.8) }
-        if isSelected { return AppTheme.Accent.primary }
-        return Color.clear
-    }
-
-    private var borderWidth: CGFloat {
-        if isDropHover { return AppTheme.BorderWidth.thick }
-        if isSelected { return AppTheme.BorderWidth.thick }
-        return 0
-    }
-
-    @ViewBuilder
-    private var contextMenuItems: some View {
-        Button("Open") { onOpen() }
-        Button("Rename") { beginRename() }
-        Divider()
-        Button("Delete", role: .destructive) { onDelete() }
-    }
-
-    private func beginRename() {
-        renameDraft = folder.name
-        isRenaming = true
-    }
-
-    private func handleClick() {
-        let now = Date()
-        if let last = lastClickTime, now.timeIntervalSince(last) < NSEvent.doubleClickInterval {
-            onOpen()
-            lastClickTime = nil
-        } else {
-            onTap()
-            lastClickTime = now
-        }
-    }
-
-    private func commit() {
-        guard isRenaming else { return }
-        let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty || trimmed == folder.name {
-            onCancelRename()
-        } else {
-            onCommitRename(trimmed)
+    private var countBadge: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Text("\(childCount)")
+                    .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(.white)
+                    .monospacedDigit()
+                    .padding(.horizontal, AppTheme.Spacing.sm)
+                    .padding(.vertical, AppTheme.Spacing.xxs)
+                    .background(.ultraThinMaterial, in: .capsule)
+                    .padding(AppTheme.Spacing.xs)
+            }
+            Spacer()
         }
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
@@ -27,7 +27,7 @@ struct FolderTileView: View {
                 .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
             Image(systemName: "folder.fill")
                 .font(.system(size: AppTheme.FontSize.display, weight: AppTheme.FontWeight.light))
-                .foregroundStyle(AppTheme.Accent.primary.opacity(0.85))
+                .foregroundStyle(AppTheme.Accent.primary.opacity(AppTheme.Opacity.prominent))
             if childCount > 0 {
                 countBadge
             }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 extension MediaTab {
     static let folderDragScheme = "palmier-folder://"
     static let assetDragScheme = "palmier-asset://"
+    static let timelineDragScheme = "palmier-timeline://"
 
     static func folderDragString(forFolderId id: String) -> String {
         folderDragScheme + id
@@ -14,6 +15,14 @@ extension MediaTab {
 
     static func folderId(fromDragString line: String) -> String? {
         line.hasPrefix(folderDragScheme) ? String(line.dropFirst(folderDragScheme.count)) : nil
+    }
+
+    static func timelineDragString(forTimelineId id: String) -> String {
+        timelineDragScheme + id
+    }
+
+    static func timelineId(fromDragString line: String) -> String? {
+        line.hasPrefix(timelineDragScheme) ? String(line.dropFirst(timelineDragScheme.count)) : nil
     }
 
     static func assetDragString(forAssetId id: String) -> String {
@@ -164,9 +173,13 @@ extension MediaTab {
     static func resolveTextDrop(_ text: String, into destFolderId: String?, editor: EditorViewModel) {
         var assetIds: Set<String> = []
         var folderIds: Set<String> = []
+        var timelineIds: Set<String> = []
         for line in text.split(separator: "\n").map(String.init) where !line.isEmpty {
             if let folderId = folderId(fromDragString: line) {
                 folderIds.insert(folderId)
+            } else if let timelineId = timelineId(fromDragString: line),
+                      editor.timeline(for: timelineId) != nil {
+                timelineIds.insert(timelineId)
             } else if let id = assetId(fromDragString: line),
                       editor.mediaAssets.contains(where: { $0.id == id }) {
                 assetIds.insert(id)
@@ -177,6 +190,9 @@ extension MediaTab {
         }
         if !folderIds.isEmpty {
             editor.moveFoldersToFolder(folderIds: folderIds, parentFolderId: destFolderId)
+        }
+        if !timelineIds.isEmpty {
+            editor.moveTimelinesToFolder(timelineIds: timelineIds, folderId: destFolderId)
         }
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -153,19 +153,20 @@ extension MediaTab {
 
 extension MediaTab {
     var flatGridView: some View {
-        let assets = sortAndFilter(editor.mediaAssets)
-        let orderedIds = assets.map(\.id)
+        var cells = searchFilteredTimelines(editor.timelines).map { MediaCell(kind: .timeline($0)) }
+        cells.append(contentsOf: sortAndFilter(editor.mediaAssets).map { MediaCell(kind: .asset($0)) })
+        let orderedIds = cells.map(\.id)
         return GeometryReader { geo in
             let dims = gridDimensions(width: geo.size.width)
             gridScroll(
-                cells: assets,
+                cells: cells,
                 orderedIds: orderedIds,
                 cols: dims.cols,
                 tileWidth: dims.tileWidth,
                 spacing: dims.spacing,
                 topPadding: AppTheme.Spacing.sm
-            ) { asset in
-                assetCellView(for: asset)
+            ) { cell in
+                cellView(for: cell)
             }
         }
     }
@@ -184,8 +185,12 @@ extension MediaTab {
         let allFolders = editor.folders
             .map { ($0, editor.folderPath(for: $0.id).map(\.name).joined(separator: " / ")) }
             .sorted { $0.1.localizedCaseInsensitiveCompare($1.1) == .orderedAscending }
-        var orderedIds = collapsedGroupedKeys.contains("") ? [] : rootAssets.map(\.id)
+        var orderedIds: [String] = []
+        if !collapsedGroupedKeys.contains("") {
+            orderedIds = filteredTimelines(in: nil).map { MediaPanelItemKey.timeline($0.id) } + rootAssets.map(\.id)
+        }
         for (folder, _) in allFolders where !collapsedGroupedKeys.contains(folder.id) {
+            orderedIds.append(contentsOf: filteredTimelines(in: folder.id).map { MediaPanelItemKey.timeline($0.id) })
             orderedIds.append(contentsOf: sortAndFilter(bucketed[folder.id] ?? []).map(\.id))
         }
         return GeometryReader { geo in
@@ -193,21 +198,23 @@ extension MediaTab {
             ScrollViewReader { proxy in
                 ScrollView(showsIndicators: false) {
                     LazyVStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
-                        if !rootAssets.isEmpty {
+                        let rootTimelines = filteredTimelines(in: nil)
+                        if !rootAssets.isEmpty || !rootTimelines.isEmpty {
                             groupedSection(
                                 title: "Library",
                                 folderId: nil,
+                                timelines: rootTimelines,
                                 assets: rootAssets,
                                 tileWidth: dims.tileWidth,
                                 spacing: dims.spacing
                             )
                         }
                         ForEach(allFolders, id: \.0.id) { folder, path in
-                            let assets = sortAndFilter(bucketed[folder.id] ?? [])
                             groupedSection(
                                 title: path,
                                 folderId: folder.id,
-                                assets: assets,
+                                timelines: filteredTimelines(in: folder.id),
+                                assets: sortAndFilter(bucketed[folder.id] ?? []),
                                 tileWidth: dims.tileWidth,
                                 spacing: dims.spacing
                             )
@@ -240,6 +247,7 @@ extension MediaTab {
     fileprivate func groupedSection(
         title: String,
         folderId: String?,
+        timelines: [Timeline],
         assets: [MediaAsset],
         tileWidth: CGFloat,
         spacing: CGFloat
@@ -298,7 +306,7 @@ extension MediaTab {
                 } else {
                     groupedSectionTitle(title)
                 }
-                Text("\(assets.count)")
+                Text("\(timelines.count + assets.count)")
                     .font(.system(size: AppTheme.FontSize.xs))
                     .foregroundStyle(AppTheme.Text.mutedColor)
                     .monospacedDigit()
@@ -310,7 +318,7 @@ extension MediaTab {
                     .fill(AppTheme.Border.subtleColor)
                     .frame(height: 0.5)
 
-                if assets.isEmpty {
+                if assets.isEmpty && timelines.isEmpty {
                     Text("Empty")
                         .font(.system(size: AppTheme.FontSize.xs))
                         .foregroundStyle(AppTheme.Text.mutedColor)
@@ -318,6 +326,12 @@ extension MediaTab {
                 } else {
                     let columns = [GridItem(.adaptive(minimum: thumbnailSize), spacing: spacing)]
                     LazyVGrid(columns: columns, alignment: .leading, spacing: spacing) {
+                        ForEach(timelines) { timeline in
+                            timelineTile(timeline)
+                                .background(assetFrameReader(for: MediaPanelItemKey.timeline(timeline.id)))
+                                .frame(width: tileWidth)
+                                .id(MediaPanelItemKey.timeline(timeline.id))
+                        }
                         ForEach(assets) { asset in
                             assetCellView(for: asset)
                                 .frame(width: tileWidth)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -5,12 +5,13 @@ import UniformTypeIdentifiers
 
 extension MediaTab {
     struct MediaCell: Identifiable {
-        enum Kind { case folder(MediaFolder), asset(MediaAsset) }
+        enum Kind { case folder(MediaFolder), timeline(Timeline), asset(MediaAsset) }
         let kind: Kind
 
         var id: String {
             switch kind {
             case .folder(let f): return MediaPanelItemKey.folder(f.id)
+            case .timeline(let t): return MediaPanelItemKey.timeline(t.id)
             case .asset(let a): return a.id
             }
         }
@@ -53,6 +54,9 @@ extension MediaTab {
         for folder in subfoldersInCurrentFolder {
             cells.append(MediaCell(kind: .folder(folder)))
         }
+        for timeline in timelinesInCurrentFolder {
+            cells.append(MediaCell(kind: .timeline(timeline)))
+        }
         for asset in assetsInCurrentFolder {
             cells.append(MediaCell(kind: .asset(asset)))
         }
@@ -66,6 +70,7 @@ extension MediaTab {
     func clearSelections() {
         if !editor.selectedMediaAssetIds.isEmpty { editor.selectedMediaAssetIds.removeAll() }
         if !editor.selectedFolderIds.isEmpty { editor.selectedFolderIds.removeAll() }
+        if !editor.selectedTimelineIds.isEmpty { editor.selectedTimelineIds.removeAll() }
     }
 
     func publishOrderedIds(_ ids: [String]) {
@@ -387,8 +392,63 @@ extension MediaTab {
         case .folder(let folder):
             folderTile(folder)
                 .background(assetFrameReader(for: cell.id))
+        case .timeline(let timeline):
+            timelineTile(timeline)
+                .background(assetFrameReader(for: cell.id))
         case .asset(let asset):
             assetCellView(for: asset)
+        }
+    }
+
+    fileprivate func timelineTile(_ timeline: Timeline) -> some View {
+        TimelineTileView(
+            timeline: timeline,
+            posterImage: timelinePoster(timeline),
+            isSelected: editor.selectedTimelineIds.contains(timeline.id),
+            isActive: editor.activeTimelineId == timeline.id,
+            canDelete: editor.timelines.count > 1,
+            isRenaming: Binding(
+                get: { renamingTimelineId == timeline.id },
+                set: { renamingTimelineId = $0 ? timeline.id : nil }
+            ),
+            onTap: { handleTimelineTap(timeline) },
+            onOpen: { editor.activateTimeline(timeline.id) },
+            onCommitRename: { newName in
+                editor.renameTimeline(timeline.id, to: newName)
+                renamingTimelineId = nil
+            },
+            onCancelRename: { renamingTimelineId = nil },
+            onDuplicate: { editor.duplicateTimeline(timeline.id) },
+            onDelete: { editor.deleteTimeline(timeline.id) }
+        )
+        .draggable(MediaTab.timelineDragString(forTimelineId: timeline.id)) {
+            TimelineDragPreview(name: timeline.name)
+        }
+    }
+
+    /// First visual clip's cached asset thumbnail — no dedicated timeline render.
+    fileprivate func timelinePoster(_ timeline: Timeline) -> NSImage? {
+        for track in timeline.tracks where track.type == .video {
+            for clip in track.clips where clip.mediaType == .video || clip.mediaType == .image {
+                if let thumb = editor.mediaAssets.first(where: { $0.id == clip.mediaRef })?.thumbnail {
+                    return thumb
+                }
+            }
+        }
+        return nil
+    }
+
+    fileprivate func handleTimelineTap(_ timeline: Timeline) {
+        if NSEvent.modifierFlags.contains(.shift) {
+            if editor.selectedTimelineIds.contains(timeline.id) {
+                editor.selectedTimelineIds.remove(timeline.id)
+            } else {
+                editor.selectedTimelineIds.insert(timeline.id)
+            }
+        } else {
+            editor.selectedTimelineIds = [timeline.id]
+            editor.selectedMediaAssetIds.removeAll()
+            editor.selectedFolderIds.removeAll()
         }
     }
 
@@ -439,6 +499,7 @@ extension MediaTab {
         } else {
             editor.selectedFolderIds = [folder.id]
             editor.selectedMediaAssetIds.removeAll()
+            editor.selectedTimelineIds.removeAll()
         }
     }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -439,16 +439,24 @@ extension MediaTab {
     }
 
     fileprivate func handleTimelineTap(_ timeline: Timeline) {
+        handleTileTap(timeline.id, select: \.selectedTimelineIds,
+                      clearing: [\.selectedMediaAssetIds, \.selectedFolderIds])
+    }
+
+    fileprivate func handleTileTap(
+        _ id: String,
+        select selection: ReferenceWritableKeyPath<EditorViewModel, Set<String>>,
+        clearing others: [ReferenceWritableKeyPath<EditorViewModel, Set<String>>]
+    ) {
         if NSEvent.modifierFlags.contains(.shift) {
-            if editor.selectedTimelineIds.contains(timeline.id) {
-                editor.selectedTimelineIds.remove(timeline.id)
+            if editor[keyPath: selection].contains(id) {
+                editor[keyPath: selection].remove(id)
             } else {
-                editor.selectedTimelineIds.insert(timeline.id)
+                editor[keyPath: selection].insert(id)
             }
         } else {
-            editor.selectedTimelineIds = [timeline.id]
-            editor.selectedMediaAssetIds.removeAll()
-            editor.selectedFolderIds.removeAll()
+            editor[keyPath: selection] = [id]
+            for other in others { editor[keyPath: other].removeAll() }
         }
     }
 
@@ -487,18 +495,8 @@ extension MediaTab {
     }
 
     fileprivate func handleFolderTap(_ folder: MediaFolder) {
-        let shift = NSEvent.modifierFlags.contains(.shift)
-        if shift {
-            if editor.selectedFolderIds.contains(folder.id) {
-                editor.selectedFolderIds.remove(folder.id)
-            } else {
-                editor.selectedFolderIds.insert(folder.id)
-            }
-        } else {
-            editor.selectedFolderIds = [folder.id]
-            editor.selectedMediaAssetIds.removeAll()
-            editor.selectedTimelineIds.removeAll()
-        }
+        handleTileTap(folder.id, select: \.selectedFolderIds,
+                      clearing: [\.selectedMediaAssetIds, \.selectedTimelineIds])
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -422,7 +422,7 @@ extension MediaTab {
             onDelete: { editor.deleteTimeline(timeline.id) }
         )
         .draggable(MediaTab.timelineDragString(forTimelineId: timeline.id)) {
-            TimelineDragPreview(name: timeline.name)
+            TileDragPreview(icon: "film.stack", name: timeline.name)
         }
     }
 
@@ -474,12 +474,10 @@ extension MediaTab {
                     renamingFolderId = nil
                 },
                 onCancelRename: { renamingFolderId = nil },
-                onDelete: { editor.deleteFolders(ids: [folder.id]) },
-                shouldAutoFocus: pendingFolderFocusId == folder.id,
-                onAutoFocusConsumed: { pendingFolderFocusId = nil }
+                onDelete: { editor.deleteFolders(ids: [folder.id]) }
             )
             .draggable(MediaTab.folderDragString(forFolderId: folder.id)) {
-                FolderDragPreview(name: folder.name)
+                TileDragPreview(icon: "folder.fill", name: folder.name)
             }
         }
         .onDrop(of: [.fileURL, .text], isTargeted: dropHover) { providers in
@@ -512,7 +510,6 @@ extension MediaTab {
             Button("New Folder") {
                 let id = editor.createFolder(name: "New Folder", in: currentFolderId)
                 editor.moveAssetsToFolder(assetIds: targetIds, folderId: id)
-                pendingFolderFocusId = id
                 renamingFolderId = id
             }
             if currentFolderId != nil || targetIds.contains(where: { id in editor.mediaAssets.first(where: { $0.id == id })?.folderId != nil }) {
@@ -548,11 +545,12 @@ struct AssetFramePreferenceKey: PreferenceKey {
     }
 }
 
-private struct FolderDragPreview: View {
+private struct TileDragPreview: View {
+    let icon: String
     let name: String
     var body: some View {
         HStack(spacing: AppTheme.Spacing.xs) {
-            Image(systemName: "folder.fill")
+            Image(systemName: icon)
                 .foregroundStyle(AppTheme.Accent.primary)
             Text(name)
                 .font(.system(size: AppTheme.FontSize.sm, weight: .medium))

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -481,7 +481,14 @@ struct MediaTab: View {
     }
 
     var timelinesInCurrentFolder: [Timeline] {
-        let timelines = editor.timelines.filter { $0.folderId == currentFolderId }
+        filteredTimelines(in: currentFolderId)
+    }
+
+    func filteredTimelines(in folderId: String?) -> [Timeline] {
+        searchFilteredTimelines(editor.timelines.filter { $0.folderId == folderId })
+    }
+
+    func searchFilteredTimelines(_ timelines: [Timeline]) -> [Timeline] {
         let q = searchQuery.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return timelines }
         return timelines.filter { $0.name.localizedCaseInsensitiveContains(q) }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -16,6 +16,7 @@ struct MediaTab: View {
     @State var currentFolderId: String? = nil
     @State var folderReturnViewMode: ViewMode?
     @State var renamingFolderId: String?
+    @State var renamingTimelineId: String?
     @State var pendingFolderFocusId: String?
     @State var dropTargetFolderId: String?
     /// Hovered grouped-section key; "" = root.
@@ -481,6 +482,13 @@ struct MediaTab: View {
         return folders.filter { $0.name.localizedCaseInsensitiveContains(q) }
     }
 
+    var timelinesInCurrentFolder: [Timeline] {
+        let timelines = editor.timelines.filter { $0.folderId == currentFolderId }
+        let q = searchQuery.trimmingCharacters(in: .whitespaces)
+        guard !q.isEmpty else { return timelines }
+        return timelines.filter { $0.name.localizedCaseInsensitiveContains(q) }
+    }
+
     private func passesFilters(_ asset: MediaAsset) -> Bool {
         let typeOk = filterTypes.isEmpty || filterTypes.contains(asset.type)
         let aiOk = !filterAI || asset.isGenerated
@@ -500,7 +508,7 @@ struct MediaTab: View {
     }
 
     private var currentFolderItemCount: Int {
-        subfoldersInCurrentFolder.count + assetsInCurrentFolder.count
+        subfoldersInCurrentFolder.count + timelinesInCurrentFolder.count + assetsInCurrentFolder.count
     }
 
     // MARK: - Toolbar helpers
@@ -661,7 +669,8 @@ struct MediaTab: View {
                     let extending = NSEvent.modifierFlags.contains(.shift)
                     marqueeSelection.begin(
                         baseAssets: extending ? editor.selectedMediaAssetIds : [],
-                        baseFolders: extending ? editor.selectedFolderIds : []
+                        baseFolders: extending ? editor.selectedFolderIds : [],
+                        baseTimelines: extending ? editor.selectedTimelineIds : []
                     )
                 }
 
@@ -669,11 +678,14 @@ struct MediaTab: View {
                 marqueeSelection.rect = rect
                 var assetIds = marqueeSelection.baseAssets
                 var folderIds = marqueeSelection.baseFolders
+                var timelineIds = marqueeSelection.baseTimelines
 
-                // Frame keys are either raw asset ids or "folder-<id>".
+                // Frame keys are raw asset ids, "folder-<id>", or "timeline-<id>".
                 for (id, frame) in assetFrames where rect.intersects(frame) {
                     if let folderId = MediaCell.folderId(fromFrameKey: id) {
                         folderIds.insert(folderId)
+                    } else if let timelineId = MediaPanelItemKey.timelineId(from: id) {
+                        timelineIds.insert(timelineId)
                     } else {
                         assetIds.insert(id)
                     }
@@ -684,6 +696,9 @@ struct MediaTab: View {
                 }
                 if folderIds != editor.selectedFolderIds {
                     editor.selectedFolderIds = folderIds
+                }
+                if timelineIds != editor.selectedTimelineIds {
+                    editor.selectedTimelineIds = timelineIds
                 }
             }
             .onEnded { _ in
@@ -779,11 +794,13 @@ struct MarqueeSelection {
     var isActive = false
     var baseAssets: Set<String> = []
     var baseFolders: Set<String> = []
+    var baseTimelines: Set<String> = []
 
-    mutating func begin(baseAssets: Set<String>, baseFolders: Set<String>) {
+    mutating func begin(baseAssets: Set<String>, baseFolders: Set<String>, baseTimelines: Set<String>) {
         isActive = true
         self.baseAssets = baseAssets
         self.baseFolders = baseFolders
+        self.baseTimelines = baseTimelines
     }
 
     mutating func reset() {
@@ -791,6 +808,7 @@ struct MarqueeSelection {
         isActive = false
         baseAssets = []
         baseFolders = []
+        baseTimelines = []
     }
 }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -17,7 +17,6 @@ struct MediaTab: View {
     @State var folderReturnViewMode: ViewMode?
     @State var renamingFolderId: String?
     @State var renamingTimelineId: String?
-    @State var pendingFolderFocusId: String?
     @State var dropTargetFolderId: String?
     /// Hovered grouped-section key; "" = root.
     @State var dropTargetGroupedKey: String?
@@ -224,7 +223,6 @@ struct MediaTab: View {
     private func pruneStaleFolderState() {
         if let id = currentFolderId, editor.folder(id: id) == nil { navigateToFolder(nil) }
         if let id = renamingFolderId, editor.folder(id: id) == nil { renamingFolderId = nil }
-        if let id = pendingFolderFocusId, editor.folder(id: id) == nil { pendingFolderFocusId = nil }
         if let id = dropTargetFolderId, editor.folder(id: id) == nil { dropTargetFolderId = nil }
     }
 
@@ -636,7 +634,6 @@ struct MediaTab: View {
 
     private func createNewFolderInCurrent() {
         let id = editor.createFolder(name: "New Folder", in: currentFolderId)
-        pendingFolderFocusId = id
         renamingFolderId = id
     }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
@@ -86,3 +86,13 @@ struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
         }
     }
 }
+
+extension View {
+    func tileBadge() -> some View {
+        foregroundStyle(.white)
+            .padding(.horizontal, AppTheme.Spacing.sm)
+            .padding(.vertical, AppTheme.Spacing.xxs)
+            .background(.ultraThinMaterial, in: .capsule)
+            .padding(AppTheme.Spacing.xs)
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// Shared chrome for grid tiles: 16:9 artwork, selection border, name row with
-/// inline rename, single/double-click, context menu.
+/// Shared grid-tile chrome: artwork, selection border, name row with rename, clicks, context menu.
 struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
     let name: String
     let isSelected: Bool
@@ -66,7 +65,7 @@ struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
     }
 
     private var borderColor: Color {
-        if isDropHover { return AppTheme.Accent.primary.opacity(0.8) }
+        if isDropHover { return AppTheme.Accent.primary.opacity(AppTheme.Opacity.prominent) }
         if isSelected { return AppTheme.Accent.primary }
         return Color.clear
     }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Shared chrome for grid tiles: 16:9 artwork, selection border, name row with
+/// inline rename, single/double-click, context menu.
+struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
+    let name: String
+    let isSelected: Bool
+    var isDropHover: Bool = false
+    var showsActiveDot: Bool = false
+    @Binding var isRenaming: Bool
+    let onTap: () -> Void
+    let onOpen: () -> Void
+    let onCommitRename: (String) -> Void
+    let onCancelRename: () -> Void
+    @ViewBuilder let artwork: () -> Artwork
+    @ViewBuilder let menuItems: () -> MenuItems
+
+    @State private var lastClickTime: Date?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            ZStack { artwork() }
+                .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .strokeBorder(borderColor, lineWidth: borderWidth)
+                )
+                .contentShape(Rectangle())
+
+            nameRow
+                .padding(.horizontal, AppTheme.Spacing.xs)
+                .padding(.vertical, AppTheme.Spacing.xxs)
+                .background(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                        .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                )
+        }
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture { handleClick() }
+        .contextMenu { menuItems() }
+    }
+
+    @ViewBuilder
+    private var nameRow: some View {
+        if isRenaming {
+            InlineRenameField(
+                originalName: name,
+                onCommit: onCommitRename,
+                onCancel: onCancelRename
+            )
+        } else {
+            HStack(spacing: AppTheme.Spacing.xs) {
+                if showsActiveDot {
+                    Circle()
+                        .fill(AppTheme.Accent.primary)
+                        .frame(width: AppTheme.Spacing.xs, height: AppTheme.Spacing.xs)
+                }
+                Text(name)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+            }
+        }
+    }
+
+    private var borderColor: Color {
+        if isDropHover { return AppTheme.Accent.primary.opacity(0.8) }
+        if isSelected { return AppTheme.Accent.primary }
+        return Color.clear
+    }
+
+    private var borderWidth: CGFloat {
+        isDropHover || isSelected ? AppTheme.BorderWidth.thick : 0
+    }
+
+    private func handleClick() {
+        let now = Date()
+        if let last = lastClickTime, now.timeIntervalSince(last) < NSEvent.doubleClickInterval {
+            onOpen()
+            lastClickTime = nil
+        } else {
+            onTap()
+            lastClickTime = now
+        }
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct TimelineTileView: View {
+    let timeline: Timeline
+    let posterImage: NSImage?
+    let isSelected: Bool
+    let isActive: Bool
+    let canDelete: Bool
+    @Binding var isRenaming: Bool
+    let onTap: () -> Void
+    let onOpen: () -> Void
+    let onCommitRename: (String) -> Void
+    let onCancelRename: () -> Void
+    let onDuplicate: () -> Void
+    let onDelete: () -> Void
+
+    @State private var renameDraft: String = ""
+    @FocusState private var isRenameFieldFocused: Bool
+    @State private var lastClickTime: Date?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+            ZStack {
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                    .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
+                if let posterImage {
+                    GeometryReader { geo in
+                        Image(nsImage: posterImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .clipped()
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
+                } else {
+                    Image(systemName: "film.stack")
+                        .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.light))
+                        .foregroundStyle(AppTheme.Text.mutedColor)
+                }
+                if timeline.totalFrames > 0 {
+                    durationBadge
+                }
+                if posterImage != nil {
+                    timelineBadge
+                }
+            }
+            .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                    .strokeBorder(isSelected ? AppTheme.Accent.primary : Color.clear, lineWidth: AppTheme.BorderWidth.thick)
+            )
+            .contentShape(Rectangle())
+
+            ZStack(alignment: .leading) {
+                if isRenaming {
+                    TextField("Timeline", text: $renameDraft)
+                        .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                        .textFieldStyle(.plain)
+                        .lineLimit(1)
+                        .focused($isRenameFieldFocused)
+                        .onSubmit { commit() }
+                        .onChange(of: isRenameFieldFocused) { _, focused in
+                            if !focused { commit() }
+                        }
+                        .onExitCommand { onCancelRename() }
+                } else {
+                    HStack(spacing: AppTheme.Spacing.xs) {
+                        if isActive {
+                            Circle()
+                                .fill(AppTheme.Accent.primary)
+                                .frame(width: AppTheme.Spacing.xs, height: AppTheme.Spacing.xs)
+                        }
+                        Text(timeline.name)
+                            .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .foregroundStyle(AppTheme.Text.primaryColor)
+                    }
+                }
+            }
+            .padding(.horizontal, AppTheme.Spacing.xs)
+            .padding(.vertical, AppTheme.Spacing.xxs)
+            .background(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                    .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture { handleClick() }
+        .contextMenu {
+            Button("Open") { onOpen() }
+            Button("Rename") { beginRename() }
+            Button("Duplicate") { onDuplicate() }
+            Divider()
+            Button("Delete", role: .destructive) { onDelete() }
+                .disabled(!canDelete)
+        }
+        .onChange(of: isRenaming) { _, newValue in
+            if newValue {
+                renameDraft = timeline.name
+                DispatchQueue.main.async { isRenameFieldFocused = true }
+            }
+        }
+    }
+
+    // Matches AssetThumbnailView: type badge top-leading, duration bottom-trailing.
+    private var timelineBadge: some View {
+        VStack {
+            HStack {
+                Image(systemName: "film.stack")
+                    .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(isActive ? AppTheme.Accent.primary : .white)
+                    .padding(AppTheme.Spacing.xxs + AppTheme.Spacing.xxs)
+                    .background(.ultraThinMaterial, in: .capsule)
+                    .padding(AppTheme.Spacing.xs)
+                Spacer()
+            }
+            Spacer()
+        }
+    }
+
+    private var durationBadge: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                Text(formatTimecode(frame: timeline.totalFrames, fps: timeline.fps))
+                    .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(.white)
+                    .monospacedDigit()
+                    .padding(.horizontal, AppTheme.Spacing.sm)
+                    .padding(.vertical, AppTheme.Spacing.xxs)
+                    .background(.ultraThinMaterial, in: .capsule)
+                    .padding(AppTheme.Spacing.xs)
+            }
+        }
+    }
+
+    private func beginRename() {
+        renameDraft = timeline.name
+        isRenaming = true
+    }
+
+    private func handleClick() {
+        let now = Date()
+        if let last = lastClickTime, now.timeIntervalSince(last) < NSEvent.doubleClickInterval {
+            onOpen()
+            lastClickTime = nil
+        } else {
+            onTap()
+            lastClickTime = now
+        }
+    }
+
+    private func commit() {
+        guard isRenaming else { return }
+        let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == timeline.name {
+            onCancelRename()
+        } else {
+            onCommitRename(trimmed)
+        }
+    }
+}
+
+struct TimelineDragPreview: View {
+    let name: String
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            Image(systemName: "film.stack")
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Accent.primary)
+            Text(name)
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .padding(.vertical, AppTheme.Spacing.xs)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
@@ -63,10 +63,8 @@ struct TimelineTileView: View {
             HStack {
                 Image(systemName: "film.stack")
                     .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
+                    .tileBadge()
                     .foregroundStyle(isActive ? AppTheme.Accent.primary : .white)
-                    .padding(AppTheme.Spacing.xxs + AppTheme.Spacing.xxs)
-                    .background(.ultraThinMaterial, in: .capsule)
-                    .padding(AppTheme.Spacing.xs)
                 Spacer()
             }
             Spacer()
@@ -80,12 +78,8 @@ struct TimelineTileView: View {
                 Spacer()
                 Text(formatTimecode(frame: timeline.totalFrames, fps: timeline.fps))
                     .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.medium))
-                    .foregroundStyle(.white)
                     .monospacedDigit()
-                    .padding(.horizontal, AppTheme.Spacing.sm)
-                    .padding(.vertical, AppTheme.Spacing.xxs)
-                    .background(.ultraThinMaterial, in: .capsule)
-                    .padding(AppTheme.Spacing.xs)
+                    .tileBadge()
             }
         }
     }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
@@ -14,93 +14,46 @@ struct TimelineTileView: View {
     let onDuplicate: () -> Void
     let onDelete: () -> Void
 
-    @State private var renameDraft: String = ""
-    @FocusState private var isRenameFieldFocused: Bool
-    @State private var lastClickTime: Date?
-
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
-            ZStack {
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
-                if let posterImage {
-                    GeometryReader { geo in
-                        Image(nsImage: posterImage)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: geo.size.width, height: geo.size.height)
-                            .clipped()
-                    }
-                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
-                } else {
-                    Image(systemName: "film.stack")
-                        .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.light))
-                        .foregroundStyle(AppTheme.Text.mutedColor)
+        MediaTileScaffold(
+            name: timeline.name,
+            isSelected: isSelected,
+            showsActiveDot: isActive,
+            isRenaming: $isRenaming,
+            onTap: onTap,
+            onOpen: onOpen,
+            onCommitRename: onCommitRename,
+            onCancelRename: onCancelRename
+        ) {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
+            if let posterImage {
+                GeometryReader { geo in
+                    Image(nsImage: posterImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .clipped()
                 }
-                if timeline.totalFrames > 0 {
-                    durationBadge
-                }
-                if posterImage != nil {
-                    timelineBadge
-                }
+                .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
+            } else {
+                Image(systemName: "film.stack")
+                    .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.light))
+                    .foregroundStyle(AppTheme.Text.mutedColor)
             }
-            .aspectRatio(16.0 / 9.0, contentMode: .fit)
-            .overlay(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(isSelected ? AppTheme.Accent.primary : Color.clear, lineWidth: AppTheme.BorderWidth.thick)
-            )
-            .contentShape(Rectangle())
-
-            ZStack(alignment: .leading) {
-                if isRenaming {
-                    TextField("Timeline", text: $renameDraft)
-                        .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
-                        .textFieldStyle(.plain)
-                        .lineLimit(1)
-                        .focused($isRenameFieldFocused)
-                        .onSubmit { commit() }
-                        .onChange(of: isRenameFieldFocused) { _, focused in
-                            if !focused { commit() }
-                        }
-                        .onExitCommand { onCancelRename() }
-                } else {
-                    HStack(spacing: AppTheme.Spacing.xs) {
-                        if isActive {
-                            Circle()
-                                .fill(AppTheme.Accent.primary)
-                                .frame(width: AppTheme.Spacing.xs, height: AppTheme.Spacing.xs)
-                        }
-                        Text(timeline.name)
-                            .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                            .foregroundStyle(AppTheme.Text.primaryColor)
-                    }
-                }
+            if timeline.totalFrames > 0 {
+                durationBadge
             }
-            .padding(.horizontal, AppTheme.Spacing.xs)
-            .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
-            )
-        }
-        .frame(maxWidth: .infinity)
-        .contentShape(Rectangle())
-        .onTapGesture { handleClick() }
-        .contextMenu {
+            if posterImage != nil {
+                timelineBadge
+            }
+        } menuItems: {
             Button("Open") { onOpen() }
-            Button("Rename") { beginRename() }
+            Button("Rename") { isRenaming = true }
             Button("Duplicate") { onDuplicate() }
             Divider()
             Button("Delete", role: .destructive) { onDelete() }
                 .disabled(!canDelete)
-        }
-        .onChange(of: isRenaming) { _, newValue in
-            if newValue {
-                renameDraft = timeline.name
-                DispatchQueue.main.async { isRenameFieldFocused = true }
-            }
         }
     }
 
@@ -135,49 +88,5 @@ struct TimelineTileView: View {
                     .padding(AppTheme.Spacing.xs)
             }
         }
-    }
-
-    private func beginRename() {
-        renameDraft = timeline.name
-        isRenaming = true
-    }
-
-    private func handleClick() {
-        let now = Date()
-        if let last = lastClickTime, now.timeIntervalSince(last) < NSEvent.doubleClickInterval {
-            onOpen()
-            lastClickTime = nil
-        } else {
-            onTap()
-            lastClickTime = now
-        }
-    }
-
-    private func commit() {
-        guard isRenaming else { return }
-        let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty || trimmed == timeline.name {
-            onCancelRename()
-        } else {
-            onCommitRename(trimmed)
-        }
-    }
-}
-
-struct TimelineDragPreview: View {
-    let name: String
-
-    var body: some View {
-        HStack(spacing: AppTheme.Spacing.xs) {
-            Image(systemName: "film.stack")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Accent.primary)
-            Text(name)
-                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
-                .lineLimit(1)
-        }
-        .padding(.horizontal, AppTheme.Spacing.sm)
-        .padding(.vertical, AppTheme.Spacing.xs)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
     }
 }

--- a/Sources/PalmierPro/Models/ClipType.swift
+++ b/Sources/PalmierPro/Models/ClipType.swift
@@ -4,6 +4,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
     case image
     case text
     case lottie
+    case sequence
 
     var sfSymbolName: String {
         switch self {
@@ -12,6 +13,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "photo"
         case .text: "textformat"
         case .lottie: "sparkles"
+        case .sequence: "film.stack"
         }
     }
 
@@ -22,13 +24,14 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
         case .image: "Image"
         case .text: "Text"
         case .lottie: "Lottie"
+        case .sequence: "Video"
         }
     }
 
     var trackLabelPrefix: String { String(trackLabel.prefix(1)) }
 
     var isVisual: Bool {
-        self == .video || self == .image || self == .text || self == .lottie
+        self != .audio
     }
 
     func isCompatible(with other: ClipType) -> Bool {

--- a/Sources/PalmierPro/Models/Keyframe.swift
+++ b/Sources/PalmierPro/Models/Keyframe.swift
@@ -37,6 +37,21 @@ struct KeyframeTrack<Value: Codable & Sendable & Equatable>: Codable, Sendable, 
     }
 }
 
+extension KeyframeTrack where Value: KeyframeInterpolatable {
+    func rebased(by offset: Int, fallback: Value) -> KeyframeTrack? {
+        guard isActive else { return nil }
+        let boundary = sample(at: offset, fallback: fallback)
+        var kfs = keyframes
+            .filter { $0.frame >= offset }
+            .map { Keyframe(frame: $0.frame - offset, value: $0.value, interpolationOut: $0.interpolationOut) }
+        if kfs.first?.frame != 0 {
+            let interp = keyframes.last { $0.frame < offset }?.interpolationOut ?? .smooth
+            kfs.insert(Keyframe(frame: 0, value: boundary, interpolationOut: interp), at: 0)
+        }
+        return kfs.isEmpty ? nil : KeyframeTrack(keyframes: kfs)
+    }
+}
+
 @inlinable func smoothstep(_ t: Double) -> Double { t * t * (3 - 2 * t) }
 
 protocol KeyframeInterpolatable {

--- a/Sources/PalmierPro/Models/ProjectFile.swift
+++ b/Sources/PalmierPro/Models/ProjectFile.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Root of project.json. Legacy projects stored a bare Timeline; decode falls back and wraps.
+struct ProjectFile: Codable, Sendable {
+    var timelines: [Timeline]
+    var activeTimelineId: String?
+    var openTimelineIds: [String]?
+
+    static func decode(_ data: Data) throws -> ProjectFile {
+        let decoder = JSONDecoder()
+        do {
+            let file = try decoder.decode(ProjectFile.self, from: data)
+            guard !file.timelines.isEmpty else {
+                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "project has no timelines"))
+            }
+            return file
+        } catch {
+            // Legacy files are a bare Timeline; anything else rethrows the real error.
+            guard let legacy = try? decoder.decode(Timeline.self, from: data) else { throw error }
+            return ProjectFile(timelines: [legacy], activeTimelineId: legacy.id, openTimelineIds: [legacy.id])
+        }
+    }
+}

--- a/Sources/PalmierPro/Models/ProjectFile.swift
+++ b/Sources/PalmierPro/Models/ProjectFile.swift
@@ -5,6 +5,7 @@ struct ProjectFile: Codable, Sendable {
     var timelines: [Timeline]
     var activeTimelineId: String?
     var openTimelineIds: [String]?
+    var viewStates: [String: TimelineViewState]?
 
     static func decode(_ data: Data) throws -> ProjectFile {
         let decoder = JSONDecoder()

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -6,12 +6,22 @@ struct ClipLocation: Equatable, Sendable {
     let clipIndex: Int
 }
 
-struct Timeline: Codable, Sendable, Equatable {
+/// Written on tab switch and save, not live — playhead mutates every frame.
+struct TimelineViewState: Codable, Sendable, Equatable {
+    var playheadFrame: Int = 0
+    var zoomScale: Double = Defaults.pixelsPerFrame
+    var scrollOffsetX: Double = 0
+}
+
+struct Timeline: Codable, Sendable, Equatable, Identifiable {
+    var id: String = UUID().uuidString
+    var name: String = "Timeline 1"
     var fps: Int = 30
     var width: Int = 1920
     var height: Int = 1080
     var settingsConfigured: Bool = false
     var tracks: [Track] = []
+    var viewState = TimelineViewState()
 
     var totalFrames: Int {
         var maxFrame = 0
@@ -19,6 +29,26 @@ struct Timeline: Codable, Sendable, Equatable {
             maxFrame = max(maxFrame, track.endFrame)
         }
         return maxFrame
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, fps, width, height, settingsConfigured, tracks, viewState
+    }
+}
+
+extension Timeline {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: (try? c.decode(String.self, forKey: .id)) ?? UUID().uuidString,
+            name: (try? c.decode(String.self, forKey: .name)) ?? "Timeline 1",
+            fps: try c.decode(Int.self, forKey: .fps),
+            width: try c.decode(Int.self, forKey: .width),
+            height: try c.decode(Int.self, forKey: .height),
+            settingsConfigured: (try? c.decode(Bool.self, forKey: .settingsConfigured)) ?? false,
+            tracks: try c.decode([Track].self, forKey: .tracks),
+            viewState: (try? c.decode(TimelineViewState.self, forKey: .viewState)) ?? TimelineViewState()
+        )
     }
 }
 
@@ -30,7 +60,6 @@ struct Track: Codable, Sendable, Equatable, Identifiable {
     var syncLocked: Bool = true
     var clips: [Clip] = []
 
-    /// Display-only height, not serialized. Reset to default on project open.
     var displayHeight: CGFloat = 50
 
     var endFrame: Int {
@@ -54,7 +83,7 @@ struct Track: Codable, Sendable, Equatable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, type, muted, hidden, syncLocked, clips
+        case id, type, muted, hidden, syncLocked, clips, displayHeight
     }
 }
 
@@ -67,7 +96,9 @@ extension Track {
             muted: (try? c.decode(Bool.self, forKey: .muted)) ?? false,
             hidden: (try? c.decode(Bool.self, forKey: .hidden)) ?? false,
             syncLocked: (try? c.decode(Bool.self, forKey: .syncLocked)) ?? true,
-            clips: (try? c.decode([Clip].self, forKey: .clips)) ?? []
+            clips: (try? c.decode([Clip].self, forKey: .clips)) ?? [],
+            displayHeight: (try? c.decode(CGFloat.self, forKey: .displayHeight))
+                .map { min(max($0, TrackSize.minHeight), TrackSize.maxHeight) } ?? 50
         )
     }
 }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -22,7 +22,6 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     var settingsConfigured: Bool = false
     var folderId: String?
     var tracks: [Track] = []
-    var viewState = TimelineViewState()
 
     var totalFrames: Int {
         var maxFrame = 0
@@ -71,7 +70,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, fps, width, height, settingsConfigured, folderId, tracks, viewState
+        case id, name, fps, width, height, settingsConfigured, folderId, tracks
     }
 }
 
@@ -86,8 +85,7 @@ extension Timeline {
             height: try c.decode(Int.self, forKey: .height),
             settingsConfigured: (try? c.decode(Bool.self, forKey: .settingsConfigured)) ?? false,
             folderId: try? c.decode(String.self, forKey: .folderId),
-            tracks: try c.decode([Track].self, forKey: .tracks),
-            viewState: (try? c.decode(TimelineViewState.self, forKey: .viewState)) ?? TimelineViewState()
+            tracks: try c.decode([Track].self, forKey: .tracks)
         )
     }
 }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -20,6 +20,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     var width: Int = 1920
     var height: Int = 1080
     var settingsConfigured: Bool = false
+    var folderId: String?
     var tracks: [Track] = []
     var viewState = TimelineViewState()
 
@@ -32,7 +33,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, fps, width, height, settingsConfigured, tracks, viewState
+        case id, name, fps, width, height, settingsConfigured, folderId, tracks, viewState
     }
 }
 
@@ -46,6 +47,7 @@ extension Timeline {
             width: try c.decode(Int.self, forKey: .width),
             height: try c.decode(Int.self, forKey: .height),
             settingsConfigured: (try? c.decode(Bool.self, forKey: .settingsConfigured)) ?? false,
+            folderId: try? c.decode(String.self, forKey: .folderId),
             tracks: try c.decode([Track].self, forKey: .tracks),
             viewState: (try? c.decode(TimelineViewState.self, forKey: .viewState)) ?? TimelineViewState()
         )

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -32,6 +32,16 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
         return maxFrame
     }
 
+    var nestedTimelineIds: Set<String> {
+        var ids: Set<String> = []
+        for track in tracks {
+            for clip in track.clips where clip.mediaType == .sequence || clip.sourceClipType == .sequence {
+                ids.insert(clip.mediaRef)
+            }
+        }
+        return ids
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id, name, fps, width, height, settingsConfigured, folderId, tracks, viewState
     }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -195,6 +195,8 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     /// Frame where this clip ends on the timeline
     var endFrame: Int { startFrame + durationFrames }
 
+    var supportsRetiming: Bool { sourceClipType != .sequence }
+
     /// Source frames consumed by the visible portion
     var sourceFramesConsumed: Int { Int((Double(durationFrames) * speed).rounded()) }
 

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -42,6 +42,34 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
         return ids
     }
 
+    var hasAudioClips: Bool {
+        tracks.contains { $0.type == .audio && !$0.clips.isEmpty }
+    }
+
+    /// Reachable nested timelines, breadth-first, deduped, excluding self and filtered by `include`.
+    func reachableTimelines(
+        resolve: (String) -> Timeline?,
+        maxDepth: Int = Int.max,
+        include: (Timeline) -> Bool = { _ in true }
+    ) -> [Timeline] {
+        var found: [Timeline] = []
+        var seen: Set<String> = [id]
+        var queue: [(t: Timeline, depth: Int)] = [(self, 0)]
+        var i = 0
+        while i < queue.count {
+            let (t, depth) = queue[i]
+            i += 1
+            guard depth < maxDepth else { continue }
+            for clip in t.tracks.flatMap(\.clips) where clip.sourceClipType == .sequence {
+                guard seen.insert(clip.mediaRef).inserted,
+                      let child = resolve(clip.mediaRef), include(child) else { continue }
+                found.append(child)
+                queue.append((child, depth + 1))
+            }
+        }
+        return found
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id, name, fps, width, height, settingsConfigured, folderId, tracks, viewState
     }
@@ -290,6 +318,20 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
 enum FadeEdge { case left, right }
 
 extension Clip {
+    /// Fresh clip id; link/caption group ids remapped consistently via `groups`.
+    mutating func freshenIds(groups: inout [String: String]) {
+        func remap(_ old: String?) -> String? {
+            guard let old else { return nil }
+            if let new = groups[old] { return new }
+            let new = UUID().uuidString
+            groups[old] = new
+            return new
+        }
+        id = UUID().uuidString
+        linkGroupId = remap(linkGroupId)
+        captionGroupId = remap(captionGroupId)
+    }
+
     /// Drops volume keyframes outside `durationFrames`. Kept for callers that only touch volume.
     mutating func clampVolumeKfsToDuration() {
         volumeTrack = clampedKeyframeTrack(volumeTrack)

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -3,6 +3,7 @@ import AVFoundation
 struct TrackMapping: @unchecked Sendable {
     enum Kind {
         case timeline(trackIndex: Int, clipIds: Set<String>?)
+        case nested(clips: [Clip], carrier: Clip, parentTrackIndex: Int)
         case blackBackground(range: CMTimeRange)
     }
     let compositionTrack: AVMutableCompositionTrack
@@ -35,6 +36,7 @@ enum CompositionBuilder {
         timeline: Timeline,
         resolveURL: @Sendable (String) -> URL?,
         resolveSourceSize: @Sendable (String) -> CGSize? = { _ in nil },
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         missingMediaRefs: Set<String> = [],
         renderSize: CGSize
     ) async throws -> CompositionResult {
@@ -65,7 +67,22 @@ enum CompositionBuilder {
                 var normalClipIds = Set<String>()
                 var normalCursor = CMTime.zero
 
+                var previousAudioEnd = Int.min
                 for clip in sortedClips {
+                    guard clip.durationFrames > 0, clip.startFrame >= previousAudioEnd else { continue }
+                    previousAudioEnd = clip.endFrame
+                    if clip.sourceClipType == .sequence {
+                        try await expandNestAudio(
+                            carrier: clip, topCarrier: clip, volumeScale: 1.0,
+                            parentTrackIndex: trackIdx, depth: 0,
+                            composition: composition, timescale: timescale, renderSize: renderSize,
+                            resolveTimeline: resolveTimeline, resolveURL: resolveURL,
+                            resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                            trackMappings: &trackMappings, offlineMediaRefs: &offlineMediaRefs,
+                            unprocessableMediaRefs: &unprocessableMediaRefs
+                        )
+                        continue
+                    }
                     let source: (asset: AVURLAsset, track: AVAssetTrack)
                     switch try await loadSource(
                         clip: clip,
@@ -80,48 +97,22 @@ enum CompositionBuilder {
                     case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
                     }
 
-                    if clip.speed != 1.0 {
-                        guard let compTrack = composition.addMutableTrack(
+                    if normalTrack == nil {
+                        normalTrack = composition.addMutableTrack(
                             withMediaType: mediaType,
                             preferredTrackID: kCMPersistentTrackID_Invalid
-                        ) else { continue }
-                        var cursor = CMTime.zero
-                        if await insertClip(
-                            clip,
-                            sourceAsset: source.asset,
-                            sourceTrack: source.track,
-                            into: compTrack,
-                            cursor: &cursor,
-                            timescale: timescale
-                        ) {
-                            trackMappings.append(TrackMapping(
-                                compositionTrack: compTrack,
-                                kind: .timeline(trackIndex: trackIdx, clipIds: [clip.id]),
-                                naturalSize: .zero,
-                                endTime: .zero,
-                                isVideo: false
-                            ))
-                        } else {
-                            composition.removeTrack(compTrack)
-                        }
-                    } else {
-                        if normalTrack == nil {
-                            normalTrack = composition.addMutableTrack(
-                                withMediaType: mediaType,
-                                preferredTrackID: kCMPersistentTrackID_Invalid
-                            )
-                        }
-                        guard let compTrack = normalTrack else { continue }
-                        if await insertClip(
-                            clip,
-                            sourceAsset: source.asset,
-                            sourceTrack: source.track,
-                            into: compTrack,
-                            cursor: &normalCursor,
-                            timescale: timescale
-                        ) {
-                            normalClipIds.insert(clip.id)
-                        }
+                        )
+                    }
+                    guard let compTrack = normalTrack else { continue }
+                    if await insertClip(
+                        clip,
+                        sourceAsset: source.asset,
+                        sourceTrack: source.track,
+                        into: compTrack,
+                        cursor: &normalCursor,
+                        timescale: timescale
+                    ) {
+                        normalClipIds.insert(clip.id)
                     }
                 }
 
@@ -152,6 +143,19 @@ enum CompositionBuilder {
             var previousEndFrame = Int.min
             for clip in sortedClips {
                 guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
+                if clip.mediaType == .sequence {
+                    try await expandNestVideo(
+                        carrier: clip, parentTrackIndex: trackIdx, depth: 0,
+                        composition: composition, timescale: timescale, renderSize: renderSize,
+                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
+                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                        trackMappings: &trackMappings, clipNaturalSizes: &clipNaturalSizes,
+                        clipTransforms: &clipTransforms, offlineMediaRefs: &offlineMediaRefs,
+                        unprocessableMediaRefs: &unprocessableMediaRefs
+                    )
+                    previousEndFrame = clip.endFrame
+                    continue
+                }
                 let source: (asset: AVURLAsset, track: AVAssetTrack)
                 switch try await loadSource(
                     clip: clip,
@@ -223,6 +227,7 @@ enum CompositionBuilder {
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
+            resolveTimeline: resolveTimeline,
             compositionDuration: composition.duration,
             renderSize: renderSize
         )
@@ -377,12 +382,190 @@ enum CompositionBuilder {
         )
     }
 
+    /// Insert a nest's child video clips as composition tracks (one per child track).
+    private static func expandNestVideo(
+        carrier: Clip,
+        parentTrackIndex: Int,
+        depth: Int,
+        composition: AVMutableComposition,
+        timescale: CMTimeScale,
+        renderSize: CGSize,
+        resolveTimeline: @Sendable (String) -> Timeline?,
+        resolveURL: @Sendable (String) -> URL?,
+        resolveSourceSize: @Sendable (String) -> CGSize?,
+        missingMediaRefs: Set<String>,
+        trackMappings: inout [TrackMapping],
+        clipNaturalSizes: inout [String: CGSize],
+        clipTransforms: inout [String: CGAffineTransform],
+        offlineMediaRefs: inout Set<String>,
+        unprocessableMediaRefs: inout Set<String>
+    ) async throws {
+        guard depth < NestFlattener.maxDepth else {
+            Log.preview.warning("nest depth limit reached; skipping \(carrier.mediaRef.prefix(8))")
+            return
+        }
+        guard let child = resolveTimeline(carrier.mediaRef) else {
+            offlineMediaRefs.insert(carrier.mediaRef)
+            return
+        }
+        let flat = NestFlattener.flatten(carrier: carrier, child: child, visual: true)
+        for childClips in flat.videoTracks {
+            var compTrack: AVMutableCompositionTrack?
+            var cursor = CMTime.zero
+            var inserted: [Clip] = []
+            var previousEndFrame = Int.min
+            for clip in childClips {
+                guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
+                if clip.mediaType == .text { continue }   // text renders inside the group
+                if clip.mediaType == .sequence {
+                    try await expandNestVideo(
+                        carrier: clip, parentTrackIndex: parentTrackIndex, depth: depth + 1,
+                        composition: composition, timescale: timescale, renderSize: renderSize,
+                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
+                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                        trackMappings: &trackMappings, clipNaturalSizes: &clipNaturalSizes,
+                        clipTransforms: &clipTransforms, offlineMediaRefs: &offlineMediaRefs,
+                        unprocessableMediaRefs: &unprocessableMediaRefs
+                    )
+                    previousEndFrame = clip.endFrame
+                    continue
+                }
+                let source: (asset: AVURLAsset, track: AVAssetTrack)
+                switch try await loadSource(
+                    clip: clip, mediaType: .video, resolveURL: resolveURL,
+                    resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                    renderSize: renderSize
+                ) {
+                case .loaded(let asset, let track): source = (asset, track)
+                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
+                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
+                }
+                if compTrack == nil {
+                    compTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+                }
+                guard let track = compTrack else { continue }
+                if let natSize = try? await source.track.load(.naturalSize),
+                   natSize.width > 0, natSize.height > 0 {
+                    let pt = (try? await source.track.load(.preferredTransform)) ?? .identity
+                    let box = CGRect(origin: .zero, size: natSize).applying(pt)
+                    clipNaturalSizes[clip.id] = CGSize(width: abs(box.width), height: abs(box.height))
+                    clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
+                }
+                if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
+                                    into: track, cursor: &cursor, timescale: timescale) {
+                    inserted.append(clip)
+                    previousEndFrame = clip.endFrame
+                }
+            }
+            if let compTrack {
+                if inserted.isEmpty {
+                    composition.removeTrack(compTrack)
+                } else {
+                    trackMappings.append(TrackMapping(
+                        compositionTrack: compTrack,
+                        kind: .nested(clips: inserted, carrier: carrier, parentTrackIndex: parentTrackIndex),
+                        naturalSize: renderSize,
+                        endTime: cursor,
+                        isVideo: true
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Child audio inserts per child track; static volumes fold, top carrier envelope multiplies at mix.
+    private static func expandNestAudio(
+        carrier: Clip,
+        topCarrier: Clip,
+        volumeScale: Double,
+        parentTrackIndex: Int,
+        depth: Int,
+        composition: AVMutableComposition,
+        timescale: CMTimeScale,
+        renderSize: CGSize,
+        resolveTimeline: @Sendable (String) -> Timeline?,
+        resolveURL: @Sendable (String) -> URL?,
+        resolveSourceSize: @Sendable (String) -> CGSize?,
+        missingMediaRefs: Set<String>,
+        trackMappings: inout [TrackMapping],
+        offlineMediaRefs: inout Set<String>,
+        unprocessableMediaRefs: inout Set<String>
+    ) async throws {
+        guard depth < NestFlattener.maxDepth else {
+            Log.preview.warning("nest depth limit reached; skipping \(carrier.mediaRef.prefix(8))")
+            return
+        }
+        guard let child = resolveTimeline(carrier.mediaRef) else {
+            offlineMediaRefs.insert(carrier.mediaRef)
+            return
+        }
+        let flat = NestFlattener.flatten(carrier: carrier, child: child, visual: false)
+        for trackClips in flat.audioTracks {
+            // Clips within a child track never overlap: share one composition track.
+            var sharedTrack: AVMutableCompositionTrack?
+            var sharedCursor = CMTime.zero
+            var sharedClips: [Clip] = []
+            var previousEnd = Int.min
+            for var clip in trackClips {
+                guard clip.durationFrames > 0, clip.startFrame >= previousEnd else { continue }
+                previousEnd = clip.endFrame
+                if clip.sourceClipType == .sequence {
+                    try await expandNestAudio(
+                        carrier: clip, topCarrier: topCarrier, volumeScale: volumeScale * clip.volume,
+                        parentTrackIndex: parentTrackIndex, depth: depth + 1,
+                        composition: composition, timescale: timescale, renderSize: renderSize,
+                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
+                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                        trackMappings: &trackMappings, offlineMediaRefs: &offlineMediaRefs,
+                        unprocessableMediaRefs: &unprocessableMediaRefs
+                    )
+                    continue
+                }
+                clip.volume *= volumeScale
+                let source: (asset: AVURLAsset, track: AVAssetTrack)
+                switch try await loadSource(
+                    clip: clip, mediaType: .audio, resolveURL: resolveURL,
+                    resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
+                    renderSize: renderSize
+                ) {
+                case .loaded(let asset, let track): source = (asset, track)
+                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
+                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
+                }
+
+                if sharedTrack == nil {
+                    sharedTrack = composition.addMutableTrack(
+                        withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+                }
+                guard let compTrack = sharedTrack else { continue }
+                if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
+                                    into: compTrack, cursor: &sharedCursor, timescale: timescale) {
+                    sharedClips.append(clip)
+                }
+            }
+            if let sharedTrack {
+                if sharedClips.isEmpty {
+                    composition.removeTrack(sharedTrack)
+                } else {
+                    trackMappings.append(TrackMapping(
+                        compositionTrack: sharedTrack,
+                        kind: .nested(clips: sharedClips, carrier: topCarrier, parentTrackIndex: parentTrackIndex),
+                        naturalSize: .zero,
+                        endTime: .zero,
+                        isVideo: false
+                    ))
+                }
+            }
+        }
+    }
+
     /// Rebuild only visual properties (transforms, opacity, volume)
     static func buildVisuals(
         timeline: Timeline,
         trackMappings: [TrackMapping],
         clipNaturalSizes: [String: CGSize] = [:],
         clipTransforms: [String: CGAffineTransform] = [:],
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         compositionDuration: CMTime,
         renderSize: CGSize
     ) -> (audioMix: AVMutableAudioMix, videoComposition: AVVideoComposition) {
@@ -390,22 +573,40 @@ enum CompositionBuilder {
 
         let audioMix = AVMutableAudioMix()
         audioMix.inputParameters = trackMappings.filter { !$0.isVideo }.compactMap { mapping in
-            guard case .timeline(let trackIndex, let clipIds) = mapping.kind,
-                  timeline.tracks.indices.contains(trackIndex) else { return nil }
-            let track = timeline.tracks[trackIndex]
-            let params = AVMutableAudioMixInputParameters(track: mapping.compositionTrack)
-            if track.muted {
-                params.setVolume(0, at: .zero)
+            switch mapping.kind {
+            case .blackBackground:
+                return nil
+            case .nested(let clips, let carrier, let parentTrackIndex):
+                let params = AVMutableAudioMixInputParameters(track: mapping.compositionTrack)
+                guard timeline.tracks.indices.contains(parentTrackIndex) else { return params }
+                let parentTrack = timeline.tracks[parentTrackIndex]
+                if parentTrack.muted {
+                    params.setVolume(0, at: .zero)
+                    return params
+                }
+                // Prefer the live carrier so nest volume/fade edits apply on refresh.
+                let liveCarrier = parentTrack.clips.first { $0.id == carrier.id } ?? carrier
+                for clip in clips {
+                    emitVolumeEnvelope(params: params, clip: clip, timescale: timescale, carrier: liveCarrier)
+                }
+                return params
+            case .timeline(let trackIndex, let clipIds):
+                guard timeline.tracks.indices.contains(trackIndex) else { return nil }
+                let track = timeline.tracks[trackIndex]
+                let params = AVMutableAudioMixInputParameters(track: mapping.compositionTrack)
+                if track.muted {
+                    params.setVolume(0, at: .zero)
+                    return params
+                }
+                var prevEndFrame = Int.min
+                for clip in track.clips.sorted(by: { $0.startFrame < $1.startFrame }) {
+                    if let clipIds, !clipIds.contains(clip.id) { continue }
+                    guard clip.durationFrames > 0, clip.startFrame >= prevEndFrame else { continue }
+                    emitVolumeEnvelope(params: params, clip: clip, timescale: timescale)
+                    prevEndFrame = clip.startFrame + clip.durationFrames
+                }
                 return params
             }
-            var prevEndFrame = Int.min
-            for clip in track.clips.sorted(by: { $0.startFrame < $1.startFrame }) {
-                if let clipIds, !clipIds.contains(clip.id) { continue }
-                guard clip.durationFrames > 0, clip.startFrame >= prevEndFrame else { continue }
-                emitVolumeEnvelope(params: params, clip: clip, timescale: timescale)
-                prevEndFrame = clip.startFrame + clip.durationFrames
-            }
-            return params
         }
 
         var vcConfig = AVVideoComposition.Configuration()
@@ -418,6 +619,7 @@ enum CompositionBuilder {
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
+            resolveTimeline: resolveTimeline,
             compositionDuration: compositionDuration,
             renderSize: renderSize
         )
@@ -430,6 +632,7 @@ enum CompositionBuilder {
         trackMappings: [TrackMapping],
         clipNaturalSizes: [String: CGSize],
         clipTransforms: [String: CGAffineTransform],
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         compositionDuration: CMTime,
         renderSize: CGSize
     ) -> [CompositorInstruction] {
@@ -441,9 +644,16 @@ enum CompositionBuilder {
         // Resolve each inserted media clip to the composition track it lives on.
         var media: [String: Slot] = [:]
         for mapping in trackMappings where mapping.isVideo {
-            guard case .timeline(let trackIndex, let clipIds) = mapping.kind,
-                  timeline.tracks.indices.contains(trackIndex) else { continue }
-            let ids = clipIds ?? Set(timeline.tracks[trackIndex].clips.filter { $0.mediaType != .text }.map(\.id))
+            let ids: Set<String>
+            switch mapping.kind {
+            case .timeline(let trackIndex, let clipIds):
+                guard timeline.tracks.indices.contains(trackIndex) else { continue }
+                ids = clipIds ?? Set(timeline.tracks[trackIndex].clips.filter { $0.mediaType != .text }.map(\.id))
+            case .nested(let clips, _, _):
+                ids = Set(clips.map(\.id))
+            case .blackBackground:
+                continue
+            }
             for id in ids {
                 media[id] = Slot(
                     trackID: mapping.compositionTrack.trackID,
@@ -451,6 +661,61 @@ enum CompositionBuilder {
                     transform: clipTransforms[id] ?? .identity
                 )
             }
+        }
+
+        // Flatten is pure per carrier — memoize; segments reuse one result.
+        var flattenCache: [String: NestFlattener.Flattened] = [:]
+        func flattened(for carrier: Clip, depth: Int) -> NestFlattener.Flattened? {
+            guard depth < NestFlattener.maxDepth else { return nil }
+            if let cached = flattenCache[carrier.id] { return cached }
+            guard let child = resolveTimeline(carrier.mediaRef) else { return nil }
+            let flat = NestFlattener.flatten(carrier: carrier, child: child, visual: true)
+            flattenCache[carrier.id] = flat
+            return flat
+        }
+
+        // Group layer for one segment window; empty children still render (nest gaps are opaque black).
+        func nestGroupPlan(carrier: Clip, depth: Int, window: Range<Int>) -> LayerPlan? {
+            guard let flat = flattened(for: carrier, depth: depth) else { return nil }
+            var children: [LayerPlan] = []
+            for childClips in flat.videoTracks.reversed() {
+                var prevEnd = Int.min
+                for clip in childClips where clip.durationFrames > 0 {
+                    let overlapsWindow = clip.startFrame < window.upperBound && clip.endFrame > window.lowerBound
+                    if clip.mediaType == .text {
+                        guard overlapsWindow, !(clip.textContent ?? "").isEmpty else { continue }
+                        children.append(LayerPlan(source: .text, clip: clip, natSize: flat.childCanvas, preferredTransform: .identity))
+                    } else if clip.mediaType == .sequence {
+                        guard clip.startFrame >= prevEnd else { continue }
+                        prevEnd = clip.endFrame
+                        guard overlapsWindow, let plan = nestGroupPlan(carrier: clip, depth: depth + 1, window: window) else { continue }
+                        children.append(plan)
+                    } else {
+                        guard clip.startFrame >= prevEnd, let slot = media[clip.id] else { continue }
+                        prevEnd = clip.endFrame
+                        guard overlapsWindow else { continue }
+                        children.append(LayerPlan(source: .track(slot.trackID), clip: clip, natSize: slot.natSize, preferredTransform: slot.transform))
+                    }
+                }
+            }
+            return LayerPlan(source: .group(children: children, canvas: flat.childCanvas),
+                             clip: carrier, natSize: flat.childCanvas, preferredTransform: .identity)
+        }
+
+        // Child clip boundaries: segments scope decoder demand to what's visible.
+        func nestCutFrames(carrier: Clip, depth: Int) -> [Int] {
+            guard let flat = flattened(for: carrier, depth: depth) else { return [] }
+            var frames: [Int] = []
+            for childClips in flat.videoTracks {
+                for clip in childClips {
+                    frames.append(clip.startFrame)
+                    frames.append(clip.endFrame)
+                    if clip.mediaType == .sequence {
+                        frames.append(contentsOf: nestCutFrames(carrier: clip, depth: depth + 1))
+                    }
+                }
+            }
+            return frames.filter { $0 > carrier.startFrame && $0 < carrier.endFrame }
         }
 
         // Walk tracks in reverse to produce bottom→top entries. Text layers follow track order.
@@ -462,6 +727,21 @@ enum CompositionBuilder {
                 if clip.mediaType == .text {
                     guard !(clip.textContent ?? "").isEmpty else { continue }
                     plan = LayerPlan(source: .text, clip: clip, natSize: renderSize, preferredTransform: .identity)
+                } else if clip.mediaType == .sequence {
+                    guard clip.startFrame >= prevEndFrame else { continue }
+                    prevEndFrame = clip.endFrame
+                    // One entry per child-boundary segment: each requires only the
+                    // source tracks visible in that segment.
+                    let bounds = ([clip.startFrame, clip.endFrame] + nestCutFrames(carrier: clip, depth: 0))
+                        .reduce(into: Set<Int>()) { $0.insert($1) }
+                        .sorted()
+                    for i in 0..<(bounds.count - 1) {
+                        let window = bounds[i]..<bounds[i + 1]
+                        guard window.count > 0,
+                              let group = nestGroupPlan(carrier: clip, depth: 0, window: window) else { continue }
+                        entries.append(Entry(start: cmTime(window.lowerBound), end: cmTime(window.upperBound), plan: group))
+                    }
+                    continue
                 } else {
                     guard clip.startFrame >= prevEndFrame, let slot = media[clip.id] else { continue }
                     plan = LayerPlan(source: .track(slot.trackID), clip: clip, natSize: slot.natSize, preferredTransform: slot.transform)
@@ -553,16 +833,23 @@ enum CompositionBuilder {
         return Array(Set(raw)).sorted()
     }
 
-    /// Linear-ramp envelope for the clip's volume curve. `volumeAt` already folds in static × kf × fade.
+    /// Linear-ramp volume envelope; a nest `carrier` multiplies its envelope in.
     private static func emitVolumeEnvelope(
         params: AVMutableAudioMixInputParameters,
         clip: Clip,
-        timescale: CMTimeScale
+        timescale: CMTimeScale,
+        carrier: Clip? = nil
     ) {
         let kfs = normalizedKeyframes(clip.volumeTrack?.keyframes ?? [], duration: clip.durationFrames)
         let hasFade = clip.fadeInFrames > 0 || clip.fadeOutFrames > 0
-        if kfs.isEmpty && !hasFade {
-            let volume = Float(clip.volumeAt(frame: clip.startFrame))
+        let carrierVaries = carrier.map {
+            ($0.volumeTrack?.isActive ?? false) || $0.fadeInFrames > 0 || $0.fadeOutFrames > 0
+        } ?? false
+        let gainAt: (Int) -> Double = { absFrame in
+            carrier.map { $0.volumeAt(frame: absFrame) } ?? 1
+        }
+        if kfs.isEmpty && !hasFade && !carrierVaries {
+            let volume = Float(clip.volumeAt(frame: clip.startFrame) * gainAt(clip.startFrame))
             let start = CMTime(value: CMTimeValue(clip.startFrame), timescale: timescale)
             let end = CMTime(value: CMTimeValue(clip.endFrame), timescale: timescale)
             guard volume.isFinite, end > start else { return }
@@ -574,11 +861,37 @@ enum CompositionBuilder {
             return
         }
 
+        var extraOffsets: [Int] = []
+        if let carrier, carrierVaries {
+            let toClipOffset: (Int) -> Int = { carrierOffset in
+                carrier.startFrame + carrierOffset - clip.startFrame
+            }
+            if carrier.fadeInFrames > 0 {
+                extraOffsets.append(toClipOffset(carrier.fadeInFrames))
+                if carrier.fadeInInterpolation == .smooth {
+                    extraOffsets += smoothSubdivisions(from: 0, to: carrier.fadeInFrames).map(toClipOffset)
+                }
+            }
+            if carrier.fadeOutFrames > 0 {
+                let fadeStart = carrier.durationFrames - carrier.fadeOutFrames
+                extraOffsets.append(toClipOffset(fadeStart))
+                if carrier.fadeOutInterpolation == .smooth {
+                    extraOffsets += smoothSubdivisions(from: fadeStart, to: carrier.durationFrames).map(toClipOffset)
+                }
+            }
+            for kf in carrier.volumeTrack?.keyframes ?? [] {
+                extraOffsets.append(toClipOffset(kf.frame))
+                extraOffsets.append(toClipOffset(kf.frame) - 1)   // hold boundaries
+            }
+            extraOffsets = extraOffsets.filter { $0 > 0 && $0 < clip.durationFrames }
+        }
+
         emitEnvelopeRamps(
             clip: clip,
             kfs: kfs,
             timescale: timescale,
-            sampleAt: { Float(clip.volumeAt(frame: clip.startFrame + $0)) },
+            extraOffsets: extraOffsets,
+            sampleAt: { Float(clip.volumeAt(frame: clip.startFrame + $0) * gainAt(clip.startFrame + $0)) },
             emit: { start, end, range in
                 params.setVolumeRamp(fromStartVolume: start, toEndVolume: end, timeRange: range)
             }
@@ -590,6 +903,7 @@ enum CompositionBuilder {
         clip: Clip,
         kfs: [Keyframe<Double>],
         timescale: CMTimeScale,
+        extraOffsets: [Int] = [],
         sampleAt: (Int) -> Float,
         emit: (Float, Float, CMTimeRange) -> Void
     ) {
@@ -598,6 +912,7 @@ enum CompositionBuilder {
         let kfs = normalizedKeyframes(kfs, duration: dur)
 
         var offsetSet: Set<Int> = [0, dur]
+        offsetSet.formUnion(extraOffsets)
         for kf in kfs { offsetSet.insert(kf.frame) }
         for i in kfs.indices.dropLast() {
             let a = kfs[i], b = kfs[i + 1]

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -34,9 +34,9 @@ enum CompositionBuilder {
 
     static func build(
         timeline: Timeline,
-        resolveURL: @Sendable (String) -> URL?,
-        resolveSourceSize: @Sendable (String) -> CGSize? = { _ in nil },
-        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
+        resolveURL: @escaping @Sendable (String) -> URL?,
+        resolveSourceSize: @escaping @Sendable (String) -> CGSize? = { _ in nil },
+        resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
         missingMediaRefs: Set<String> = [],
         renderSize: CGSize
     ) async throws -> CompositionResult {
@@ -45,13 +45,15 @@ enum CompositionBuilder {
             Log.preview.fault("build: invalid timeline fps=\(timeline.fps) size=\(timeline.width)x\(timeline.height)")
             throw InvalidTimelineError(reason: "fps=\(timeline.fps) size=\(timeline.width)x\(timeline.height)")
         }
-        let composition = AVMutableComposition()
-        let timescale = CMTimeScale(timeline.fps)
-        var trackMappings: [TrackMapping] = []
-        var clipNaturalSizes: [String: CGSize] = [:]
-        var clipTransforms: [String: CGAffineTransform] = [:]
-        var offlineMediaRefs: Set<String> = []
-        var unprocessableMediaRefs: Set<String> = []
+        let ctx = BuildContext(
+            composition: AVMutableComposition(),
+            timescale: CMTimeScale(timeline.fps),
+            renderSize: renderSize,
+            resolveURL: resolveURL,
+            resolveSourceSize: resolveSourceSize,
+            resolveTimeline: resolveTimeline,
+            missingMediaRefs: missingMediaRefs
+        )
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
             // Text is composited at render, not as a track.
@@ -59,188 +61,200 @@ enum CompositionBuilder {
                 .sorted { $0.startFrame < $1.startFrame }
                 .filter { $0.mediaType != .text }
             guard !sortedClips.isEmpty else { continue }
-            let isAudio = track.type == .audio
-            let mediaType: AVMediaType = isAudio ? .audio : .video
-
-            if isAudio {
-                var normalTrack: AVMutableCompositionTrack?
-                var normalClipIds = Set<String>()
-                var normalCursor = CMTime.zero
-
-                var previousAudioEnd = Int.min
-                for clip in sortedClips {
-                    guard clip.durationFrames > 0, clip.startFrame >= previousAudioEnd else { continue }
-                    previousAudioEnd = clip.endFrame
-                    if clip.sourceClipType == .sequence {
-                        try await expandNestAudio(
-                            carrier: clip, topCarrier: clip, volumeScale: 1.0,
-                            parentTrackIndex: trackIdx, depth: 0,
-                            composition: composition, timescale: timescale, renderSize: renderSize,
-                            resolveTimeline: resolveTimeline, resolveURL: resolveURL,
-                            resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                            trackMappings: &trackMappings, offlineMediaRefs: &offlineMediaRefs,
-                            unprocessableMediaRefs: &unprocessableMediaRefs
-                        )
-                        continue
-                    }
-                    let source: (asset: AVURLAsset, track: AVAssetTrack)
-                    switch try await loadSource(
-                        clip: clip,
-                        mediaType: mediaType,
-                        resolveURL: resolveURL,
-                        resolveSourceSize: resolveSourceSize,
-                        missingMediaRefs: missingMediaRefs,
-                        renderSize: renderSize
-                    ) {
-                    case .loaded(let asset, let track): source = (asset, track)
-                    case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
-                    case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
-                    }
-
-                    if normalTrack == nil {
-                        normalTrack = composition.addMutableTrack(
-                            withMediaType: mediaType,
-                            preferredTrackID: kCMPersistentTrackID_Invalid
-                        )
-                    }
-                    guard let compTrack = normalTrack else { continue }
-                    if await insertClip(
-                        clip,
-                        sourceAsset: source.asset,
-                        sourceTrack: source.track,
-                        into: compTrack,
-                        cursor: &normalCursor,
-                        timescale: timescale
-                    ) {
-                        normalClipIds.insert(clip.id)
-                    }
-                }
-
-                if let normalTrack {
-                    if normalClipIds.isEmpty {
-                        composition.removeTrack(normalTrack)
-                    } else {
-                        trackMappings.append(TrackMapping(
-                            compositionTrack: normalTrack,
-                            kind: .timeline(trackIndex: trackIdx, clipIds: normalClipIds),
-                            naturalSize: .zero,
-                            endTime: .zero,
-                            isVideo: false
-                        ))
-                    }
-                }
-                continue
+            if track.type == .audio {
+                try await insertAudioLane(clips: sortedClips, parentTrackIndex: trackIdx, nest: nil, depth: 0, ctx: ctx)
+            } else {
+                try await insertVideoLane(clips: sortedClips, parentTrackIndex: trackIdx, nestCarrier: nil, depth: 0, ctx: ctx)
             }
-
-            guard let compTrack = composition.addMutableTrack(
-                withMediaType: mediaType,
-                preferredTrackID: kCMPersistentTrackID_Invalid
-            ) else { continue }
-
-            var cursor = CMTime.zero
-            var insertedCount = 0
-            var insertedClipIds = Set<String>()
-            var previousEndFrame = Int.min
-            for clip in sortedClips {
-                guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
-                if clip.mediaType == .sequence {
-                    try await expandNestVideo(
-                        carrier: clip, parentTrackIndex: trackIdx, depth: 0,
-                        composition: composition, timescale: timescale, renderSize: renderSize,
-                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
-                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                        trackMappings: &trackMappings, clipNaturalSizes: &clipNaturalSizes,
-                        clipTransforms: &clipTransforms, offlineMediaRefs: &offlineMediaRefs,
-                        unprocessableMediaRefs: &unprocessableMediaRefs
-                    )
-                    previousEndFrame = clip.endFrame
-                    continue
-                }
-                let source: (asset: AVURLAsset, track: AVAssetTrack)
-                switch try await loadSource(
-                    clip: clip,
-                    mediaType: mediaType,
-                    resolveURL: resolveURL,
-                    resolveSourceSize: resolveSourceSize,
-                    missingMediaRefs: missingMediaRefs,
-                    renderSize: renderSize
-                ) {
-                case .loaded(let asset, let track): source = (asset, track)
-                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
-                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
-                }
-
-                if let natSize = try? await source.track.load(.naturalSize),
-                   natSize.width > 0, natSize.height > 0 {
-                    // Store clip display size and transform with origin at (0,0)
-                    let pt = (try? await source.track.load(.preferredTransform)) ?? .identity
-                    let box = CGRect(origin: .zero, size: natSize).applying(pt)
-                    clipNaturalSizes[clip.id] = CGSize(width: abs(box.width), height: abs(box.height))
-                    clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
-                }
-
-                if await insertClip(
-                    clip,
-                    sourceAsset: source.asset,
-                    sourceTrack: source.track,
-                    into: compTrack,
-                    cursor: &cursor,
-                    timescale: timescale
-                ) {
-                    insertedCount += 1
-                    insertedClipIds.insert(clip.id)
-                    previousEndFrame = clip.endFrame
-                }
-            }
-
-            guard insertedCount > 0 else {
-                composition.removeTrack(compTrack)
-                continue
-            }
-            let naturalSize = (try? await compTrack.load(.naturalSize)).flatMap { $0.width > 0 && $0.height > 0 ? $0 : nil } ?? renderSize
-            trackMappings.append(TrackMapping(
-                compositionTrack: compTrack,
-                kind: .timeline(trackIndex: trackIdx, clipIds: insertedClipIds),
-                naturalSize: naturalSize,
-                endTime: cursor,
-                isVideo: true
-            ))
         }
 
         guard !Task.isCancelled else { throw CancellationError() }
 
         // Opaque black background layer (bottommost) for full timeline
-        let lastVideoEnd = trackMappings.filter(\.isVideo).map(\.endTime).max() ?? .zero
-        let desiredDuration = max(CMTime(value: CMTimeValue(timeline.totalFrames), timescale: timescale), lastVideoEnd)
+        let lastVideoEnd = ctx.trackMappings.filter(\.isVideo).map(\.endTime).max() ?? .zero
+        let desiredDuration = max(CMTime(value: CMTimeValue(timeline.totalFrames), timescale: ctx.timescale), lastVideoEnd)
         if desiredDuration > .zero {
             if let mapping = try await insertBlackBackground(
-                composition: composition,
+                composition: ctx.composition,
                 size: renderSize,
                 range: CMTimeRange(start: .zero, duration: desiredDuration)
             ) {
-                trackMappings.append(mapping)
+                ctx.trackMappings.append(mapping)
             }
         }
 
         let (audioMix, videoComposition) = buildVisuals(
             timeline: timeline,
-            trackMappings: trackMappings,
-            clipNaturalSizes: clipNaturalSizes,
-            clipTransforms: clipTransforms,
+            trackMappings: ctx.trackMappings,
+            clipNaturalSizes: ctx.clipNaturalSizes,
+            clipTransforms: ctx.clipTransforms,
             resolveTimeline: resolveTimeline,
-            compositionDuration: composition.duration,
+            compositionDuration: ctx.composition.duration,
             renderSize: renderSize
         )
 
         return CompositionResult(
-            composition: composition,
+            composition: ctx.composition,
             audioMix: audioMix,
             videoComposition: videoComposition,
-            trackMappings: trackMappings,
-            clipNaturalSizes: clipNaturalSizes,
-            clipTransforms: clipTransforms,
-            offlineMediaRefs: offlineMediaRefs,
-            unprocessableMediaRefs: unprocessableMediaRefs
+            trackMappings: ctx.trackMappings,
+            clipNaturalSizes: ctx.clipNaturalSizes,
+            clipTransforms: ctx.clipTransforms,
+            offlineMediaRefs: ctx.offlineMediaRefs,
+            unprocessableMediaRefs: ctx.unprocessableMediaRefs
+        )
+    }
+
+    /// Everything a build pass threads through insertion: inputs plus accumulators.
+    private final class BuildContext {
+        let composition: AVMutableComposition
+        let timescale: CMTimeScale
+        let renderSize: CGSize
+        let resolveURL: @Sendable (String) -> URL?
+        let resolveSourceSize: @Sendable (String) -> CGSize?
+        let resolveTimeline: @Sendable (String) -> Timeline?
+        let missingMediaRefs: Set<String>
+        var trackMappings: [TrackMapping] = []
+        var clipNaturalSizes: [String: CGSize] = [:]
+        var clipTransforms: [String: CGAffineTransform] = [:]
+        var offlineMediaRefs: Set<String> = []
+        var unprocessableMediaRefs: Set<String> = []
+
+        init(
+            composition: AVMutableComposition,
+            timescale: CMTimeScale,
+            renderSize: CGSize,
+            resolveURL: @escaping @Sendable (String) -> URL?,
+            resolveSourceSize: @escaping @Sendable (String) -> CGSize?,
+            resolveTimeline: @escaping @Sendable (String) -> Timeline?,
+            missingMediaRefs: Set<String>
+        ) {
+            self.composition = composition
+            self.timescale = timescale
+            self.renderSize = renderSize
+            self.resolveURL = resolveURL
+            self.resolveSourceSize = resolveSourceSize
+            self.resolveTimeline = resolveTimeline
+            self.missingMediaRefs = missingMediaRefs
+        }
+    }
+
+    /// One lane of video clips → at most one composition track; sequence clips expand recursively.
+    private static func insertVideoLane(
+        clips: [Clip],
+        parentTrackIndex: Int,
+        nestCarrier: Clip?,
+        depth: Int,
+        ctx: BuildContext
+    ) async throws {
+        var compTrack: AVMutableCompositionTrack?
+        var cursor = CMTime.zero
+        var inserted: [Clip] = []
+        var previousEndFrame = Int.min
+        for clip in clips {
+            guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
+            if clip.mediaType == .text { continue }   // text renders in instructions, nests render it in groups
+            if clip.mediaType == .sequence {
+                try await expandNestVideo(carrier: clip, parentTrackIndex: parentTrackIndex, depth: depth, ctx: ctx)
+                previousEndFrame = clip.endFrame
+                continue
+            }
+            let source: (asset: AVURLAsset, track: AVAssetTrack)
+            switch try await loadSource(clip: clip, mediaType: .video, ctx: ctx) {
+            case .loaded(let asset, let track): source = (asset, track)
+            case .offline: ctx.offlineMediaRefs.insert(clip.mediaRef); continue
+            case .unprocessable: ctx.unprocessableMediaRefs.insert(clip.mediaRef); continue
+            }
+            if compTrack == nil {
+                compTrack = ctx.composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+            }
+            guard let track = compTrack else { continue }
+            await recordSourceGeometry(for: clip, sourceTrack: source.track, ctx: ctx)
+            if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
+                                into: track, cursor: &cursor, timescale: ctx.timescale) {
+                inserted.append(clip)
+                previousEndFrame = clip.endFrame
+            }
+        }
+        guard let compTrack else { return }
+        guard !inserted.isEmpty else {
+            ctx.composition.removeTrack(compTrack)
+            return
+        }
+        let naturalSize = (try? await compTrack.load(.naturalSize)).flatMap { $0.width > 0 && $0.height > 0 ? $0 : nil } ?? ctx.renderSize
+        let kind: TrackMapping.Kind = nestCarrier.map { .nested(clips: inserted, carrier: $0, parentTrackIndex: parentTrackIndex) }
+            ?? .timeline(trackIndex: parentTrackIndex, clipIds: Set(inserted.map(\.id)))
+        ctx.trackMappings.append(TrackMapping(
+            compositionTrack: compTrack, kind: kind, naturalSize: naturalSize, endTime: cursor, isVideo: true
+        ))
+    }
+
+    /// One lane of audio clips → at most one shared composition track (per-lane clips never overlap).
+    private static func insertAudioLane(
+        clips: [Clip],
+        parentTrackIndex: Int,
+        nest: (topCarrier: Clip, volumeScale: Double)?,
+        depth: Int,
+        ctx: BuildContext
+    ) async throws {
+        var compTrack: AVMutableCompositionTrack?
+        var cursor = CMTime.zero
+        var inserted: [Clip] = []
+        var previousEndFrame = Int.min
+        for var clip in clips {
+            guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
+            previousEndFrame = clip.endFrame
+            if clip.sourceClipType == .sequence {
+                try await expandNestAudio(
+                    carrier: clip,
+                    topCarrier: nest?.topCarrier ?? clip,
+                    volumeScale: nest.map { $0.volumeScale * clip.volume } ?? 1.0,
+                    parentTrackIndex: parentTrackIndex, depth: depth, ctx: ctx
+                )
+                continue
+            }
+            if let nest { clip.volume *= nest.volumeScale }
+            let source: (asset: AVURLAsset, track: AVAssetTrack)
+            switch try await loadSource(clip: clip, mediaType: .audio, ctx: ctx) {
+            case .loaded(let asset, let track): source = (asset, track)
+            case .offline: ctx.offlineMediaRefs.insert(clip.mediaRef); continue
+            case .unprocessable: ctx.unprocessableMediaRefs.insert(clip.mediaRef); continue
+            }
+            if compTrack == nil {
+                compTrack = ctx.composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+            }
+            guard let track = compTrack else { continue }
+            if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
+                                into: track, cursor: &cursor, timescale: ctx.timescale) {
+                inserted.append(clip)
+            }
+        }
+        guard let compTrack else { return }
+        guard !inserted.isEmpty else {
+            ctx.composition.removeTrack(compTrack)
+            return
+        }
+        let kind: TrackMapping.Kind = nest.map { .nested(clips: inserted, carrier: $0.topCarrier, parentTrackIndex: parentTrackIndex) }
+            ?? .timeline(trackIndex: parentTrackIndex, clipIds: Set(inserted.map(\.id)))
+        ctx.trackMappings.append(TrackMapping(
+            compositionTrack: compTrack, kind: kind, naturalSize: .zero, endTime: .zero, isVideo: false
+        ))
+    }
+
+    private static func recordSourceGeometry(for clip: Clip, sourceTrack: AVAssetTrack, ctx: BuildContext) async {
+        guard let natSize = try? await sourceTrack.load(.naturalSize), natSize.width > 0, natSize.height > 0 else { return }
+        // Store clip display size and transform with origin at (0,0)
+        let pt = (try? await sourceTrack.load(.preferredTransform)) ?? .identity
+        let box = CGRect(origin: .zero, size: natSize).applying(pt)
+        ctx.clipNaturalSizes[clip.id] = CGSize(width: abs(box.width), height: abs(box.height))
+        ctx.clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
+    }
+
+    private static func loadSource(clip: Clip, mediaType: AVMediaType, ctx: BuildContext) async throws -> LoadOutcome {
+        try await loadSource(
+            clip: clip, mediaType: mediaType, resolveURL: ctx.resolveURL,
+            resolveSourceSize: ctx.resolveSourceSize, missingMediaRefs: ctx.missingMediaRefs,
+            renderSize: ctx.renderSize
         )
     }
 
@@ -382,180 +396,39 @@ enum CompositionBuilder {
         )
     }
 
-    /// Insert a nest's child video clips as composition tracks (one per child track).
-    private static func expandNestVideo(
-        carrier: Clip,
-        parentTrackIndex: Int,
-        depth: Int,
-        composition: AVMutableComposition,
-        timescale: CMTimeScale,
-        renderSize: CGSize,
-        resolveTimeline: @Sendable (String) -> Timeline?,
-        resolveURL: @Sendable (String) -> URL?,
-        resolveSourceSize: @Sendable (String) -> CGSize?,
-        missingMediaRefs: Set<String>,
-        trackMappings: inout [TrackMapping],
-        clipNaturalSizes: inout [String: CGSize],
-        clipTransforms: inout [String: CGAffineTransform],
-        offlineMediaRefs: inout Set<String>,
-        unprocessableMediaRefs: inout Set<String>
-    ) async throws {
+    private static func expandNestVideo(carrier: Clip, parentTrackIndex: Int, depth: Int, ctx: BuildContext) async throws {
         guard depth < NestFlattener.maxDepth else {
             Log.preview.warning("nest depth limit reached; skipping \(carrier.mediaRef.prefix(8))")
             return
         }
-        guard let child = resolveTimeline(carrier.mediaRef) else {
-            offlineMediaRefs.insert(carrier.mediaRef)
+        guard let child = ctx.resolveTimeline(carrier.mediaRef) else {
+            ctx.offlineMediaRefs.insert(carrier.mediaRef)
             return
         }
         let flat = NestFlattener.flatten(carrier: carrier, child: child, visual: true)
         for childClips in flat.videoTracks {
-            var compTrack: AVMutableCompositionTrack?
-            var cursor = CMTime.zero
-            var inserted: [Clip] = []
-            var previousEndFrame = Int.min
-            for clip in childClips {
-                guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
-                if clip.mediaType == .text { continue }   // text renders inside the group
-                if clip.mediaType == .sequence {
-                    try await expandNestVideo(
-                        carrier: clip, parentTrackIndex: parentTrackIndex, depth: depth + 1,
-                        composition: composition, timescale: timescale, renderSize: renderSize,
-                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
-                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                        trackMappings: &trackMappings, clipNaturalSizes: &clipNaturalSizes,
-                        clipTransforms: &clipTransforms, offlineMediaRefs: &offlineMediaRefs,
-                        unprocessableMediaRefs: &unprocessableMediaRefs
-                    )
-                    previousEndFrame = clip.endFrame
-                    continue
-                }
-                let source: (asset: AVURLAsset, track: AVAssetTrack)
-                switch try await loadSource(
-                    clip: clip, mediaType: .video, resolveURL: resolveURL,
-                    resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                    renderSize: renderSize
-                ) {
-                case .loaded(let asset, let track): source = (asset, track)
-                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
-                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
-                }
-                if compTrack == nil {
-                    compTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
-                }
-                guard let track = compTrack else { continue }
-                if let natSize = try? await source.track.load(.naturalSize),
-                   natSize.width > 0, natSize.height > 0 {
-                    let pt = (try? await source.track.load(.preferredTransform)) ?? .identity
-                    let box = CGRect(origin: .zero, size: natSize).applying(pt)
-                    clipNaturalSizes[clip.id] = CGSize(width: abs(box.width), height: abs(box.height))
-                    clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
-                }
-                if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
-                                    into: track, cursor: &cursor, timescale: timescale) {
-                    inserted.append(clip)
-                    previousEndFrame = clip.endFrame
-                }
-            }
-            if let compTrack {
-                if inserted.isEmpty {
-                    composition.removeTrack(compTrack)
-                } else {
-                    trackMappings.append(TrackMapping(
-                        compositionTrack: compTrack,
-                        kind: .nested(clips: inserted, carrier: carrier, parentTrackIndex: parentTrackIndex),
-                        naturalSize: renderSize,
-                        endTime: cursor,
-                        isVideo: true
-                    ))
-                }
-            }
+            try await insertVideoLane(clips: childClips, parentTrackIndex: parentTrackIndex,
+                                      nestCarrier: carrier, depth: depth + 1, ctx: ctx)
         }
     }
 
-    /// Child audio inserts per child track; static volumes fold, top carrier envelope multiplies at mix.
+    /// Static volumes fold down the chain; the top carrier's envelope multiplies at mix time.
     private static func expandNestAudio(
-        carrier: Clip,
-        topCarrier: Clip,
-        volumeScale: Double,
-        parentTrackIndex: Int,
-        depth: Int,
-        composition: AVMutableComposition,
-        timescale: CMTimeScale,
-        renderSize: CGSize,
-        resolveTimeline: @Sendable (String) -> Timeline?,
-        resolveURL: @Sendable (String) -> URL?,
-        resolveSourceSize: @Sendable (String) -> CGSize?,
-        missingMediaRefs: Set<String>,
-        trackMappings: inout [TrackMapping],
-        offlineMediaRefs: inout Set<String>,
-        unprocessableMediaRefs: inout Set<String>
+        carrier: Clip, topCarrier: Clip, volumeScale: Double,
+        parentTrackIndex: Int, depth: Int, ctx: BuildContext
     ) async throws {
         guard depth < NestFlattener.maxDepth else {
             Log.preview.warning("nest depth limit reached; skipping \(carrier.mediaRef.prefix(8))")
             return
         }
-        guard let child = resolveTimeline(carrier.mediaRef) else {
-            offlineMediaRefs.insert(carrier.mediaRef)
+        guard let child = ctx.resolveTimeline(carrier.mediaRef) else {
+            ctx.offlineMediaRefs.insert(carrier.mediaRef)
             return
         }
         let flat = NestFlattener.flatten(carrier: carrier, child: child, visual: false)
         for trackClips in flat.audioTracks {
-            // Clips within a child track never overlap: share one composition track.
-            var sharedTrack: AVMutableCompositionTrack?
-            var sharedCursor = CMTime.zero
-            var sharedClips: [Clip] = []
-            var previousEnd = Int.min
-            for var clip in trackClips {
-                guard clip.durationFrames > 0, clip.startFrame >= previousEnd else { continue }
-                previousEnd = clip.endFrame
-                if clip.sourceClipType == .sequence {
-                    try await expandNestAudio(
-                        carrier: clip, topCarrier: topCarrier, volumeScale: volumeScale * clip.volume,
-                        parentTrackIndex: parentTrackIndex, depth: depth + 1,
-                        composition: composition, timescale: timescale, renderSize: renderSize,
-                        resolveTimeline: resolveTimeline, resolveURL: resolveURL,
-                        resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                        trackMappings: &trackMappings, offlineMediaRefs: &offlineMediaRefs,
-                        unprocessableMediaRefs: &unprocessableMediaRefs
-                    )
-                    continue
-                }
-                clip.volume *= volumeScale
-                let source: (asset: AVURLAsset, track: AVAssetTrack)
-                switch try await loadSource(
-                    clip: clip, mediaType: .audio, resolveURL: resolveURL,
-                    resolveSourceSize: resolveSourceSize, missingMediaRefs: missingMediaRefs,
-                    renderSize: renderSize
-                ) {
-                case .loaded(let asset, let track): source = (asset, track)
-                case .offline: offlineMediaRefs.insert(clip.mediaRef); continue
-                case .unprocessable: unprocessableMediaRefs.insert(clip.mediaRef); continue
-                }
-
-                if sharedTrack == nil {
-                    sharedTrack = composition.addMutableTrack(
-                        withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
-                }
-                guard let compTrack = sharedTrack else { continue }
-                if await insertClip(clip, sourceAsset: source.asset, sourceTrack: source.track,
-                                    into: compTrack, cursor: &sharedCursor, timescale: timescale) {
-                    sharedClips.append(clip)
-                }
-            }
-            if let sharedTrack {
-                if sharedClips.isEmpty {
-                    composition.removeTrack(sharedTrack)
-                } else {
-                    trackMappings.append(TrackMapping(
-                        compositionTrack: sharedTrack,
-                        kind: .nested(clips: sharedClips, carrier: topCarrier, parentTrackIndex: parentTrackIndex),
-                        naturalSize: .zero,
-                        endTime: .zero,
-                        isVideo: false
-                    ))
-                }
-            }
+            try await insertAudioLane(clips: trackClips, parentTrackIndex: parentTrackIndex,
+                                      nest: (topCarrier, volumeScale), depth: depth + 1, ctx: ctx)
         }
     }
 
@@ -881,7 +754,10 @@ enum CompositionBuilder {
             }
             for kf in carrier.volumeTrack?.keyframes ?? [] {
                 extraOffsets.append(toClipOffset(kf.frame))
-                extraOffsets.append(toClipOffset(kf.frame) - 1)   // hold boundaries
+            }
+            for (a, b) in zip(carrier.volumeTrack?.keyframes ?? [], carrier.volumeTrack?.keyframes.dropFirst() ?? [])
+            where a.interpolationOut == .hold {
+                extraOffsets.append(toClipOffset(b.frame) - 1)
             }
             extraOffsets = extraOffsets.filter { $0 > 0 && $0 < clip.durationFrames }
         }

--- a/Sources/PalmierPro/Preview/NestFlattener.swift
+++ b/Sources/PalmierPro/Preview/NestFlattener.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import Foundation
+
+/// Expands a nest carrier one level: child clips remapped into parent frames.
+enum NestFlattener {
+    static let maxDepth = 8
+
+    struct Flattened: Sendable {
+        /// Child visual tracks, child track order preserved (text clips included).
+        var videoTracks: [[Clip]] = []
+        /// Unmuted child audio tracks; clips within a track never overlap.
+        var audioTracks: [[Clip]] = []
+        var childCanvas: CGSize = .zero
+    }
+
+    /// `carrier` = the video `.sequence` clip or its linked audio clip.
+    static func flatten(carrier: Clip, child: Timeline, visual: Bool) -> Flattened {
+        var out = Flattened()
+        out.childCanvas = CGSize(width: child.width, height: child.height)
+        let window = carrier.trimStartFrame..<(carrier.trimStartFrame + carrier.durationFrames)
+        let shift = carrier.startFrame - carrier.trimStartFrame
+
+        for track in child.tracks {
+            if visual {
+                guard track.type == .video, !track.hidden else { continue }
+                let clips = track.clips
+                    .sorted { $0.startFrame < $1.startFrame }
+                    .compactMap { remap($0, window: window, shift: shift, nestId: carrier.id) }
+                if !clips.isEmpty { out.videoTracks.append(clips) }
+            } else {
+                guard track.type == .audio, !track.muted else { continue }
+                let clips = track.clips
+                    .sorted { $0.startFrame < $1.startFrame }
+                    .compactMap { remap($0, window: window, shift: shift, nestId: carrier.id) }
+                if !clips.isEmpty { out.audioTracks.append(clips) }
+            }
+        }
+        return out
+    }
+
+    private static func remap(_ clip: Clip, window: Range<Int>, shift: Int, nestId: String) -> Clip? {
+        let start = max(clip.startFrame, window.lowerBound)
+        let end = min(clip.endFrame, window.upperBound)
+        guard end > start else { return nil }
+
+        var c = clip
+        let headCut = start - clip.startFrame
+        if headCut > 0 {
+            c.trimStartFrame += Int((Double(headCut) * c.speed).rounded())
+            c.fadeInFrames = 0
+            shiftKeyframeTracks(&c, by: headCut)
+        }
+        if end < clip.endFrame { c.fadeOutFrames = 0 }
+        c.startFrame = start + shift
+        c.durationFrames = end - start
+        c.clampFadesToDuration()
+        c.clampKeyframesToDuration()
+        // Unique per nest instance so the same child nested twice can't collide.
+        c.id = "\(nestId)/\(clip.id)"
+        return c
+    }
+
+    private static func shiftKeyframeTracks(_ clip: inout Clip, by headCut: Int) {
+        clip.opacityTrack = clip.opacityTrack?.rebased(by: headCut, fallback: clip.opacity)
+        clip.volumeTrack = clip.volumeTrack?.rebased(by: headCut, fallback: 0)
+        clip.positionTrack = clip.positionTrack?.rebased(by: headCut, fallback: AnimPair(a: 0, b: 0))
+        clip.scaleTrack = clip.scaleTrack?.rebased(by: headCut, fallback: AnimPair(a: 1, b: 1))
+        clip.rotationTrack = clip.rotationTrack?.rebased(by: headCut, fallback: 0)
+        clip.cropTrack = clip.cropTrack?.rebased(by: headCut, fallback: clip.crop)
+    }
+}

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -496,7 +496,7 @@ struct PreviewContainerView: View {
         let isActive = tab.id == editor.activePreviewTabId
         let isHovered = hoveredTabId == tab.id
         return HStack(spacing: AppTheme.Spacing.xs) {
-            Text(tab.displayName)
+            Text(tab == .timeline ? editor.timeline.name : tab.displayName)
                 .font(.system(size: AppTheme.FontSize.xs, weight: isActive ? .semibold : .medium))
                 .foregroundStyle(isActive || isHovered ? AppTheme.Text.primaryColor : AppTheme.Text.secondaryColor)
                 .lineLimit(1)

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -471,21 +471,8 @@ struct PreviewContainerView: View {
                 }
             }
 
-            ScrollViewReader { proxy in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: AppTheme.Spacing.md) {
-                        ForEach(editor.previewTabs) { tab in
-                            tabItem(for: tab).id(tab.id)
-                        }
-                    }
-                    .padding(.horizontal, AppTheme.Spacing.sm)
-                }
-                .mouseWheelScrollsHorizontally()
-                .onChange(of: editor.activePreviewTabId) { _, newId in
-                    withAnimation(.easeOut(duration: AppTheme.Anim.transition)) {
-                        proxy.scrollTo(newId, anchor: .center)
-                    }
-                }
+            TabStrip(items: editor.previewTabs, activeId: editor.activePreviewTabId) { tab in
+                tabItem(for: tab)
             }
 
             overflowMenu
@@ -502,7 +489,11 @@ struct PreviewContainerView: View {
                 .lineLimit(1)
 
             if tab.isCloseable {
-                closeButton(tabId: tab.id)
+                TabCloseButton {
+                    withAnimation(.easeInOut(duration: AppTheme.Anim.transition)) {
+                        editor.closePreviewTab(id: tab.id)
+                    }
+                }
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xs)
@@ -559,21 +550,6 @@ struct PreviewContainerView: View {
         .fixedSize()
         .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
         .help("More")
-    }
-
-    private func closeButton(tabId: String) -> some View {
-        Button {
-            withAnimation(.easeInOut(duration: AppTheme.Anim.transition)) {
-                editor.closePreviewTab(id: tabId)
-            }
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: AppTheme.FontSize.micro, weight: .bold))
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
-                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
-                .hoverHighlight(cornerRadius: 7)
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Scrub bar

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -14,6 +14,7 @@ enum TimelineRenderer {
     static func render(
         timeline: Timeline,
         resolver: MediaResolver,
+        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
         missingMediaRefs: Set<String> = [],
         startFrame: Int,
         frameCount: Int,
@@ -31,6 +32,7 @@ enum TimelineRenderer {
         let result = try await CompositionBuilder.build(
             timeline: timeline,
             resolveURL: { mediaURLs[$0] },
+            resolveTimeline: resolveTimeline,
             missingMediaRefs: missingMediaRefs,
             renderSize: renderSize
         )

--- a/Sources/PalmierPro/Preview/TimelineRenderer.swift
+++ b/Sources/PalmierPro/Preview/TimelineRenderer.swift
@@ -14,7 +14,7 @@ enum TimelineRenderer {
     static func render(
         timeline: Timeline,
         resolver: MediaResolver,
-        resolveTimeline: @Sendable (String) -> Timeline? = { _ in nil },
+        resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
         missingMediaRefs: Set<String> = [],
         startFrame: Int,
         frameCount: Int,

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -36,6 +36,7 @@ final class VideoEngine {
     func teardown() {
         rebuildTask?.cancel()
         rebuildTask = nil
+        compositionCache.removeAll()
         invalidateSeekState()
         if let timeObserver { player.removeTimeObserver(timeObserver) }
         timeObserver = nil
@@ -166,16 +167,17 @@ final class VideoEngine {
             return
         }
 
+        let snapshot = inputs.involved[0]
         rebuildTask = Task {
             let result: CompositionResult
             do {
                 result = try await CompositionBuilder.build(
-                    timeline: editor.timeline,
+                    timeline: snapshot,
                     resolveURL: { mediaURLs[$0] },
                     resolveSourceSize: { assetSizes[$0] },
                     resolveTimeline: resolveTimeline,
                     missingMediaRefs: missingMediaRefs,
-                    renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
+                    renderSize: CGSize(width: snapshot.width, height: snapshot.height)
                 )
             } catch {
                 if !Task.isCancelled {
@@ -188,13 +190,19 @@ final class VideoEngine {
             rebuildTask = nil
             guard !Task.isCancelled else { return }
 
-            compositionCache[timelineId] = (inputs, result)
+            if result.offlineMediaRefs.isEmpty && result.unprocessableMediaRefs.isEmpty {
+                compositionCache[timelineId] = (inputs, result)
+            }
             compositionCache = compositionCache.filter { editor.openTimelineIds.contains($0.key) }
             apply(result, resolveTimeline: resolveTimeline, editor: editor)
         }
     }
 
     private var compositionCache: [String: (inputs: RebuildInputs, result: CompositionResult)] = [:]
+
+    func evictComposition(for timelineId: String) {
+        compositionCache.removeValue(forKey: timelineId)
+    }
 
     private func apply(_ result: CompositionResult, resolveTimeline: @escaping @Sendable (String) -> Timeline?, editor: EditorViewModel) {
         trackMappings = result.trackMappings

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -131,6 +131,14 @@ final class VideoEngine {
 
     // MARK: - Composition
 
+    /// Everything CompositionBuilder.build reads; equal inputs → identical composition.
+    private struct RebuildInputs: Equatable {
+        let involved: [Timeline]  // active timeline plus nested children
+        let mediaURLs: [String: URL]
+        let assetSizes: [String: CGSize]
+        let missingMediaRefs: Set<String>
+    }
+
     func rebuild() {
         guard let editor, editor.activePreviewTab == .timeline else { return }
         rebuildTask?.cancel()
@@ -144,6 +152,19 @@ final class VideoEngine {
             }
         )
         let resolveTimeline = editor.timelineResolver()
+
+        let timelineId = editor.timeline.id
+        let inputs = RebuildInputs(
+            involved: [editor.timeline] + editor.timeline.reachableTimelines(resolve: { editor.timeline(for: $0) }),
+            mediaURLs: mediaURLs,
+            assetSizes: assetSizes,
+            missingMediaRefs: missingMediaRefs
+        )
+        if let cached = compositionCache[timelineId], cached.inputs == inputs {
+            rebuildTask = nil
+            apply(cached.result, resolveTimeline: resolveTimeline, editor: editor)
+            return
+        }
 
         rebuildTask = Task {
             let result: CompositionResult
@@ -167,22 +188,30 @@ final class VideoEngine {
             rebuildTask = nil
             guard !Task.isCancelled else { return }
 
-            trackMappings = result.trackMappings
-            clipNaturalSizes = result.clipNaturalSizes
-            clipTransforms = result.clipTransforms
-            compositionDuration = result.composition.duration
-            resolveTimelineSnapshot = resolveTimeline
-            editor.offlineMediaRefs = result.offlineMediaRefs
-            editor.unprocessableMediaRefs = result.unprocessableMediaRefs
-
-            let item = AVPlayerItem(asset: result.composition)
-            item.audioMix = result.audioMix
-            item.videoComposition = result.videoComposition
-            replacePlayerItem(item, reason: "rebuild")
-
-            seek(to: editor.currentFrame, mode: .exact)
-            if editor.isPlaying { player.play() }
+            compositionCache[timelineId] = (inputs, result)
+            compositionCache = compositionCache.filter { editor.openTimelineIds.contains($0.key) }
+            apply(result, resolveTimeline: resolveTimeline, editor: editor)
         }
+    }
+
+    private var compositionCache: [String: (inputs: RebuildInputs, result: CompositionResult)] = [:]
+
+    private func apply(_ result: CompositionResult, resolveTimeline: @escaping @Sendable (String) -> Timeline?, editor: EditorViewModel) {
+        trackMappings = result.trackMappings
+        clipNaturalSizes = result.clipNaturalSizes
+        clipTransforms = result.clipTransforms
+        compositionDuration = result.composition.duration
+        resolveTimelineSnapshot = resolveTimeline
+        editor.offlineMediaRefs = result.offlineMediaRefs
+        editor.unprocessableMediaRefs = result.unprocessableMediaRefs
+
+        let item = AVPlayerItem(asset: result.composition)
+        item.audioMix = result.audioMix
+        item.videoComposition = result.videoComposition
+        replacePlayerItem(item, reason: "rebuild")
+
+        seek(to: editor.currentFrame, mode: .exact)
+        if editor.isPlaying { player.play() }
     }
 
     func refreshVisuals() {

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -20,6 +20,7 @@ final class VideoEngine {
 
     private var trackMappings: [TrackMapping] = []
     private var clipNaturalSizes: [String: CGSize] = [:]
+    private var resolveTimelineSnapshot: @Sendable (String) -> Timeline? = { _ in nil }
     private var clipTransforms: [String: CGAffineTransform] = [:]
     private var compositionDuration: CMTime = .zero
 
@@ -142,6 +143,7 @@ final class VideoEngine {
                 return (asset.id, CGSize(width: w, height: h))
             }
         )
+        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
 
         rebuildTask = Task {
             let result: CompositionResult
@@ -150,6 +152,7 @@ final class VideoEngine {
                     timeline: editor.timeline,
                     resolveURL: { mediaURLs[$0] },
                     resolveSourceSize: { assetSizes[$0] },
+                    resolveTimeline: { timelinesById[$0] },
                     missingMediaRefs: missingMediaRefs,
                     renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
                 )
@@ -168,6 +171,7 @@ final class VideoEngine {
             clipNaturalSizes = result.clipNaturalSizes
             clipTransforms = result.clipTransforms
             compositionDuration = result.composition.duration
+            resolveTimelineSnapshot = { timelinesById[$0] }
             editor.offlineMediaRefs = result.offlineMediaRefs
             editor.unprocessableMediaRefs = result.unprocessableMediaRefs
 
@@ -194,6 +198,7 @@ final class VideoEngine {
             trackMappings: trackMappings,
             clipNaturalSizes: clipNaturalSizes,
             clipTransforms: clipTransforms,
+            resolveTimeline: resolveTimelineSnapshot,
             compositionDuration: compositionDuration,
             renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
         )
@@ -360,7 +365,7 @@ final class VideoEngine {
         return editor.timeline.tracks.count { track in
             guard track.type == .video, !track.hidden else { return false }
             return track.clips.contains { clip in
-                (clip.mediaType == .video || clip.mediaType == .image)
+                (clip.mediaType == .video || clip.mediaType == .image || clip.mediaType == .sequence)
                     && frame >= clip.startFrame
                     && frame < clip.endFrame
             }

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -143,7 +143,7 @@ final class VideoEngine {
                 return (asset.id, CGSize(width: w, height: h))
             }
         )
-        let timelinesById = Dictionary(uniqueKeysWithValues: editor.timelines.map { ($0.id, $0) })
+        let resolveTimeline = editor.timelineResolver()
 
         rebuildTask = Task {
             let result: CompositionResult
@@ -152,7 +152,7 @@ final class VideoEngine {
                     timeline: editor.timeline,
                     resolveURL: { mediaURLs[$0] },
                     resolveSourceSize: { assetSizes[$0] },
-                    resolveTimeline: { timelinesById[$0] },
+                    resolveTimeline: resolveTimeline,
                     missingMediaRefs: missingMediaRefs,
                     renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
                 )
@@ -171,7 +171,7 @@ final class VideoEngine {
             clipNaturalSizes = result.clipNaturalSizes
             clipTransforms = result.clipTransforms
             compositionDuration = result.composition.duration
-            resolveTimelineSnapshot = { timelinesById[$0] }
+            resolveTimelineSnapshot = resolveTimeline
             editor.offlineMediaRefs = result.offlineMediaRefs
             editor.unprocessableMediaRefs = result.unprocessableMediaRefs
 

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -149,13 +149,18 @@ final class VideoProject: NSDocument {
                 snapshotSourceProjectURL = fileURL
             }
         }
-        defer {
-            snapshotPreparedForWrite = false
-            snapshotSourceProjectURL = nil
-        }
-        // Snapshot values are captured; editing can resume while we encode and write.
+
+        let file = snapshotProjectFile
+        let manifest = snapshotManifest
+        let generationLog = snapshotGenerationLog
+        let thumbnail = snapshotThumbnail
+        let chatSessionFiles = snapshotChatSessionFiles
+        let sourceURL = snapshotSourceProjectURL
+        snapshotPreparedForWrite = false
+        snapshotSourceProjectURL = nil
         unblockUserInteraction()
-        guard let file = snapshotProjectFile, let data = try? JSONEncoder().encode(file) else {
+
+        guard let file, let data = try? JSONEncoder().encode(file) else {
             Log.project.error("save: project snapshot missing at write()")
             throw CocoaError(.fileWriteUnknown)
         }
@@ -163,16 +168,16 @@ final class VideoProject: NSDocument {
         try Self.writeProjectPackage(
             ProjectPackageSnapshot(
                 timeline: data,
-                manifest: snapshotManifest.flatMap { try? JSONEncoder().encode($0) },
-                generationLog: snapshotGenerationLog.flatMap { try? JSONEncoder().encode($0) },
-                thumbnail: snapshotThumbnail,
-                chatSessionFiles: snapshotChatSessionFiles
+                manifest: manifest.flatMap { try? JSONEncoder().encode($0) },
+                generationLog: generationLog.flatMap { try? JSONEncoder().encode($0) },
+                thumbnail: thumbnail,
+                chatSessionFiles: chatSessionFiles
             ),
             to: url,
-            sourceURL: snapshotSourceProjectURL
+            sourceURL: sourceURL
         )
         // A real manifest was just written, so the unreadable original is gone; stop preserving it.
-        if snapshotManifest != nil { manifestLoadFailed = false }
+        if manifest != nil { manifestLoadFailed = false }
     }
 
     private func captureSaveSnapshot() {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -38,10 +38,10 @@ final class VideoProject: NSDocument {
     /// Set when media.json existed but failed to decode, so saves preserve it instead of clobbering.
     private nonisolated(unsafe) var manifestLoadFailed = false
 
-    /// Captured on main thread before writes may continue off-main.
-    private nonisolated(unsafe) var snapshotTimeline: Data?
-    private nonisolated(unsafe) var snapshotManifest: Data?
-    private nonisolated(unsafe) var snapshotGenerationLog: Data?
+    /// Captured on main thread as cheap value copies; encoded off-main in write().
+    private nonisolated(unsafe) var snapshotProjectFile: ProjectFile?
+    private nonisolated(unsafe) var snapshotManifest: MediaManifest?
+    private nonisolated(unsafe) var snapshotGenerationLog: GenerationLog?
     private nonisolated(unsafe) var snapshotThumbnail: Data?
     private nonisolated(unsafe) var snapshotChatSessionFiles: [(name: String, data: Data)] = []
     private nonisolated(unsafe) var snapshotSourceProjectURL: URL?
@@ -51,6 +51,9 @@ final class VideoProject: NSDocument {
     // MARK: - Persistence
 
     override class var autosavesInPlace: Bool { true }
+
+    // The save snapshot is captured on main before super.save; the encode + disk write run off-main.
+    override func canAsynchronouslyWrite(to url: URL, ofType typeName: String, for saveOperation: NSDocument.SaveOperationType) -> Bool { true }
 
     @MainActor
     static func load(from url: URL) async throws -> VideoProject {
@@ -150,16 +153,18 @@ final class VideoProject: NSDocument {
             snapshotPreparedForWrite = false
             snapshotSourceProjectURL = nil
         }
-        guard let data = snapshotTimeline else {
-            Log.project.error("save: snapshotTimeline missing at write()")
+        // Snapshot values are captured; editing can resume while we encode and write.
+        unblockUserInteraction()
+        guard let file = snapshotProjectFile, let data = try? JSONEncoder().encode(file) else {
+            Log.project.error("save: project snapshot missing at write()")
             throw CocoaError(.fileWriteUnknown)
         }
 
         try Self.writeProjectPackage(
             ProjectPackageSnapshot(
                 timeline: data,
-                manifest: snapshotManifest,
-                generationLog: snapshotGenerationLog,
+                manifest: snapshotManifest.flatMap { try? JSONEncoder().encode($0) },
+                generationLog: snapshotGenerationLog.flatMap { try? JSONEncoder().encode($0) },
                 thumbnail: snapshotThumbnail,
                 chatSessionFiles: snapshotChatSessionFiles
             ),
@@ -171,9 +176,9 @@ final class VideoProject: NSDocument {
     }
 
     private func captureSaveSnapshot() {
-        snapshotTimeline = try? JSONEncoder().encode(editorViewModel.projectFileSnapshot())
-        snapshotManifest = Self.manifestSnapshotData(manifest: editorViewModel.mediaManifest, loadFailed: manifestLoadFailed)
-        snapshotGenerationLog = try? JSONEncoder().encode(editorViewModel.generationLog)
+        snapshotProjectFile = editorViewModel.projectFileSnapshot()
+        snapshotManifest = Self.manifestSnapshot(manifest: editorViewModel.mediaManifest, loadFailed: manifestLoadFailed)
+        snapshotGenerationLog = editorViewModel.generationLog
         snapshotThumbnail = captureThumbnail()
         snapshotChatSessionFiles = editorViewModel.agentService.sessions
             .filter { !$0.messages.isEmpty }
@@ -183,10 +188,10 @@ final class VideoProject: NSDocument {
         snapshotPreparedForWrite = true
     }
 
-    nonisolated static func manifestSnapshotData(manifest: MediaManifest, loadFailed: Bool) -> Data? {
+    nonisolated static func manifestSnapshot(manifest: MediaManifest, loadFailed: Bool) -> MediaManifest? {
         // If the manifest failed to load, don't overwrite the (recoverable) original with an empty one.
         if loadFailed && manifest.entries.isEmpty && manifest.folders.isEmpty { return nil }
-        return try? JSONEncoder().encode(manifest)
+        return manifest
     }
 
     private nonisolated static func requiredData(_ name: String, in packageURL: URL) throws -> Data {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -4,7 +4,7 @@ import AVFoundation
 import UniformTypeIdentifiers
 
 struct ProjectPackageContents: Sendable {
-    var timeline: Timeline
+    var projectFile: ProjectFile
     var manifest: MediaManifest?
     var generationLog: GenerationLog?
     var manifestUnreadable: Bool = false
@@ -31,7 +31,7 @@ final class VideoProject: NSDocument {
     let editorViewModel = EditorViewModel()
 
     /// Decoded off-main in read(), applied on main in makeWindowControllers.
-    private nonisolated(unsafe) var loadedTimeline: Timeline?
+    private nonisolated(unsafe) var loadedProjectFile: ProjectFile?
     private nonisolated(unsafe) var loadedManifest: MediaManifest?
     private nonisolated(unsafe) var loadedGenerationLog: GenerationLog?
 
@@ -69,16 +69,18 @@ final class VideoProject: NSDocument {
     }
 
     private nonisolated func applyLoadedContents(_ contents: ProjectPackageContents) {
-        loadedTimeline = contents.timeline
+        loadedProjectFile = contents.projectFile
         loadedManifest = contents.manifest
         loadedGenerationLog = contents.generationLog
         manifestLoadFailed = contents.manifestUnreadable
+        let timelines = loadedProjectFile?.timelines ?? []
         Log.project.notice(
-            "read ok tracks=\(self.loadedTimeline?.tracks.count ?? 0)",
+            "read ok timelines=\(timelines.count)",
             telemetry: "Project read",
             data: [
-                "tracks": loadedTimeline?.tracks.count ?? 0,
-                "clips": loadedTimeline?.tracks.reduce(0) { $0 + $1.clips.count } ?? 0,
+                "timelines": timelines.count,
+                "tracks": timelines.reduce(0) { $0 + $1.tracks.count },
+                "clips": timelines.reduce(0) { $0 + $1.tracks.reduce(0) { $0 + $1.clips.count } },
                 "media": loadedManifest?.entries.count ?? 0,
                 "hasGenerationLog": loadedGenerationLog != nil
             ]
@@ -87,9 +89,9 @@ final class VideoProject: NSDocument {
 
     nonisolated static func readProjectPackage(at url: URL) throws -> ProjectPackageContents {
         let data = try requiredData(Project.timelineFilename, in: url)
-        let timeline: Timeline
+        let projectFile: ProjectFile
         do {
-            timeline = try JSONDecoder().decode(Timeline.self, from: data)
+            projectFile = try ProjectFile.decode(data)
         } catch {
             Log.project.error("read: timeline decode failed: \(String(describing: error))")
             throw error
@@ -116,7 +118,7 @@ final class VideoProject: NSDocument {
             .flatMap { try? JSONDecoder().decode(GenerationLog.self, from: $0) }
 
         return ProjectPackageContents(
-            timeline: timeline,
+            projectFile: projectFile,
             manifest: manifest,
             generationLog: generationLog,
             manifestUnreadable: manifestUnreadable
@@ -169,7 +171,7 @@ final class VideoProject: NSDocument {
     }
 
     private func captureSaveSnapshot() {
-        snapshotTimeline = try? JSONEncoder().encode(editorViewModel.timeline)
+        snapshotTimeline = try? JSONEncoder().encode(editorViewModel.projectFileSnapshot())
         snapshotManifest = Self.manifestSnapshotData(manifest: editorViewModel.mediaManifest, loadFailed: manifestLoadFailed)
         snapshotGenerationLog = try? JSONEncoder().encode(editorViewModel.generationLog)
         snapshotThumbnail = captureThumbnail()
@@ -327,9 +329,9 @@ final class VideoProject: NSDocument {
     // MARK: - Window setup
 
     override func makeWindowControllers() {
-        if let loaded = loadedTimeline {
-            editorViewModel.timeline = loaded
-            loadedTimeline = nil
+        if let loaded = loadedProjectFile {
+            editorViewModel.applyProjectFile(loaded)
+            loadedProjectFile = nil
         }
         editorViewModel.undoManager = undoManager
         editorViewModel.projectURL = fileURL

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -131,6 +131,13 @@ enum ClipRenderer {
             context.strokePath()
         }
 
+        // Subtle wash while the clip's media is being rendered/generated.
+        if isGenerating {
+            context.setFillColor(NSColor.white.withAlphaComponent(AppTheme.Opacity.faint).cgColor)
+            context.addPath(path)
+            context.fillPath()
+        }
+
         // Red wash + border for clips whose source media is missing.
         if isMissing && !isGenerating {
             context.setFillColor(AppTheme.Status.error.withAlphaComponent(AppTheme.Opacity.moderate).cgColor)

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -38,6 +38,7 @@ struct TimelineContainerView: NSViewRepresentable {
         context.coordinator.headerView = headerView
         context.coordinator.timelineView = timelineView
         context.coordinator.scrollView = scrollView
+        context.coordinator.editor = editor
 
         scrollView.contentView.postsBoundsChangedNotifications = true
         scrollView.contentView.postsFrameChangedNotifications = true
@@ -73,6 +74,13 @@ struct TimelineContainerView: NSViewRepresentable {
             context.coordinator.headerView?.needsDisplay = true
         }
 
+        if let x = editor.timelineScrollRestoreX,
+           let scrollView = context.coordinator.scrollView {
+            let y = scrollView.contentView.bounds.origin.y
+            scrollView.contentView.setBoundsOrigin(NSPoint(x: max(0, x), y: y))
+            DispatchQueue.main.async { editor.timelineScrollRestoreX = nil }
+        }
+
         if editor.isPlaying,
            let timelineView = context.coordinator.timelineView,
            let scrollView = context.coordinator.scrollView {
@@ -106,6 +114,7 @@ struct TimelineContainerView: NSViewRepresentable {
         var headerView: TimelineHeaderView?
         var timelineView: TimelineView?
         var scrollView: NSScrollView?
+        weak var editor: EditorViewModel?
         private var renderState: RenderState?
 
         func needsRender(for next: RenderState) -> Bool {
@@ -116,6 +125,9 @@ struct TimelineContainerView: NSViewRepresentable {
         @MainActor @objc func scrollViewBoundsChanged(_ notification: Notification) {
             timelineView?.needsDisplay = true
             timelineView?.updatePlayheadLayer()
+            if let scrollX = scrollView?.contentView.bounds.origin.x {
+                editor?.timelineScrollOffsetX = scrollX
+            }
             if let scrollY = scrollView?.contentView.bounds.origin.y {
                 headerView?.setBoundsOrigin(NSPoint(x: 0, y: scrollY))
                 headerView?.needsDisplay = true

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -47,6 +47,11 @@ final class TimelineInputController {
             let ti = geometry.trackAt(y: point.y)
             if let hit = hitTestClip(at: point, trackIndex: ti, geometry: geometry) {
                 let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
+                if clip.sourceClipType == .sequence {
+                    editor.activateTimeline(clip.mediaRef)
+                    dragState = .idle
+                    return
+                }
                 if let asset = editor.mediaAssets.first(where: { $0.id == clip.mediaRef }) {
                     editor.selectMediaAsset(asset)
                     editor.mediaPanelRevealAssetId = asset.id

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -29,6 +29,15 @@ final class TimelineInputController {
 
     // MARK: - Mouse down
 
+
+    /// Nest trim limits come from the child's live length, not creation time.
+    private func effectiveTrimEnd(for clip: Clip) -> Int {
+        guard clip.sourceClipType == .sequence, let child = editor.timeline(for: clip.mediaRef) else {
+            return clip.trimEndFrame
+        }
+        return max(0, child.totalFrames - clip.trimStartFrame - clip.durationFrames)
+    }
+
     func mouseDown(with event: NSEvent, geometry: TimelineGeometry) {
         let point = view.convert(event.locationInWindow, from: nil)
         let scrollOffsetY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
@@ -144,7 +153,7 @@ final class TimelineInputController {
                     clipId: clip.id,
                     trackIndex: hit.trackIndex,
                     originalTrimStart: clip.trimStartFrame,
-                    originalTrimEnd: clip.trimEndFrame,
+                    originalTrimEnd: effectiveTrimEnd(for: clip),
                     originalStartFrame: clip.startFrame,
                     originalDuration: clip.durationFrames,
                     hasNoSourceMedia: clip.mediaType == .image || clip.mediaType == .text,
@@ -156,7 +165,7 @@ final class TimelineInputController {
                     clipId: clip.id,
                     trackIndex: hit.trackIndex,
                     originalTrimStart: clip.trimStartFrame,
-                    originalTrimEnd: clip.trimEndFrame,
+                    originalTrimEnd: effectiveTrimEnd(for: clip),
                     originalStartFrame: clip.startFrame,
                     originalDuration: clip.durationFrames,
                     hasNoSourceMedia: clip.mediaType == .image || clip.mediaType == .text,

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct TimelineTabBar: View {
+    @Environment(EditorViewModel.self) private var editor
+    @State private var renamingTabId: String?
+    @State private var renameDraft = ""
+    @FocusState private var renameFocused: Bool
+
+    private var openTimelines: [Timeline] {
+        editor.openTimelineIds.compactMap { editor.timeline(for: $0) }
+    }
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: AppTheme.Spacing.md) {
+                        ForEach(openTimelines) { timeline in
+                            tabItem(timeline).id(timeline.id)
+                        }
+                        addButton
+                    }
+                    .padding(.horizontal, AppTheme.Spacing.sm)
+                }
+                .mouseWheelScrollsHorizontally()
+                .onChange(of: editor.activeTimelineId) { _, newId in
+                    withAnimation(.easeOut(duration: AppTheme.Anim.transition)) {
+                        proxy.scrollTo(newId, anchor: .center)
+                    }
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+        .panelHeaderBar()
+    }
+
+    private func tabItem(_ timeline: Timeline) -> some View {
+        let isActive = timeline.id == editor.activeTimelineId
+        return HStack(spacing: AppTheme.Spacing.xs) {
+            if renamingTabId == timeline.id {
+                renameField(timeline)
+            } else {
+                Text(timeline.name)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: isActive ? AppTheme.FontWeight.semibold : AppTheme.FontWeight.medium))
+                    .foregroundStyle(isActive ? AppTheme.Text.primaryColor : AppTheme.Text.secondaryColor)
+                    .lineLimit(1)
+            }
+
+            if editor.openTimelineIds.count > 1 {
+                closeButton(timeline.id)
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.xs)
+        .padding(.vertical, AppTheme.Spacing.xxs)
+        .padding(.bottom, AppTheme.Spacing.xxs)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(isActive ? AppTheme.Accent.primary : Color.clear)
+                .frame(height: AppTheme.BorderWidth.medium)
+        }
+        .fixedSize()
+        .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+        .gesture(TapGesture(count: 2).onEnded { beginRename(timeline) })
+        .simultaneousGesture(TapGesture().onEnded { editor.activateTimeline(timeline.id) })
+        .contextMenu {
+            Button("Rename") { beginRename(timeline) }
+            Button("Duplicate") { editor.duplicateTimeline(timeline.id) }
+            Divider()
+            Button("Close Tab") { editor.closeTimelineTab(timeline.id) }
+                .disabled(editor.openTimelineIds.count <= 1)
+            Button("Close Other Tabs") { editor.closeOtherTimelineTabs(keeping: timeline.id) }
+                .disabled(editor.openTimelineIds.count <= 1)
+            Divider()
+            Button("Delete Timeline", role: .destructive) { editor.deleteTimeline(timeline.id) }
+                .disabled(editor.timelines.count <= 1)
+        }
+        .animation(.easeOut(duration: AppTheme.Anim.hover), value: isActive)
+    }
+
+    private func renameField(_ timeline: Timeline) -> some View {
+        TextField("", text: $renameDraft)
+            .textFieldStyle(.plain)
+            .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold))
+            .foregroundStyle(AppTheme.Text.primaryColor)
+            .frame(width: AppTheme.ComponentSize.timelineTabRenameWidth)
+            .focused($renameFocused)
+            .onSubmit { commitRename(timeline.id) }
+            .onExitCommand { renamingTabId = nil }
+            .onChange(of: renameFocused) { _, focused in
+                if !focused { commitRename(timeline.id) }
+            }
+    }
+
+    private func beginRename(_ timeline: Timeline) {
+        renameDraft = timeline.name
+        renamingTabId = timeline.id
+        DispatchQueue.main.async { renameFocused = true }
+    }
+
+    private func commitRename(_ id: String) {
+        guard renamingTabId == id else { return }
+        renamingTabId = nil
+        editor.renameTimeline(id, to: renameDraft)
+    }
+
+    private var addButton: some View {
+        Button {
+            editor.createTimeline()
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.md)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+        }
+        .buttonStyle(.plain)
+        .help("New timeline")
+    }
+
+    private func closeButton(_ id: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: AppTheme.Anim.transition)) {
+                editor.closeTimelineTab(id)
+            }
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: AppTheme.FontSize.micro, weight: AppTheme.FontWeight.bold))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -26,6 +26,12 @@ struct TimelineTabBar: View {
                         proxy.scrollTo(newId, anchor: .center)
                     }
                 }
+                .onChange(of: editor.timelineTabRenameRequest) { _, id in
+                    guard let id else { return }
+                    editor.timelineTabRenameRequest = nil
+                    renamingTabId = id
+                    proxy.scrollTo(id, anchor: .center)
+                }
             }
             .fixedSize(horizontal: false, vertical: true)
 

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -10,6 +10,7 @@ struct TimelineTabBar: View {
 
     var body: some View {
         HStack(spacing: AppTheme.Spacing.xs) {
+            allTimelinesMenu
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: AppTheme.Spacing.md) {
@@ -38,6 +39,34 @@ struct TimelineTabBar: View {
             Spacer(minLength: 0)
         }
         .panelHeaderBar()
+    }
+
+    private var allTimelinesMenu: some View {
+        Menu {
+            ForEach(editor.timelines) { timeline in
+                Button {
+                    editor.activateTimeline(timeline.id)
+                } label: {
+                    if timeline.id == editor.activeTimelineId {
+                        Label(timeline.name, systemImage: "checkmark")
+                    } else {
+                        Text(timeline.name)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.md)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .padding(.leading, AppTheme.Spacing.xs)
+        .help("All timelines")
     }
 
     private func tabItem(_ timeline: Timeline) -> some View {
@@ -130,3 +159,4 @@ struct TimelineTabBar: View {
         .buttonStyle(.plain)
     }
 }
+

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -2,10 +2,37 @@ import SwiftUI
 
 struct TimelineTabBar: View {
     @Environment(EditorViewModel.self) private var editor
+
+    var body: some View {
+        TimelineTabBarContent(
+            editor: editor,
+            tabs: editor.openTimelineIds.compactMap { id in
+                editor.timeline(for: id).map { TimelineTabInfo(id: $0.id, name: $0.name) }
+            },
+            allTabs: editor.timelines.map { TimelineTabInfo(id: $0.id, name: $0.name) },
+            activeId: editor.activeTimelineId,
+            renameRequest: editor.timelineTabRenameRequest
+        )
+        .equatable()
+    }
+}
+
+private struct TimelineTabInfo: Equatable, Identifiable {
+    let id: String
+    let name: String
+}
+
+private struct TimelineTabBarContent: View, Equatable {
+    let editor: EditorViewModel
+    let tabs: [TimelineTabInfo]
+    let allTabs: [TimelineTabInfo]
+    let activeId: String
+    let renameRequest: String?
     @State private var renamingTabId: String?
 
-    private var openTimelines: [Timeline] {
-        editor.openTimelineIds.compactMap { editor.timeline(for: $0) }
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.tabs == rhs.tabs && lhs.allTabs == rhs.allTabs
+            && lhs.activeId == rhs.activeId && lhs.renameRequest == rhs.renameRequest
     }
 
     var body: some View {
@@ -14,20 +41,20 @@ struct TimelineTabBar: View {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: AppTheme.Spacing.md) {
-                        ForEach(openTimelines) { timeline in
-                            tabItem(timeline).id(timeline.id)
+                        ForEach(tabs) { tab in
+                            tabItem(tab).id(tab.id)
                         }
                         addButton
                     }
                     .padding(.horizontal, AppTheme.Spacing.sm)
                 }
                 .mouseWheelScrollsHorizontally()
-                .onChange(of: editor.activeTimelineId) { _, newId in
+                .onChange(of: activeId) { _, newId in
                     withAnimation(.easeOut(duration: AppTheme.Anim.transition)) {
                         proxy.scrollTo(newId, anchor: .center)
                     }
                 }
-                .onChange(of: editor.timelineTabRenameRequest) { _, id in
+                .onChange(of: renameRequest) { _, id in
                     guard let id else { return }
                     editor.timelineTabRenameRequest = nil
                     renamingTabId = id
@@ -43,14 +70,14 @@ struct TimelineTabBar: View {
 
     private var allTimelinesMenu: some View {
         Menu {
-            ForEach(editor.timelines) { timeline in
+            ForEach(allTabs) { tab in
                 Button {
-                    editor.activateTimeline(timeline.id)
+                    editor.activateTimeline(tab.id)
                 } label: {
-                    if timeline.id == editor.activeTimelineId {
-                        Label(timeline.name, systemImage: "checkmark")
+                    if tab.id == activeId {
+                        Label(tab.name, systemImage: "checkmark")
                     } else {
-                        Text(timeline.name)
+                        Text(tab.name)
                     }
                 }
             }
@@ -69,20 +96,20 @@ struct TimelineTabBar: View {
         .help("All timelines")
     }
 
-    private func tabItem(_ timeline: Timeline) -> some View {
-        let isActive = timeline.id == editor.activeTimelineId
+    private func tabItem(_ tab: TimelineTabInfo) -> some View {
+        let isActive = tab.id == activeId
         return HStack(spacing: AppTheme.Spacing.xs) {
-            if renamingTabId == timeline.id {
-                renameField(timeline)
+            if renamingTabId == tab.id {
+                renameField(tab)
             } else {
-                Text(timeline.name)
+                Text(tab.name)
                     .font(.system(size: AppTheme.FontSize.xs, weight: isActive ? AppTheme.FontWeight.semibold : AppTheme.FontWeight.medium))
                     .foregroundStyle(isActive ? AppTheme.Text.primaryColor : AppTheme.Text.secondaryColor)
                     .lineLimit(1)
             }
 
-            if editor.openTimelineIds.count > 1 {
-                closeButton(timeline.id)
+            if tabs.count > 1 {
+                closeButton(tab.id)
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xs)
@@ -95,39 +122,35 @@ struct TimelineTabBar: View {
         }
         .fixedSize()
         .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
-        .gesture(TapGesture(count: 2).onEnded { beginRename(timeline) })
-        .simultaneousGesture(TapGesture().onEnded { editor.activateTimeline(timeline.id) })
+        .gesture(TapGesture(count: 2).onEnded { renamingTabId = tab.id })
+        .simultaneousGesture(TapGesture().onEnded { editor.activateTimeline(tab.id) })
         .contextMenu {
-            Button("Rename") { beginRename(timeline) }
-            Button("Duplicate") { editor.duplicateTimeline(timeline.id) }
+            Button("Rename") { renamingTabId = tab.id }
+            Button("Duplicate") { editor.duplicateTimeline(tab.id) }
             Divider()
-            Button("Close Tab") { editor.closeTimelineTab(timeline.id) }
-                .disabled(editor.openTimelineIds.count <= 1)
-            Button("Close Other Tabs") { editor.closeOtherTimelineTabs(keeping: timeline.id) }
-                .disabled(editor.openTimelineIds.count <= 1)
+            Button("Close Tab") { editor.closeTimelineTab(tab.id) }
+                .disabled(tabs.count <= 1)
+            Button("Close Other Tabs") { editor.closeOtherTimelineTabs(keeping: tab.id) }
+                .disabled(tabs.count <= 1)
             Divider()
-            Button("Delete Timeline", role: .destructive) { editor.deleteTimeline(timeline.id) }
-                .disabled(editor.timelines.count <= 1)
+            Button("Delete Timeline", role: .destructive) { editor.deleteTimeline(tab.id) }
+                .disabled(allTabs.count <= 1)
         }
         .animation(.easeOut(duration: AppTheme.Anim.hover), value: isActive)
     }
 
-    private func renameField(_ timeline: Timeline) -> some View {
+    private func renameField(_ tab: TimelineTabInfo) -> some View {
         InlineRenameField(
-            originalName: timeline.name,
+            originalName: tab.name,
             font: .system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold),
             onCommit: { name in
-                editor.renameTimeline(timeline.id, to: name)
+                editor.renameTimeline(tab.id, to: name)
                 renamingTabId = nil
             },
             onCancel: { renamingTabId = nil }
         )
         .foregroundStyle(AppTheme.Text.primaryColor)
         .frame(width: AppTheme.ComponentSize.timelineTabRenameWidth)
-    }
-
-    private func beginRename(_ timeline: Timeline) {
-        renamingTabId = timeline.id
     }
 
     private var addButton: some View {
@@ -159,4 +182,3 @@ struct TimelineTabBar: View {
         .buttonStyle(.plain)
     }
 }
-

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -3,8 +3,6 @@ import SwiftUI
 struct TimelineTabBar: View {
     @Environment(EditorViewModel.self) private var editor
     @State private var renamingTabId: String?
-    @State private var renameDraft = ""
-    @FocusState private var renameFocused: Bool
 
     private var openTimelines: [Timeline] {
         editor.openTimelineIds.compactMap { editor.timeline(for: $0) }
@@ -80,29 +78,21 @@ struct TimelineTabBar: View {
     }
 
     private func renameField(_ timeline: Timeline) -> some View {
-        TextField("", text: $renameDraft)
-            .textFieldStyle(.plain)
-            .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold))
-            .foregroundStyle(AppTheme.Text.primaryColor)
-            .frame(width: AppTheme.ComponentSize.timelineTabRenameWidth)
-            .focused($renameFocused)
-            .onSubmit { commitRename(timeline.id) }
-            .onExitCommand { renamingTabId = nil }
-            .onChange(of: renameFocused) { _, focused in
-                if !focused { commitRename(timeline.id) }
-            }
+        InlineRenameField(
+            originalName: timeline.name,
+            font: .system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold),
+            onCommit: { name in
+                editor.renameTimeline(timeline.id, to: name)
+                renamingTabId = nil
+            },
+            onCancel: { renamingTabId = nil }
+        )
+        .foregroundStyle(AppTheme.Text.primaryColor)
+        .frame(width: AppTheme.ComponentSize.timelineTabRenameWidth)
     }
 
     private func beginRename(_ timeline: Timeline) {
-        renameDraft = timeline.name
         renamingTabId = timeline.id
-        DispatchQueue.main.async { renameFocused = true }
-    }
-
-    private func commitRename(_ id: String) {
-        guard renamingTabId == id else { return }
-        renamingTabId = nil
-        editor.renameTimeline(id, to: renameDraft)
     }
 
     private var addButton: some View {

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -38,30 +38,17 @@ private struct TimelineTabBarContent: View, Equatable {
     var body: some View {
         HStack(spacing: AppTheme.Spacing.xs) {
             allTimelinesMenu
-            ScrollViewReader { proxy in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: AppTheme.Spacing.md) {
-                        ForEach(tabs) { tab in
-                            tabItem(tab).id(tab.id)
-                        }
-                        addButton
-                    }
-                    .padding(.horizontal, AppTheme.Spacing.sm)
-                }
-                .mouseWheelScrollsHorizontally()
-                .onChange(of: activeId) { _, newId in
-                    withAnimation(.easeOut(duration: AppTheme.Anim.transition)) {
-                        proxy.scrollTo(newId, anchor: .center)
-                    }
-                }
-                .onChange(of: renameRequest) { _, id in
-                    guard let id else { return }
-                    editor.timelineTabRenameRequest = nil
-                    renamingTabId = id
-                    proxy.scrollTo(id, anchor: .center)
-                }
+            TabStrip(items: tabs, activeId: activeId, scrollRequest: renameRequest) { tab in
+                tabItem(tab)
+            } trailing: {
+                addButton
             }
             .fixedSize(horizontal: false, vertical: true)
+            .onChange(of: renameRequest) { _, id in
+                guard let id else { return }
+                editor.timelineTabRenameRequest = nil
+                renamingTabId = id
+            }
 
             Spacer(minLength: 0)
         }
@@ -109,7 +96,11 @@ private struct TimelineTabBarContent: View, Equatable {
             }
 
             if tabs.count > 1 {
-                closeButton(tab.id)
+                TabCloseButton {
+                    withAnimation(.easeInOut(duration: AppTheme.Anim.transition)) {
+                        editor.closeTimelineTab(tab.id)
+                    }
+                }
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xs)
@@ -167,18 +158,4 @@ private struct TimelineTabBarContent: View, Equatable {
         .help("New timeline")
     }
 
-    private func closeButton(_ id: String) -> some View {
-        Button {
-            withAnimation(.easeInOut(duration: AppTheme.Anim.transition)) {
-                editor.closeTimelineTab(id)
-            }
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: AppTheme.FontSize.micro, weight: AppTheme.FontWeight.bold))
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
-                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
-                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
-        }
-        .buttonStyle(.plain)
-    }
 }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -896,6 +896,9 @@ final class TimelineView: NSView {
 
         // Nest
         var nestItems: [NSMenuItem] = []
+        let nestClipsItem = NSMenuItem(title: "Create Nested Timeline", action: #selector(performNestClips(_:)), keyEquivalent: "")
+        nestClipsItem.target = self
+        nestItems.append(nestClipsItem)
         if clip.sourceClipType == .sequence {
             let openItem = NSMenuItem(title: "Open Timeline", action: #selector(performOpenNestedTimeline(_:)), keyEquivalent: "")
             openItem.target = self
@@ -1044,6 +1047,10 @@ final class TimelineView: NSView {
         guard let item = sender as? NSMenuItem,
               let clipId = item.representedObject as? String else { return }
         editor.beginMediaSwap(clipId: clipId)
+    }
+
+    @objc private func performNestClips(_ sender: Any?) {
+        editor.nestSelectedClips()
     }
 
     @objc private func performOpenNestedTimeline(_ sender: Any?) {

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1157,6 +1157,18 @@ final class TimelineView: NSView {
         guard let urlString = sender.draggingPasteboard.string(forType: .string) else { return false }
 
         let editor = self.editor
+
+        let timelineIds = editor.timelineIdsFromDragPayload(urlString)
+        if !timelineIds.isEmpty {
+            var frame = targetFrame
+            for id in timelineIds {
+                guard editor.nestTimeline(id, cursor: cursorTarget, atFrame: frame) else { continue }
+                frame += editor.timeline(for: id)?.totalFrames ?? 0
+            }
+            needsDisplay = true
+            return true
+        }
+
         let assets = editor.assetsFromDragPayload(urlString)
         let segments = editor.segmentsFromDragPayload(urlString)
         guard !assets.isEmpty else { return false }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -904,6 +904,12 @@ final class TimelineView: NSView {
             openItem.target = self
             openItem.representedObject = clip.mediaRef
             nestItems.append(openItem)
+            if singleLinkGroup {
+                let decomposeItem = NSMenuItem(title: "Decompose Nested Timeline", action: #selector(performDecomposeNest(_:)), keyEquivalent: "")
+                decomposeItem.target = self
+                decomposeItem.representedObject = clip.id
+                nestItems.append(decomposeItem)
+            }
         }
 
         // Media
@@ -1051,6 +1057,12 @@ final class TimelineView: NSView {
 
     @objc private func performNestClips(_ sender: Any?) {
         editor.nestSelectedClips()
+    }
+
+    @objc private func performDecomposeNest(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let clipId = item.representedObject as? String else { return }
+        editor.decomposeNest(clipId: clipId)
     }
 
     @objc private func performOpenNestedTimeline(_ sender: Any?) {

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -894,9 +894,18 @@ final class TimelineView: NSView {
             aiItems.append(aiEditItem)
         }
 
+        // Nest
+        var nestItems: [NSMenuItem] = []
+        if clip.sourceClipType == .sequence {
+            let openItem = NSMenuItem(title: "Open Timeline", action: #selector(performOpenNestedTimeline(_:)), keyEquivalent: "")
+            openItem.target = self
+            openItem.representedObject = clip.mediaRef
+            nestItems.append(openItem)
+        }
+
         // Media
         var mediaItems: [NSMenuItem] = []
-        if clip.mediaType != .text, singleLinkGroup {
+        if clip.mediaType != .text, clip.sourceClipType != .sequence, singleLinkGroup {
             let swapItem = NSMenuItem(title: "Swap Media", action: #selector(performSwapMedia(_:)), keyEquivalent: "")
             swapItem.target = self
             swapItem.representedObject = clip.id
@@ -917,7 +926,7 @@ final class TimelineView: NSView {
             syncItems.append(syncItem)
         }
 
-        for group in [timelineItems, aiItems, mediaItems, syncItems] where !group.isEmpty {
+        for group in [timelineItems, aiItems, nestItems, mediaItems, syncItems] where !group.isEmpty {
             if !menu.items.isEmpty { menu.addItem(.separator()) }
             group.forEach { menu.addItem($0) }
         }
@@ -1035,6 +1044,12 @@ final class TimelineView: NSView {
         guard let item = sender as? NSMenuItem,
               let clipId = item.representedObject as? String else { return }
         editor.beginMediaSwap(clipId: clipId)
+    }
+
+    @objc private func performOpenNestedTimeline(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let timelineId = item.representedObject as? String else { return }
+        editor.activateTimeline(timelineId)
     }
 
     @objc private func performSetVolumeKfInterpolation(_ sender: Any?) {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -268,6 +268,7 @@ enum AppTheme {
         static let projectCardWidth: CGFloat = 150
         static let projectCardHeight: CGFloat = 120
         static let timelineClipDetailMinWidth: CGFloat = 32
+        static let timelineTabRenameWidth: CGFloat = 120
         static let timelineClipLabelMinWidth: CGFloat = 56
         static let updateOverlayWidth: CGFloat = 640
     }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -178,6 +178,7 @@ enum AppTheme {
         static let image = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
         static let text = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
         static let lottie = NSColor(red: 0xE0/255.0, green: 0xA8/255.0, blue: 0x00/255.0, alpha: 1)
+        static let sequence = NSColor(red: 0x2D/255.0, green: 0x9D/255.0, blue: 0x78/255.0, alpha: 1)
     }
 
     // MARK: - Corner radii
@@ -368,6 +369,7 @@ extension ClipType {
         case .image: AppTheme.TrackColor.image
         case .text: AppTheme.TrackColor.text
         case .lottie: AppTheme.TrackColor.lottie
+        case .sequence: AppTheme.TrackColor.sequence
         }
     }
 }

--- a/Sources/PalmierPro/UI/InlineRenameField.swift
+++ b/Sources/PalmierPro/UI/InlineRenameField.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Commit on Return or blur; Esc cancels. Empty or unchanged input cancels.
+struct InlineRenameField: View {
+    let originalName: String
+    var placeholder: String = ""
+    var font: Font = .system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium)
+    let onCommit: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var draft = ""
+    @State private var finished = false
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextField(placeholder, text: $draft)
+            .font(font)
+            .textFieldStyle(.plain)
+            .lineLimit(1)
+            .focused($focused)
+            .onSubmit { commit() }
+            .onChange(of: focused) { _, isFocused in
+                if !isFocused { commit() }
+            }
+            .onExitCommand {
+                finished = true
+                onCancel()
+            }
+            .onAppear {
+                draft = originalName
+                // Same-transaction focus fails to attach; defer one runloop turn.
+                DispatchQueue.main.async { focused = true }
+            }
+    }
+
+    private func commit() {
+        guard !finished else { return }
+        finished = true
+        let trimmed = draft.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == originalName {
+            onCancel()
+        } else {
+            onCommit(trimmed)
+        }
+    }
+}

--- a/Sources/PalmierPro/UI/TabStrip.swift
+++ b/Sources/PalmierPro/UI/TabStrip.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct TabStrip<Item: Identifiable, Tab: View, Trailing: View>: View where Item.ID == String {
+    let items: [Item]
+    let activeId: String
+    var scrollRequest: String? = nil
+    @ViewBuilder let tab: (Item) -> Tab
+    @ViewBuilder let trailing: () -> Trailing
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: AppTheme.Spacing.md) {
+                    ForEach(items) { item in
+                        tab(item).id(item.id)
+                    }
+                    trailing()
+                }
+                .padding(.horizontal, AppTheme.Spacing.sm)
+            }
+            .mouseWheelScrollsHorizontally()
+            .onChange(of: activeId) { _, newId in
+                withAnimation(.easeOut(duration: AppTheme.Anim.transition)) {
+                    proxy.scrollTo(newId, anchor: .center)
+                }
+            }
+            .onChange(of: scrollRequest) { _, id in
+                if let id { proxy.scrollTo(id, anchor: .center) }
+            }
+        }
+    }
+}
+
+extension TabStrip where Trailing == EmptyView {
+    init(items: [Item], activeId: String, scrollRequest: String? = nil, @ViewBuilder tab: @escaping (Item) -> Tab) {
+        self.init(items: items, activeId: activeId, scrollRequest: scrollRequest, tab: tab, trailing: { EmptyView() })
+    }
+}
+
+struct TabCloseButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "xmark")
+                .font(.system(size: AppTheme.FontSize.micro, weight: AppTheme.FontWeight.bold))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                .hoverHighlight(cornerRadius: AppTheme.Radius.xs)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Tests/PalmierProTests/Agent/ExportProjectToolTests.swift
+++ b/Tests/PalmierProTests/Agent/ExportProjectToolTests.swift
@@ -85,6 +85,35 @@ struct ExportProjectToolTests {
         #expect(!FileManager.default.fileExists(atPath: uiActiveVideo.path))
     }
 
+    @Test func exportsXMLForANonActiveTimelineById() async throws {
+        let h = ToolHarness()
+        var other = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "missing", start: 0, duration: 42)])])
+        other.name = "B-Roll Cut"
+        h.editor.timelines.append(other)
+        let activeBefore = h.editor.activeTimelineId
+
+        let out = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export-tool-tl-\(UUID().uuidString).xml")
+        defer { try? FileManager.default.removeItem(at: out) }
+
+        let result = try await h.runOK("export_project", args: [
+            "mode": "xml", "outputPath": out.path,
+            "timelineId": String(other.id.prefix(8)),
+        ]) as? [String: Any]
+        #expect(result?["timeline"] as? String == "B-Roll Cut")
+        #expect(result?["durationFrames"] as? Int == 42)
+        // Exporting by id doesn't switch the active timeline.
+        #expect(h.editor.activeTimelineId == activeBefore)
+        let xml = String(decoding: try Data(contentsOf: out), as: UTF8.self)
+        #expect(xml.contains("<name>B-Roll Cut</name>"))
+
+        let unknown = await h.runRaw("export_project", args: ["mode": "xml", "outputPath": "/tmp/x.xml", "timelineId": "ffffffff"])
+        #expect(unknown.isError)
+        let palmier = await h.runRaw("export_project", args: ["mode": "palmier", "outputPath": "/tmp/x.palmier", "timelineId": String(other.id.prefix(8))])
+        #expect(palmier.isError)
+        #expect(ToolHarness.textOf(palmier).contains("palmier"))
+    }
+
     @Test func exportsXML() async throws {
         let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
             Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "missing", start: 0, duration: 30)]),

--- a/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
+++ b/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("ToolExecutor — timelines")
+@MainActor
+struct TimelineToolsTests {
+
+    @Test func getTimelineListsTimelinesOnlyWhenSeveralExist() async throws {
+        let h = ToolHarness()
+        let single = try await h.runOK("get_timeline") as? [String: Any]
+        #expect(single?["timelines"] == nil)
+
+        var second = Fixtures.timeline()
+        second.name = "B-Roll"
+        h.editor.timelines.append(second)
+        let multi = try await h.runOK("get_timeline") as? [String: Any]
+        let listed = multi?["timelines"] as? [[String: Any]]
+        #expect(listed?.count == 2)
+        #expect(listed?.first?["active"] as? Bool == true)
+        #expect(listed?.last?["name"] as? String == "B-Roll")
+        #expect(multi?["viewState"] == nil)
+    }
+
+    @Test func createTimelineSwitchesAndInheritsSettings() async throws {
+        let h = ToolHarness()
+        h.editor.timeline.fps = 60
+        let result = await h.runRaw("create_timeline", args: ["name": "Intro"])
+        #expect(!result.isError)
+        #expect(ToolHarness.textOf(result).contains("Intro"))
+        #expect(h.editor.timeline.name == "Intro")
+        #expect(h.editor.timeline.fps == 60)
+        #expect(h.editor.timelines.count == 2)
+    }
+
+    @Test func setActiveTimelineSwitchesByShortPrefix() async throws {
+        let h = ToolHarness()
+        let firstId = h.editor.activeTimelineId
+        var second = Fixtures.timeline()
+        second.name = "Cutdown"
+        h.editor.timelines.append(second)
+
+        let result = await h.runRaw("set_active_timeline", args: ["timelineId": String(second.id.prefix(8))])
+        #expect(!result.isError)
+        #expect(h.editor.activeTimelineId == second.id)
+        #expect(h.editor.activeTimelineId != firstId)
+        // Switching registers no undo — the agent undo stack must stay clean.
+        let undo = await h.runRaw("undo")
+        #expect(undo.isError)
+    }
+
+    @Test func duplicateTimelineCopiesRenamesAndSwitches() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "orig", start: 0, duration: 30)])
+        ]))
+        let sourceId = h.editor.activeTimelineId
+
+        let result = await h.runRaw("duplicate_timeline", args: ["name": "Vertical Cut"])
+        #expect(!result.isError)
+        #expect(h.editor.timelines.count == 2)
+        #expect(h.editor.timeline.name == "Vertical Cut")
+        #expect(h.editor.activeTimelineId != sourceId)
+        // Fresh clip ids; content copied.
+        #expect(h.editor.timeline.tracks[0].clips.count == 1)
+        #expect(h.editor.timeline.tracks[0].clips[0].id != "orig")
+        #expect(h.editor.timeline.tracks[0].clips[0].durationFrames == 30)
+    }
+
+    @Test func setActiveTimelineRejectsUnknownId() async throws {
+        let h = ToolHarness()
+        let result = await h.runRaw("set_active_timeline", args: ["timelineId": "ffffffff"])
+        #expect(result.isError)
+    }
+}

--- a/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
+++ b/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
@@ -71,4 +71,64 @@ struct TimelineToolsTests {
         let result = await h.runRaw("set_active_timeline", args: ["timelineId": "ffffffff"])
         #expect(result.isError)
     }
+
+    @Test func addClipsNestsTimelineWithLinkedAudio() async throws {
+        let h = ToolHarness()
+        let child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(mediaType: .audio, start: 0, duration: 60)])
+        ])
+        h.editor.timelines.append(child)
+
+        let result = await h.runRaw("add_clips", args: ["entries": [
+            ["mediaRef": child.id, "startFrame": 30]
+        ]])
+        #expect(!result.isError, "\(ToolHarness.textOf(result))")
+
+        let video = h.editor.timeline.tracks.first { $0.type == .video }!.clips[0]
+        let audio = h.editor.timeline.tracks.first { $0.type == .audio }!.clips[0]
+        #expect(video.mediaType == .sequence && video.sourceClipType == .sequence)
+        #expect(video.mediaRef == child.id)
+        #expect(video.startFrame == 30 && video.durationFrames == 60)
+        #expect(audio.sourceClipType == .sequence)
+        #expect(audio.linkGroupId == video.linkGroupId && video.linkGroupId != nil)
+    }
+
+    @Test func addClipsRejectsNestCyclesAndEmptyTimelines() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])
+        ]))
+        // Self-nesting rejected.
+        let selfNest = await h.runRaw("add_clips", args: ["entries": [
+            ["mediaRef": h.editor.activeTimelineId, "startFrame": 0]
+        ]])
+        #expect(selfNest.isError)
+
+        // Empty child rejected.
+        let empty = Fixtures.timeline()
+        h.editor.timelines.append(empty)
+        let emptyNest = await h.runRaw("add_clips", args: ["entries": [
+            ["mediaRef": empty.id, "startFrame": 0]
+        ]])
+        #expect(emptyNest.isError)
+    }
+
+    @Test func renameAndDeleteMediaAcceptTimelines() async throws {
+        let h = ToolHarness()
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])])
+        h.editor.timelines.append(child)
+
+        let rename = await h.runRaw("rename_media", args: ["mediaRef": child.id, "name": "Selects"])
+        #expect(!rename.isError)
+        #expect(h.editor.timeline(for: child.id)?.name == "Selects")
+
+        let delete = await h.runRaw("delete_media", args: ["assetIds": [child.id]])
+        #expect(!delete.isError)
+        #expect(h.editor.timelines.count == 1)
+
+        // The last timeline is protected.
+        let last = await h.runRaw("delete_media", args: ["assetIds": [h.editor.activeTimelineId]])
+        #expect(last.isError)
+        #expect(h.editor.timelines.count == 1)
+    }
 }

--- a/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
+++ b/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
@@ -275,7 +275,10 @@ struct CompositionBuildAudioTrackTests {
         )
     }
 
-    @Test func speedChangedAudioClipsUseDedicatedCompositionTracks() async throws {
+    @Test func mixedSpeedAudioClipsShareOneCompositionTrack() async throws {
+        // One audio queue per composition track: retimed clips must not fan out
+        // into dedicated tracks. insertClip scales each clip immediately after
+        // inserting it, so mixed speeds are safe on a shared track.
         let audioURL = try makeSilentWav(durationSeconds: 4)
         defer { try? FileManager.default.removeItem(at: audioURL) }
 
@@ -293,9 +296,18 @@ struct CompositionBuildAudioTrackTests {
         )
 
         let audioMappings = result.trackMappings.filter { !$0.isVideo }
-        #expect(audioMappings.count == 2)
-        #expect(Set(audioMappings.map(\.compositionTrack.trackID)).count == 2)
-        #expect(Set(audioMappings.compactMap(clipIds)) == [["a1", "a3"], ["speed"]])
+        #expect(audioMappings.count == 1)
+        #expect(audioMappings.first.flatMap(clipIds) == ["a1", "a3", "speed"])
+
+        // The retimed clip occupies exactly [24,48) with 48 source frames scaled in,
+        // and the following clip still lands at [48,72).
+        let track = try #require(audioMappings.first?.compositionTrack)
+        let ts = CMTimeScale(timeline.fps)
+        let mappings = track.segments.filter { !$0.isEmpty }.map(\.timeMapping)
+        #expect(mappings.count == 3)
+        #expect(mappings[1].target == CMTimeRange(start: CMTime(value: 24, timescale: ts), duration: CMTime(value: 24, timescale: ts)))
+        #expect(mappings[1].source.duration == CMTime(value: 48, timescale: ts))
+        #expect(mappings[2].target.start == CMTime(value: 48, timescale: ts))
     }
 
     @Test func fractionalSpeedAudioUsesTruncatedSourceFramesForCompositionInsertion() async throws {

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -74,7 +74,7 @@ struct FCPXMLExporterTests {
         #expect(xml.contains("colorSpace=\"1-1-1 (Rec. 709)\""))
         #expect(xml.contains("<library>"))
         #expect(xml.contains("<event name=\"Palmier Export\">"))
-        #expect(xml.contains("<project name=\"Timeline Export\">"))
+        #expect(xml.contains("<project name=\"\(timeline.name)\">"))
         #expect(xml.contains("<sequence format=\"r1\" duration=\"0s\""))
         #expect(xml.contains("<spine/>"))
     }
@@ -750,5 +750,129 @@ struct FCPXMLExporterTests {
         await #expect(svc.error == nil)
         await #expect(svc.progress == 1.0)
         #expect(FileManager.default.fileExists(atPath: outURL.path))
+    }
+}
+
+@Suite("FCPXMLExporter — nested timelines")
+struct FCPXMLNestExportTests {
+
+    private func makeResolver(entries: [MediaManifestEntry]) throws -> MediaResolver {
+        for entry in entries {
+            if case let .external(absolutePath) = entry.source {
+                FileManager.default.createFile(atPath: absolutePath, contents: Data())
+            }
+        }
+        var manifest = MediaManifest()
+        manifest.entries = entries
+        return MediaResolver(manifest: { manifest }, projectURL: { nil })
+    }
+
+    private func videoEntry(id: String, hasAudio: Bool? = nil) -> MediaManifestEntry {
+        MediaManifestEntry(
+            id: id, name: id, type: .video,
+            source: .external(absolutePath: (NSTemporaryDirectory() as NSString).appendingPathComponent("\(id)-\(UUID().uuidString).mp4")),
+            duration: 5, sourceWidth: 1920, sourceHeight: 1080, hasAudio: hasAudio
+        )
+    }
+
+    private func carrier(for child: Timeline, start: Int, duration: Int? = nil, trimStart: Int = 0) -> Clip {
+        var c = Clip(mediaRef: child.id, mediaType: .sequence, sourceClipType: .sequence,
+                     startFrame: start, durationFrames: duration ?? child.totalFrames)
+        c.trimStartFrame = trimStart
+        return c
+    }
+
+    private func render(_ parent: Timeline, timelines: [Timeline], resolver: MediaResolver) -> String {
+        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
+        return FCPXMLExporter.render(timeline: parent, resolver: resolver, resolveTimeline: { byId[$0] })
+    }
+
+    @Test func nestEmitsCompoundResourceAndRefClip() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        var child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)])])
+        child.name = "Intro"
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: child, start: 30)])])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        #expect(xml.contains("<media id=\"nest1\" name=\"Intro\">"))
+        #expect(xml.contains("<ref-clip ref=\"nest1\""))
+        // Video-only carrier pins to the video stream; nest sequence reuses the project format.
+        let refClipLine = xml.components(separatedBy: "\n").first { $0.contains("<ref-clip ref=\"nest1\"") } ?? ""
+        #expect(refClipLine.contains("srcEnable=\"video\""))
+        #expect(refClipLine.contains("offset=\"1s\""))
+        #expect(refClipLine.contains("duration=\"2s\""))
+        // The child's own clip lives inside the compound sequence.
+        #expect(xml.contains("<ref-clip ref=\"media1\""))
+    }
+
+    @Test func linkedCarrierPairCollapsesIntoOneRefClip() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1", hasAudio: true)])
+        let child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(mediaRef: "v1", mediaType: .audio, start: 0, duration: 60)])
+        ])
+        var video = carrier(for: child, start: 0)
+        var audio = Fixtures.clip(mediaRef: child.id, mediaType: .audio, start: 0, duration: 60)
+        audio.sourceClipType = .sequence
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let parent = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio])
+        ])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        let nestRefs = xml.components(separatedBy: "<ref-clip ref=\"nest1\"").count - 1
+        #expect(nestRefs == 1)
+        let refClipLine = xml.components(separatedBy: "\n").first { $0.contains("<ref-clip ref=\"nest1\"") } ?? ""
+        #expect(!refClipLine.contains("srcEnable"))
+    }
+
+    @Test func twoLevelNestingEmitsBothCompounds() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        var grandchild = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 30)])])
+        grandchild.name = "Deep"
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: grandchild, start: 0)])])
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: child, start: 0)])])
+
+        let xml = render(parent, timelines: [grandchild, child, parent], resolver: resolver)
+
+        #expect(xml.contains("<media id=\"nest1\""))
+        #expect(xml.contains("<media id=\"nest2\" name=\"Deep\">"))
+        #expect(xml.contains("<ref-clip ref=\"nest2\""))
+    }
+
+    @Test func frozenCarrierClampsToChildContent() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)])])
+        // Carrier frozen at 100 frames with 10 trimmed off the head: only 50 frames of content remain.
+        let parent = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [carrier(for: child, start: 0, duration: 100, trimStart: 10)])
+        ])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        let refClipLine = xml.components(separatedBy: "\n").first { $0.contains("<ref-clip ref=\"nest1\"") } ?? ""
+        #expect(refClipLine.contains("start=\"1/3s\""))
+        #expect(refClipLine.contains("duration=\"5/3s\""))
+    }
+
+    @Test func emptyOrMissingChildDropsCarrier() throws {
+        let resolver = try makeResolver(entries: [])
+        let empty = Fixtures.timeline()
+        let parent = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                carrier(for: empty, start: 0, duration: 30),
+                { var c = Fixtures.clip(mediaRef: "no-such-timeline", start: 60, duration: 30)
+                  c.mediaType = .sequence; c.sourceClipType = .sequence; return c }()
+            ])
+        ])
+
+        let xml = render(parent, timelines: [empty, parent], resolver: resolver)
+
+        #expect(!xml.contains("<media id=\"nest"))
+        #expect(!xml.contains("<ref-clip"))
     }
 }

--- a/Tests/PalmierProTests/Export/PalmierProjectExportTests.swift
+++ b/Tests/PalmierProTests/Export/PalmierProjectExportTests.swift
@@ -42,7 +42,7 @@ struct PalmierProjectExportTests {
         defer { try? fm.removeItem(at: root) }
 
         let report = try PalmierProjectExporter.export(
-            timeline: Fixtures.timeline(),
+            projectFile: ProjectFile(timelines: [Fixtures.timeline()], activeTimelineId: nil, openTimelineIds: nil),
             manifest: manifest(externalPath: root.appendingPathComponent("external-clip.mov").path),
             generationLog: GenerationLog(),
             sourceProjectURL: source,
@@ -81,7 +81,7 @@ struct PalmierProjectExportTests {
         defer { try? fm.removeItem(at: root) }
 
         try PalmierProjectExporter.export(
-            timeline: Fixtures.timeline(),
+            projectFile: ProjectFile(timelines: [Fixtures.timeline()], activeTimelineId: nil, openTimelineIds: nil),
             manifest: manifest(externalPath: root.appendingPathComponent("external-clip.mov").path),
             generationLog: GenerationLog(),
             sourceProjectURL: source,
@@ -109,7 +109,7 @@ struct PalmierProjectExportTests {
         ]
 
         let report = try PalmierProjectExporter.export(
-            timeline: Fixtures.timeline(), manifest: m, generationLog: GenerationLog(),
+            projectFile: ProjectFile(timelines: [Fixtures.timeline()], activeTimelineId: nil, openTimelineIds: nil), manifest: m, generationLog: GenerationLog(),
             sourceProjectURL: source, to: dest
         )
 

--- a/Tests/PalmierProTests/Export/XMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/XMLExporterTests.swift
@@ -795,3 +795,143 @@ struct XMLExporterTests {
         #expect(!xml.contains("<keyframe>"))
     }
 }
+
+@Suite("XMLExporter — nested timelines")
+struct XMEMLNestExportTests {
+
+    private func makeResolver(entries: [MediaManifestEntry]) throws -> MediaResolver {
+        for entry in entries {
+            if case let .external(absolutePath) = entry.source {
+                FileManager.default.createFile(atPath: absolutePath, contents: Data())
+            }
+        }
+        var manifest = MediaManifest()
+        manifest.entries = entries
+        return MediaResolver(manifest: { manifest }, projectURL: { nil })
+    }
+
+    private func videoEntry(id: String) -> MediaManifestEntry {
+        MediaManifestEntry(
+            id: id, name: id, type: .video,
+            source: .external(absolutePath: (NSTemporaryDirectory() as NSString).appendingPathComponent("\(id)-\(UUID().uuidString).mp4")),
+            duration: 5
+        )
+    }
+
+    private func carrier(for child: Timeline, start: Int, duration: Int? = nil, trimStart: Int = 0) -> Clip {
+        var c = Clip(mediaRef: child.id, mediaType: .sequence, sourceClipType: .sequence,
+                     startFrame: start, durationFrames: duration ?? child.totalFrames)
+        c.trimStartFrame = trimStart
+        return c
+    }
+
+    private func render(_ parent: Timeline, timelines: [Timeline], resolver: MediaResolver) -> String {
+        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
+        return XMLExporter.render(timeline: parent, resolver: resolver, resolveTimeline: { byId[$0] })
+    }
+
+    @Test func nestEmitsInlineSequenceInsideClipitem() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        var child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)])])
+        child.name = "Intro"
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: child, start: 30)])])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        #expect(xml.contains("<sequence id=\"sequence-2\">"))
+        #expect(xml.contains("<name>Intro</name>"))
+        // Carrier placement and trims in parent frames.
+        let clipitem = xml.components(separatedBy: "<clipitem").first { $0.contains("sequence-2") } ?? ""
+        #expect(clipitem.contains("<start>30</start>"))
+        #expect(clipitem.contains("<end>90</end>"))
+        #expect(clipitem.contains("<in>0</in>"))
+        #expect(clipitem.contains("<out>60</out>"))
+        // The child's own clip is inside the nested sequence definition.
+        #expect(xml.contains("<pathurl>"))
+    }
+
+    @Test func secondCarrierReferencesTheSequenceById() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)])])
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [
+            carrier(for: child, start: 0),
+            carrier(for: child, start: 60),
+        ])])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        let fullDefs = xml.components(separatedBy: "<sequence id=\"sequence-2\">").count - 1
+        let refs = xml.components(separatedBy: "<sequence id=\"sequence-2\"/>").count - 1
+        #expect(fullDefs == 1)
+        #expect(refs == 1)
+    }
+
+    @Test func twoLevelNestingEmitsBothSequences() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        var grandchild = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 30)])])
+        grandchild.name = "Deep"
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: grandchild, start: 0)])])
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: child, start: 0)])])
+
+        let xml = render(parent, timelines: [grandchild, child, parent], resolver: resolver)
+
+        #expect(xml.contains("<sequence id=\"sequence-2\">"))
+        #expect(xml.contains("<sequence id=\"sequence-3\">"))
+        #expect(xml.contains("<name>Deep</name>"))
+    }
+
+    @Test func frozenCarrierClampsToChildContent() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)])])
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [carrier(for: child, start: 0, duration: 100, trimStart: 10)])])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        let clipitem = xml.components(separatedBy: "<clipitem").first { $0.contains("sequence-2") } ?? ""
+        #expect(clipitem.contains("<in>10</in>"))
+        #expect(clipitem.contains("<out>60</out>"))
+        #expect(clipitem.contains("<end>50</end>"))
+    }
+
+    @Test func emptyOrMissingChildDropsCarrier() throws {
+        let resolver = try makeResolver(entries: [])
+        let empty = Fixtures.timeline()
+        let parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [
+            carrier(for: empty, start: 0, duration: 30),
+            { var c = Fixtures.clip(mediaRef: "no-such-timeline", start: 60, duration: 30)
+              c.mediaType = .sequence; c.sourceClipType = .sequence; return c }()
+        ])])
+
+        let xml = render(parent, timelines: [empty, parent], resolver: resolver)
+
+        #expect(!xml.contains("<clipitem"))
+        #expect(!xml.contains("sequence-2"))
+    }
+
+    @Test func linkedCarrierPairEmitsLinkedClipitems() throws {
+        let resolver = try makeResolver(entries: [videoEntry(id: "v1")])
+        let child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "v1", start: 0, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(mediaRef: "v1", mediaType: .audio, start: 0, duration: 60)])
+        ])
+        var video = carrier(for: child, start: 0)
+        var audio = Fixtures.clip(mediaRef: child.id, mediaType: .audio, start: 0, duration: 60)
+        audio.sourceClipType = .sequence
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let parent = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio])
+        ])
+
+        let xml = render(parent, timelines: [child, parent], resolver: resolver)
+
+        // Both carriers emit; one holds the definition, the other a reference; links pair them.
+        let fullDefs = xml.components(separatedBy: "<sequence id=\"sequence-2\">").count - 1
+        let refs = xml.components(separatedBy: "<sequence id=\"sequence-2\"/>").count - 1
+        #expect(fullDefs == 1)
+        #expect(refs == 1)
+        #expect(xml.contains("<linkclipref>clipitem-\(video.id)</linkclipref>"))
+        #expect(xml.contains("<linkclipref>clipitem-\(audio.id)</linkclipref>"))
+    }
+}

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -86,17 +86,17 @@ struct VideoProjectLoadTests {
     @Test func emptyManifestNotSerializedAfterLoadFailure() {
         // Opening with a corrupt manifest leaves an empty in-memory manifest. Serializing it
         // would overwrite the (recoverable) original on the next autosave — so it must be nil.
-        #expect(VideoProject.manifestSnapshotData(manifest: MediaManifest(), loadFailed: true) == nil)
+        #expect(VideoProject.manifestSnapshot(manifest: MediaManifest(), loadFailed: true) == nil)
     }
 
     @Test func rebuiltManifestIsSerializedAfterLoadFailure() {
         // Once the user adds media, the manifest is no longer empty and must be written.
-        #expect(VideoProject.manifestSnapshotData(manifest: sampleManifest(), loadFailed: true) != nil)
+        #expect(VideoProject.manifestSnapshot(manifest: sampleManifest(), loadFailed: true) != nil)
     }
 
     @Test func manifestSerializedNormallyWhenLoadSucceeded() {
         // Regression guard: ordinary saves still persist the (possibly empty) manifest.
-        #expect(VideoProject.manifestSnapshotData(manifest: MediaManifest(), loadFailed: false) != nil)
+        #expect(VideoProject.manifestSnapshot(manifest: MediaManifest(), loadFailed: false) != nil)
     }
 
     @Test func saveAsPreservesUnreadableManifestFile() throws {

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -44,7 +44,7 @@ struct VideoProjectLoadTests {
 
         #expect(contents.manifest == nil)
         #expect(contents.manifestUnreadable == true)
-        #expect(contents.timeline.tracks.count == 2)   // creative work survives
+        #expect(contents.projectFile.timelines.first?.tracks.count == 2)   // creative work survives
     }
 
     @Test func missingManifestOpensAndIsNotFlaggedUnreadable() throws {

--- a/Tests/PalmierProTests/Rendering/CompositorFixtures.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorFixtures.swift
@@ -9,6 +9,12 @@ import UniformTypeIdentifiers
 /// pattern (TL red, TR green, BL blue, BR white) so flips, rotations, and crops all
 /// produce measurably distinct frames, plus a still-video, clip, and timeline built on it.
 enum CompositorFixtures {
+    static func isRed(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 140 && p.g < 100 && p.b < 100 }
+    static func isGreen(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.g > 140 && p.r < 110 && p.b < 110 }
+    static func isBlue(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.b > 140 && p.r < 100 && p.g < 100 }
+    static func isWhite(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 170 && p.g > 170 && p.b > 170 }
+    static func isBlack(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r < 45 && p.g < 45 && p.b < 45 }
+
     static let renderSize = CGSize(width: 320, height: 180)
 
     static func patternPNG(size: CGSize) throws -> URL {

--- a/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
@@ -34,13 +34,15 @@ struct CompositorRenderTests {
 
     static func render(
         _ timeline: Timeline, frame: Int,
-        renderSize: CGSize = size, imageURLs: [String: URL] = [:]
+        renderSize: CGSize = size, imageURLs: [String: URL] = [:],
+        timelines: [Timeline] = []
     ) async throws -> Frame {
         var urls = imageURLs
         if urls["pattern"] == nil { urls["pattern"] = try await CompositorFixtures.patternVideoURL() }
         let resolved = urls
+        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
         let result = try await CompositionBuilder.build(
-            timeline: timeline, resolveURL: { resolved[$0] }, renderSize: renderSize
+            timeline: timeline, resolveURL: { resolved[$0] }, resolveTimeline: { byId[$0] }, renderSize: renderSize
         )
         let gen = AVAssetImageGenerator(asset: result.composition)
         gen.videoComposition = result.videoComposition
@@ -55,11 +57,11 @@ struct CompositorRenderTests {
 
 // MARK: - Color classification
 
-private func isRed(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 140 && p.g < 100 && p.b < 100 }
-private func isGreen(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.g > 140 && p.r < 110 && p.b < 110 }
-private func isBlue(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.b > 140 && p.r < 100 && p.g < 100 }
-private func isWhite(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 170 && p.g > 170 && p.b > 170 }
-private func isBlack(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r < 45 && p.g < 45 && p.b < 45 }
+private let isRed = CompositorFixtures.isRed
+private let isGreen = CompositorFixtures.isGreen
+private let isBlue = CompositorFixtures.isBlue
+private let isWhite = CompositorFixtures.isWhite
+private let isBlack = CompositorFixtures.isBlack
 
 // MARK: - Tests
 
@@ -267,10 +269,5 @@ extension CompositorRenderTests {
 // MARK: - Fixture helper
 
 extension CompositorRenderTests {
-    static func timelineWith(_ tracks: Track...) -> Timeline {
-        var t = Fixtures.timeline(tracks: tracks)
-        t.width = Int(size.width)
-        t.height = Int(size.height)
-        return t
-    }
+    static func timelineWith(_ tracks: Track...) -> Timeline { CompositorFixtures.timeline(tracks) }
 }

--- a/Tests/PalmierProTests/Rendering/NestRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/NestRenderTests.swift
@@ -12,32 +12,8 @@ struct NestRenderTests {
 
     static let size = CompositorFixtures.renderSize  // 320×180
 
-    static func render(
-        _ timeline: Timeline, timelines: [Timeline], frame: Int
-    ) async throws -> CompositorRenderTests.Frame {
-        let pattern = try await CompositorFixtures.patternVideoURL()
-        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
-        let result = try await CompositionBuilder.build(
-            timeline: timeline,
-            resolveURL: { $0 == "pattern" ? pattern : nil },
-            resolveTimeline: { byId[$0] },
-            renderSize: size
-        )
-        let gen = AVAssetImageGenerator(asset: result.composition)
-        gen.videoComposition = result.videoComposition
-        gen.requestedTimeToleranceBefore = .zero
-        gen.requestedTimeToleranceAfter = .zero
-        let cg = try await gen.image(
-            at: CMTime(value: CMTimeValue(frame), timescale: CMTimeScale(timeline.fps))
-        ).image
-        return CompositorRenderTests.Frame(bytes: ColorProbeHelpers.srgbBytes(cg, size: size), w: Int(size.width))
-    }
-
     static func childTimeline() -> Timeline {
-        var child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [CompositorFixtures.patternClip()])])
-        child.width = Int(size.width)
-        child.height = Int(size.height)
-        return child
+        CompositorFixtures.timeline([Fixtures.videoTrack(clips: [CompositorFixtures.patternClip()])])
     }
 
     static func nestClip(for child: Timeline, start: Int = 0) -> Clip {
@@ -47,17 +23,11 @@ struct NestRenderTests {
         )
     }
 
-    private func isRed(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 140 && p.g < 100 && p.b < 100 }
-    private func isWhite(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 170 && p.g > 170 && p.b > 170 }
-    private func isBlack(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r < 45 && p.g < 45 && p.b < 45 }
-
     @Test func nestedPatternMatchesDirectRender() async throws {
         let child = Self.childTimeline()
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: child)])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [Self.nestClip(for: child)])])
 
-        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        let f = try await CompositorRenderTests.render(parent, frame: 15, timelines: [child, parent])
         #expect(isRed(f.tl), "TL \(f.tl)")
         #expect(isWhite(f.br), "BR \(f.br)")
     }
@@ -66,11 +36,9 @@ struct NestRenderTests {
         let child = Self.childTimeline()
         var nest = Self.nestClip(for: child)
         nest.opacity = 0.5
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [nest])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [nest])])
 
-        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        let f = try await CompositorRenderTests.render(parent, frame: 15, timelines: [child, parent])
         // White quadrant at 50% over black ≈ mid grey.
         let br = f.br
         #expect(br.r > 80 && br.r < 170, "BR should be dimmed white: \(br)")
@@ -80,43 +48,35 @@ struct NestRenderTests {
         let child = Self.childTimeline()
         var nest = Self.nestClip(for: child)
         nest.transform = Transform(centerX: 0.25, centerY: 0.25, width: 0.5, height: 0.5)
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [nest])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [nest])])
 
-        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        let f = try await CompositorRenderTests.render(parent, frame: 15, timelines: [child, parent])
         #expect(isBlack(f.at(300, 170)), "outside the scaled nest should be black: \(f.at(300, 170))")
         #expect(isRed(f.at(20, 10)), "nest TL quadrant lands top-left: \(f.at(20, 10))")
     }
 
     @Test func nestOffsetInTimeShowsBlackBeforeStart() async throws {
         let child = Self.childTimeline()
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: child, start: 30)])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [Self.nestClip(for: child, start: 30)])])
 
-        let before = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        let before = try await CompositorRenderTests.render(parent, frame: 15, timelines: [child, parent])
         #expect(isBlack(before.center), "before the nest starts: \(before.center)")
-        let during = try await Self.render(parent, timelines: [child, parent], frame: 45)
+        let during = try await CompositorRenderTests.render(parent, frame: 45, timelines: [child, parent])
         #expect(isRed(during.tl), "nest content at frame 45: \(during.tl)")
     }
 
     @Test func nestSegmentsScopeDecoderDemand() async throws {
         // Child: clip A on track 1 for [0,30), clip B on track 2 for [30,60).
         // The nest must not require both source tracks across its whole span.
-        var child = Fixtures.timeline(tracks: [
+        let child = CompositorFixtures.timeline([
             Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "a", duration: 30)]),
             Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "b", start: 30, duration: 30)])
         ])
-        child.width = Int(Self.size.width)
-        child.height = Int(Self.size.height)
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [{
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [{
             var nest = Self.nestClip(for: child)
             nest.durationFrames = 60
             return nest
         }()])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
 
         let pattern = try await CompositorFixtures.patternVideoURL()
         let byId = Dictionary(uniqueKeysWithValues: [child, parent].map { ($0.id, $0) })
@@ -135,15 +95,15 @@ struct NestRenderTests {
 
     @Test func twoLevelNestRendersThrough() async throws {
         let grandchild = Self.childTimeline()
-        var middle = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: grandchild)])])
-        middle.width = Int(Self.size.width)
-        middle.height = Int(Self.size.height)
-        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: middle)])])
-        parent.width = Int(Self.size.width)
-        parent.height = Int(Self.size.height)
+        let middle = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [Self.nestClip(for: grandchild)])])
+        let parent = CompositorFixtures.timeline([Fixtures.videoTrack(clips: [Self.nestClip(for: middle)])])
 
-        let f = try await Self.render(parent, timelines: [grandchild, middle, parent], frame: 15)
+        let f = try await CompositorRenderTests.render(parent, frame: 15, timelines: [grandchild, middle, parent])
         #expect(isRed(f.tl), "TL through two nest levels: \(f.tl)")
         #expect(isWhite(f.br), "BR through two nest levels: \(f.br)")
     }
 }
+
+private let isRed = CompositorFixtures.isRed
+private let isWhite = CompositorFixtures.isWhite
+private let isBlack = CompositorFixtures.isBlack

--- a/Tests/PalmierProTests/Rendering/NestRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/NestRenderTests.swift
@@ -1,0 +1,149 @@
+import AVFoundation
+import CoreImage
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// Pixel-level tests for live nested timelines: child clips composite through a
+/// group layer, with the nest clip's transform/opacity applied to the unit.
+@Suite("Compositor — nested timelines")
+@MainActor
+struct NestRenderTests {
+
+    static let size = CompositorFixtures.renderSize  // 320×180
+
+    static func render(
+        _ timeline: Timeline, timelines: [Timeline], frame: Int
+    ) async throws -> CompositorRenderTests.Frame {
+        let pattern = try await CompositorFixtures.patternVideoURL()
+        let byId = Dictionary(uniqueKeysWithValues: timelines.map { ($0.id, $0) })
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { $0 == "pattern" ? pattern : nil },
+            resolveTimeline: { byId[$0] },
+            renderSize: size
+        )
+        let gen = AVAssetImageGenerator(asset: result.composition)
+        gen.videoComposition = result.videoComposition
+        gen.requestedTimeToleranceBefore = .zero
+        gen.requestedTimeToleranceAfter = .zero
+        let cg = try await gen.image(
+            at: CMTime(value: CMTimeValue(frame), timescale: CMTimeScale(timeline.fps))
+        ).image
+        return CompositorRenderTests.Frame(bytes: ColorProbeHelpers.srgbBytes(cg, size: size), w: Int(size.width))
+    }
+
+    static func childTimeline() -> Timeline {
+        var child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [CompositorFixtures.patternClip()])])
+        child.width = Int(size.width)
+        child.height = Int(size.height)
+        return child
+    }
+
+    static func nestClip(for child: Timeline, start: Int = 0) -> Clip {
+        Clip(
+            mediaRef: child.id, mediaType: .sequence, sourceClipType: .sequence,
+            startFrame: start, durationFrames: child.totalFrames
+        )
+    }
+
+    private func isRed(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 140 && p.g < 100 && p.b < 100 }
+    private func isWhite(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r > 170 && p.g > 170 && p.b > 170 }
+    private func isBlack(_ p: (r: Int, g: Int, b: Int)) -> Bool { p.r < 45 && p.g < 45 && p.b < 45 }
+
+    @Test func nestedPatternMatchesDirectRender() async throws {
+        let child = Self.childTimeline()
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: child)])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        #expect(isRed(f.tl), "TL \(f.tl)")
+        #expect(isWhite(f.br), "BR \(f.br)")
+    }
+
+    @Test func nestOpacityDimsWholeGroup() async throws {
+        let child = Self.childTimeline()
+        var nest = Self.nestClip(for: child)
+        nest.opacity = 0.5
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [nest])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        // White quadrant at 50% over black ≈ mid grey.
+        let br = f.br
+        #expect(br.r > 80 && br.r < 170, "BR should be dimmed white: \(br)")
+    }
+
+    @Test func nestTransformScalesGroupAsUnit() async throws {
+        let child = Self.childTimeline()
+        var nest = Self.nestClip(for: child)
+        nest.transform = Transform(centerX: 0.25, centerY: 0.25, width: 0.5, height: 0.5)
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [nest])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let f = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        #expect(isBlack(f.at(300, 170)), "outside the scaled nest should be black: \(f.at(300, 170))")
+        #expect(isRed(f.at(20, 10)), "nest TL quadrant lands top-left: \(f.at(20, 10))")
+    }
+
+    @Test func nestOffsetInTimeShowsBlackBeforeStart() async throws {
+        let child = Self.childTimeline()
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: child, start: 30)])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let before = try await Self.render(parent, timelines: [child, parent], frame: 15)
+        #expect(isBlack(before.center), "before the nest starts: \(before.center)")
+        let during = try await Self.render(parent, timelines: [child, parent], frame: 45)
+        #expect(isRed(during.tl), "nest content at frame 45: \(during.tl)")
+    }
+
+    @Test func nestSegmentsScopeDecoderDemand() async throws {
+        // Child: clip A on track 1 for [0,30), clip B on track 2 for [30,60).
+        // The nest must not require both source tracks across its whole span.
+        var child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "a", duration: 30)]),
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "b", start: 30, duration: 30)])
+        ])
+        child.width = Int(Self.size.width)
+        child.height = Int(Self.size.height)
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [{
+            var nest = Self.nestClip(for: child)
+            nest.durationFrames = 60
+            return nest
+        }()])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let pattern = try await CompositorFixtures.patternVideoURL()
+        let byId = Dictionary(uniqueKeysWithValues: [child, parent].map { ($0.id, $0) })
+        let result = try await CompositionBuilder.build(
+            timeline: parent,
+            resolveURL: { _ in pattern },
+            resolveTimeline: { byId[$0] },
+            renderSize: Self.size
+        )
+        let counts = result.videoComposition.instructions
+            .compactMap { $0 as? CompositorInstruction }
+            .filter { !$0.layers.isEmpty }
+            .map { $0.requiredSourceTrackIDs?.count ?? 0 }
+        #expect(counts.max() == 1, "each nest segment should require one source track: \(counts)")
+    }
+
+    @Test func twoLevelNestRendersThrough() async throws {
+        let grandchild = Self.childTimeline()
+        var middle = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: grandchild)])])
+        middle.width = Int(Self.size.width)
+        middle.height = Int(Self.size.height)
+        var parent = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Self.nestClip(for: middle)])])
+        parent.width = Int(Self.size.width)
+        parent.height = Int(Self.size.height)
+
+        let f = try await Self.render(parent, timelines: [grandchild, middle, parent], frame: 15)
+        #expect(isRed(f.tl), "TL through two nest levels: \(f.tl)")
+        #expect(isWhite(f.br), "BR through two nest levels: \(f.br)")
+    }
+}

--- a/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
@@ -1,0 +1,316 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+@Suite("Multi-timeline — proxy, switching, CRUD")
+struct MultiTimelineTests {
+
+    @Test func proxyAssignmentAdoptsUnknownIdInActiveSlot() {
+        let e = EditorViewModel()
+        let replacement = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+        e.timeline = replacement
+        #expect(e.activeTimelineId == replacement.id)
+        #expect(e.timelines.count == 1)
+        #expect(e.openTimelineIds == [replacement.id])
+    }
+
+    @Test func proxyAssignmentRoutesByIdAndActivates() {
+        let e = EditorViewModel()
+        let firstId = e.activeTimelineId
+        let secondId = e.createTimeline(activate: false)
+        #expect(e.activeTimelineId == firstId)
+
+        var second = e.timeline(for: secondId)!
+        second.tracks = [Fixtures.videoTrack()]
+        e.timeline = second
+
+        #expect(e.activeTimelineId == secondId)
+        #expect(e.timeline(for: secondId)?.tracks.count == 1)
+        #expect(e.timeline(for: firstId)?.tracks.isEmpty == true)
+    }
+
+    @Test func activateStashesAndRestoresViewState() {
+        let e = EditorViewModel()
+        let firstId = e.activeTimelineId
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 500)])]
+        let secondId = e.createTimeline(activate: false)
+
+        e.currentFrame = 120
+        e.zoomScale = 9.5
+        e.activateTimeline(secondId)
+
+        #expect(e.viewState(for: firstId).playheadFrame == 120)
+        #expect(e.viewState(for: firstId).zoomScale == 9.5)
+        #expect(e.zoomScale == Defaults.pixelsPerFrame)
+        #expect(e.currentFrame == 0)
+
+        e.activateTimeline(firstId)
+        #expect(e.currentFrame == 120)
+        #expect(e.zoomScale == 9.5)
+    }
+
+    @Test func activateClearsTimelineScopedSelection() {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])]
+        e.selectedClipIds = [e.timeline.tracks[0].clips[0].id]
+        let secondId = e.createTimeline(activate: false)
+        e.activateTimeline(secondId)
+        #expect(e.selectedClipIds.isEmpty)
+    }
+
+    @Test func createInheritsSettingsAndAutoNames() {
+        let e = EditorViewModel()
+        e.applyTimelineSettings(fps: 24, width: 1080, height: 1920)
+        let id = e.createTimeline()
+        let t = e.timeline(for: id)!
+        #expect(t.fps == 24)
+        #expect(t.width == 1080)
+        #expect(t.height == 1920)
+        #expect(t.settingsConfigured)
+        #expect(t.name == "Timeline 2")
+        #expect(e.activeTimelineId == id)
+        #expect(e.openTimelineIds.contains(id))
+    }
+
+    @Test func duplicateCopiesContentWithFreshIds() {
+        let e = EditorViewModel()
+        let a = Fixtures.clip(start: 0, duration: 30)
+        var b = Fixtures.clip(mediaType: .audio, start: 0, duration: 30)
+        b.linkGroupId = "g1"
+        var a2 = a
+        a2.linkGroupId = "g1"
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [a2]), Fixtures.audioTrack(clips: [b])]
+        e.timeline.name = "Main"
+        let sourceId = e.activeTimelineId
+
+        let dupId = e.duplicateTimeline(sourceId)!
+        let dup = e.timeline(for: dupId)!
+        let source = e.timeline(for: sourceId)!
+
+        #expect(dup.name == "Main copy")
+        #expect(dup.tracks.count == 2)
+        #expect(dup.tracks[0].id != source.tracks[0].id)
+        #expect(dup.tracks[0].clips[0].id != source.tracks[0].clips[0].id)
+        let g = dup.tracks[0].clips[0].linkGroupId
+        #expect(g != nil && g != "g1")
+        #expect(dup.tracks[1].clips[0].linkGroupId == g)
+    }
+
+    @Test func deleteKeepsAtLeastOneAndReactivates() {
+        let e = EditorViewModel()
+        let firstId = e.activeTimelineId
+        e.deleteTimeline(firstId)
+        #expect(e.timelines.count == 1)   // last timeline is not deletable
+
+        let secondId = e.createTimeline()
+        #expect(e.activeTimelineId == secondId)
+        e.deleteTimeline(secondId)
+        #expect(e.activeTimelineId == firstId)
+        #expect(e.timelines.count == 1)
+        #expect(!e.openTimelineIds.contains(secondId))
+    }
+
+    @Test func deleteUndoRestoresTimelineAndTab() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        let secondId = e.createTimeline()
+        e.timeline.tracks = [Fixtures.videoTrack()]
+
+        undo.removeAllActions()
+        e.deleteTimeline(secondId)
+        #expect(e.timeline(for: secondId) == nil)
+
+        undo.undo()
+        #expect(e.timeline(for: secondId)?.tracks.count == 1)
+        #expect(e.openTimelineIds.contains(secondId))
+
+        undo.redo()
+        #expect(e.timeline(for: secondId) == nil)
+    }
+
+    @Test func renameTrimsAndUndoes() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        let id = e.activeTimelineId
+        let original = e.timeline.name
+        e.renameTimeline(id, to: "  Selects  ")
+        #expect(e.timeline.name == "Selects")
+        undo.undo()
+        #expect(e.timeline.name == original)
+    }
+
+    @Test func closeTabNeverClosesLastAndReactivatesNeighbor() {
+        let e = EditorViewModel()
+        let firstId = e.activeTimelineId
+        let secondId = e.createTimeline()
+        e.closeTimelineTab(secondId)
+        #expect(e.openTimelineIds == [firstId])
+        #expect(e.activeTimelineId == firstId)
+        #expect(e.timeline(for: secondId) != nil)   // closing a tab never deletes
+        e.closeTimelineTab(firstId)
+        #expect(e.openTimelineIds == [firstId])
+    }
+
+    @Test func deleteMediaSweepsAllTimelines() {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "m1", start: 0, duration: 30)])]
+        let secondId = e.createTimeline(activate: false)
+        var second = e.timeline(for: secondId)!
+        second.tracks = [Fixtures.videoTrack(clips: [
+            Fixtures.clip(mediaRef: "m1", start: 0, duration: 30),
+            Fixtures.clip(mediaRef: "m2", start: 30, duration: 30)
+        ])]
+        e.timelines[e.timelines.firstIndex(where: { $0.id == secondId })!] = second
+
+        let removed = e.removeClipsReferencingAssets(["m1"])
+
+        #expect(removed.count == 2)
+        #expect(e.timeline.tracks.isEmpty)   // emptied track pruned
+        let rest = e.timeline(for: secondId)!
+        #expect(rest.tracks.count == 1)
+        #expect(rest.tracks[0].clips.map(\.mediaRef) == ["m2"])
+    }
+
+    @Test func settingsUndoLandsOnOwningTimeline() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        let firstId = e.activeTimelineId
+        e.applyTimelineSettings(fps: 30, width: 1920, height: 1080)
+        undo.removeAllActions()
+
+        e.applyTimelineSettings(fps: 30, width: 3840, height: 2160)
+        undo.disableUndoRegistration()
+        let secondId = e.createTimeline()
+        undo.enableUndoRegistration()
+        #expect(e.activeTimelineId == secondId)
+
+        undo.undo()   // resolution undo must land back on A, not B
+        #expect(e.activeTimelineId == firstId)
+        #expect(e.timeline(for: firstId)?.width == 1920)
+        #expect(e.timeline(for: secondId)?.width == 3840)   // B untouched
+    }
+
+    @Test func projectFileSnapshotMergesLiveViewState() {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 500)])]
+        e.currentFrame = 250
+        e.zoomScale = 6
+        let file = e.projectFileSnapshot()
+        #expect(file.timelines[0].viewState.playheadFrame == 250)
+        #expect(file.timelines[0].viewState.zoomScale == 6)
+        // Snapshot must not dirty the observed timelines (Equatable stays clean).
+        #expect(e.timelines[0].viewState == TimelineViewState())
+    }
+
+    @Test func deleteActiveTimelineUndoReactivatesWithFreshViewState() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 900)])]
+        let firstId = e.activeTimelineId
+        _ = e.createTimeline()
+        e.activateTimeline(firstId)
+        e.currentFrame = 800
+        undo.removeAllActions()
+
+        e.deleteTimeline(firstId)
+        undo.undo()
+
+        #expect(e.activeTimelineId == firstId)
+        #expect(e.currentFrame == 800)
+    }
+
+    @Test func timelineUndoReactivatesOwningTimeline() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        let aId = e.activeTimelineId
+        let bId = e.createTimeline(activate: false)
+        undo.removeAllActions()
+
+        var undoneOnTimeline: String?
+        e.registerTimelineUndo { vm in undoneOnTimeline = vm.activeTimelineId }
+        e.activateTimeline(bId)
+        undo.undo()
+
+        #expect(undoneOnTimeline == aId)
+        #expect(e.activeTimelineId == aId)
+    }
+
+    @Test func fpsChangeRescalesEveryTimeline() {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 30, duration: 30)])]
+        let secondId = e.createTimeline(activate: false)
+        var second = e.timeline(for: secondId)!
+        second.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 60, duration: 60)])]
+        second.viewState.playheadFrame = 90
+        e.timelines[e.timelines.firstIndex(where: { $0.id == secondId })!] = second
+
+        e.applyTimelineSettings(fps: 60, width: e.timeline.width, height: e.timeline.height)
+
+        #expect(e.timelines.allSatisfy { $0.fps == 60 })
+        #expect(e.timeline.tracks[0].clips[0].startFrame == 60)
+        let rescaled = e.timeline(for: secondId)!
+        #expect(rescaled.tracks[0].clips[0].startFrame == 120)
+        #expect(rescaled.tracks[0].clips[0].durationFrames == 120)
+        #expect(rescaled.viewState.playheadFrame == 180)
+    }
+}
+
+@Suite("Multi-timeline — persistence")
+struct ProjectFilePersistenceTests {
+
+    @Test func legacyBareTimelineDecodesAndWraps() throws {
+        let legacy = Fixtures.timeline(fps: 24, tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 10)])])
+        let data = try JSONEncoder().encode(legacy)
+        let file = try ProjectFile.decode(data)
+        #expect(file.timelines.count == 1)
+        #expect(file.timelines[0].fps == 24)
+        #expect(file.activeTimelineId == file.timelines[0].id)
+    }
+
+    @Test func projectFileRoundTripsViewStateAndTabs() throws {
+        var a = Fixtures.timeline()
+        a.name = "Main"
+        a.viewState = TimelineViewState(playheadFrame: 42, zoomScale: 7, scrollOffsetX: 300)
+        a.tracks = [Fixtures.videoTrack()]
+        a.tracks[0].displayHeight = 88
+        var b = Fixtures.timeline()
+        b.name = "Vertical"
+
+        let file = ProjectFile(timelines: [a, b], activeTimelineId: b.id, openTimelineIds: [a.id, b.id])
+        let decoded = try ProjectFile.decode(JSONEncoder().encode(file))
+
+        #expect(decoded.timelines.map(\.name) == ["Main", "Vertical"])
+        #expect(decoded.activeTimelineId == b.id)
+        #expect(decoded.openTimelineIds == [a.id, b.id])
+        #expect(decoded.timelines[0].viewState == a.viewState)
+        #expect(decoded.timelines[0].tracks[0].displayHeight == 88)
+    }
+
+    @Test func legacyTimelineWithoutIdGetsOne() throws {
+        // Hand-built legacy JSON lacking id/name/viewState keys entirely.
+        let json = """
+        {"fps": 30, "width": 1920, "height": 1080, "settingsConfigured": true, "tracks": []}
+        """
+        let file = try ProjectFile.decode(Data(json.utf8))
+        #expect(!file.timelines[0].id.isEmpty)
+        #expect(file.timelines[0].name == "Timeline 1")
+        #expect(file.timelines[0].settingsConfigured)
+    }
+
+    @MainActor
+    @Test func applyProjectFileValidatesActiveAndOpenIds() {
+        let e = EditorViewModel()
+        let a = Fixtures.timeline()
+        let b = Fixtures.timeline()
+        let file = ProjectFile(timelines: [a, b], activeTimelineId: "missing", openTimelineIds: ["missing", b.id])
+        e.applyProjectFile(file)
+        #expect(e.activeTimelineId == a.id)
+        #expect(e.openTimelineIds == [b.id, a.id])
+    }
+}

--- a/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
@@ -194,16 +194,14 @@ struct MultiTimelineTests {
         #expect(e.timeline(for: secondId)?.width == 3840)   // B untouched
     }
 
-    @Test func projectFileSnapshotMergesLiveViewState() {
+    @Test func projectFileSnapshotCarriesLiveViewState() {
         let e = EditorViewModel()
         e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 500)])]
         e.currentFrame = 250
         e.zoomScale = 6
         let file = e.projectFileSnapshot()
-        #expect(file.timelines[0].viewState.playheadFrame == 250)
-        #expect(file.timelines[0].viewState.zoomScale == 6)
-        // Snapshot must not dirty the observed timelines (Equatable stays clean).
-        #expect(e.timelines[0].viewState == TimelineViewState())
+        #expect(file.viewStates?[e.activeTimelineId]?.playheadFrame == 250)
+        #expect(file.viewStates?[e.activeTimelineId]?.zoomScale == 6)
     }
 
     @Test func deleteActiveTimelineUndoReactivatesWithFreshViewState() {
@@ -282,8 +280,8 @@ struct MultiTimelineTests {
         let secondId = e.createTimeline(activate: false)
         var second = e.timeline(for: secondId)!
         second.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 60, duration: 60)])]
-        second.viewState.playheadFrame = 90
         e.timelines[e.timelines.firstIndex(where: { $0.id == secondId })!] = second
+        e.liveViewStates[secondId] = TimelineViewState(playheadFrame: 90)
 
         e.applyTimelineSettings(fps: 60, width: e.timeline.width, height: e.timeline.height)
 
@@ -292,7 +290,7 @@ struct MultiTimelineTests {
         let rescaled = e.timeline(for: secondId)!
         #expect(rescaled.tracks[0].clips[0].startFrame == 120)
         #expect(rescaled.tracks[0].clips[0].durationFrames == 120)
-        #expect(rescaled.viewState.playheadFrame == 180)
+        #expect(e.viewState(for: secondId).playheadFrame == 180)
     }
 }
 
@@ -311,19 +309,22 @@ struct ProjectFilePersistenceTests {
     @Test func projectFileRoundTripsViewStateAndTabs() throws {
         var a = Fixtures.timeline()
         a.name = "Main"
-        a.viewState = TimelineViewState(playheadFrame: 42, zoomScale: 7, scrollOffsetX: 300)
         a.tracks = [Fixtures.videoTrack()]
         a.tracks[0].displayHeight = 88
         var b = Fixtures.timeline()
         b.name = "Vertical"
+        let vs = TimelineViewState(playheadFrame: 42, zoomScale: 7, scrollOffsetX: 300)
 
-        let file = ProjectFile(timelines: [a, b], activeTimelineId: b.id, openTimelineIds: [a.id, b.id])
+        let file = ProjectFile(
+            timelines: [a, b], activeTimelineId: b.id, openTimelineIds: [a.id, b.id],
+            viewStates: [a.id: vs]
+        )
         let decoded = try ProjectFile.decode(JSONEncoder().encode(file))
 
         #expect(decoded.timelines.map(\.name) == ["Main", "Vertical"])
         #expect(decoded.activeTimelineId == b.id)
         #expect(decoded.openTimelineIds == [a.id, b.id])
-        #expect(decoded.timelines[0].viewState == a.viewState)
+        #expect(decoded.viewStates?[a.id] == vs)
         #expect(decoded.timelines[0].tracks[0].displayHeight == 88)
     }
 

--- a/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
@@ -241,6 +241,41 @@ struct MultiTimelineTests {
         #expect(e.activeTimelineId == aId)
     }
 
+    @Test func moveTimelinesToFolderSetsParentAndUndoes() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+        let folderId = e.createFolder(name: "Cuts")
+        let tid = e.activeTimelineId
+        undo.removeAllActions()
+
+        e.moveTimelinesToFolder(timelineIds: [tid], folderId: folderId)
+        #expect(e.timeline(for: tid)?.folderId == folderId)
+
+        undo.undo()
+        #expect(e.timeline(for: tid)?.folderId == nil)
+    }
+
+    @Test func deleteFolderReparentsContainedTimelinesToRoot() {
+        let e = EditorViewModel()
+        let folderId = e.createFolder(name: "Cuts")
+        let tid = e.activeTimelineId
+        e.moveTimelinesToFolder(timelineIds: [tid], folderId: folderId)
+
+        e.deleteFolders(ids: [folderId])
+
+        #expect(e.timeline(for: tid) != nil)   // never cascade-deleted
+        #expect(e.timeline(for: tid)?.folderId == nil)
+    }
+
+    @Test func timelineFolderIdPersists() throws {
+        var t = Fixtures.timeline()
+        t.folderId = "f1"
+        let file = ProjectFile(timelines: [t], activeTimelineId: t.id, openTimelineIds: [t.id])
+        let decoded = try ProjectFile.decode(JSONEncoder().encode(file))
+        #expect(decoded.timelines[0].folderId == "f1")
+    }
+
     @Test func fpsChangeRescalesEveryTimeline() {
         let e = EditorViewModel()
         e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 30, duration: 30)])]

--- a/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
@@ -239,6 +239,21 @@ struct MultiTimelineTests {
         #expect(e.activeTimelineId == aId)
     }
 
+    @Test func finalizeGeneratingClipPatchesDuplicatedCopies() {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(mediaRef: "gen-1", start: 0, duration: 300)])]
+        let copyId = e.duplicateTimeline(e.activeTimelineId, activate: false)
+        let asset = MediaAsset(id: "gen-1", url: URL(fileURLWithPath: "/tmp/x.mp4"), type: .video, name: "gen", duration: 2)
+
+        e.finalizeGeneratingClip(placeholderId: "gen-1", asset: asset)
+
+        let expected = 2 * e.timeline.fps
+        for id in [e.activeTimelineId, copyId].compactMap({ $0 }) {
+            let clip = e.timeline(for: id)?.tracks.flatMap(\.clips).first { $0.mediaRef == "gen-1" }
+            #expect(clip?.durationFrames == expected)
+        }
+    }
+
     @Test func moveTimelinesToFolderSetsParentAndUndoes() {
         let e = EditorViewModel()
         let undo = UndoManager()

--- a/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MultiTimelineTests.swift
@@ -254,6 +254,14 @@ struct MultiTimelineTests {
         }
     }
 
+    @Test func deleteTimelineClearsMediaPanelSelection() {
+        let e = EditorViewModel()
+        let second = e.createTimeline(activate: false)
+        e.selectedTimelineIds = [second]
+        e.deleteTimeline(second)
+        #expect(e.selectedTimelineIds.isEmpty)
+    }
+
     @Test func moveTimelinesToFolderSetsParentAndUndoes() {
         let e = EditorViewModel()
         let undo = UndoManager()

--- a/Tests/PalmierProTests/Timeline/NestingTests.swift
+++ b/Tests/PalmierProTests/Timeline/NestingTests.swift
@@ -81,6 +81,49 @@ struct NestingTests {
         #expect(e.timelines.count == 1)
     }
 
+    @Test func nestSelectedClipsKeepsUnselectedClipInsideSpan() {
+        let e = EditorViewModel()
+        e.undoManager = UndoManager()
+        e.timeline.tracks = [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "s1", start: 0, duration: 20),
+                Fixtures.clip(id: "mid", start: 30, duration: 20),
+                Fixtures.clip(id: "s2", start: 60, duration: 20),
+            ])
+        ]
+        e.selectedClipIds = ["s1", "s2"]
+
+        e.nestSelectedClips()
+
+        // The unselected mid clip survives on its track; the carrier lands on a fresh one.
+        let all = e.timeline.tracks.flatMap(\.clips)
+        #expect(all.contains { $0.id == "mid" })
+        let carrier = all.first { $0.sourceClipType == .sequence }
+        #expect(carrier?.startFrame == 0)
+        #expect(carrier?.durationFrames == 80)
+        #expect(e.timeline.tracks.count == 2)
+    }
+
+    @Test func nestSelectedClipsRegeneratesGroupIdsInChild() {
+        let e = EditorViewModel()
+        e.undoManager = UndoManager()
+        var v = Fixtures.clip(id: "v", start: 0, duration: 30)
+        v.linkGroupId = "g1"
+        var a = Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 30)
+        a.linkGroupId = "g1"
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [v]), Fixtures.audioTrack(clips: [a])]
+        e.selectedClipIds = ["v"]
+
+        e.nestSelectedClips()
+
+        // A partially-nested link group must not span two timelines.
+        let child = e.timelines.first { $0.name == "Nest 1" }
+        let moved = child?.tracks.flatMap(\.clips).first
+        #expect(moved != nil)
+        #expect(moved?.linkGroupId != "g1")
+        #expect(e.timeline.tracks.flatMap(\.clips).contains { $0.id == "a" && $0.linkGroupId == "g1" })
+    }
+
     @Test func decomposeReplacesNestWithChildClipsInPlace() {
         let e = EditorViewModel()
         let undo = UndoManager()

--- a/Tests/PalmierProTests/Timeline/NestingTests.swift
+++ b/Tests/PalmierProTests/Timeline/NestingTests.swift
@@ -37,6 +37,50 @@ struct NestingTests {
         #expect(e.timeline.tracks.allSatisfy { $0.clips.isEmpty })
     }
 
+    @Test func nestSelectedClipsMovesSelectionIntoNewTimeline() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+
+        // Two video lanes + audio; selection skips the top-lane clip at 0 and the audio tail.
+        e.timeline.tracks = [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "t1", start: 0, duration: 20), Fixtures.clip(id: "t2", start: 40, duration: 20)]),
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "v1", start: 30, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(id: "a1", mediaType: .audio, start: 30, duration: 30), Fixtures.clip(id: "a2", mediaType: .audio, start: 100, duration: 10)])
+        ]
+        let before = e.timeline
+        e.selectedClipIds = ["t2", "v1", "a1"]
+        undo.removeAllActions()
+
+        e.nestSelectedClips()
+
+        // Child holds the moved clips rebased to the span start (30), lane order preserved.
+        let child = e.timelines.first { $0.name == "Nest 1" }
+        #expect(child != nil)
+        #expect(child?.tracks.map(\.type) == [.video, .video, .audio])
+        #expect(child?.tracks[0].clips.map(\.startFrame) == [10])
+        #expect(child?.tracks[1].clips.map(\.startFrame) == [0])
+        #expect(child?.tracks[2].clips.map(\.startFrame) == [0])
+        #expect(child?.totalFrames == 60)
+
+        // Parent: v1's emptied lane pruned; linked carriers span [30, 90); "t1"/"a2" survive.
+        let videoLane = e.timeline.tracks.first { $0.type == .video }!
+        let audioLane = e.timeline.tracks.first { $0.type == .audio }!
+        #expect(e.timeline.tracks.count == 2)
+        let v = videoLane.clips.first { $0.sourceClipType == .sequence }
+        let a = audioLane.clips.first { $0.sourceClipType == .sequence }
+        #expect(v?.startFrame == 30 && v?.durationFrames == 60)
+        #expect(a?.mediaType == .audio)
+        #expect(v?.linkGroupId != nil && v?.linkGroupId == a?.linkGroupId)
+        #expect(videoLane.clips.contains { $0.id == "t1" })
+        #expect(audioLane.clips.contains { $0.id == "a2" })
+        #expect(e.selectedClipIds == Set([v?.id, a?.id].compactMap { $0 }))
+
+        undo.undo()
+        #expect(e.timeline == before)
+        #expect(e.timelines.count == 1)
+    }
+
     @Test func nestRejectsCyclesAndEmptyTimelines() {
         let e = EditorViewModel()
 

--- a/Tests/PalmierProTests/Timeline/NestingTests.swift
+++ b/Tests/PalmierProTests/Timeline/NestingTests.swift
@@ -81,6 +81,88 @@ struct NestingTests {
         #expect(e.timelines.count == 1)
     }
 
+    @Test func decomposeReplacesNestWithChildClipsInPlace() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+
+        // Child: two video lanes + one audio lane; the audio clip carries volume 0.8.
+        var linked = Fixtures.clip(id: "cv", start: 0, duration: 40)
+        linked.linkGroupId = "g1"
+        var linkedAudio = Fixtures.clip(id: "ca", mediaType: .audio, start: 0, duration: 40, volume: 0.8)
+        linkedAudio.linkGroupId = "g1"
+        let child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "top", start: 10, duration: 20)]),
+            Fixtures.videoTrack(clips: [linked]),
+            Fixtures.audioTrack(clips: [linkedAudio])
+        ])
+        e.timelines.append(child)
+        #expect(e.nestTimeline(child.id, cursor: .newTrackAt(0), atFrame: 100))
+        let nestId = e.timeline.tracks.first { $0.type == .video }!.clips[0].id
+        let nestVolume = 0.5
+        let carrierIdx = e.timeline.tracks.firstIndex { $0.type == .audio }!
+        e.timeline.tracks[carrierIdx].clips[0].volume = nestVolume
+        undo.removeAllActions()
+        let before = e.timeline
+
+        e.decomposeNest(clipId: nestId)
+
+        let videoTracks = e.timeline.tracks.filter { $0.type == .video }
+        let audioTracks = e.timeline.tracks.filter { $0.type == .audio }
+        #expect(videoTracks.count == 2)
+        #expect(audioTracks.count == 1)
+        // Child track order preserved, remapped by the nest's start frame.
+        #expect(videoTracks[0].clips.map(\.startFrame) == [110])
+        #expect(videoTracks[1].clips.map(\.startFrame) == [100])
+        #expect(audioTracks[0].clips.map(\.startFrame) == [100])
+        // Fresh ids; child A/V link survives under a remapped group id.
+        let v = videoTracks[1].clips[0], a = audioTracks[0].clips[0]
+        #expect(v.id != "cv" && a.id != "ca")
+        #expect(v.linkGroupId != nil && v.linkGroupId == a.linkGroupId && v.linkGroupId != "g1")
+        // Carrier volume folds into the child audio clip; no group look → no toast.
+        #expect(abs(a.volume - 0.8 * nestVolume) < 0.0001)
+        #expect(e.mediaPanelToast == nil)
+
+        undo.undo()
+        #expect(e.timeline == before)
+    }
+
+    @Test func composeThenDecomposeRoundTripsToOriginalTracks() {
+        // Leftovers on every lane; the moved clips must return to the tracks they left.
+        let e = EditorViewModel()
+        e.timeline.tracks = [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "capIntro", start: 0, duration: 25), Fixtures.clip(id: "cap", start: 30, duration: 40)]),
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "vIntro", start: 0, duration: 25), Fixtures.clip(id: "v", start: 30, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(id: "aIntro", mediaType: .audio, start: 0, duration: 25), Fixtures.clip(id: "a", mediaType: .audio, start: 30, duration: 60)])
+        ]
+        e.selectedClipIds = ["cap", "v", "a"]
+
+        e.nestSelectedClips()
+        let carrier = e.timeline.tracks.flatMap(\.clips).first { $0.mediaType == .sequence }!
+        e.decomposeNest(clipId: carrier.id)
+
+        // Same three tracks, no extras, each lane's content back beside its leftover.
+        #expect(e.timeline.tracks.count == 3)
+        #expect(e.timeline.tracks[0].clips.map(\.startFrame) == [0, 30])
+        #expect(e.timeline.tracks[1].clips.map(\.startFrame) == [0, 30])
+        #expect(e.timeline.tracks[2].clips.map(\.startFrame) == [0, 30])
+        #expect(e.timeline.tracks[1].clips[1].durationFrames == 60)
+        #expect(!e.timeline.tracks.contains { $0.clips.isEmpty })
+    }
+
+    @Test func decomposeWarnsWhenGroupLookIsDiscarded() {
+        let e = EditorViewModel()
+        let child = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])])
+        e.timelines.append(child)
+        #expect(e.nestTimeline(child.id, cursor: .newTrackAt(0), atFrame: 0))
+        let nestId = e.timeline.tracks[0].clips[0].id
+        e.timeline.tracks[0].clips[0].crop = Crop(left: 0.2, top: 0, right: 0, bottom: 0)
+
+        e.decomposeNest(clipId: nestId)
+        #expect(e.mediaPanelToast != nil)
+        #expect(!e.timeline.tracks[0].clips.contains { $0.sourceClipType == .sequence })
+    }
+
     @Test func nestRejectsCyclesAndEmptyTimelines() {
         let e = EditorViewModel()
 

--- a/Tests/PalmierProTests/Timeline/NestingTests.swift
+++ b/Tests/PalmierProTests/Timeline/NestingTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+@Suite("Nesting — drop flow")
+struct NestingTests {
+
+    @Test func nestTimelineCreatesLinkedClipsAndUndoes() {
+        let e = EditorViewModel()
+        let undo = UndoManager()
+        e.undoManager = undo
+
+        var child = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 60)]),
+            Fixtures.audioTrack(clips: [Fixtures.clip(mediaType: .audio, start: 0, duration: 60)])
+        ])
+        child.name = "Intro"
+        e.timelines.append(child)
+        undo.removeAllActions()
+
+        #expect(e.nestTimeline(child.id, cursor: .newTrackAt(0), atFrame: 30))
+
+        let videoClips = e.timeline.tracks.first { $0.type == .video }?.clips ?? []
+        let audioClips = e.timeline.tracks.first { $0.type == .audio }?.clips ?? []
+        #expect(videoClips.count == 1)
+        #expect(videoClips[0].mediaType == .sequence)
+        #expect(videoClips[0].mediaRef == child.id)
+        #expect(videoClips[0].startFrame == 30)
+        #expect(videoClips[0].durationFrames == 60)
+        #expect(audioClips.count == 1)
+        #expect(audioClips[0].sourceClipType == .sequence)
+        #expect(audioClips[0].linkGroupId == videoClips[0].linkGroupId)
+        #expect(e.clipDisplayLabel(for: videoClips[0]) == "Intro")
+
+        undo.undo()
+        #expect(e.timeline.tracks.allSatisfy { $0.clips.isEmpty })
+    }
+
+    @Test func nestRejectsCyclesAndEmptyTimelines() {
+        let e = EditorViewModel()
+
+        // Empty child rejected.
+        let empty = Fixtures.timeline()
+        e.timelines.append(empty)
+        #expect(!e.nestTimeline(empty.id, cursor: .newTrackAt(0), atFrame: 0))
+
+        // Self-nesting rejected.
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])]
+        #expect(!e.nestTimeline(e.activeTimelineId, cursor: .newTrackAt(0), atFrame: 0))
+
+        // Transitive cycle rejected: A nests B; nesting A into B would loop.
+        let b = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])])
+        e.timelines.append(b)
+        let aId = e.activeTimelineId
+        #expect(e.nestTimeline(b.id, cursor: .newTrackAt(0), atFrame: 0))   // A nests B
+        e.activateTimeline(b.id)
+        #expect(!e.nestTimeline(aId, cursor: .newTrackAt(0), atFrame: 0))   // B can't nest A
+    }
+}


### PR DESCRIPTION
tldr: multi-timeline in a project.

what users can do:
1. create a new timeline within a project
2. select clips and create a nested timeline

what agents can do:
1. create timeline
2. duplicate timeline
3. export timeline

<img width="1458" height="1008" alt="Screenshot 2026-07-02 at 11 54 02 PM" src="https://github.com/user-attachments/assets/4f56f4c2-29e4-4b3c-817d-f78b1b0d266e" />


below is ai-generated summary of code changes:
## 1. Files

### Core model & persistence

| File | Change | +/− |
|---|---|---|
| `Models/Timeline.swift` | Timeline gains id/name/folderId/viewState, `nestedTimelineIds`, tolerant decoder, Track.displayHeight | +47/−4 |
| `Models/ProjectFile.swift` *(new)* | New project.json root `{timelines, activeTimelineId, openTimelineIds}` with legacy bare-Timeline fallback | +23/−0 |
| `Models/ClipType.swift` | `.sequence` clip type (icon, label, isVisual) | +4/−1 |
| `Models/Keyframe.swift` | Shared `KeyframeTrack.rebased(by:fallback:)` (split + nest flatten) | +15/−0 |
| `Project/VideoProject.swift` | Load/save ProjectFile instead of bare Timeline | +15/−13 |

### Editor state & timeline operations

| File | Change | +/− |
|---|---|---|
| `EditorViewModel.swift` | `timelines` array + active-timeline proxy (get/set/`_modify`), open-tab ids, rename-request signal | +47/−5 |
| `EditorViewModel+Timelines.swift` *(new)* | Switch/stash-restore view state, CRUD, per-timeline undo routing, nest/compose/decompose, cycle detection | +460/−0 |
| `EditorViewModel+ProjectSettings.swift` | Settings apply per timeline; undo lands on owning timeline | +47/−27 |
| `EditorViewModel+MediaLibrary.swift` | Asset deletion sweeps all timelines; undo snapshots carry timelines | +35/−2 |
| `EditorViewModel+ClipMutations.swift` | Speed blocked on nests; shared split keyframe rebase | +11/−25 |
| `EditorViewModel+Clipboard.swift` | Paste cycle-guard for nests | +6/−0 |
| `EditorViewModel+GeneratedClips.swift` | Generated-clip finalize searches all timelines | +12/−15 |
| `EditorViewModel+Folders.swift` | Timelines participate in folders; delete reparents | +31/−17 |
| `EditorViewModel+Ripple.swift`, `+Tracks.swift`, `+SaveAsMedia.swift`, `+PreviewTabs.swift` | Nest linked-audio in ripple insert; small threading | +11/−5 |

### Playback (live nesting)

| File | Change | +/− |
|---|---|---|
| `Preview/CompositionBuilder.swift` | Nest expansion into AVComposition (video/audio lanes, segmented instructions, carrier volume), BuildContext refactor | +379/−188 |
| `Preview/NestFlattener.swift` *(new)* | Child-clip remap: window intersection, trims, keyframe rebase, deterministic ids | +71/−0 |
| `Compositing/FrameRenderer.swift` | Group layers: children composite at child canvas, then carrier pipeline | +71/−11 |
| `Compositing/CompositorInstruction.swift` | `LayerPlan.Source.group`, recursive track-id collection | +15/−3 |
| `Preview/VideoEngine.swift`, `TimelineRenderer.swift` | resolveTimeline snapshots threaded into rebuilds | +8/−1 |

### Timeline & preview UI

| File | Change | +/− |
|---|---|---|
| `Timeline/TimelineTabBar.swift` *(new)* | Tab strip: activate, inline rename, close, context menu, "…" all-timelines menu | +162/−0 |
| `Timeline/TimelineView.swift` | Nest context-menu items (Open / Create Nested Timeline / Decompose) | +48/−2 |
| `Timeline/TimelineInputController.swift` | Double-click nest opens child; live nest trim limits | +16/−2 |
| `Timeline/TimelineContainerView.swift`, `ClipRenderer.swift` | Tab bar mount; nest clip label resolves child name | +19/−0 |
| `UI/InlineRenameField.swift` *(new)* | Shared commit/cancel rename text field | +46/−0 |
| `Editor/EditorView.swift`, `EditorWindowController.swift`, `Inspector`, `PreviewContainerView` | Mounting + nest speed hidden in inspector | +15/−5 |

### Media panel

| File | Change | +/− |
|---|---|---|
| `MediaPanel/MediaTab/MediaTileScaffold.swift` *(new)* | Shared tile scaffold (selection, rename, drag) for folders/timelines/assets | +98/−0 |
| `MediaPanel/MediaTab/TimelineTileView.swift` *(new)* | Timeline grid tile with badge + active tint | +86/−0 |
| `MediaPanel/MediaTab/MediaTab+Grids.swift` | Timelines as grid items, selection routing, grouped/flat views | +101/−30 |
| `MediaPanel/MediaTab/FolderTileView.swift` | Rebuilt on shared scaffold | +32/−125 |
| `MediaPanel/MediaTab/MediaTab.swift`, `+Drag.swift`, `AssetThumbnailView.swift` | `palmier-timeline://` drag scheme, drop-to-nest | +57/−35 |

### Agent tools

| File | Change | +/− |
|---|---|---|
| `Agent/Tools/ToolExecutor+Timeline.swift` | `create_timeline` / `set_active_timeline` / `duplicate_timeline`; `get_timeline` lists timelines | +43/−0 |
| `Agent/Tools/ToolExecutor+Export.swift` | `timelineId` on export_project; accurate nest warnings | +69/−27 |
| `Agent/Tools/ToolDefinitions.swift` | Schemas + descriptions for all of the above | +37/−4 |
| `Agent/Tools/ToolExecutor.swift` | `clipSource` (timeline-as-mediaRef for nesting), dispatch, undo-stack exemption | +30/−2 |
| `Agent/Tools/ToolExecutor+Folders.swift` | rename/delete_media accept timelines | +26/−7 |
| `Agent/Tools/ToolExecutor+Clips.swift`, `+ShortId.swift`, `+Generate.swift`, `+InspectTimeline.swift`, `+Texts.swift`, `AgentInstructions.swift` | Nest placement, timeline ids in ShortId universe, nested rendering in inspect/generate | +30/−15 |

### Export

| File | Change | +/− |
|---|---|---|
| `Export/FCPXMLExporter.swift` | Nested timelines as compound clips (`<media><sequence>` + ref-clip), recursive, real timeline names | +142/−18 |
| `Export/XMLExporter.swift` | Nested `<sequence>` inside carrier clipitems (Premiere convention), recursive | +114/−22 |
| `Export/ExportView.swift` | Timeline dropdown; readouts/filename follow selection | +31/−9 |
| `Export/ExportService.swift`, `PalmierProjectExporter.swift` | resolveTimeline threading; .palmier carries all timelines | +13/−10 |
| `Generation/*` (5 files) | resolveTimeline into generation/edit render paths | +16/−9 |
| `UI/AppTheme.swift` | Tab rename width constant | +3/−0 |

### Tests

| File | Change | +/− |
|---|---|---|
| `Timeline/MultiTimelineTests.swift` *(new)* | Proxy, persistence/migration, view state, undo routing, settings | +351/−0 |
| `Timeline/NestingTests.swift` *(new)* | Drop flow, compose, decompose round-trip, cycles | +186/−0 |
| `Export/XMLExporterTests.swift` | XMEML nested-sequence suite | +140/−0 |
| `Agent/TimelineToolsTests.swift` *(new)* | create/switch/duplicate/nest/rename/delete tools | +134/−0 |
| `Export/FCPXMLExporterTests.swift` | FCPXML compound-clip suite | +125/−1 |
| `Rendering/NestRenderTests.swift` *(new)* | Pixel tests: nested rendering, group opacity/transform, 2-level, decoder scoping | +109/−0 |
| `Agent/ExportProjectToolTests.swift`, `Export/CompositionBuilderTests.swift`, `Rendering/CompositorRenderTests.swift` + fixtures, `Project/VideoProjectLoadTests.swift` | timelineId export, shared audio tracks, shared render harness | +65/−21 |

## 2. Features

- Multiple timelines per project with a tab strip (rename, close, context menu, "…" all-timelines menu)
- Timelines as media-grid items: badge tile, foldering, drag to timeline to nest
- Live nested timelines — rendered by composition flattening, no baking, edits inside propagate instantly
- Compose: select clips → "Create Nested Timeline" (in-place replacement, auto-named, tab opens pre-focused for rename)
- Decompose in place — true round-trip back to original tracks, carrier volume folded, group looks warned
- Double-click a nest (or "Open Timeline") to enter its child timeline
- Per-timeline view state (playhead/zoom/scroll) and undo that lands on the owning timeline
- Persistence: new ProjectFile root with transparent migration of legacy single-timeline projects
- Agent tools: `create_timeline`, `set_active_timeline`, `duplicate_timeline`, timelines listed in `get_timeline`, nest via `add_clips`/`insert_clips`, rename/delete timelines via media tools
- Export: FCPXML compound clips (FCP/Resolve-verified) and XMEML nested sequences (Premiere-verified), recursive
- Per-timeline export: dialog dropdown + `export_project timelineId`, both defaulting to the active timeline
- Perf: nest instructions segmented per child-clip boundary; audio speed-track rule retired (72 → 2 audio queue threads)

## 3. Code distribution

| Bucket | + | − | Share of additions |
|---|---|---|---|
| Test code (all) | 1,110 | 22 | 30% |
| Export XML code (`FCPXMLExporter` + `XMLExporter` sources) | 256 | 40 | 7% |
| Everything else (model, playback, UI, agent) | 2,284 | 599 | 63% |

Within the test bucket, 265 of the 1,110 added lines are the two export-XML test suites — so export nesting all-in is ~520 lines, and roughly 1 in 3 lines of the PR is a test.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to editor state, compositing, persistence, and export; nested timelines and undo routing affect core editing and project file format.
> 
> **Overview**
> Projects can hold **multiple timelines** with tab switching, per-timeline playhead/zoom/scroll state, and persistence via a new **`ProjectFile`** root (legacy single-timeline `project.json` still loads). **Nested timelines** use `sequence` clips whose `mediaRef` is a child `timelineId`: drag from the media panel, compose selected clips into a nest, or decompose back in place, with cycle checks and no retiming on nest carriers.
> 
> **Playback and export** thread a `resolveTimeline` snapshot through composition, preview, generation renders, and exports. Nested content composites live (group layers in `FrameRenderer`) rather than baking. **FCPXML** and **XMEML** emit nested timelines as compound/nested sequences; video/XML/FCP export can target a specific timeline via `timelineId`, while `.palmier` packages every timeline.
> 
> The **agent** gains `create_timeline`, `set_active_timeline`, and `duplicate_timeline`; `get_timeline` lists timelines; `add_clips` / `insert_clips` accept timeline IDs; rename/delete media tools cover timelines; undo routes through `registerTimelineUndo` so edits land on the owning timeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b90fce3e55c9b01bc5b07e09985bf99a94f5e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->