### PR TITLE
fix(agent): bound frame args so an LLM tool call can't overflow Int and crash the app

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -140,8 +140,11 @@ extension ToolExecutor {
     ) throws -> (trimStart: Int, duration: Int, trimEnd: Int?) {
         let trimStart = trimStartFrame ?? 0
         guard trimStart >= 0 else { throw ToolError("\(path): trimStartFrame must be >= 0 (got \(trimStart))") }
+        try requireFrameInBounds(trimStart, label: "trimStartFrame", path: path)
         if let t = trimEndFrame, t < 0 { throw ToolError("\(path): trimEndFrame must be >= 0 (got \(t))") }
+        if let t = trimEndFrame { try requireFrameInBounds(t, label: "trimEndFrame", path: path) }
         if let d = durationFrames, d < 1 { throw ToolError("\(path): durationFrames must be >= 1 (got \(d))") }
+        if let d = durationFrames { try requireFrameInBounds(d, label: "durationFrames", path: path) }
         guard durationFrames == nil || trimEndFrame == nil else {
             throw ToolError("\(path): set durationFrames OR trimEndFrame, not both — both define the clip's end. Use durationFrames for an explicit length, trimEndFrame to trim the tail.")
         }
@@ -197,6 +200,7 @@ extension ToolExecutor {
             guard entry.startFrame >= 0 else {
                 throw ToolError("entries[\(idx)]: startFrame must be >= 0 (got \(entry.startFrame))")
             }
+            try requireFrameInBounds(entry.startFrame, label: "startFrame", path: "entries[\(idx)]")
             prepared.append((entry, asset, trackId))
         }
 
@@ -321,6 +325,7 @@ extension ToolExecutor {
             throw ToolError("trackIndex \(input.trackIndex) out of range (0..\(editor.timeline.tracks.count - 1))")
         }
         guard input.atFrame >= 0 else { throw ToolError("atFrame must be >= 0 (got \(input.atFrame))") }
+        try requireFrameInBounds(input.atFrame, label: "atFrame")
         let targetType = editor.timeline.tracks[input.trackIndex].type
 
         // Apply settings before deriving durations: it may change FPS, which clipDurationFrames depends on.
@@ -419,6 +424,7 @@ extension ToolExecutor {
             if let f = m.toFrame, f < 0 {
                 throw ToolError("\(path): toFrame must be >= 0 (got \(f))")
             }
+            if let f = m.toFrame { try requireFrameInBounds(f, label: "toFrame", path: path) }
             parsed.append(ParsedMove(clipId: m.clipId, destTrackId: destTrackId, toFrame: m.toFrame))
         }
 
@@ -475,6 +481,7 @@ extension ToolExecutor {
         if let df = input.durationFrames, df < 1 {
             throw ToolError("durationFrames must be >= 1 (got \(df))")
         }
+        if let df = input.durationFrames { try requireFrameInBounds(df, label: "durationFrames") }
         if let s = input.speed, s <= 0 {
             throw ToolError("speed must be > 0 (got \(s))")
         }
@@ -487,9 +494,11 @@ extension ToolExecutor {
         if let t = input.trimStartFrame, t < 0 {
             throw ToolError("trimStartFrame must be >= 0 (got \(t))")
         }
+        if let t = input.trimStartFrame { try requireFrameInBounds(t, label: "trimStartFrame") }
         if let t = input.trimEndFrame, t < 0 {
             throw ToolError("trimEndFrame must be >= 0 (got \(t))")
         }
+        if let t = input.trimEndFrame { try requireFrameInBounds(t, label: "trimEndFrame") }
 
         // Resolve clipIds + collect types for blend-mode validation.
         var clipTypes: [String: ClipType] = [:]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
@@ -95,7 +95,9 @@ extension ToolExecutor {
         var settingsNote: String?
         if usesMedia {
             guard startFrame >= 0 else { throw ToolError("startFrame must be >= 0 (got \(startFrame))") }
+            try requireFrameInBounds(startFrame, label: "startFrame")
             guard duration >= 1 else { throw ToolError("apply_layout placing new clips requires durationFrames >= 1.") }
+            try requireFrameInBounds(duration, label: "durationFrames")
             for e in entries {
                 let a = try asset(e.entry.mediaRef!, editor: editor)
                 guard a.type == .video || a.type == .image else {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -164,9 +164,11 @@ extension ToolExecutor {
             guard durationFrames >= 1 else {
                 throw ToolError("\(path): durationFrames must be >= 1 (got \(durationFrames))")
             }
+            try requireFrameInBounds(durationFrames, label: "durationFrames", path: path)
             guard startFrame >= 0 else {
                 throw ToolError("\(path): startFrame must be >= 0 (got \(startFrame))")
             }
+            try requireFrameInBounds(startFrame, label: "startFrame", path: path)
 
             var style = TextStyle()
             _ = Self.applyTextStylePatch(try parseTextStylePatch(entry, path: path), to: &style)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -316,6 +316,16 @@ func clampInt(_ d: Double, min lo: Int, max hi: Int) -> Int {
     return Int(d.rounded())
 }
 
+// Frame ceiling low enough that startFrame + durationFrames can't overflow Int, high enough for any real timeline.
+let maxToolFrame = 1_000_000_000
+
+func requireFrameInBounds(_ value: Int, label: String, path: String = "") throws {
+    guard value <= maxToolFrame else {
+        let prefix = path.isEmpty ? "" : "\(path): "
+        throw ToolError("\(prefix)\(label) \(value) exceeds the maximum supported frame (\(maxToolFrame))")
+    }
+}
+
 extension Dictionary where Key == String, Value == Any {
     func string(_ key: String) -> String? {
         if let v = self[key] as? String, !v.isEmpty { return v }

--- a/Tests/PalmierProTests/Agent/ToolArgOverflowTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolArgOverflowTests.swift
@@ -84,4 +84,66 @@ struct ToolArgOverflowE2ETests {
         ])
         #expect(result.isError == true)
     }
+
+    /// A near-Int.max integer startFrame decodes into Int (unlike 1e19) and reached startFrame + durationFrames, which trapped the process.
+    @Test func addClipsRejectsFrameThatWouldOverflowEndFrame() async {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let asset = h.addAsset(type: .video, duration: 5)
+        let result = await h.runRaw("add_clips", args: [
+            "entries": [[
+                "mediaRef": asset.id,
+                "trackIndex": 0,
+                "startFrame": Int.max,
+                "durationFrames": 60,
+            ]]
+        ])
+        #expect(result.isError == true)          // was: hard crash (Int overflow trap)
+        #expect(h.editor.timeline.tracks[0].clips.isEmpty)   // rejected before any placement
+    }
+
+    /// insert_clips routes atFrame into the same endFrame arithmetic.
+    @Test func insertClipsRejectsOverflowAtFrame() async {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+        let asset = h.addAsset(type: .video, duration: 5)
+        let result = await h.runRaw("insert_clips", args: [
+            "trackIndex": 0,
+            "atFrame": Int.max,
+            "entries": [["mediaRef": asset.id, "durationFrames": 30]],
+        ])
+        #expect(result.isError == true)
+    }
+
+    /// move_clips sets a clip's startFrame directly from toFrame.
+    @Test func moveClipsRejectsOverflowToFrame() async {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "M1", start: 0, duration: 100)]),
+        ]))
+        let result = await h.runRaw("move_clips", args: [
+            "moves": [["clipId": "M1", "toFrame": Int.max]],
+        ])
+        #expect(result.isError == true)
+    }
+
+    /// set_clip_properties writes durationFrames straight onto the clip.
+    @Test func setClipPropertiesRejectsOverflowDuration() async {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "S1", start: 0, duration: 100)]),
+        ]))
+        let result = await h.runRaw("set_clip_properties", args: [
+            "clipIds": ["S1"], "durationFrames": Int.max,
+        ])
+        #expect(result.isError == true)
+    }
+
+    /// add_texts places a text clip at an unbounded startFrame.
+    @Test func addTextsRejectsOverflowStartFrame() async {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .text)
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [["content": "hi", "startFrame": Int.max, "durationFrames": 60]],
+        ])
+        #expect(result.isError == true)
+    }
 }


