### PR TITLE
Feat: Beat Detection

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -35,6 +35,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case setKeyframes = "set_keyframes"
     case applyLayout = "apply_layout"
     case syncAudio = "sync_audio"
+    case detectBeats = "detect_beats"
     case undo = "undo"
 
     // Transcript
@@ -550,6 +551,19 @@ enum ToolDefinitions {
                     "minConfidence": ["type": "number", "description": "Minimum correlation confidence 0–1 (default 0.5)."],
                 ],
                 required: ["referenceClipId"]
+            )
+        ),
+        AgentTool(
+            name: .detectBeats,
+            description: "Detect the musical tempo (BPM) and beat positions of an asset's audio. Pass clipId to get beatFrames as project frames mapped through that clip's trim, speed, and position — feed them straight into split_clips, move_clips, or set_keyframes to cut or animate on the beat. Without clipId, returns beatSeconds in source seconds — pass a pair straight to add_clips as source, or use them to plan spans; no unit conversion. Results cache per asset, so repeat calls are instant; detected beats also appear as ticks on the clip and edits snap to them in the timeline. When capped, pass the returned nextStartSeconds as startSeconds for the next page.",
+            inputSchema: objectSchema(
+                properties: [
+                    "mediaRef": ["type": "string", "description": "Asset ID from get_media. Must have an audio track."],
+                    "clipId": ["type": "string", "description": "Optional. A clip referencing this mediaRef; beats return as project frames for that clip (beats outside its trimmed range dropped)."],
+                    "startSeconds": ["type": "number", "description": "Optional. Source-time window start; only beats at or after this."],
+                    "endSeconds": ["type": "number", "description": "Optional. Window end; only beats before this."],
+                ],
+                required: ["mediaRef"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+extension ToolExecutor {
+    fileprivate struct DetectBeatsInput: DecodableToolArgs {
+        let mediaRef: String
+        let clipId: String?
+        let startSeconds: Double?
+        let endSeconds: Double?
+        static let allowedKeys: Set<String> = ["mediaRef", "clipId", "startSeconds", "endSeconds"]
+    }
+
+    private static let detectBeatsCap = 2000
+
+    func detectBeats(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        let input: DetectBeatsInput = try decodeToolArgs(args, path: "detect_beats")
+        let asset = try asset(input.mediaRef, editor: editor)
+        guard asset.type == .audio || (asset.type == .video && asset.hasAudio) else {
+            throw ToolError("detect_beats: asset \(asset.id) has no audio track.")
+        }
+        guard FileManager.default.fileExists(atPath: asset.url.path) else {
+            throw ToolError("detect_beats: media file for \(asset.id) is not on disk yet. Poll get_media and retry once generationStatus becomes 'none'.")
+        }
+
+        var clip: Clip?
+        if let clipId = input.clipId {
+            guard let c = editor.clipFor(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
+            guard c.sourceClipType != .sequence else {
+                throw ToolError("detect_beats: clip \(clipId) is a nested sequence; pass a clip that references the audio asset directly.")
+            }
+            guard c.mediaRef == asset.id else {
+                throw ToolError("detect_beats: clip \(clipId) references \(c.mediaRef), not \(asset.id).")
+            }
+            clip = c
+        }
+
+        let analysis = try await editor.mediaVisualCache.beats.analysisAwaiting(for: asset)
+        guard !analysis.beats.isEmpty else {
+            return .ok("No beats detected — the audio may be too quiet, too short, or non-rhythmic.")
+        }
+
+        var beats = analysis.beats
+        if let s = input.startSeconds { beats = beats.filter { $0 >= s } }
+        if let e = input.endSeconds { beats = beats.filter { $0 < e } }
+
+        var nextStartSeconds: Double?
+        if beats.count > Self.detectBeatsCap {
+            nextStartSeconds = beats[Self.detectBeatsCap]
+            beats = Array(beats.prefix(Self.detectBeatsCap))
+        }
+
+        var payload: [String: Any] = ["bpm": analysis.bpm]
+        if let clip {
+            let fps = editor.timeline.fps
+            payload["clipId"] = clip.id
+            payload["beatFrames"] = beats.compactMap { clip.timelineFrame(sourceSeconds: $0, fps: fps) }
+        } else {
+            payload["beatSeconds"] = beats
+        }
+        payload["beatCount"] = (payload["beatFrames"] as? [Int])?.count ?? beats.count
+        if let nextStartSeconds { payload["nextStartSeconds"] = nextStartSeconds }
+        return .ok(Self.jsonString(roundJSONFloatingPointNumbers(payload, toPlaces: 3)) ?? "Detected \(Int(analysis.bpm.rounded())) BPM, \(beats.count) beats.")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
@@ -30,7 +30,6 @@ extension ToolExecutor {
             return .ok("No beats detected — the audio may be too quiet, too short, or non-rhythmic.")
         }
 
-        // Re-resolve after the await so edits made during detection map correctly.
         let clip = try input.clipId.map { try Self.validatedClip($0, asset: asset, editor: editor) }
 
         var beats = analysis.beats

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Beats.swift
@@ -21,22 +21,17 @@ extension ToolExecutor {
             throw ToolError("detect_beats: media file for \(asset.id) is not on disk yet. Poll get_media and retry once generationStatus becomes 'none'.")
         }
 
-        var clip: Clip?
         if let clipId = input.clipId {
-            guard let c = editor.clipFor(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
-            guard c.sourceClipType != .sequence else {
-                throw ToolError("detect_beats: clip \(clipId) is a nested sequence; pass a clip that references the audio asset directly.")
-            }
-            guard c.mediaRef == asset.id else {
-                throw ToolError("detect_beats: clip \(clipId) references \(c.mediaRef), not \(asset.id).")
-            }
-            clip = c
+            _ = try Self.validatedClip(clipId, asset: asset, editor: editor)
         }
 
         let analysis = try await editor.mediaVisualCache.beats.analysisAwaiting(for: asset)
         guard !analysis.beats.isEmpty else {
             return .ok("No beats detected — the audio may be too quiet, too short, or non-rhythmic.")
         }
+
+        // Re-resolve after the await so edits made during detection map correctly.
+        let clip = try input.clipId.map { try Self.validatedClip($0, asset: asset, editor: editor) }
 
         var beats = analysis.beats
         if let s = input.startSeconds { beats = beats.filter { $0 >= s } }
@@ -59,5 +54,16 @@ extension ToolExecutor {
         payload["beatCount"] = (payload["beatFrames"] as? [Int])?.count ?? beats.count
         if let nextStartSeconds { payload["nextStartSeconds"] = nextStartSeconds }
         return .ok(Self.jsonString(roundJSONFloatingPointNumbers(payload, toPlaces: 3)) ?? "Detected \(Int(analysis.bpm.rounded())) BPM, \(beats.count) beats.")
+    }
+
+    private static func validatedClip(_ clipId: String, asset: MediaAsset, editor: EditorViewModel) throws -> Clip {
+        guard let clip = editor.clipFor(id: clipId) else { throw ToolError("Clip not found: \(clipId)") }
+        guard clip.sourceClipType != .sequence else {
+            throw ToolError("detect_beats: clip \(clipId) is a nested sequence; pass a clip that references the audio asset directly.")
+        }
+        guard clip.mediaRef == asset.id else {
+            throw ToolError("detect_beats: clip \(clipId) references \(clip.mediaRef), not \(asset.id).")
+        }
+        return clip
     }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -106,6 +106,7 @@ final class ToolExecutor {
         case .removeWords:   return try await removeWords(editor, args)
         case .removeSilence: return try removeSilence(editor, args)
         case .syncAudio:     return try await syncAudio(editor, args)
+        case .detectBeats:   return try await detectBeats(editor, args)
         case .undo:          return try undo(editor)
         case .addTexts:      return try addTexts(editor, args)
         case .updateText:    return try updateText(editor, args)

--- a/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
+++ b/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
@@ -16,6 +16,9 @@ enum BeatDetector {
 
     private static let pipelineGate = AsyncSemaphore(value: 2)
 
+    // @concurrent keeps decode + detection off the caller's actor even if the
+    // default nonisolated-async execution semantics change.
+    @concurrent
     static func analysis(for sourceURL: URL, mediaRef: String, force: Bool = false) async throws -> BeatAnalysis {
         if !force, let cached = cachedAnalysis(for: sourceURL, mediaRef: mediaRef) { return cached }
         try await pipelineGate.wait()

--- a/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
+++ b/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
@@ -1,0 +1,113 @@
+import Accelerate
+import Foundation
+
+struct BeatAnalysis: Codable, Sendable, Equatable {
+    let bpm: Double
+    let beats: [Double]
+}
+
+enum BeatDetector {
+    static let cache = DiskCache(named: "BeatAnalysis")
+
+    static let minBPM: Double = 60
+    static let maxBPM: Double = 200
+    private static let driftTolerance = 0.2
+    private static let onsetFloor: Float = 0.25
+
+    private static let pipelineGate = AsyncSemaphore(value: 2)
+
+    static func analysis(for sourceURL: URL, mediaRef: String, force: Bool = false) async throws -> BeatAnalysis {
+        if !force, let cached = cachedAnalysis(for: sourceURL, mediaRef: mediaRef) { return cached }
+        try await pipelineGate.wait()
+        defer { Task { await pipelineGate.signal() } }
+        let envelope = try await AudioEnvelopeExtractor.extract(from: sourceURL)
+        let analysis = detect(envelope: envelope)
+        let outputURL = analysisURL(for: sourceURL, mediaRef: mediaRef)
+        removeStaleCaches(for: mediaRef, keeping: outputURL)
+        if let data = try? JSONEncoder().encode(analysis) {
+            try? data.write(to: outputURL)
+        }
+        return analysis
+    }
+
+    static func cachedAnalysis(for sourceURL: URL, mediaRef: String) -> BeatAnalysis? {
+        guard let data = try? Data(contentsOf: analysisURL(for: sourceURL, mediaRef: mediaRef)) else { return nil }
+        return try? JSONDecoder().decode(BeatAnalysis.self, from: data)
+    }
+
+    private static func analysisURL(for sourceURL: URL, mediaRef: String) -> URL {
+        cache.directory.appendingPathComponent("\(mediaRef)_\(DiskCache.sizeMtimeTag(for: sourceURL))_beats.json")
+    }
+
+    private static func removeStaleCaches(for mediaRef: String, keeping keep: URL) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: cache.directory, includingPropertiesForKeys: nil) else { return }
+        for entry in entries where entry.lastPathComponent.hasPrefix("\(mediaRef)_") && entry.lastPathComponent != keep.lastPathComponent {
+            try? fm.removeItem(at: entry)
+        }
+    }
+
+    static func detect(envelope: AudioEnvelope) -> BeatAnalysis {
+        let hop = envelope.hopSeconds
+        let env = envelope.samples
+        let minLag = max(1, Int((60.0 / maxBPM / hop).rounded()))
+        let maxLag = Int((60.0 / minBPM / hop).rounded())
+        guard hop > 0, env.count >= maxLag * 4 else { return BeatAnalysis(bpm: 0, beats: []) }
+
+        var onset = [Float](repeating: 0, count: env.count)
+        for i in 1..<env.count { onset[i] = max(0, env[i] - env[i - 1]) }
+        var mean: Float = 0
+        vDSP_meanv(onset, 1, &mean, vDSP_Length(onset.count))
+        guard mean > .ulpOfOne else { return BeatAnalysis(bpm: 0, beats: []) }
+
+        var bestLag = 0
+        var bestScore: Float = 0
+        onset.withUnsafeBufferPointer { buf in
+            let base = buf.baseAddress!
+            for lag in minLag...maxLag {
+                var dot: Float = 0
+                vDSP_dotpr(base, 1, base + lag, 1, &dot, vDSP_Length(onset.count - lag))
+                let score = dot / Float(onset.count - lag)
+                if score > bestScore {
+                    bestScore = score
+                    bestLag = lag
+                }
+            }
+        }
+        guard bestLag > 0, bestScore > 0 else { return BeatAnalysis(bpm: 0, beats: []) }
+        let bpm = 60.0 / (Double(bestLag) * hop)
+
+        var bestOffset = 0
+        var bestSum: Float = -1
+        for offset in 0..<bestLag {
+            var sum: Float = 0
+            var i = offset
+            while i < onset.count {
+                sum += onset[i]
+                i += bestLag
+            }
+            if sum > bestSum {
+                bestSum = sum
+                bestOffset = offset
+            }
+        }
+
+        let tolerance = max(1, Int(Double(bestLag) * driftTolerance))
+        let floor = mean * onsetFloor
+        var beats: [Double] = []
+        var expected = bestOffset
+        while expected < onset.count {
+            let lo = max(0, expected - tolerance)
+            let hi = min(onset.count - 1, expected + tolerance)
+            var peak = expected
+            for i in lo...hi where onset[i] > onset[peak] { peak = i }
+            if onset[peak] >= floor {
+                beats.append(Double(peak) * hop)
+                expected = peak + bestLag
+            } else {
+                expected += bestLag
+            }
+        }
+        return BeatAnalysis(bpm: bpm, beats: beats)
+    }
+}

--- a/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
+++ b/Sources/PalmierPro/Audio/Analysis/BeatDetector.swift
@@ -16,8 +16,6 @@ enum BeatDetector {
 
     private static let pipelineGate = AsyncSemaphore(value: 2)
 
-    // @concurrent keeps decode + detection off the caller's actor even if the
-    // default nonisolated-async execution semantics change.
     @concurrent
     static func analysis(for sourceURL: URL, mediaRef: String, force: Bool = false) async throws -> BeatAnalysis {
         if !force, let cached = cachedAnalysis(for: sourceURL, mediaRef: mediaRef) { return cached }

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -23,6 +23,10 @@ extension InspectorView {
                         .padding(.top, AppTheme.Spacing.md)
                     denoiseRow(audios: audios)
                         .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
+                    sectionTitleLabel(title: "Beats")
+                        .padding(.top, AppTheme.Spacing.md)
+                    beatsRow(audios: audios)
+                        .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
                     if nonTextVisualClips.isEmpty {
                         speedSection(clips: audios)
                             .padding(.trailing, KeyframesMetrics.controlsColumnWidth + AppTheme.Spacing.sm)
@@ -47,6 +51,10 @@ extension InspectorView {
                 VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
                     sectionTitleLabel(title: "Enhance")
                     denoiseRow(audios: audios)
+                }
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+                    sectionTitleLabel(title: "Beats")
+                    beatsRow(audios: audios)
                 }
                 if nonTextVisualClips.isEmpty {
                     speedSection(clips: audios)
@@ -144,6 +152,60 @@ extension InspectorView {
         }
     }
 
+
+    @ViewBuilder
+    private func beatsRow(audios: [Clip]) -> some View {
+        let refs = beatMediaRefs(audios)
+        if !refs.isEmpty {
+            let store = editor.mediaVisualCache.beats
+            let analyses = refs.compactMap { store.analysis(for: $0) }
+            let analyzing = refs.contains { store.isAnalyzing($0) }
+            let failed = !analyzing && refs.contains { store.hasFailed($0) }
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+                propertyRow(label: "Beats") {
+                    HStack(spacing: AppTheme.Spacing.sm) {
+                        if refs.count == 1, let analysis = analyses.first, analyses.count == 1 {
+                            Text(analysis.beats.isEmpty
+                                 ? "None found"
+                                 : "\(Int(analysis.bpm.rounded())) BPM · \(analysis.beats.count) beats")
+                                .font(.system(size: AppTheme.FontSize.xs))
+                                .foregroundStyle(AppTheme.Text.mutedColor)
+                        }
+                        Button(analyses.isEmpty ? "Detect Beats" : "Redetect Beats") {
+                            for ref in refs {
+                                guard let asset = editor.mediaAssets.first(where: { $0.id == ref }) else { continue }
+                                store.generate(for: asset, force: store.analysis(for: ref) != nil)
+                            }
+                        }
+                        .controlSize(.small)
+                        .disabled(analyzing)
+                    }
+                }
+                .help("Detects tempo and beat positions — beats show as ticks on the clip and edits snap to them.")
+                if analyzing {
+                    HStack(spacing: AppTheme.Spacing.xs) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Detecting beats…")
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .foregroundStyle(AppTheme.Text.mutedColor)
+                    }
+                } else if failed {
+                    Text("Beat detection failed. Check that the media file is reachable, then retry.")
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Status.errorColor)
+                }
+            }
+        }
+    }
+
+    private func beatMediaRefs(_ audios: [Clip]) -> [String] {
+        var seen = Set<String>()
+        return audios.compactMap { clip in
+            guard clip.sourceClipType != .sequence, seen.insert(clip.mediaRef).inserted else { return nil }
+            return clip.mediaRef
+        }
+    }
 
     @ViewBuilder
     private func fadeRow(label: String, clips: [Clip], edge: FadeEdge) -> some View {

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -31,12 +31,19 @@ final class BeatStore {
     }
 
     func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
-        // Join any in-flight detection so a forced redetect never answers with the stale cache.
-        if tasks[asset.id] == nil, let existing = analyses[asset.id] { return existing }
+        // Join any in-flight detection so a forced redetect never answers with the stale
+        // cache; retry rather than trust the cache after a failed run.
+        if tasks[asset.id] == nil, !failed.contains(asset.id), let existing = analyses[asset.id] {
+            return existing
+        }
         do {
             return try await detectionTask(for: asset, force: false).value
         } catch {
-            if let existing = analyses[asset.id] { return existing }
+            // Superseded or invalidated mid-flight; a newer task may have already
+            // stored a fresh result. Real failures propagate.
+            if error is BeatStoreStaleAnalysisError, let existing = analyses[asset.id] {
+                return existing
+            }
             throw error
         }
     }

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -71,8 +71,8 @@ final class BeatStore {
                 if !(error is BeatStoreStaleAnalysisError) {
                     Log.preview.error("beats failed mediaRef=\(key): \(Log.detail(error))")
                 }
-                if let self, self.epoch[key, default: 0] == startEpoch {
-                    if self.tasks[key]?.id == id { self.tasks[key] = nil }
+                if let self, self.epoch[key, default: 0] == startEpoch, self.tasks[key]?.id == id {
+                    self.tasks[key] = nil
                     self.failed.insert(key)
                 }
                 throw error

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -49,7 +49,7 @@ final class BeatStore {
         let startEpoch = epoch[key, default: 0]
 
         let url = asset.url
-        let task = Task(priority: .utility) { [weak self] in
+        let task = Task(priority: .utility) { @MainActor [weak self] in
             do {
                 let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
                 guard let self, self.epoch[key, default: 0] == startEpoch else {

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -7,7 +7,8 @@ struct BeatStoreStaleAnalysisError: Error {}
 final class BeatStore {
     private var analyses: [String: BeatAnalysis] = [:]
     private var failed: Set<String> = []
-    @ObservationIgnored private var tasks: [String: Task<BeatAnalysis, Error>] = [:]
+    @ObservationIgnored private var tasks: [String: (id: Int, force: Bool, task: Task<BeatAnalysis, Error>)] = [:]
+    @ObservationIgnored private var nextTaskID = 0
     @ObservationIgnored private var epoch: [String: Int] = [:]
 
     @ObservationIgnored var onBeatsReady: (() -> Void)?
@@ -40,22 +41,30 @@ final class BeatStore {
         }
     }
 
-    /// One in-flight task per mediaRef; every caller joins it. Results are dropped
-    /// when `invalidate`/`reset` bumped `epoch` while the analysis was running.
+    /// One in-flight task per mediaRef; every caller joins it. A forced request
+    /// supersedes a non-forced one by chaining after it, so redetect never gets
+    /// downgraded to a cache hit. Results are dropped when `invalidate`/`reset`
+    /// bumped `epoch` while the analysis was running.
     private func detectionTask(for asset: MediaAsset, force: Bool) -> Task<BeatAnalysis, Error> {
         let key = asset.id
-        if let existing = tasks[key] { return existing }
+        let predecessor = tasks[key]
+        if let predecessor, !force || predecessor.force { return predecessor.task }
+
         failed.remove(key)
         let startEpoch = epoch[key, default: 0]
+        nextTaskID += 1
+        let id = nextTaskID
 
         let url = asset.url
+        let previous = predecessor?.task
         let task = Task(priority: .utility) { @MainActor [weak self] in
+            _ = try? await previous?.value
             do {
                 let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
                 guard let self, self.epoch[key, default: 0] == startEpoch else {
                     throw BeatStoreStaleAnalysisError()
                 }
-                self.tasks[key] = nil
+                if self.tasks[key]?.id == id { self.tasks[key] = nil }
                 self.analyses[key] = analysis
                 self.onBeatsReady?()
                 return analysis
@@ -64,13 +73,13 @@ final class BeatStore {
                     Log.preview.error("beats failed mediaRef=\(key): \(Log.detail(error))")
                 }
                 if let self, self.epoch[key, default: 0] == startEpoch {
-                    self.tasks[key] = nil
+                    if self.tasks[key]?.id == id { self.tasks[key] = nil }
                     self.failed.insert(key)
                 }
                 throw error
             }
         }
-        tasks[key] = task
+        tasks[key] = (id, force, task)
         return task
     }
 

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+struct BeatStoreStaleAnalysisError: Error {}
+
 @MainActor
 @Observable
 final class BeatStore {
@@ -55,10 +57,21 @@ final class BeatStore {
     }
 
     func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
-        if let existing = analyses[asset.id] { return existing }
-        let analysis = try await BeatDetector.analysis(for: asset.url, mediaRef: asset.id)
-        analyses[asset.id] = analysis
-        failed.remove(asset.id)
+        let key = asset.id
+        if let existing = analyses[key] { return existing }
+
+        inFlight.insert(key)
+        failed.remove(key)
+        let startEpoch = epoch[key, default: 0]
+        defer { inFlight.remove(key) }
+
+        let analysis = try await BeatDetector.analysis(for: asset.url, mediaRef: key)
+        guard epoch[key, default: 0] == startEpoch else {
+            if let existing = analyses[key] { return existing }
+            throw BeatStoreStaleAnalysisError()
+        }
+
+        analyses[key] = analysis
         onBeatsReady?()
         return analysis
     }

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -31,16 +31,12 @@ final class BeatStore {
     }
 
     func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
-        // Join any in-flight detection so a forced redetect never answers with the stale
-        // cache; retry rather than trust the cache after a failed run.
         if tasks[asset.id] == nil, !failed.contains(asset.id), let existing = analyses[asset.id] {
             return existing
         }
         do {
             return try await detectionTask(for: asset, force: false).value
         } catch {
-            // Superseded or invalidated mid-flight; a newer task may have already
-            // stored a fresh result. Real failures propagate.
             if error is BeatStoreStaleAnalysisError, let existing = analyses[asset.id] {
                 return existing
             }
@@ -48,10 +44,6 @@ final class BeatStore {
         }
     }
 
-    /// One in-flight task per mediaRef; every caller joins it. A forced request
-    /// supersedes a non-forced one by chaining after it, so redetect never gets
-    /// downgraded to a cache hit. Results are dropped when `invalidate`/`reset`
-    /// bumped `epoch` while the analysis was running.
     private func detectionTask(for asset: MediaAsset, force: Bool) -> Task<BeatAnalysis, Error> {
         let key = asset.id
         let predecessor = tasks[key]

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -7,7 +7,7 @@ struct BeatStoreStaleAnalysisError: Error {}
 final class BeatStore {
     private var analyses: [String: BeatAnalysis] = [:]
     private var failed: Set<String> = []
-    private var inFlight: Set<String> = []
+    @ObservationIgnored private var tasks: [String: Task<BeatAnalysis, Error>] = [:]
     @ObservationIgnored private var epoch: [String: Int] = [:]
 
     @ObservationIgnored var onBeatsReady: (() -> Void)?
@@ -16,76 +16,74 @@ final class BeatStore {
         MainActor.assumeIsolated { analyses[mediaRef] }
     }
 
-    func isAnalyzing(_ mediaRef: String) -> Bool { inFlight.contains(mediaRef) }
+    func isAnalyzing(_ mediaRef: String) -> Bool { tasks[mediaRef] != nil }
     func hasFailed(_ mediaRef: String) -> Bool { failed.contains(mediaRef) }
 
     func generate(for asset: MediaAsset, force: Bool = false, completion: (@MainActor (BeatAnalysis?) -> Void)? = nil) {
-        let key = asset.id
-        if !force, let existing = analyses[key] {
+        if !force, let existing = analyses[asset.id] {
             completion?(existing)
             return
         }
-        guard !inFlight.contains(key) else { return }
-        inFlight.insert(key)
+        let task = detectionTask(for: asset, force: force)
+        guard let completion else { return }
+        Task { completion(try? await task.value) }
+    }
+
+    func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
+        // Join any in-flight detection so a forced redetect never answers with the stale cache.
+        if tasks[asset.id] == nil, let existing = analyses[asset.id] { return existing }
+        do {
+            return try await detectionTask(for: asset, force: false).value
+        } catch {
+            if let existing = analyses[asset.id] { return existing }
+            throw error
+        }
+    }
+
+    /// One in-flight task per mediaRef; every caller joins it. Results are dropped
+    /// when `invalidate`/`reset` bumped `epoch` while the analysis was running.
+    private func detectionTask(for asset: MediaAsset, force: Bool) -> Task<BeatAnalysis, Error> {
+        let key = asset.id
+        if let existing = tasks[key] { return existing }
         failed.remove(key)
         let startEpoch = epoch[key, default: 0]
 
         let url = asset.url
-        Task.detached(priority: .utility) { [weak self] in
-            var analysis: BeatAnalysis?
+        let task = Task(priority: .utility) { [weak self] in
             do {
-                analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
-            } catch {
-                Log.preview.error("beats failed mediaRef=\(key): \(Log.detail(error))")
-            }
-            guard let self else { return }
-            await MainActor.run { [self] in
-                guard self.epoch[key, default: 0] == startEpoch else {
-                    completion?(nil)
-                    return
+                let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
+                guard let self, self.epoch[key, default: 0] == startEpoch else {
+                    throw BeatStoreStaleAnalysisError()
                 }
-                self.inFlight.remove(key)
-                if let analysis {
-                    self.analyses[key] = analysis
-                    self.onBeatsReady?()
-                } else {
+                self.tasks[key] = nil
+                self.analyses[key] = analysis
+                self.onBeatsReady?()
+                return analysis
+            } catch {
+                if !(error is BeatStoreStaleAnalysisError) {
+                    Log.preview.error("beats failed mediaRef=\(key): \(Log.detail(error))")
+                }
+                if let self, self.epoch[key, default: 0] == startEpoch {
+                    self.tasks[key] = nil
                     self.failed.insert(key)
                 }
-                completion?(analysis)
+                throw error
             }
         }
-    }
-
-    func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
-        let key = asset.id
-        if let existing = analyses[key] { return existing }
-
-        inFlight.insert(key)
-        failed.remove(key)
-        let startEpoch = epoch[key, default: 0]
-        defer { inFlight.remove(key) }
-
-        let analysis = try await BeatDetector.analysis(for: asset.url, mediaRef: key)
-        guard epoch[key, default: 0] == startEpoch else {
-            if let existing = analyses[key] { return existing }
-            throw BeatStoreStaleAnalysisError()
-        }
-
-        analyses[key] = analysis
-        onBeatsReady?()
-        return analysis
+        tasks[key] = task
+        return task
     }
 
     func reset() {
-        for key in inFlight { epoch[key, default: 0] += 1 }
-        inFlight.removeAll()
+        for key in tasks.keys { epoch[key, default: 0] += 1 }
+        tasks.removeAll()
         analyses.removeAll()
         failed.removeAll()
     }
 
     func invalidate(_ mediaRef: String) {
         epoch[mediaRef, default: 0] += 1
-        inFlight.remove(mediaRef)
+        tasks.removeValue(forKey: mediaRef)
         analyses.removeValue(forKey: mediaRef)
         failed.remove(mediaRef)
     }

--- a/Sources/PalmierPro/Timeline/BeatStore.swift
+++ b/Sources/PalmierPro/Timeline/BeatStore.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+@MainActor
+@Observable
+final class BeatStore {
+    private var analyses: [String: BeatAnalysis] = [:]
+    private var failed: Set<String> = []
+    private var inFlight: Set<String> = []
+    @ObservationIgnored private var epoch: [String: Int] = [:]
+
+    @ObservationIgnored var onBeatsReady: (() -> Void)?
+
+    nonisolated func analysis(for mediaRef: String) -> BeatAnalysis? {
+        MainActor.assumeIsolated { analyses[mediaRef] }
+    }
+
+    func isAnalyzing(_ mediaRef: String) -> Bool { inFlight.contains(mediaRef) }
+    func hasFailed(_ mediaRef: String) -> Bool { failed.contains(mediaRef) }
+
+    func generate(for asset: MediaAsset, force: Bool = false, completion: (@MainActor (BeatAnalysis?) -> Void)? = nil) {
+        let key = asset.id
+        if !force, let existing = analyses[key] {
+            completion?(existing)
+            return
+        }
+        guard !inFlight.contains(key) else { return }
+        inFlight.insert(key)
+        failed.remove(key)
+        let startEpoch = epoch[key, default: 0]
+
+        let url = asset.url
+        Task.detached(priority: .utility) { [weak self] in
+            var analysis: BeatAnalysis?
+            do {
+                analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
+            } catch {
+                Log.preview.error("beats failed mediaRef=\(key): \(Log.detail(error))")
+            }
+            guard let self else { return }
+            await MainActor.run { [self] in
+                guard self.epoch[key, default: 0] == startEpoch else {
+                    completion?(nil)
+                    return
+                }
+                self.inFlight.remove(key)
+                if let analysis {
+                    self.analyses[key] = analysis
+                    self.onBeatsReady?()
+                } else {
+                    self.failed.insert(key)
+                }
+                completion?(analysis)
+            }
+        }
+    }
+
+    func analysisAwaiting(for asset: MediaAsset) async throws -> BeatAnalysis {
+        if let existing = analyses[asset.id] { return existing }
+        let analysis = try await BeatDetector.analysis(for: asset.url, mediaRef: asset.id)
+        analyses[asset.id] = analysis
+        failed.remove(asset.id)
+        onBeatsReady?()
+        return analysis
+    }
+
+    func reset() {
+        for key in inFlight { epoch[key, default: 0] += 1 }
+        inFlight.removeAll()
+        analyses.removeAll()
+        failed.removeAll()
+    }
+
+    func invalidate(_ mediaRef: String) {
+        epoch[mediaRef, default: 0] += 1
+        inFlight.remove(mediaRef)
+        analyses.removeValue(forKey: mediaRef)
+        failed.remove(mediaRef)
+    }
+}
+
+extension EditorViewModel {
+    func beatSnapFrames(for clip: Clip) -> [Int] {
+        guard clip.sourceClipType != .sequence,
+              let analysis = mediaVisualCache.beats.analysis(for: clip.mediaRef) else { return [] }
+        let fps = timeline.fps
+        return analysis.beats.compactMap { clip.timelineFrame(sourceSeconds: $0, fps: fps) }
+    }
+}

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -169,6 +169,10 @@ enum ClipRenderer {
             drawTrimHandles(in: rect, context: context)
         }
 
+        if clip.sourceClipType != .sequence, let beats = cache?.beatAnalysis(for: clip.mediaRef) {
+            drawBeatTicks(analysis: beats, clip: clip, in: rect, fps: fps, context: context)
+        }
+
         if opacity < 1.0 {
             context.restoreGState()
         }
@@ -205,6 +209,35 @@ enum ClipRenderer {
             context.addPath(p)
             context.drawPath(using: .fillStroke)
         }
+    }
+
+    private static let beatTickColor = NSColor.systemCyan.withAlphaComponent(0.95).cgColor
+    private static let beatTickBackingColor = NSColor.black.withAlphaComponent(0.55).cgColor
+    private static let beatTickWidth: CGFloat = 2
+    private static let beatTickHeight: CGFloat = 7
+    private static let beatTickMinSpacing: CGFloat = 4
+
+    private static func drawBeatTicks(analysis: BeatAnalysis, clip: Clip, in rect: NSRect, fps: Int, context: CGContext) {
+        guard clip.durationFrames > 0, !analysis.beats.isEmpty else { return }
+        let pxPerFrame = rect.width / CGFloat(clip.durationFrames)
+        guard pxPerFrame > 0 else { return }
+        let body = clipBodyRect(in: rect)
+        guard body.height > beatTickHeight * 2 else { return }
+
+        var ticks: [CGRect] = []
+        var lastX = -CGFloat.greatestFiniteMagnitude
+        for t in analysis.beats {
+            guard let frame = clip.timelineFrame(sourceSeconds: t, fps: fps) else { continue }
+            let x = rect.minX + CGFloat(frame - clip.startFrame) * pxPerFrame
+            guard x - lastX >= beatTickMinSpacing else { continue }
+            lastX = x
+            ticks.append(CGRect(x: x - beatTickWidth / 2, y: body.minY, width: beatTickWidth, height: beatTickHeight))
+        }
+        guard !ticks.isEmpty else { return }
+        context.setFillColor(beatTickBackingColor)
+        context.fill(ticks.map { CGRect(x: $0.minX - 1, y: $0.minY, width: $0.width + 2, height: $0.height + 1) })
+        context.setFillColor(beatTickColor)
+        context.fill(ticks)
     }
 
     // MARK: - Waveform

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -24,8 +24,15 @@ final class MediaVisualCache {
         MainActor.assumeIsolated { speakerMasks[mediaRef] }
     }
 
+    let beats = BeatStore()
+
+    nonisolated func beatAnalysis(for mediaRef: String) -> BeatAnalysis? {
+        beats.analysis(for: mediaRef)
+    }
+
     init() {
         speech.onMaskReady = { [weak self] in self?.timelineView?.needsDisplay = true }
+        beats.onBeatsReady = { [weak self] in self?.timelineView?.needsDisplay = true }
     }
 
     // MARK: - Video thumbnails (sorted by time)
@@ -89,6 +96,7 @@ final class MediaVisualCache {
         waveformSamples.removeAll()
         speakerMasks.removeAll()
         speech.reset()
+        beats.reset()
         videoThumbnails.removeAll()
         imageThumbnails.removeAll()
         timelineView?.needsDisplay = true
@@ -99,6 +107,7 @@ final class MediaVisualCache {
         waveformSamples.removeValue(forKey: mediaRef)
         speakerMasks.removeValue(forKey: mediaRef)
         speech.invalidate(mediaRef)
+        beats.invalidate(mediaRef)
         videoThumbnails.removeValue(forKey: mediaRef)
         imageThumbnails.removeValue(forKey: mediaRef)
     }

--- a/Sources/PalmierPro/Timeline/SnapEngine.swift
+++ b/Sources/PalmierPro/Timeline/SnapEngine.swift
@@ -8,7 +8,7 @@ enum SnapEngine {
     struct SnapTarget {
         let frame: Int
         let kind: Kind
-        enum Kind { case playhead, clipEdge }
+        enum Kind { case playhead, clipEdge, beat }
     }
 
     struct SnapResult {
@@ -32,16 +32,26 @@ enum SnapEngine {
         tracks: [Track],
         playheadFrame: Int = 0,
         excludeClipIds: Set<String> = [],
-        includePlayhead: Bool = false
+        includePlayhead: Bool = false,
+        beatFrames: ((Clip) -> [Int])? = nil,
+        includeExcludedClipBeats: Bool = false
     ) -> [SnapTarget] {
         var targets: [SnapTarget] = []
         if includePlayhead {
             targets.append(SnapTarget(frame: playheadFrame, kind: .playhead))
         }
         for track in tracks {
-            for clip in track.clips where !excludeClipIds.contains(clip.id) {
-                targets.append(SnapTarget(frame: clip.startFrame, kind: .clipEdge))
-                targets.append(SnapTarget(frame: clip.endFrame, kind: .clipEdge))
+            for clip in track.clips {
+                let excluded = excludeClipIds.contains(clip.id)
+                if !excluded {
+                    targets.append(SnapTarget(frame: clip.startFrame, kind: .clipEdge))
+                    targets.append(SnapTarget(frame: clip.endFrame, kind: .clipEdge))
+                }
+                if let beatFrames, !excluded || includeExcludedClipBeats {
+                    for frame in beatFrames(clip) {
+                        targets.append(SnapTarget(frame: frame, kind: .beat))
+                    }
+                }
             }
         }
         return targets
@@ -80,7 +90,7 @@ enum SnapEngine {
             for target in targets {
                 let threshold: Double = switch target.kind {
                 case .playhead: baseFrameThreshold * Snap.playheadMultiplier
-                case .clipEdge: baseFrameThreshold
+                case .clipEdge, .beat: baseFrameThreshold
                 }
                 let dist = abs(Double(probePos - target.frame))
                 if dist <= threshold, dist < (best?.distance ?? .infinity) {

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -236,7 +236,8 @@ final class TimelineInputController {
             let targets = SnapEngine.collectTargets(
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
-                includePlayhead: true
+                includePlayhead: true,
+                beatFrames: editor.beatSnapFrames(for:)
             )
             let rangeEndFrame: Int
             if let snap = SnapEngine.findSnap(
@@ -261,7 +262,8 @@ final class TimelineInputController {
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: allDraggedIds,
-                includePlayhead: true
+                includePlayhead: true,
+                beatFrames: editor.beatSnapFrames(for:)
             )
 
             // Let any selected edge drive snapping, not just the lead start.
@@ -307,7 +309,9 @@ final class TimelineInputController {
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
-                includePlayhead: true
+                includePlayhead: true,
+                beatFrames: editor.beatSnapFrames(for:),
+                includeExcludedClipBeats: true
             )
             let snappedStart: Int
             if let snap = SnapEngine.findSnap(
@@ -336,7 +340,9 @@ final class TimelineInputController {
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
-                includePlayhead: true
+                includePlayhead: true,
+                beatFrames: editor.beatSnapFrames(for:),
+                includeExcludedClipBeats: true
             )
             let snappedEnd: Int
             if let snap = SnapEngine.findSnap(
@@ -544,7 +550,8 @@ final class TimelineInputController {
             let targets = SnapEngine.collectTargets(
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
-                includePlayhead: true
+                includePlayhead: true,
+                beatFrames: editor.beatSnapFrames(for:)
             )
             if let snap = SnapEngine.findSnap(
                 position: candidate,

--- a/Sources/PalmierPro/Timeline/TimelineView+BeatsMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+BeatsMenu.swift
@@ -7,13 +7,18 @@ extension TimelineView {
         let force = editor.mediaVisualCache.beats.analysis(for: mediaRef) != nil
         editor.mediaVisualCache.beats.generate(for: asset, force: force) { [weak self] analysis in
             guard let self else { return }
-            if let analysis, !analysis.beats.isEmpty {
-                editor.mediaPanelToast = MediaPanelToast(
-                    message: "Detected \(Int(analysis.bpm.rounded())) BPM, \(analysis.beats.count) beats.",
-                    kind: .success
-                )
+            if let analysis {
+                editor.mediaPanelToast = analysis.beats.isEmpty
+                    ? MediaPanelToast(message: "No beats detected.", kind: .warning)
+                    : MediaPanelToast(
+                        message: "Detected \(Int(analysis.bpm.rounded())) BPM, \(analysis.beats.count) beats.",
+                        kind: .success
+                    )
             } else {
-                editor.mediaPanelToast = MediaPanelToast(message: "No beats detected.", kind: .warning)
+                editor.mediaPanelToast = MediaPanelToast(
+                    message: "Beat detection failed. Check that the media file is reachable, then retry.",
+                    kind: .warning
+                )
             }
             needsDisplay = true
         }

--- a/Sources/PalmierPro/Timeline/TimelineView+BeatsMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+BeatsMenu.swift
@@ -1,0 +1,21 @@
+import AppKit
+
+extension TimelineView {
+    @objc func performDetectBeats(_ sender: Any?) {
+        guard let mediaRef = (sender as? NSMenuItem)?.representedObject as? String,
+              let asset = editor.mediaAssets.first(where: { $0.id == mediaRef }) else { return }
+        let force = editor.mediaVisualCache.beats.analysis(for: mediaRef) != nil
+        editor.mediaVisualCache.beats.generate(for: asset, force: force) { [weak self] analysis in
+            guard let self else { return }
+            if let analysis, !analysis.beats.isEmpty {
+                editor.mediaPanelToast = MediaPanelToast(
+                    message: "Detected \(Int(analysis.bpm.rounded())) BPM, \(analysis.beats.count) beats.",
+                    kind: .success
+                )
+            } else {
+                editor.mediaPanelToast = MediaPanelToast(message: "No beats detected.", kind: .warning)
+            }
+            needsDisplay = true
+        }
+    }
+}

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -944,6 +944,15 @@ final class TimelineView: NSView {
             syncItem.representedObject = ["referenceClipId": pair.referenceClipId, "targetClipIds": pair.targetClipIds] as [String: Any]
             syncItems.append(syncItem)
         }
+        if clip.sourceClipType != .sequence,
+           let asset = editor.mediaAssets.first(where: { $0.id == clip.mediaRef }),
+           asset.type == .audio || (asset.type == .video && asset.hasAudio) {
+            let hasBeats = editor.mediaVisualCache.beats.analysis(for: clip.mediaRef) != nil
+            let beatsItem = NSMenuItem(title: hasBeats ? "Redetect Beats" : "Detect Beats", action: #selector(performDetectBeats(_:)), keyEquivalent: "")
+            beatsItem.target = self
+            beatsItem.representedObject = clip.mediaRef
+            syncItems.append(beatsItem)
+        }
 
         for group in [timelineItems, aiItems, nestItems, mediaItems, syncItems] where !group.isEmpty {
             if !menu.items.isEmpty { menu.addItem(.separator()) }
@@ -1178,7 +1187,8 @@ final class TimelineView: NSView {
         }
         let totalDur = assets.reduce(0) { $0 + editor.clipDurationFrames(for: $1, segment: externalDragSegments[$1.id]) }
         let targets = SnapEngine.collectTargets(
-            tracks: editor.timeline.tracks
+            tracks: editor.timeline.tracks,
+            beatFrames: editor.beatSnapFrames(for:)
         )
         if let snap = SnapEngine.findSnap(
             position: candidate,

--- a/Tests/PalmierProTests/Audio/BeatDetectorTests.swift
+++ b/Tests/PalmierProTests/Audio/BeatDetectorTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Beat detection")
+struct BeatDetectorTests {
+
+    private func pulseEnvelope(period: Double, duration: Double, hop: Double = 0.01) -> AudioEnvelope {
+        let count = Int(duration / hop)
+        var samples = [Float](repeating: 0.05, count: count)
+        let periodHops = Int(period / hop)
+        var i = periodHops
+        while i < count {
+            samples[i] = 1.0
+            if i + 1 < count { samples[i + 1] = 0.6 }
+            i += periodHops
+        }
+        return AudioEnvelope(hopSeconds: hop, samples: samples)
+    }
+
+    @Test func detectsTempoOfRegularPulseTrain() {
+        let analysis = BeatDetector.detect(envelope: pulseEnvelope(period: 0.5, duration: 30))
+        #expect(abs(analysis.bpm - 120) < 3)
+        #expect(!analysis.beats.isEmpty)
+
+        let gaps = zip(analysis.beats.dropFirst(), analysis.beats).map(-)
+        for gap in gaps {
+            #expect(abs(gap - 0.5) < 0.11)
+        }
+    }
+
+    @Test func detectsSlowTempo() {
+        let analysis = BeatDetector.detect(envelope: pulseEnvelope(period: 0.8, duration: 40))
+        #expect(abs(analysis.bpm - 75) < 3)
+    }
+
+    @Test func silenceYieldsNoBeats() {
+        let envelope = AudioEnvelope(hopSeconds: 0.01, samples: [Float](repeating: 0, count: 3000))
+        let analysis = BeatDetector.detect(envelope: envelope)
+        #expect(analysis.beats.isEmpty)
+        #expect(analysis.bpm == 0)
+    }
+
+    @Test func tooShortAudioYieldsNoBeats() {
+        let analysis = BeatDetector.detect(envelope: pulseEnvelope(period: 0.5, duration: 1))
+        #expect(analysis.beats.isEmpty)
+    }
+
+    @Test func beatsMapThroughTrimAndSpeed() {
+        let clip = Clip(mediaRef: "m", mediaType: .audio, startFrame: 100, durationFrames: 150, trimStartFrame: 60, speed: 2.0)
+        #expect(clip.timelineFrame(sourceSeconds: 3.0, fps: 30) == 115)
+        #expect(clip.timelineFrame(sourceSeconds: 1.0, fps: 30) == nil)
+    }
+}


### PR DESCRIPTION
Tool call to detect beat. Tool returns frames at which the beat happens. The agent can then place the footage on the beat. 
Works well with well defined beats. Not so much for irregular tempos and unclear beats. Example below shows transition between mushy beat to clear beat. Tested across multiple music genres (ip hop, electronic, jazz, etc) and overall it is fairly accurate. 

Clips also "snap" to beat when beat detection is enabled.

Example below 

https://github.com/user-attachments/assets/b58b5237-720c-478a-a09a-4659dc8fbd97

https://github.com/user-attachments/assets/6c52752c-1f01-4726-ad74-8612015ef3e6


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async audio analysis and snap behavior affect core timeline editing; incorrect beats could misalign cuts, though detection is read-only until the user or agent applies edits.
> 
> **Overview**
> Adds **on-device beat detection** (BPM + beat times) for audio/video assets, wired through the agent, inspector, timeline UI, and snapping.
> 
> A new **`detect_beats`** agent tool returns cached **BPM** and either **project `beatFrames`** (with `clipId`, respecting trim/speed) or **source `beatSeconds`**, with optional time windows and paging via `nextStartSeconds`. Analysis runs in **`BeatDetector`** (envelope → onset autocorrelation, disk cache) and is orchestrated by **`BeatStore`** on `MediaVisualCache`.
> 
> In the app, users can **Detect / Redetect Beats** from the Audio inspector and clip context menu; results show as **cyan ticks** on clips. **`SnapEngine`** gains a **beat** target kind so moves, trims, razor, range selection, and external drags snap to detected beats when analysis exists.
> 
> Unit tests cover the detector on synthetic pulse trains and clip frame mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3b8bb357fd24292408478f501be3a495fda18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->