### PR TITLE
[fix] preview color tags

### DIFF
--- a/Sources/PalmierPro/Compositing/CustomVideoCompositor.swift
+++ b/Sources/PalmierPro/Compositing/CustomVideoCompositor.swift
@@ -7,7 +7,7 @@ final class CustomVideoCompositor: NSObject, AVVideoCompositing, @unchecked Send
 
     struct RenderError: Error {}
 
-    // Shared across all instances. Color management off so CI keeps source pixels raw.
+    // Shared across all instances. Color management stays at explicit render boundaries.
     static let ciContext: CIContext = {
         let options: [CIContextOption: Any] = [
             .workingColorSpace: NSNull(),

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -20,8 +20,15 @@ enum FrameRenderer {
             layers: instruction.layers, over: base, frame: frame,
             renderSize: instruction.renderSize, sourceFrame: sourceFrame, gateByClipRange: false
         )
-        context.render(accum, to: output, bounds: renderRect, colorSpace: nil)
-        tag709(output)
+        let tagSource = colorTagSource(
+            layers: instruction.layers,
+            frame: frame,
+            sourceFrame: sourceFrame,
+            gateByClipRange: false
+        )
+        let outputColorSpace = tagSource.flatMap(colorSpace(for:)) ?? fallbackVideoColorSpace
+        context.render(accum, to: output, bounds: renderRect, colorSpace: outputColorSpace)
+        tagOutput(output, source: tagSource, colorSpace: outputColorSpace)
     }
 
     /// Bottom→top layer stack; `gateByClipRange` skips group children outside `frame`.
@@ -101,7 +108,81 @@ enum FrameRenderer {
         return (f?.outputImage ?? blended).cropped(to: background.extent)
     }
 
-    /// Tag output Rec. 709 at the buffer level so downstream reads our bytes correctly.
+    private static func tagOutput(
+        _ output: CVPixelBuffer,
+        source: CVPixelBuffer?,
+        colorSpace: CGColorSpace
+    ) {
+        if let source {
+            copyColorTags(from: source, to: output)
+        } else {
+            tag709(output)
+        }
+        CVBufferSetAttachment(output, kCVImageBufferCGColorSpaceKey, colorSpace, .shouldPropagate)
+    }
+
+    private static func colorTagSource(
+        layers: [LayerPlan],
+        frame: Int,
+        sourceFrame: (CMPersistentTrackID) -> CVPixelBuffer?,
+        gateByClipRange: Bool
+    ) -> CVPixelBuffer? {
+        for layer in layers.reversed() {
+            if gateByClipRange, !layer.clip.contains(timelineFrame: frame) { continue }
+            guard layer.clip.opacityAt(frame: frame) > 0 else { continue }
+            switch layer.source {
+            case .track(let id):
+                if let buffer = sourceFrame(id) { return buffer }
+            case .text:
+                continue
+            case .group(let children, _):
+                if let buffer = colorTagSource(
+                    layers: children,
+                    frame: frame,
+                    sourceFrame: sourceFrame,
+                    gateByClipRange: true
+                ) {
+                    return buffer
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func copyColorTags(from source: CVPixelBuffer, to output: CVPixelBuffer) {
+        let keys: [CFString] = [
+            kCVImageBufferICCProfileKey,
+            kCVImageBufferCGColorSpaceKey,
+            kCVImageBufferColorPrimariesKey,
+            kCVImageBufferTransferFunctionKey,
+            kCVImageBufferGammaLevelKey,
+            kCVImageBufferYCbCrMatrixKey,
+            kCVImageBufferMasteringDisplayColorVolumeKey,
+            kCVImageBufferContentLightLevelInfoKey,
+        ]
+        for key in keys {
+            if let value = CVBufferCopyAttachment(source, key, nil) {
+                CVBufferSetAttachment(output, key, value, .shouldPropagate)
+            } else {
+                CVBufferRemoveAttachment(output, key)
+            }
+        }
+    }
+
+    private static let fallbackVideoColorSpace =
+        CGColorSpace(name: CGColorSpace.itur_709) ?? CGColorSpaceCreateDeviceRGB()
+
+    private static func colorSpace(for buffer: CVPixelBuffer) -> CGColorSpace? {
+        if let attachments = CVBufferCopyAttachments(buffer, .shouldPropagate),
+           let unmanaged = CVImageBufferCreateColorSpaceFromAttachments(attachments) {
+            return unmanaged.takeRetainedValue()
+        }
+        guard let attachment = CVBufferCopyAttachment(buffer, kCVImageBufferCGColorSpaceKey, nil) else {
+            return nil
+        }
+        return (attachment as! CGColorSpace)
+    }
+
     private static func tag709(_ buffer: CVPixelBuffer) {
         CVBufferSetAttachment(buffer, kCVImageBufferColorPrimariesKey,
                               kCVImageBufferColorPrimaries_ITU_R_709_2, .shouldPropagate)
@@ -122,7 +203,10 @@ enum FrameRenderer {
         guard alpha > 0 else { return nil }
 
         // Undo premultiplied alpha to avoid dark edges.
-        let image = CIImage(cvPixelBuffer: buffer, options: [.colorSpace: NSNull()])
+        let image = CIImage(
+            cvPixelBuffer: buffer,
+            options: [.colorSpace: colorSpace(for: buffer) ?? fallbackVideoColorSpace]
+        )
             .unpremultiplyingAlpha()
         return applyClipPipeline(
             image: image, srcHeight: CGFloat(CVPixelBufferGetHeight(buffer)), layer: layer,

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -275,7 +275,7 @@ final class VideoEngine {
                 kCIInputExtentKey: ext, "inputScale": 1.0, "inputCount": count,
             ])
             var raw = [Float](repeating: 0, count: count * 4)
-            CustomVideoCompositor.ciContext.render(
+            ColorScopes.context.render(
                 hist, toBitmap: &raw, rowBytes: count * 4 * MemoryLayout<Float>.size,
                 bounds: CGRect(x: 0, y: 0, width: count, height: 1), format: .RGBAf, colorSpace: nil)
             return raw

--- a/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
+++ b/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
@@ -94,6 +94,21 @@ struct CompositionBuildValidationTests {
 @Suite("CompositionBuilder.buildVisuals — instructions")
 struct CompositionBuildVisualInstructionTests {
 
+    @Test func videoCompositionDoesNotOverrideSourceColorimetry() {
+        let timeline = Fixtures.timeline(fps: 30, tracks: [])
+
+        let (_, videoComposition) = CompositionBuilder.buildVisuals(
+            timeline: timeline,
+            trackMappings: [],
+            compositionDuration: .zero,
+            renderSize: CGSize(width: 320, height: 180)
+        )
+
+        #expect(videoComposition.colorPrimaries == nil)
+        #expect(videoComposition.colorTransferFunction == nil)
+        #expect(videoComposition.colorYCbCrMatrix == nil)
+    }
+
     @Test func textInstructionsPreserveLayerOrderAcrossCaptionBoundaries() {
         let topA = textClip(id: "top-a", start: 0, duration: 10)
         let topB = textClip(id: "top-b", start: 10, duration: 10)
@@ -126,6 +141,62 @@ struct CompositionBuildVisualInstructionTests {
         var clip = Fixtures.clip(id: id, mediaRef: "text-\(id)", mediaType: .text, start: start, duration: duration)
         clip.textContent = id
         return clip
+    }
+}
+
+@Suite("FrameRenderer — color tags")
+struct FrameRendererColorTagTests {
+
+    @Test func propagatesSourceTransferAndGammaTags() throws {
+        let source = try pixelBuffer()
+        let output = try pixelBuffer()
+        CVBufferSetAttachment(source, kCVImageBufferColorPrimariesKey, kCVImageBufferColorPrimaries_ITU_R_709_2, .shouldPropagate)
+        CVBufferSetAttachment(source, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_UseGamma, .shouldPropagate)
+        CVBufferSetAttachment(source, kCVImageBufferGammaLevelKey, NSNumber(value: 2.4), .shouldPropagate)
+        CVBufferSetAttachment(source, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_709_2, .shouldPropagate)
+
+        let clip = Fixtures.clip(id: "clip", mediaRef: "src", start: 0, duration: 1)
+        let layer = LayerPlan(source: .track(7), clip: clip, natSize: CGSize(width: 2, height: 2), preferredTransform: .identity)
+        let instruction = CompositorInstruction(
+            timeRange: CMTimeRange(start: .zero, duration: CMTime(value: 1, timescale: 30)),
+            layers: [layer],
+            renderSize: CGSize(width: 2, height: 2),
+            fps: 30
+        )
+
+        FrameRenderer.render(
+            instruction: instruction,
+            sourceFrame: { $0 == 7 ? source : nil },
+            compositionTime: .zero,
+            into: output,
+            context: CustomVideoCompositor.ciContext
+        )
+
+        #expect(CVBufferCopyAttachment(output, kCVImageBufferColorPrimariesKey, nil) as? String == kCVImageBufferColorPrimaries_ITU_R_709_2 as String)
+        #expect(CVBufferCopyAttachment(output, kCVImageBufferCGColorSpaceKey, nil) != nil)
+        #expect(CVBufferCopyAttachment(output, kCVImageBufferTransferFunctionKey, nil) as? String == kCVImageBufferTransferFunction_UseGamma as String)
+        #expect((CVBufferCopyAttachment(output, kCVImageBufferGammaLevelKey, nil) as? NSNumber)?.doubleValue == 2.4)
+        #expect(CVBufferCopyAttachment(output, kCVImageBufferYCbCrMatrixKey, nil) as? String == kCVImageBufferYCbCrMatrix_ITU_R_709_2 as String)
+    }
+
+    private func pixelBuffer() throws -> CVPixelBuffer {
+        var buffer: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            nil,
+            2,
+            2,
+            kCVPixelFormatType_32BGRA,
+            [kCVPixelBufferCGImageCompatibilityKey as String: true] as CFDictionary,
+            &buffer
+        )
+        let pixelBuffer = try #require(buffer)
+        #expect(status == kCVReturnSuccess)
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            memset(base, 255, CVPixelBufferGetDataSize(pixelBuffer))
+        }
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+        return pixelBuffer
     }
 }
 


### PR DESCRIPTION
- preserve source color attachments through custom frame rendering
- keep video composition colorimetry unset so source metadata drives output
- keep color scopes rendering on its own context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview/export pixel interpretation and buffer attachments; wrong tagging could shift colors, but behavior is covered by new tests and falls back to 709.
> 
> **Overview**
> Fixes preview/export color handling so **source pixel buffers drive colorimetry** instead of forcing Rec. 709 on every composed frame.
> 
> **`FrameRenderer`** now picks the top visible video layer as the color-tag source, builds `CIImage` from buffers with their attached `CGColorSpace` (709 fallback when missing), renders with that color space, and **copies ICC/primaries/transfer/gamma/HDR attachments** onto the output (still 709-only when there is no video source).
> 
> **`CompositionBuilder`** is expected to leave `AVVideoComposition` color primaries/transfer/YCbCr matrix **unset** so downstream metadata is not overridden (new test).
> 
> **Preview histograms** render through **`ColorScopes.context`** instead of the compositor’s shared `CIContext`, isolating scopes from the preview/export render path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42f1c8e94f0ae5cfb54a39a55bb96fbdc976843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->