### PR TITLE
[sentry fix] unreadable media readiness

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -277,9 +277,12 @@ extension ToolExecutor {
 
     @MainActor
     private static func finishImportedAsset(_ asset: MediaAsset, editor: EditorViewModel) async {
-        await editor.finalizeImportedAsset(asset)
+        let finalized = await editor.finalizeImportedAsset(asset)
+        guard finalized else {
+            editor.onProjectCheckpointRequired?()
+            return
+        }
         asset.importInput = nil
-        asset.generationStatus = .none
         editor.updateManifestMetadata(for: asset)
         editor.onProjectCheckpointRequired?()
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -607,6 +607,7 @@ extension EditorViewModel {
                 data: ["assetId": Telemetry.shortId(asset.id), "type": asset.type.rawValue]
             )
             refreshMissingMediaCache()
+            refreshPreviewForFinalizedAsset(asset)
             return false
         }
         if asset.isGenerating {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -583,13 +583,35 @@ extension EditorViewModel {
         }
     }
 
-    func finalizeImportedAsset(_ asset: MediaAsset) async {
+    @discardableResult
+    func finalizeImportedAsset(_ asset: MediaAsset) async -> Bool {
         Log.project.notice(
             "media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
             telemetry: "Media asset finalize started",
             data: ["assetId": Telemetry.shortId(asset.id), "type": asset.type.rawValue]
         )
-        await asset.loadMetadata()
+        let metadataLoaded = await asset.loadMetadata()
+        guard metadataLoaded else {
+            if FileManager.default.fileExists(atPath: asset.url.path) {
+                unprocessableMediaRefs.insert(asset.id)
+            } else {
+                missingMediaRefs.insert(asset.id)
+            }
+            if asset.isGenerating || asset.isGenerated || asset.importInput != nil {
+                asset.generationStatus = .failed("Could not read media file.")
+            }
+            updateManifestMetadata(for: asset)
+            Log.project.warning(
+                "media finalize unreadable asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
+                telemetry: "Media asset finalize unreadable",
+                data: ["assetId": Telemetry.shortId(asset.id), "type": asset.type.rawValue]
+            )
+            refreshMissingMediaCache()
+            return false
+        }
+        if asset.isGenerating {
+            asset.generationStatus = .none
+        }
         updateManifestMetadata(for: asset)
         if FileManager.default.fileExists(atPath: asset.url.path) {
             missingMediaRefs.remove(asset.id)
@@ -623,6 +645,7 @@ extension EditorViewModel {
                 "hasAudio": asset.hasAudio
             ]
         )
+        return true
     }
 
     private func refreshPreviewForFinalizedAsset(_ asset: MediaAsset) {

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -251,11 +251,12 @@ final class GenerationService {
             }.value
 
             asset.pendingDownloadURL = nil
-            asset.generationStatus = .none
             editor.importMediaAsset(asset, skipAppend: true)
-            editor.appendGenerationLog(for: asset)
-            await editor.finalizeImportedAsset(asset)
-            return true
+            let finalized = await editor.finalizeImportedAsset(asset)
+            if finalized {
+                editor.appendGenerationLog(for: asset)
+            }
+            return finalized
         } catch {
             let message = error.localizedDescription
             Log.generation.error("download failed url=\(remoteURL.absoluteString) error=\(message)")

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -142,7 +142,8 @@ final class MediaAsset: Identifiable {
         )
     }
 
-    func loadMetadata() async {
+    @discardableResult
+    func loadMetadata() async -> Bool {
         if type == .image {
             duration = Defaults.imageDurationSeconds
             let imageURL = url
@@ -154,11 +155,11 @@ final class MediaAsset: Identifiable {
             if let image = metadata.thumbnail {
                 thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
             }
-            return
+            return metadata.width != nil && metadata.height != nil
         }
 
         if type == .lottie {
-            guard let info = try? await LottieVideoGenerator.inspect(fileAt: url) else { return }
+            guard let info = try? await LottieVideoGenerator.inspect(fileAt: url) else { return false }
             duration = info.meta.duration
             sourceWidth = Int(info.meta.size.width)
             sourceHeight = Int(info.meta.size.height)
@@ -166,8 +167,10 @@ final class MediaAsset: Identifiable {
             if let cg = info.thumbnail {
                 thumbnail = NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
             }
-            return
+            return true
         }
+
+        guard type == .video || type == .audio else { return true }
 
         let avAsset = AVURLAsset(url: url)
         if type != .video, let d = try? await avAsset.load(.duration) {
@@ -207,6 +210,11 @@ final class MediaAsset: Identifiable {
                     thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
                 }
             }
+            return hasVideoTrack
         }
+        if type == .audio {
+            return (try? await avAsset.loadTracks(withMediaType: .audio).first) != nil
+        }
+        return true
     }
 }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -122,6 +122,7 @@ enum CompositionBuilder {
         var clipTransforms: [String: CGAffineTransform] = [:]
         var offlineMediaRefs: Set<String> = []
         var unprocessableMediaRefs: Set<String> = []
+        var failedLoadOutcomes: [SourceLoadKey: LoadOutcome] = [:]
 
         init(
             composition: AVMutableComposition,
@@ -290,17 +291,38 @@ enum CompositionBuilder {
     }
 
     private static func loadSource(clip: Clip, mediaType: AVMediaType, ctx: BuildContext) async throws -> LoadOutcome {
-        try await loadSource(
+        let key = SourceLoadKey(mediaRef: clip.mediaRef, mediaType: mediaType)
+        if let failedOutcome = ctx.failedLoadOutcomes[key] {
+            return failedOutcome
+        }
+        let outcome = try await loadSource(
             clip: clip, mediaType: mediaType, resolveURL: ctx.resolveURL,
             resolveSourceSize: ctx.resolveSourceSize, missingMediaRefs: ctx.missingMediaRefs,
             renderSize: ctx.renderSize
         )
+        switch outcome {
+        case .loaded:
+            break
+        case .offline, .unprocessable:
+            ctx.failedLoadOutcomes[key] = outcome
+        }
+        return outcome
     }
 
     private enum LoadOutcome {
         case loaded(asset: AVURLAsset, track: AVAssetTrack)
         case offline
         case unprocessable
+    }
+
+    private struct SourceLoadKey: Hashable {
+        let mediaRef: String
+        let mediaType: String
+
+        init(mediaRef: String, mediaType: AVMediaType) {
+            self.mediaRef = mediaRef
+            self.mediaType = mediaType.rawValue
+        }
     }
 
     private static func loadSource(
@@ -354,7 +376,7 @@ enum CompositionBuilder {
             }
             return .loaded(asset: sourceAsset, track: sourceTrack)
         } catch {
-            Log.preview.error("loadTracks failed — skipping clip. clipId=\(clip.id) mediaRef=\(clip.mediaRef): \(error.localizedDescription)")
+            Log.preview.warning("loadTracks failed — skipping clip. clipId=\(clip.id) mediaRef=\(clip.mediaRef): \(error.localizedDescription)")
             return .offline
         }
     }

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1,5 +1,8 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import Testing
+import UniformTypeIdentifiers
 @testable import PalmierPro
 
 /// Holds both editor and executor strongly so the executor's weak ref to the editor
@@ -123,7 +126,7 @@ struct ToolExecutorImportMediaTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let source = root.appendingPathComponent("source.png")
-        try Data("fake-png".utf8).write(to: source)
+        try writeTestPNG(to: source)
 
         let h = ToolHarness()
         h.editor.projectURL = root.appendingPathComponent("Import.palmier", isDirectory: true)
@@ -151,6 +154,31 @@ struct ToolExecutorImportMediaTests {
         #expect(h.editor.mediaManifest.entries.first?.importInput == nil)
     }
 
+    @Test func importPathLeavesUnreadableMediaFailed() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp-import-invalid-path-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let source = root.appendingPathComponent("source.png")
+        try Data("fake-png".utf8).write(to: source)
+
+        let h = ToolHarness()
+        h.editor.projectURL = root.appendingPathComponent("Import.palmier", isDirectory: true)
+
+        let result = await h.runRaw("import_media", args: [
+            "source": ["path": source.path],
+            "name": "Unreadable Still",
+        ])
+
+        #expect(result.isError == false)
+        let asset = try #require(h.editor.mediaAssets.first)
+        try await waitForImportFailure(in: h.editor, assetId: asset.id)
+
+        #expect(asset.generationStatus == .failed("Could not read media file."))
+        #expect(asset.importInput?.sourcePath == source.path)
+        #expect(h.editor.mediaManifest.entries.first?.importInput?.sourcePath == source.path)
+    }
+
     private func waitForImportCompletion(in editor: EditorViewModel, assetId: String) async throws {
         for _ in 0..<100 {
             if let status = editor.mediaAssets.first(where: { $0.id == assetId })?.generationStatus,
@@ -160,6 +188,38 @@ struct ToolExecutorImportMediaTests {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         Issue.record("import did not complete")
+    }
+
+    private func waitForImportFailure(in editor: EditorViewModel, assetId: String) async throws {
+        for _ in 0..<100 {
+            if let status = editor.mediaAssets.first(where: { $0.id == assetId })?.generationStatus,
+               case .failed = status {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("import did not fail")
+    }
+
+    private func writeTestPNG(to url: URL) throws {
+        let width = 2
+        let height = 2
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(srgbRed: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+        let destination = try #require(CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil))
+        CGImageDestinationAddImage(destination, try #require(context.makeImage()), nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(domain: "ToolExecutorImportMediaTests", code: 1)
+        }
     }
 }
 

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -179,6 +179,32 @@ struct ToolExecutorImportMediaTests {
         #expect(h.editor.mediaManifest.entries.first?.importInput?.sourcePath == source.path)
     }
 
+    @Test func unreadableFinalizeRefreshesTimelinePreview() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp-finalize-invalid-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let source = root.appendingPathComponent("bad.png")
+        try Data("fake-png".utf8).write(to: source)
+
+        let editor = EditorViewModel()
+        let asset = MediaAsset(id: "bad-image", url: source, type: .image, name: "Bad Still")
+        asset.importInput = MediaImportInput(sourcePath: source.path, createdAt: Date())
+        asset.generationStatus = .downloading
+        editor.importMediaAsset(asset)
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(mediaRef: asset.id, mediaType: .image, start: 0, duration: 30),
+            ]),
+        ])
+        let before = editor.timelineRenderRevision
+
+        let finalized = await editor.finalizeImportedAsset(asset)
+
+        #expect(finalized == false)
+        #expect(editor.timelineRenderRevision == before + 1)
+    }
+
     private func waitForImportCompletion(in editor: EditorViewModel, assetId: String) async throws {
         for _ in 0..<100 {
             if let status = editor.mediaAssets.first(where: { $0.id == assetId })?.generationStatus,


### PR DESCRIPTION
## Summary

- Validate imported and generated media before marking it ready.
- Keep unreadable generated/imported assets failed instead of clearing their pending status.
- Cache failed preview source loads per build and log AV load failures as warnings to reduce Sentry noise.

## Root Cause

Generated/imported assets could be treated as ready once a file existed on disk, even when AVFoundation could not load a usable media track. Preview composition then discovered the bad asset later and reported repeated `loadTracks failed` errors.

## Validation

- `swift build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core media readiness and preview composition behavior for imports, downloads, and corrupt files; mistakes could leave assets stuck failed or skip timeline updates, but scope is localized to finalize/load paths with new tests.
> 
> **Overview**
> Imported and generated media are no longer treated as ready just because a file landed on disk. **`finalizeImportedAsset`** now returns success only when **`loadMetadata()`** can read usable tracks/dimensions; on failure it marks the asset missing or unprocessable, sets **`generationStatus`** to failed (keeping import/generation pending state), and rebuilds the timeline preview when that media is in use.
> 
> Import and generation completion paths (**`finishImportedAsset`**, **`downloadAndFinalize`**) honor that boolean so they do not clear **`importInput`** or append generation logs for corrupt files. Preview composition **caches failed AV source loads per build** and logs **`loadTracks`** failures as warnings instead of errors to cut repeated Sentry noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb4c66cc856f16121ca84bb7686649f6185b11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->