### PR DESCRIPTION
Fixes #264.

### Problem

Frame-valued agent tool args (`startFrame`, `atFrame`, `toFrame`, `durationFrames`, trim frames) were only lower-bounded. A value near `Int.max` decodes cleanly into `Int` (it is finite, so it passes the decode-time finiteness check) and then traps the process on `startFrame + durationFrames` (`Clip.endFrame`, `clearRegion`, `placeClip`). Arithmetic traps are not catchable by the `do`/`catch` in `ToolExecutor.execute`, so the app crashes rather than returning a tool error. Same class as the `1e19` overflow fixed in #201.

### Fix

One shared ceiling + helper in `ToolExecutor.swift`, applied alongside each existing lower-bound guard:

```swift
let maxToolFrame = 1_000_000_000

func requireFrameInBounds(_ value: Int, label: String, path: String = "") throws {
    guard value <= maxToolFrame else {
        let prefix = path.isEmpty ? "" : "\(path): "
        throw ToolError("\(prefix)\(label) \(value) exceeds the maximum supported frame (\(maxToolFrame))")
    }
}
```

Applied in `add_clips` / `resolvePlacement`, `insert_clips`, `move_clips`, `set_clip_properties`, `add_texts`, and `apply_layout`. With both operands capped at 1e9, any `start + duration` stays well below `Int.max`.

