### PR TITLE
[UI] Refine timeline fade handles

### DIFF
--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -447,10 +447,8 @@ enum ClipRenderer {
         // 5) Knees — sit in the fade lane near the top of the body.
         let leftKneeRect = CGRect(x: leftKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
         let rightKneeRect = CGRect(x: rightKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
-        context.fill(leftKneeRect)
-        context.stroke(leftKneeRect)
-        context.fill(rightKneeRect)
-        context.stroke(rightKneeRect)
+        drawFadeHandle(in: leftKneeRect, edge: .left, fillColor: lineColor, context: context)
+        drawFadeHandle(in: rightKneeRect, edge: .right, fillColor: lineColor, context: context)
     }
 
     private static func drawOpacityFades(clip: Clip, in rect: NSRect, showsFadeControls: Bool, context: CGContext) {
@@ -503,10 +501,71 @@ enum ClipRenderer {
         let half = volumeKeyframeSize / 2
         let leftKneeRect = CGRect(x: leftKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
         let rightKneeRect = CGRect(x: rightKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
-        context.fill(leftKneeRect)
-        context.stroke(leftKneeRect)
-        context.fill(rightKneeRect)
-        context.stroke(rightKneeRect)
+        drawFadeHandle(in: leftKneeRect, edge: .left, fillColor: lineColor, context: context)
+        drawFadeHandle(in: rightKneeRect, edge: .right, fillColor: lineColor, context: context)
+    }
+
+    private static func drawFadeHandle(
+        in rect: CGRect,
+        edge: FadeEdge,
+        fillColor: CGColor,
+        context: CGContext
+    ) {
+        context.saveGState()
+        defer { context.restoreGState() }
+
+        context.setFillColor(fillColor)
+        context.setStrokeColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
+        context.setLineWidth(AppTheme.BorderWidth.hairline)
+        context.fill(rect)
+        context.stroke(rect)
+
+        let glyphRect = rect.insetBy(dx: AppTheme.BorderWidth.medium, dy: AppTheme.BorderWidth.medium)
+        guard glyphRect.width > 0, glyphRect.height > 0 else { return }
+
+        context.addPath(fadeHandleFillPath(in: glyphRect, edge: edge))
+        context.setFillColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
+        context.fillPath()
+
+        context.addPath(fadeHandleLinePath(in: glyphRect, edge: edge))
+        context.setStrokeColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.prominent)).cgColor)
+        context.setLineWidth(AppTheme.BorderWidth.thin)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+        context.strokePath()
+    }
+
+    private static func fadeHandleFillPath(in rect: CGRect, edge: FadeEdge) -> CGPath {
+        let path = CGMutablePath()
+        switch edge {
+        case .left:
+            path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        case .right:
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        }
+        path.closeSubpath()
+        return path
+    }
+
+    private static func fadeHandleLinePath(in rect: CGRect, edge: FadeEdge) -> CGPath {
+        let path = CGMutablePath()
+        let start: CGPoint
+        let end: CGPoint
+        switch edge {
+        case .left:
+            start = CGPoint(x: rect.minX, y: rect.maxY)
+            end = CGPoint(x: rect.maxX, y: rect.minY)
+        case .right:
+            start = CGPoint(x: rect.minX, y: rect.minY)
+            end = CGPoint(x: rect.maxX, y: rect.maxY)
+        }
+        path.move(to: start)
+        path.addLine(to: end)
+        return path
     }
 
     private static func drawFadeWedge(

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -422,12 +422,13 @@ enum ClipRenderer {
 
         guard showsFadeControls else { return }
 
-        context.setFillColor(lineColor)
-        context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
-        context.setLineWidth(0.5)
         let half = volumeKeyframeSize / 2
 
         if isSelected {
+            context.setFillColor(lineColor)
+            context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
+            context.setLineWidth(0.5)
+
             // 4) Keyframe diamonds — independent of the fade knees.
             for kf in clip.volumeTrack?.keyframes ?? []
                 where kf.frame >= 0 && kf.frame <= clip.durationFrames {
@@ -495,9 +496,6 @@ enum ClipRenderer {
 
         guard showsFadeControls else { return }
 
-        context.setFillColor(lineColor)
-        context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
-        context.setLineWidth(0.5)
         let half = volumeKeyframeSize / 2
         let leftKneeRect = CGRect(x: leftKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
         let rightKneeRect = CGRect(x: rightKneeX - half, y: kneeY - half, width: volumeKeyframeSize, height: volumeKeyframeSize)
@@ -523,49 +521,37 @@ enum ClipRenderer {
         let glyphRect = rect.insetBy(dx: AppTheme.BorderWidth.medium, dy: AppTheme.BorderWidth.medium)
         guard glyphRect.width > 0, glyphRect.height > 0 else { return }
 
-        context.addPath(fadeHandleFillPath(in: glyphRect, edge: edge))
+        let start: CGPoint
+        let end: CGPoint
+        let fillCorner: CGPoint
+        switch edge {
+        case .left:
+            start = CGPoint(x: glyphRect.minX, y: glyphRect.maxY)
+            end = CGPoint(x: glyphRect.maxX, y: glyphRect.minY)
+            fillCorner = CGPoint(x: glyphRect.maxX, y: glyphRect.maxY)
+        case .right:
+            start = CGPoint(x: glyphRect.minX, y: glyphRect.minY)
+            end = CGPoint(x: glyphRect.maxX, y: glyphRect.maxY)
+            fillCorner = CGPoint(x: glyphRect.minX, y: glyphRect.maxY)
+        }
+
+        let fill = CGMutablePath()
+        fill.move(to: start)
+        fill.addLine(to: fillCorner)
+        fill.addLine(to: end)
+        fill.closeSubpath()
+        context.addPath(fill)
         context.setFillColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
         context.fillPath()
 
-        context.addPath(fadeHandleLinePath(in: glyphRect, edge: edge))
+        context.beginPath()
+        context.move(to: start)
+        context.addLine(to: end)
         context.setStrokeColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.prominent)).cgColor)
         context.setLineWidth(AppTheme.BorderWidth.thin)
         context.setLineCap(.round)
         context.setLineJoin(.round)
         context.strokePath()
-    }
-
-    private static func fadeHandleFillPath(in rect: CGRect, edge: FadeEdge) -> CGPath {
-        let path = CGMutablePath()
-        switch edge {
-        case .left:
-            path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
-            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
-        case .right:
-            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
-            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        }
-        path.closeSubpath()
-        return path
-    }
-
-    private static func fadeHandleLinePath(in rect: CGRect, edge: FadeEdge) -> CGPath {
-        let path = CGMutablePath()
-        let start: CGPoint
-        let end: CGPoint
-        switch edge {
-        case .left:
-            start = CGPoint(x: rect.minX, y: rect.maxY)
-            end = CGPoint(x: rect.maxX, y: rect.minY)
-        case .right:
-            start = CGPoint(x: rect.minX, y: rect.minY)
-            end = CGPoint(x: rect.maxX, y: rect.maxY)
-        }
-        path.move(to: start)
-        path.addLine(to: end)
-        return path
     }
 
     private static func drawFadeWedge(

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -39,13 +39,10 @@ enum ClipRenderer {
         return volumeRubberBandTopDb - frac * (volumeRubberBandTopDb - volumeRubberBandBottomDb)
     }
 
-    static func fadeHandleRenderX(in clipRect: NSRect, kfOffset: Int, isLeft: Bool, pxPerFrame: CGFloat) -> CGFloat {
+    static func fadeHandleRenderX(in clipRect: NSRect, kfOffset: Int, pxPerFrame: CGFloat) -> CGFloat {
         let actual = clipRect.minX + CGFloat(kfOffset) * pxPerFrame
-        if isLeft {
-            return max(clipRect.minX + volumeFadeHandleEdgeInset, actual)
-        } else {
-            return min(clipRect.maxX - volumeFadeHandleEdgeInset, actual)
-        }
+        let edgeInset = min(volumeFadeHandleEdgeInset, max(0, clipRect.width / 2))
+        return min(clipRect.maxX - edgeInset, max(clipRect.minX + edgeInset, actual))
     }
 
     static func draw(
@@ -393,8 +390,8 @@ enum ClipRenderer {
         // Fade endpoints. Knees sit in a fixed "fade lane" near the top of the body
         let leftOffset = min(clip.fadeInFrames, clip.durationFrames)
         let rightOffset = max(0, clip.durationFrames - clip.fadeOutFrames)
-        let leftKneeX = fadeHandleRenderX(in: rect, kfOffset: leftOffset, isLeft: true, pxPerFrame: pxPerFrame)
-        let rightKneeX = fadeHandleRenderX(in: rect, kfOffset: rightOffset, isLeft: false, pxPerFrame: pxPerFrame)
+        let leftKneeX = fadeHandleRenderX(in: rect, kfOffset: leftOffset, pxPerFrame: pxPerFrame)
+        let rightKneeX = fadeHandleRenderX(in: rect, kfOffset: rightOffset, pxPerFrame: pxPerFrame)
         let kneeY = fadeKneeY(in: body)
         let silenceY = body.maxY
 
@@ -465,8 +462,8 @@ enum ClipRenderer {
 
         let leftOffset = min(clip.fadeInFrames, clip.durationFrames)
         let rightOffset = max(0, clip.durationFrames - clip.fadeOutFrames)
-        let leftKneeX = fadeHandleRenderX(in: rect, kfOffset: leftOffset, isLeft: true, pxPerFrame: pxPerFrame)
-        let rightKneeX = fadeHandleRenderX(in: rect, kfOffset: rightOffset, isLeft: false, pxPerFrame: pxPerFrame)
+        let leftKneeX = fadeHandleRenderX(in: rect, kfOffset: leftOffset, pxPerFrame: pxPerFrame)
+        let rightKneeX = fadeHandleRenderX(in: rect, kfOffset: rightOffset, pxPerFrame: pxPerFrame)
         let kneeY = fadeKneeY(in: body)
         let silenceY = body.maxY
 

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -6,7 +6,7 @@ enum ClipRenderer {
 
     static let volumeKeyframeSize: CGFloat = 7
     static let volumeKeyframeHitSize: CGFloat = 14
-    static let volumeFadeHandleEdgeInset: CGFloat = 6
+    static let volumeFadeHandleEdgeInset: CGFloat = Trim.handleWidth + volumeKeyframeHitSize / 2 + AppTheme.Spacing.xxs
     static let volumeRubberBandTopDb: Double = 6
     static let volumeRubberBandBottomDb: Double = -60
     static let fadeKneeTopInset: CGFloat = 4
@@ -53,6 +53,7 @@ enum ClipRenderer {
         type: ClipType,
         in rect: NSRect,
         isSelected: Bool,
+        isHovered: Bool = false,
         opacity: CGFloat = 1.0,
         context: CGContext,
         cache: MediaVisualCache? = nil,
@@ -108,10 +109,11 @@ enum ClipRenderer {
                          clip: clip, type: colorType, in: audioRect, context: context)
         }
 
+        let showsFadeControls = isSelected || isHovered
         if type == .audio {
-            drawVolumeRubberBand(clip: clip, in: rect, isSelected: isSelected, context: context)
+            drawVolumeRubberBand(clip: clip, in: rect, isSelected: isSelected, showsFadeControls: showsFadeControls, context: context)
         } else {
-            drawOpacityFades(clip: clip, in: rect, isSelected: isSelected, context: context)
+            drawOpacityFades(clip: clip, in: rect, showsFadeControls: showsFadeControls, context: context)
         }
 
         // Color-coded left edge strip (uses the same source-type as the fill).
@@ -328,13 +330,19 @@ enum ClipRenderer {
 
     // MARK: - Volume rubber band
 
-    private static func drawVolumeRubberBand(clip: Clip, in rect: NSRect, isSelected: Bool, context: CGContext) {
+    private static func drawVolumeRubberBand(
+        clip: Clip,
+        in rect: NSRect,
+        isSelected: Bool,
+        showsFadeControls: Bool,
+        context: CGContext
+    ) {
         guard clip.durationFrames > 0 else { return }
         let pxPerFrame = rect.width / CGFloat(clip.durationFrames)
         guard pxPerFrame > 0 else { return }
 
         let body = clipBodyRect(in: rect)
-        let alpha: CGFloat = isSelected ? 0.95 : 0.75
+        let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
         let lineColor = NSColor.white.withAlphaComponent(alpha).cgColor
         let fadeColor = NSColor.white.withAlphaComponent(alpha * 0.7).cgColor
 
@@ -412,26 +420,28 @@ enum ClipRenderer {
             )
         }
 
-        guard isSelected else { return }
+        guard showsFadeControls else { return }
 
         context.setFillColor(lineColor)
         context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
         context.setLineWidth(0.5)
         let half = volumeKeyframeSize / 2
 
-        // 4) Keyframe diamonds — independent of the fade knees.
-        for kf in clip.volumeTrack?.keyframes ?? []
-            where kf.frame >= 0 && kf.frame <= clip.durationFrames {
-            let cx = rect.minX + CGFloat(kf.frame) * pxPerFrame
-            let cy = y(forDb: kf.value, in: body)
-            let p = CGMutablePath()
-            p.move(to: CGPoint(x: cx, y: cy - half))
-            p.addLine(to: CGPoint(x: cx + half, y: cy))
-            p.addLine(to: CGPoint(x: cx, y: cy + half))
-            p.addLine(to: CGPoint(x: cx - half, y: cy))
-            p.closeSubpath()
-            context.addPath(p)
-            context.drawPath(using: .fillStroke)
+        if isSelected {
+            // 4) Keyframe diamonds — independent of the fade knees.
+            for kf in clip.volumeTrack?.keyframes ?? []
+                where kf.frame >= 0 && kf.frame <= clip.durationFrames {
+                let cx = rect.minX + CGFloat(kf.frame) * pxPerFrame
+                let cy = y(forDb: kf.value, in: body)
+                let p = CGMutablePath()
+                p.move(to: CGPoint(x: cx, y: cy - half))
+                p.addLine(to: CGPoint(x: cx + half, y: cy))
+                p.addLine(to: CGPoint(x: cx, y: cy + half))
+                p.addLine(to: CGPoint(x: cx - half, y: cy))
+                p.closeSubpath()
+                context.addPath(p)
+                context.drawPath(using: .fillStroke)
+            }
         }
 
         // 5) Knees — sit in the fade lane near the top of the body.
@@ -443,14 +453,14 @@ enum ClipRenderer {
         context.stroke(rightKneeRect)
     }
 
-    private static func drawOpacityFades(clip: Clip, in rect: NSRect, isSelected: Bool, context: CGContext) {
+    private static func drawOpacityFades(clip: Clip, in rect: NSRect, showsFadeControls: Bool, context: CGContext) {
         guard clip.durationFrames > 0 else { return }
-        guard clip.fadeInFrames > 0 || clip.fadeOutFrames > 0 || isSelected else { return }
+        guard clip.fadeInFrames > 0 || clip.fadeOutFrames > 0 || showsFadeControls else { return }
         let pxPerFrame = rect.width / CGFloat(clip.durationFrames)
         guard pxPerFrame > 0 else { return }
 
         let body = clipBodyRect(in: rect)
-        let alpha: CGFloat = isSelected ? 0.95 : 0.75
+        let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
         let lineColor = NSColor.white.withAlphaComponent(alpha).cgColor
         let fadeColor = NSColor.white.withAlphaComponent(alpha * 0.7).cgColor
 
@@ -485,7 +495,7 @@ enum ClipRenderer {
             )
         }
 
-        guard isSelected else { return }
+        guard showsFadeControls else { return }
 
         context.setFillColor(lineColor)
         context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)

--- a/Sources/PalmierPro/Timeline/TimelineGeometry.swift
+++ b/Sources/PalmierPro/Timeline/TimelineGeometry.swift
@@ -160,7 +160,7 @@ struct TimelineGeometry {
         let kfOffset = edge == .left
             ? min(clip.fadeInFrames, clip.durationFrames)
             : max(0, clip.durationFrames - clip.fadeOutFrames)
-        let x = ClipRenderer.fadeHandleRenderX(in: clipRect, kfOffset: kfOffset, isLeft: edge == .left, pxPerFrame: pxPerFrame)
+        let x = ClipRenderer.fadeHandleRenderX(in: clipRect, kfOffset: kfOffset, pxPerFrame: pxPerFrame)
         let y = ClipRenderer.fadeKneeY(in: body)
         let half = ClipRenderer.volumeKeyframeHitSize / 2
         return NSRect(x: x - half, y: y - half, width: half * 2, height: half * 2)

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -74,6 +74,7 @@ final class TimelineInputController {
         }
 
         if point.y >= scrollOffsetY && point.y < scrollOffsetY + geometry.rulerHeight {
+            view.setHoveredClipId(nil)
             let frame = geometry.frameAt(x: point.x)
             if let edge = timelineRangeEdgeHit(at: point, geometry: geometry) {
                 beginTimelineRangeEdgeDrag(edge)
@@ -215,6 +216,7 @@ final class TimelineInputController {
                 ))
             }
         } else {
+            view.setHoveredClipId(nil)
             if !event.modifierFlags.contains(.shift) {
                 editor.selectedClipIds.removeAll()
             }

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -20,7 +20,14 @@ final class TimelineInputController {
         case end
     }
 
+    private enum TrimEdge {
+        case left
+        case right
+    }
+
     private static let timelineRangeEdgeHitSlop: CGFloat = 8
+    private static let trimLeftCursor = makeTrimCursor(edge: .left)
+    private static let trimRightCursor = makeTrimCursor(edge: .right)
 
     init(editor: EditorViewModel, view: TimelineView) {
         self.editor = editor
@@ -101,7 +108,8 @@ final class TimelineInputController {
             let linkedOn = !isOption
 
             let localX = point.x - rect.minX
-            let onTrimHandle = !isOption && Self.isOnTrimZone(localX: localX, clipWidth: rect.width)
+            let trimEdge = isOption ? nil : Self.trimEdge(localX: localX, clipWidth: rect.width)
+            let onTrimHandle = trimEdge != nil
             let rippleTrim = isShift && onTrimHandle
 
             if rippleTrim {
@@ -154,7 +162,8 @@ final class TimelineInputController {
             } else if isCommand, clip.mediaType == .audio,
                       addVolumeKeyframeOnClick(at: point, clip: clip, clipRect: rect) {
                 dragState = .idle
-            } else if !isOption, localX <= Trim.handleWidth {
+            } else if trimEdge == .left {
+                Self.trimCursor(for: .left).set()
                 dragState = .trimLeft(DragState.TrimDrag(
                     clipId: clip.id,
                     trackIndex: hit.trackIndex,
@@ -166,7 +175,8 @@ final class TimelineInputController {
                     propagateToLinked: linkedOn,
                     isRipple: rippleTrim
                 ))
-            } else if !isOption, localX >= rect.width - Trim.handleWidth {
+            } else if trimEdge == .right {
+                Self.trimCursor(for: .right).set()
                 dragState = .trimRight(DragState.TrimDrag(
                     clipId: clip.id,
                     trackIndex: hit.trackIndex,
@@ -574,8 +584,8 @@ final class TimelineInputController {
             view.setHoveredClipId(clip.id)
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
             let localX = point.x - rect.minX
-            if Self.isOnTrimZone(localX: localX, clipWidth: rect.width) {
-                NSCursor.resizeLeftRight.set()
+            if let trimEdge = Self.trimEdge(localX: localX, clipWidth: rect.width) {
+                Self.trimCursor(for: trimEdge).set()
                 return
             }
             if fadeKneeHit(at: point, clip: clip, clipRect: rect) != nil {
@@ -593,8 +603,60 @@ final class TimelineInputController {
         NSCursor.arrow.set()
     }
 
-    private static func isOnTrimZone(localX: CGFloat, clipWidth: CGFloat) -> Bool {
-        localX <= Trim.handleWidth || localX >= clipWidth - Trim.handleWidth
+    private static func trimEdge(localX: CGFloat, clipWidth: CGFloat) -> TrimEdge? {
+        if localX <= Trim.handleWidth { return .left }
+        if localX >= clipWidth - Trim.handleWidth { return .right }
+        return nil
+    }
+
+    private static func trimCursor(for edge: TrimEdge) -> NSCursor {
+        switch edge {
+        case .left: trimLeftCursor
+        case .right: trimRightCursor
+        }
+    }
+
+    private static func makeTrimCursor(edge: TrimEdge) -> NSCursor {
+        let size = NSSize(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let midX = rect.midX
+            let midY = rect.midY
+            let direction: CGFloat = edge == .left ? 1 : -1
+            let bracket = NSBezierPath()
+            let bracketTop = midY + AppTheme.Spacing.smMd
+            let bracketBottom = midY - AppTheme.Spacing.smMd
+            let capX = midX + direction * AppTheme.Spacing.sm
+            bracket.move(to: NSPoint(x: midX, y: bracketBottom))
+            bracket.line(to: NSPoint(x: midX, y: bracketTop))
+            bracket.move(to: NSPoint(x: midX, y: bracketTop))
+            bracket.line(to: NSPoint(x: capX, y: bracketTop))
+            bracket.move(to: NSPoint(x: midX, y: bracketBottom))
+            bracket.line(to: NSPoint(x: capX, y: bracketBottom))
+            bracket.lineCapStyle = .square
+
+            AppTheme.Background.base.setStroke()
+            bracket.lineWidth = AppTheme.BorderWidth.thick + AppTheme.BorderWidth.thin
+            bracket.stroke()
+            AppTheme.Status.error.setStroke()
+            bracket.lineWidth = AppTheme.BorderWidth.thick
+            bracket.stroke()
+
+            let arrowTipX = midX + direction * AppTheme.Spacing.md
+            let arrowBaseX = midX + direction * AppTheme.Spacing.xs
+            let arrow = NSBezierPath()
+            arrow.move(to: NSPoint(x: arrowTipX, y: midY))
+            arrow.line(to: NSPoint(x: arrowBaseX, y: midY + AppTheme.Spacing.sm))
+            arrow.line(to: NSPoint(x: arrowBaseX, y: midY - AppTheme.Spacing.sm))
+            arrow.close()
+            arrow.lineJoinStyle = .round
+            arrow.lineWidth = AppTheme.BorderWidth.thick
+            AppTheme.Text.primary.setStroke()
+            arrow.stroke()
+            AppTheme.Status.error.setFill()
+            arrow.fill()
+            return true
+        }
+        return NSCursor(image: image, hotSpot: NSPoint(x: size.width / 2, y: size.height / 2))
     }
 
     func audioVolumeKfHit(at point: NSPoint, clip: Clip, clipRect: NSRect) -> Int? {

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -93,6 +93,7 @@ final class TimelineInputController {
 
         if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
             let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
+            view.setHoveredClipId(clip.id)
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
             let isShift = event.modifierFlags.contains(.shift)
             let isOption = event.modifierFlags.contains(.option)
@@ -527,6 +528,7 @@ final class TimelineInputController {
         let scrollOffsetY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
 
         if point.y >= scrollOffsetY && point.y < scrollOffsetY + geometry.rulerHeight {
+            view.setHoveredClipId(nil)
             if timelineRangeEdgeHit(at: point, geometry: geometry) != nil {
                 NSCursor.resizeLeftRight.set()
             } else if event.modifierFlags.contains(.shift) {
@@ -540,6 +542,7 @@ final class TimelineInputController {
         }
 
         if editor.toolMode == .razor && point.y >= scrollOffsetY + geometry.rulerHeight {
+            view.setHoveredClipId(nil)
             let candidate = geometry.frameAt(x: point.x)
             let targets = SnapEngine.collectTargets(
                 tracks: editor.timeline.tracks,
@@ -568,6 +571,7 @@ final class TimelineInputController {
 
         if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
             let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
+            view.setHoveredClipId(clip.id)
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
             let localX = point.x - rect.minX
             if Self.isOnTrimZone(localX: localX, clipWidth: rect.width) {
@@ -583,6 +587,8 @@ final class TimelineInputController {
                 NSCursor.openHand.set()
                 return
             }
+        } else {
+            view.setHoveredClipId(nil)
         }
         NSCursor.arrow.set()
     }
@@ -603,6 +609,7 @@ final class TimelineInputController {
     }
 
     func fadeKneeHit(at point: NSPoint, clip: Clip, clipRect: NSRect) -> FadeEdge? {
+        guard editor.selectedClipIds.contains(clip.id) || view.hoveredClipId == clip.id else { return nil }
         let geo = view.geometry
         if geo.fadeKneeRect(clip: clip, edge: .left, in: clipRect).contains(point) { return .left }
         if geo.fadeKneeRect(clip: clip, edge: .right, in: clipRect).contains(point) { return .right }

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -767,6 +767,7 @@ final class TimelineInputController {
     /// Option+scroll zooms; Cmd+scroll pans horizontally (maps vertical delta to X, for mouse wheels);
     /// plain scroll pans (forwarded to the scroll view, both axes).
     func scrollWheel(with event: NSEvent, geometry: TimelineGeometry) {
+        view.setHoveredClipId(nil)
         if event.modifierFlags.contains(.option) {
             let cursorDocX = view.convert(event.locationInWindow, from: nil).x
             applyZoom(factor: exp(event.scrollingDeltaY * Zoom.scrollSensitivity), anchorDocX: cursorDocX)
@@ -788,6 +789,7 @@ final class TimelineInputController {
 
     /// Trackpad pinch-to-zoom.
     func magnify(with event: NSEvent) {
+        view.setHoveredClipId(nil)
         let cursorDocX = view.convert(event.locationInWindow, from: nil).x
         applyZoom(factor: 1.0 + event.magnification * Zoom.magnifySensitivity, anchorDocX: cursorDocX)
     }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -9,6 +9,7 @@ final class TimelineView: NSView {
     private(set) var snapOverlay: SnapIndicatorOverlay!
     private var generatingClipOverlays: [String: NSHostingView<ClipGeneratingOverlay>] = [:]
     private var clipDisplayRects: [String: NSRect] = [:]
+    private(set) var hoveredClipId: String?
     private let canvas = TimelineCanvasView()
 
     // MARK: - Init
@@ -137,6 +138,12 @@ final class TimelineView: NSView {
 
     func markZoomApplied() {
         lastAppliedZoomScale = editor.zoomScale
+    }
+
+    func setHoveredClipId(_ clipId: String?) {
+        guard hoveredClipId != clipId else { return }
+        hoveredClipId = clipId
+        needsDisplay = true
     }
 
     @discardableResult
@@ -436,7 +443,7 @@ final class TimelineView: NSView {
                 clipDisplayRects[clip.id] = rect
                 guard rect.intersects(dirtyRect) else { continue }
                 ClipRenderer.draw(clip, type: clip.mediaType, in: rect,
-                                  isSelected: isSelected, context: ctx,
+                                  isSelected: isSelected, isHovered: hoveredClipId == clip.id, context: ctx,
                                   cache: editor.mediaVisualCache,
                                   displayName: editor.clipDisplayLabel(for: clip),
                                   linkOffset: linkOffsets[clip.id],
@@ -776,6 +783,11 @@ final class TimelineView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         inputController.mouseMoved(with: event, geometry: geometry)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setHoveredClipId(nil)
+        NSCursor.arrow.set()
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -1134,7 +1146,7 @@ final class TimelineView: NSView {
         for area in trackingAreas { removeTrackingArea(area) }
         addTrackingArea(NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
             owner: self
         ))
     }


### PR DESCRIPTION


- Move timeline fade handles inward and show them only on selected or hovered clips.
- Draw a filled straight ramp glyph in audio and opacity fade handles.
<img width="680" height="440" alt="image" src="https://github.com/user-attachments/assets/e0054867-b429-43c5-ac28-5767db17267f" />

- Add inward-pointing trim cursors with bracket and arrow shapes for left and right clip edges.
<img width="550" height="335" alt="Screenshot 2026-07-07 at 9 26 40 PM" src="https://github.com/user-attachments/assets/2c52dc2d-3a93-4851-8f26-32feda11f849" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeline rendering and pointer UX only; fade/trim interaction logic is tightened but does not change clip data models or export paths.
> 
> **Overview**
> Timeline fade controls are **inset from clip edges** (aligned with trim width and hit targets) and use **symmetric X clamping** so knees stay draggable on narrow clips.
> 
> **Fade handles** show ramp glyphs (filled triangle + diagonal) for audio volume and opacity fades; interactive fade knees and stronger rubber-band styling appear when a clip is **selected or hovered**, while volume keyframe diamonds stay **selection-only**.
> 
> **Hover state** is tracked on `TimelineView` (`hoveredClipId`), updated from mouse move/down/exit and cleared on ruler, razor, zoom/pan; fade knee hit-testing matches the same visibility rules.
> 
> **Trim edges** use custom **left/right cursors** (bracket + inward arrow) instead of generic resize-left-right.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dcd66b0b3f3b4dee14f3272ad41dea8bdcff443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->