### PR TITLE
[sentry fix]: adopt package mod date after out-of-band thumbnail write

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -475,9 +475,17 @@ final class VideoProject: NSDocument {
         cachedThumbnail = data
         guard let packageURL = fileURL else { return }
         let thumbURL = packageURL.appendingPathComponent(Project.thumbnailFilename, isDirectory: false)
-        try? await Task.detached(priority: .utility) {
+
+        // Pick up package mod date from our write so autosave won't hit "changed by another application".
+        let newDate: Date? = try? await Task.detached(priority: .utility) {
             try data.write(to: thumbURL, options: .atomic)
+            var resolved = packageURL
+            resolved.removeCachedResourceValue(forKey: .contentModificationDateKey)
+            return try resolved.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
         }.value
+        if let newDate {
+            fileModificationDate = newDate
+        }
     }
 
     // MARK: - Media restore


### PR DESCRIPTION
Checkpoint autosaves intermittently failed with 'The document could not be autosaved. The file has been changed by another application.' - and the other application was us.

### Root cause
The project is an NSDocument file package with `autosavesInPlace`. NSDocument compares its remembered `fileModificationDate` against the package's on-disk date before each autosave. `generateThumbnail()` runs asynchronously after a save and writes `thumbnail.jpg` directly into the package root, bumping the directory's modification date behind NSDocument's back — so the next autosave sees a "foreign" change and refuses.

### Change
After the thumbnail write, re-stat the package and adopt the new date as `fileModificationDate`. Both the write and the stat run in a detached utility task (projects can live on slow external volumes; stat on the main actor can stall) — only the resulting date is assigned on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted NSDocument metadata sync; does not change save encoding or package structure.
> 
> **Overview**
> Fixes intermittent checkpoint autosave errors where NSDocument refused to save because the package directory’s modification time changed without the document knowing.
> 
> **`generateThumbnail()`** still writes `thumbnail.jpg` into the project package on a detached utility task, but that task now also re-reads the package’s **content modification date** (after clearing the cached value) and the main actor assigns it to **`fileModificationDate`**, matching what **`save(to:...)`** already does after a normal save.
> 
> Disk I/O and the stat stay off the main thread; only the resulting date is applied on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4182af2092ec1b91191759cb4f7f4e9d07d9da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->