Deliberately additive: existing error messages are untouched (some tests assert on them), and the intentionally clamp-tolerant tools (e.g. `ripple_delete_ranges`, which uses `clampInt`) are left as-is.

**Why not a blanket check in `decodeToolArgs`?** A decode-level ceiling on all integers would be terser but would flip the deliberate design where some tools clamp huge values instead of rejecting them (`ripple_delete_ranges` tolerates `1e300` via `clampInt`). The per-boundary guard matches the existing `guard >= 0` style and returns a clear, actionable error to the model.

### Tests

5 new end-to-end regression tests in `ToolArgOverflowTests.swift`, each driving a tool with `Int.max` and asserting a clean tool error (no trap): `add_clips`, `insert_clips`, `move_clips`, `set_clip_properties`, `add_texts`.

- Before: the `add_clips` test crashes the test process (SIGTRAP).
- After: `swift test` = 948 tests / 146 suites pass; `swift build` clean.

### Scope

23 lines across 4 source files + 62 lines of tests. Additive only; no behavior change for in-range values; no model internals touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive validation on agent tool inputs only; in-range frame values behave the same, and clamp-tolerant tools are explicitly left alone.
> 
> **Overview**
> Agent timeline tools only rejected negative frame values; huge integers like `Int.max` still decoded and then **trapped the process** on `startFrame + durationFrames` (and similar), which `ToolExecutor` cannot catch as a tool error.
> 
> This PR adds **`maxToolFrame` (1e9)** and **`requireFrameInBounds`** in `ToolExecutor.swift`, wired next to existing `>= 0` checks for clip placement, insert/move, property updates, text placement, and layout. Out-of-range values now return a **`ToolError`** instead of crashing. Tools that intentionally **clamp** huge numbers (e.g. `ripple_delete_ranges`) are unchanged.
> 
> Five E2E tests in `ToolArgOverflowTests` drive `add_clips`, `insert_clips`, `move_clips`, `set_clip_properties`, and `add_texts` with `Int.max` and assert a clean error with no timeline mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68dc7255110cf1e2cdd435663e253991075aac2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->