### PR TITLE
[sentry fix]: log expected submit failures as warnings

### DIFF
--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -306,15 +306,15 @@ final class GenerationService {
         }
     }
 
-    private func backendErrorMessage(_ error: Error) -> String {
+    private func backendError(_ error: Error) -> (code: String?, message: String) {
         struct Payload: Decodable { let code: String?; let message: String? }
         if case let ClientError.ConvexError(data) = error,
            let json = data.data(using: .utf8),
            let payload = try? JSONDecoder().decode(Payload.self, from: json),
            let message = payload.message {
-            return message
+            return (payload.code, message)
         }
-        return error.localizedDescription
+        return (nil, error.localizedDescription)
     }
 
     private func updateGenerationMetadata(
@@ -420,8 +420,16 @@ final class GenerationService {
                 projectId: editor.projectId,
             )
         } catch {
-            let message = backendErrorMessage(error)
-            Log.generation.error("submit failed model=\(genInput.model) error=\(message)")
+            let (code, message) = backendError(error)
+            let expected: Set<String> = [
+                "insufficient_credits", "subscription_required", "plan_required",
+                "rate_limited", "invalid_params",
+            ]
+            if let code, expected.contains(code) {
+                Log.generation.warning("submit failed model=\(genInput.model) code=\(code) error=\(message)")
+            } else {
+                Log.generation.error("submit failed model=\(genInput.model) error=\(message)")
+            }
             for placeholder in placeholders {
                 updateGenerationMetadata(placeholder, editor: editor, status: .failed(message))
             }


### PR DESCRIPTION
too much noise from sentry for user errors. log the expected generation error as warning instead of errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change on an existing error path; no change to submit behavior or how failures are surfaced to users.
> 
> **Overview**
> **Generation submit failures** now distinguish **expected user/backend policy errors** from unexpected failures when logging, so Sentry is not flooded with noise from normal cases like out-of-credits or rate limits.
> 
> `backendErrorMessage` is replaced by `backendError`, which returns both the Convex **error code** and message. In `runJob`, when `GenerationBackend.submit` fails, codes such as `insufficient_credits`, `subscription_required`, `plan_required`, `rate_limited`, and `invalid_params` are logged at **warning** level (including the code in the log line); all other failures still use **error**. Placeholder failure handling and user-visible messages are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67542d86a88ab938fd63b2243730091010e9624c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->