### PR TITLE
Multicam layout: use program camera audio when group has no mics

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -301,8 +301,12 @@ extension EditorViewModel {
         var before: [(id: String, clip: Clip)] = []
         for ti in timeline.tracks.indices {
             for ci in timeline.tracks[ti].clips.indices where ids.contains(timeline.tracks[ti].clips[ci].id) {
-                before.append((timeline.tracks[ti].clips[ci].id, timeline.tracks[ti].clips[ci]))
-                modify(&timeline.tracks[ti].clips[ci])
+                // Modify a copy so the closure can read `timeline` without an
+                // exclusivity conflict against the in-place inout access.
+                var clip = timeline.tracks[ti].clips[ci]
+                before.append((clip.id, clip))
+                modify(&clip)
+                timeline.tracks[ti].clips[ci] = clip
             }
         }
         guard !before.isEmpty else { return }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -145,9 +145,15 @@ extension EditorViewModel {
     ) -> MulticamLayoutResult {
         var result = MulticamLayoutResult()
         let camera = defaultCameraRef.flatMap { group.member(for: $0) } ?? group.cameras.first
+        // No dedicated mics: the program camera's own audio becomes the audio bed.
+        var audioMembers = group.mics
+        if audioMembers.isEmpty, let camera,
+           mediaAssets.first(where: { $0.id == camera.mediaRef })?.hasAudio == true {
+            audioMembers = [camera]
+        }
         var toPlace: [MulticamGroup.Member] = []
         if let camera { toPlace.append(camera) }
-        toPlace.append(contentsOf: group.mics)
+        toPlace.append(contentsOf: audioMembers)
 
         let assetsById = Dictionary(mediaAssets.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         let placeable = toPlace.filter { assetsById[$0.mediaRef] != nil }
@@ -172,7 +178,7 @@ extension EditorViewModel {
                 result.placedClipIds.append(contentsOf: ids)
             }
 
-            for mic in group.mics {
+            for mic in audioMembers {
                 guard let asset = assetsById[mic.mediaRef] else { continue }
                 let duration = clipDurationFrames(for: asset, segment: nil)
                 let frame = startFrame + mic.syncOffsetFrames - minOffset

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -394,7 +394,9 @@ final class EditorViewModel {
             }
         }
 
-        var clip = Clip(mediaRef: asset.id, mediaType: asset.type, sourceClipType: asset.type, startFrame: startFrame, durationFrames: durationFrames, transform: fitTransform(for: asset))
+        // A video asset placed on an audio track contributes its audio only.
+        let mediaType: ClipType = (!targetIsVideo && asset.type == .video && asset.hasAudio) ? .audio : asset.type
+        var clip = Clip(mediaRef: asset.id, mediaType: mediaType, sourceClipType: asset.type, startFrame: startFrame, durationFrames: durationFrames, transform: fitTransform(for: asset))
         clip.linkGroupId = linkGroupId
         applyTrim(&clip)
         timeline.tracks[trackIndex].clips.append(clip)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A multicam group with cameras only (no mic members) laid out a silent timeline: the program camera is placed with `addLinkedAudio: false` and audio tracks were created only for `group.mics`.

- `layoutMulticamGroup` now falls back to the program camera as the audio member when the group has no mics and the camera's asset has audio, placing its audio full-length on a sync-locked audio track like a mic. Keeping it as a standalone track (not linked audio) means `switch_angle` cuts on the program video track never touch the audio bed.
- `placeClip` places a video asset on an audio track as an audio-only clip (`mediaType = .audio`), which the fallback relies on.

## Testing

Not built here (Linux VM, macOS-only target). Verify locally: create a cameras-only multicam via `create_multicam`, confirm an audio track appears and plays, then run `switch_angle` and confirm audio stays continuous.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0768622-572a-44ba-934f-08c46dbdbc16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0768622-572a-44ba-934f-08c46dbdbc16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

