### PR TITLE
Sonnet 5 Adaptive Thinking Set To Low

### DIFF
--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -14,6 +14,13 @@ enum AnthropicModel: String, CaseIterable, Sendable {
         case .haiku45: "Haiku 4.5"
         }
     }
+
+    var requestExtras: [String: Any] {
+        switch self {
+        case .sonnet5: ["output_config": ["effort": "low"]]
+        default: [:]
+        }
+    }
 }
 
 enum AnthropicStopReason: String, Sendable {
@@ -189,6 +196,7 @@ enum AnthropicRequestBody {
             "messages": messageBlocks,
         ]
         if !toolBlocks.isEmpty { body["tools"] = toolBlocks }
+        for (key, value) in model.requestExtras { body[key] = value }
         return body
     }
 }


### PR DESCRIPTION
Sonnet 5 uses adaptive thinking at high effort by default.
This made the chat feel particularly slow (as we show little ui data on thinking tokens) and the long thinking would time out the chat. Setting adaptive thinking to low. Still has thinking tokens just not as long, avoids timeout issues, and consumes less credits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small request-body tweak for one model only; no auth, persistence, or shared protocol changes beyond optional extra JSON keys.
> 
> **Overview**
> **Sonnet 5** chat requests now include **`output_config.effort: "low"`** so adaptive thinking runs at low effort instead of the default high setting.
> 
> A new **`AnthropicModel.requestExtras`** hook supplies model-specific body fields; **`AnthropicRequestBody.build`** merges them into every streaming request. Opus and Haiku are unchanged (empty extras).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfff02ff9893535c0d8005d33102ea1b8283d545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->