### PR TITLE
[sentry fix] perf: fix three main-thread stalls (draw-path asset lookup, URL stat, font registration)

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -369,7 +369,7 @@ extension EditorViewModel {
                 .replacingOccurrences(of: "\n", with: " ")
                 .replacingOccurrences(of: "\r", with: " ")
         }
-        if let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }), asset.isGenerating {
+        if let asset = mediaAssetsById[clip.mediaRef], asset.isGenerating {
             return asset.name
         }
         if clip.sourceClipType == .sequence, let nested = timeline(for: clip.mediaRef) {
@@ -421,7 +421,7 @@ extension EditorViewModel {
 
     func isClipMediaGenerating(_ clip: Clip) -> Bool {
         guard clip.mediaType != .text else { return false }
-        return mediaAssets.first(where: { $0.id == clip.mediaRef })?.isGenerating ?? false
+        return mediaAssetsById[clip.mediaRef]?.isGenerating ?? false
     }
 
     enum MediaSelectionDirection {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -148,7 +148,13 @@ final class EditorViewModel {
     }
     // MARK: - Media library (in-memory, rebuilt on project open)
 
-    var mediaAssets: [MediaAsset] = []
+    var mediaAssets: [MediaAsset] = [] {
+        didSet {
+            mediaAssetsById = Dictionary(mediaAssets.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        }
+    }
+    /// O(1) lookup for draw-path callers; rebuilt on any `mediaAssets` mutation.
+    private(set) var mediaAssetsById: [String: MediaAsset] = [:]
     var offlineMediaRefs: Set<String> = []
     var unprocessableMediaRefs: Set<String> = []
     var missingMediaRefs: Set<String> = []

--- a/Sources/PalmierPro/Models/MediaResolver.swift
+++ b/Sources/PalmierPro/Models/MediaResolver.swift
@@ -33,10 +33,10 @@ final class MediaResolver: @unchecked Sendable {
     private static func expectedURL(for entry: MediaManifestEntry, projectURL: URL?) -> URL? {
         switch entry.source {
         case .external(let absolutePath):
-            return URL(fileURLWithPath: absolutePath)
+            return URL(fileURLWithPath: absolutePath, isDirectory: false)
         case .project(let relativePath):
             guard let base = projectURL else { return nil }
-            return base.appendingPathComponent(relativePath)
+            return base.appendingPathComponent(relativePath, isDirectory: false)
         }
     }
 

--- a/Sources/PalmierPro/Utilities/BundledFonts.swift
+++ b/Sources/PalmierPro/Utilities/BundledFonts.swift
@@ -13,20 +13,33 @@ enum BundledFonts {
         guard !registered else { return }
         registered = true
 
-        // Avoid `Bundle.module` — its SwiftPM-generated accessor fatalErrors
-        // when the resource bundle isn't on disk, taking the whole app down at
-        // launch. Locate `Fonts/` manually and degrade to a warning instead.
+        // Manually locate Fonts/ instead of Bundle.module to avoid SwiftPM crash.
         guard let fontsRoot = findFontsRoot() else {
             Log.app.warning("BundledFonts: Fonts/ not found in main bundle; skipping registration")
             return
         }
 
+        // Run font registration off the main thread.
+        Task.detached(priority: .userInitiated) {
+            let familySet = registerFonts(under: fontsRoot)
+            // Precompute to avoid delay on first font picker open.
+            let system = NSFontManager.shared.availableFontFamilies
+                .filter { !familySet.contains($0) }
+                .map { (name: $0, previewable: canPreviewText(family: $0)) }
+            await MainActor.run {
+                families = familySet.sorted()
+                cachedSystemFamilies = system
+            }
+        }
+    }
+
+    private nonisolated static func registerFonts(under fontsRoot: URL) -> Set<String> {
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(
             at: fontsRoot,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
-        ) else { return }
+        ) else { return [] }
 
         var urls: [URL] = []
         var familySet = Set<String>()
@@ -46,7 +59,7 @@ enum BundledFonts {
 
         guard !urls.isEmpty else {
             Log.app.warning("BundledFonts: no TTF/OTF files under \(fontsRoot.path)")
-            return
+            return []
         }
 
         // URL-based; descriptor-based registration trips on variable fonts
@@ -64,8 +77,8 @@ enum BundledFonts {
             return true
         }
 
-        families = familySet.sorted()
-        Log.app.notice("BundledFonts: registered \(urls.count) files across \(families.count) families")
+        Log.app.notice("BundledFonts: registered \(urls.count) files across \(familySet.count) families")
+        return familySet
     }
 
     // MARK: - System fonts (for picker)
@@ -83,9 +96,7 @@ enum BundledFonts {
         return result
     }
 
-     /// Checks both possible layouts — `dev.sh`'s assembled `.app` flattens
-    /// Fonts/ into Contents/Resources/ even in debug builds, while a raw
-    /// `swift run` leaves it inside the SwiftPM-generated resource bundle.
+     // Handles both flattened and bundled Fonts/ layouts
     private static func findFontsRoot() -> URL? {
         guard let resourceURL = Bundle.main.resourceURL else { return nil }
         let candidates = [
@@ -97,7 +108,7 @@ enum BundledFonts {
 
     /// False for symbol/emoji/dingbat fonts — they'd render the family name
     /// as glyphs instead of letters.
-    private static func canPreviewText(family: String) -> Bool {
+    private nonisolated static func canPreviewText(family: String) -> Bool {
         guard let font = NSFont(name: family, size: 12) else { return false }
         let charset = font.coveredCharacterSet
         for scalar in "Aa1".unicodeScalars where !charset.contains(scalar) {


### PR DESCRIPTION
3 sentry issues for app hangs caused by main-thread stall:

### Timeline draw path: O(1) asset lookup
`isClipMediaGenerating` / `clipDisplayLabel` did a linear scan of `mediaAssets` per clip per draw pass — O(clips × assets) per frame. Adds a `mediaAssetsById` index rebuilt on `mediaAssets` mutation (6 mutation sites, none per-frame) and uses it in both hot paths.

### MediaResolver: skip stat when building expected URLs
`URL(fileURLWithPath:)` / `appendingPathComponent` without an `isDirectory` hint stat the path to decide on a trailing slash. On a slow or disconnecting external volume that stat can block for seconds inside `VideoEngine.rebuild`. Passing `isDirectory: false` avoids touching the filesystem.

### BundledFonts: register off the main thread
`CTFontManagerCreateFontDescriptorsFromURL` parses every bundled font's name tables synchronously at launch. Registration now runs in a detached task (`.process`-scope registration is thread-safe), and the system-family picker list is precomputed on the same task so the font picker's first open no longer scans every installed family via fontd.

Trade-off: bundled fonts land a few hundred ms after launch; text rendered in that window falls back until registration completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and threading changes in non-critical paths; brief post-launch font fallback is the main user-visible trade-off.
> 
> **Overview**
> Addresses three **main-thread hang** paths reported via Sentry.
> 
> **Timeline draw path:** Adds a `mediaAssetsById` dictionary rebuilt whenever `mediaAssets` changes, and switches `clipDisplayLabel` / `isClipMediaGenerating` from per-clip linear scans to **O(1)** lookups during draw.
> 
> **Media resolution:** Builds expected media URLs with `isDirectory: false` so `URL(fileURLWithPath:)` / `appendingPathComponent` do not **stat** paths—important when `VideoEngine.rebuild` walks manifest entries on slow or disconnecting external volumes.
> 
> **Launch / fonts:** Moves bundled font enumeration, `CTFontManager` registration, and system font-picker list precomputation onto a **detached** `.userInitiated` task; results are published on the main actor. Bundled fonts may appear slightly after launch, with a short fallback window for text rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e92de75e305c54d5c655bc237be0746eba32f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->