### PR TITLE
fix(catalog): resubscribe when models:list subscription fails

### DIFF
--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -41,13 +41,18 @@ final class ModelCatalog {
 
     @ObservationIgnored private var subscription: AnyCancellable?
     @ObservationIgnored private var didConfigure = false
+    @ObservationIgnored private var retryTask: Task<Void, Never>?
+    @ObservationIgnored private var failureCount = 0
 
     private init() {}
 
     func configure() {
         guard !didConfigure else { return }
         didConfigure = true
+        startSubscription()
+    }
 
+    private func startSubscription() {
         guard let client = AccountService.shared.convex else { return }
 
         subscription = client
@@ -56,14 +61,32 @@ final class ModelCatalog {
             .sink(
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let err) = completion {
-                        Log.generation.error("ModelCatalog subscription failed: \(err.localizedDescription)")
-                        self?.lastError = err.localizedDescription
+                        self?.handleFailure(err)
                     }
                 },
                 receiveValue: { [weak self] entries in
+                    self?.failureCount = 0
                     self?.apply(entries)
                 }
             )
+    }
+
+    private func handleFailure(_ err: ClientError) {
+        failureCount += 1
+        lastError = err.localizedDescription
+        // First failure goes to Sentry; retries only log locally.
+        if failureCount == 1 {
+            Log.generation.error("ModelCatalog subscription failed: \(err.localizedDescription)")
+        } else {
+            Log.generation.warning("ModelCatalog subscription failed (attempt \(self.failureCount)): \(err.localizedDescription)")
+        }
+        let delay = min(pow(2.0, Double(failureCount - 1)), 60)
+        retryTask?.cancel()
+        retryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            self?.startSubscription()
+        }
     }
 
     private func apply(_ entries: [CatalogEntry]) {


### PR DESCRIPTION
sentry issue with model catalog.

The Combine publisher returned by convex-swift's `subscribe` is terminal on failure: once it emits `.failure` (e.g. "channel closed" when launching without a network connection, or after a connection drop), it never emits again. `ModelCatalog` only logged the failure, so the model catalog stayed empty or stale for the rest of the session — empty model pickers until relaunch.

### Change
- On subscription failure, resubscribe with exponential backoff (1s, 2s, 4s… capped at 60s)
- A successful value resets the backoff counter
- Only the first failure in an outage logs at error level; retries log as warnings, so an extended offline period doesn't spam telemetry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized catalog subscription/retry logic with no auth or data-model changes; main risk is duplicate subscriptions if edge cases around cancellation are mishandled.
> 
> **Overview**
> **`ModelCatalog`** now **recovers** when the Convex `models:list` subscription terminates on failure instead of leaving pickers empty for the session.
> 
> Subscription setup moves into **`startSubscription()`**, invoked from **`configure()`** and again after backoff. **`handleFailure`** increments a failure counter, stores **`lastError`**, schedules a cancellable retry task with exponential delay (1s, 2s, 4s… capped at 60s), and logs only the **first** failure at error level; later attempts use warnings. A successful **`receiveValue`** resets **`failureCount`** before **`apply`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27313759fbdfec2eb68083835b8ae715491ad6d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->