### PR TITLE
[ui] Refine timeline clip styling

### DIFF
--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -176,9 +176,9 @@ enum ClipRenderer {
         for kf in clip.cropTrack?.keyframes ?? [] { frameSet.insert(kf.frame + absStart) }
         let frames = frameSet.sorted()
         guard !frames.isEmpty, clip.durationFrames > 0 else { return }
-        let pxPerFrame = (rect.width - 2 * Trim.handleWidth) / CGFloat(clip.durationFrames)
+        let pxPerFrame = rect.width / CGFloat(clip.durationFrames)
         guard pxPerFrame > 0 else { return }
-        let baseX = rect.minX + Trim.handleWidth
+        let baseX = rect.minX
         let y = rect.maxY - 5
         let half: CGFloat = 3
         context.setFillColor(NSColor.systemYellow.withAlphaComponent(0.95).cgColor)

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -70,19 +70,13 @@ enum ClipRenderer {
 
 
         let colorType = clip.sourceClipType
-        let baseColor = colorType.themeColor
-        let fill = isSelected
-            ? baseColor.withAlphaComponent(0.45)
-            : baseColor.withAlphaComponent(0.3)
-        context.setFillColor(fill.cgColor)
+        context.setFillColor(colorType.themeColor.cgColor)
         context.addPath(path)
         context.fillPath()
 
         // --- Layout zones ---
-        let stripWidth: CGFloat = 3
-        let handleW = Trim.handleWidth
-        let contentX = rect.minX + stripWidth + 1
-        let contentWidth = rect.width - stripWidth - 1 - handleW
+        let contentX = rect.minX
+        let contentWidth = rect.width
 
         // Label bar at top
         let labelRect = CGRect(x: contentX, y: rect.minY, width: contentWidth, height: labelBarHeight)
@@ -113,22 +107,17 @@ enum ClipRenderer {
             drawOpacityFades(clip: clip, in: rect, showsFadeControls: showsFadeControls, context: context)
         }
 
-        // Color-coded left edge strip (uses the same source-type as the fill).
-        let stripRect = NSRect(x: rect.minX, y: rect.minY, width: stripWidth, height: rect.height)
-        let stripPath = CGPath(roundedRect: stripRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
-        context.setFillColor(colorType.themeColor.cgColor)
-        context.addPath(stripPath)
-        context.fillPath()
-
         // Border
-        if isSelected {
-            context.setStrokeColor(CGColor(red: 1, green: 1, blue: 1, alpha: 0.9))
-            context.setLineWidth(1.5)
+        if rect.width >= AppTheme.ComponentSize.timelineClipBorderMinWidth {
+            context.setStrokeColor(AppTheme.Border.timelineClip.cgColor)
+            context.setLineWidth(AppTheme.BorderWidth.thin)
             context.addPath(path)
             context.strokePath()
-        } else {
-            context.setStrokeColor(AppTheme.Border.primary.cgColor)
-            context.setLineWidth(0.5)
+        }
+
+        if isSelected {
+            context.setStrokeColor(AppTheme.Text.primary.cgColor)
+            context.setLineWidth(AppTheme.BorderWidth.medium)
             context.addPath(path)
             context.strokePath()
         }
@@ -164,8 +153,6 @@ enum ClipRenderer {
 
         if showDetailChrome {
             drawKeyframeMarkers(clip: clip, in: rect, context: context)
-
-            drawTrimHandles(in: rect, context: context)
         }
 
         if markBeats, type == .audio, clip.sourceClipType != .sequence, let beats = cache?.beatAnalysis(for: clip.mediaRef) {
@@ -303,8 +290,7 @@ enum ClipRenderer {
         let lastBar = min(barCount, Int(ceil(visible.maxX - drawRect.minX)))
         guard firstBar < lastBar else { return }
 
-        let color = (type.themeColor.blended(withFraction: 0.3, of: .white) ?? type.themeColor).withAlphaComponent(0.85).cgColor
-        context.setFillColor(color)
+        context.setFillColor(AppTheme.Text.primary.withAlphaComponent(AppTheme.Opacity.high).cgColor)
 
         let dur = CGFloat(max(1, clip.durationFrames))
         let frameStep = dur / CGFloat(barCount)
@@ -829,16 +815,6 @@ enum ClipRenderer {
         context.restoreGState()
     }
 
-    // MARK: - Trim handles
-
-    private static func drawTrimHandles(in rect: NSRect, context: CGContext) {
-        let w = Trim.handleWidth
-        context.setFillColor(AppTheme.Text.muted.cgColor)
-        // Left handle
-        context.fill(NSRect(x: rect.minX, y: rect.minY, width: w, height: rect.height))
-        // Right handle
-        context.fill(NSRect(x: rect.maxX - w, y: rect.minY, width: w, height: rect.height))
-    }
 }
 
 private extension String {

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -755,7 +755,7 @@ enum ClipRenderer {
     private static func drawLabelBar(clip: Clip, type: ClipType, in labelRect: NSRect, clipRect: NSRect, context: CGContext, displayName: String? = nil, fps: Int) {
         guard clipRect.width > 20 else { return }
 
-        let timecode = formatTimecode(frame: clip.durationFrames, fps: fps)
+        let timecode = formatClipDuration(frame: clip.durationFrames, fps: fps)
         let rawName = displayName ?? clip.mediaRef
         let name = rawName.firstNonEmptyLine()
         let text = "\(name)  \(timecode)"
@@ -769,7 +769,7 @@ enum ClipRenderer {
             attributed.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: (name as NSString).length))
         }
         let size = attributed.size()
-        let inset: CGFloat = 6
+        let inset = AppTheme.Spacing.sm
         let origin = NSPoint(
             x: labelRect.minX + inset,
             y: labelRect.minY + (labelRect.height - size.height) / 2
@@ -779,6 +779,14 @@ enum ClipRenderer {
         context.clip(to: labelRect.insetBy(dx: inset, dy: 0))
         attributed.draw(at: origin)
         context.restoreGState()
+    }
+
+    private static func formatClipDuration(frame: Int, fps: Int) -> String {
+        let full = formatTimecode(frame: frame, fps: fps)
+        guard fps > 0, abs(frame) >= fps * 3600 else {
+            return full.hasPrefix("-") ? "-" + String(full.dropFirst(4)) : String(full.dropFirst(3))
+        }
+        return full
     }
 
     // MARK: - Out-of-sync offset badge

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -28,6 +28,7 @@ enum AppTheme {
         static let primary = NSColor.white.withAlphaComponent(0.16)
         static let subtle = NSColor.white.withAlphaComponent(0.12)
         static let divider = NSColor.white.withAlphaComponent(0.44)
+        static let timelineClip = NSColor.black
 
         static var primaryColor: Color { Color(primary) }
         static var subtleColor: Color { Color(subtle) }
@@ -167,18 +168,19 @@ enum AppTheme {
         static let moderate: Double = 0.25
         static let medium: Double = 0.35
         static let strong: Double = 0.55
+        static let high: Double = 0.70
         static let prominent: Double = 0.80
     }
 
     // MARK: - Track type colors
 
     enum TrackColor {
-        static let video = NSColor(red: 0x00/255.0, green: 0x91/255.0, blue: 0xC2/255.0, alpha: 1)
-        static let audio = NSColor(red: 0x58/255.0, green: 0xA8/255.0, blue: 0x22/255.0, alpha: 1)
-        static let image = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
-        static let text = NSColor(red: 0xB7/255.0, green: 0x2D/255.0, blue: 0xD2/255.0, alpha: 1)
-        static let lottie = NSColor(red: 0xE0/255.0, green: 0xA8/255.0, blue: 0x00/255.0, alpha: 1)
-        static let sequence = NSColor(red: 0x2D/255.0, green: 0x9D/255.0, blue: 0x78/255.0, alpha: 1)
+        static let video = NSColor(red: 0x1D/255.0, green: 0x58/255.0, blue: 0x78/255.0, alpha: 1)
+        static let audio = NSColor(red: 0x2E/255.0, green: 0x77/255.0, blue: 0x65/255.0, alpha: 1)
+        static let image = NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
+        static let text = NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
+        static let lottie = NSColor(red: 0xA0/255.0, green: 0x78/255.0, blue: 0x22/255.0, alpha: 1)
+        static let sequence = NSColor(red: 0xB9/255.0, green: 0xB2/255.0, blue: 0x9A/255.0, alpha: 1)
     }
 
     // MARK: - Corner radii
@@ -268,6 +270,7 @@ enum AppTheme {
         static let toolImagePreviewMaxHeight: CGFloat = 50
         static let projectCardWidth: CGFloat = 150
         static let projectCardHeight: CGFloat = 120
+        static let timelineClipBorderMinWidth: CGFloat = 8
         static let timelineClipDetailMinWidth: CGFloat = 32
         static let timelineTabRenameWidth: CGFloat = 120
         static let timelineClipLabelMinWidth: CGFloat = 56

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -99,7 +99,7 @@ enum TimelineAutoScroll {
 
 enum Trim {
     static let handleWidth: CGFloat = 4.0
-    static let clipCornerRadius: CGFloat = 3.0
+    static let clipCornerRadius: CGFloat = AppTheme.Radius.xsSm
 }
 
 enum Project {


### PR DESCRIPTION
<img width="1938" height="1020" alt="image" src="https://github.com/user-attachments/assets/36c13cc8-2c6d-48ab-9d9f-6f1297def690" />

- Unifies track and timeline clip colors behind `ClipType.themeColor`.
- Updates the timeline palette
- Simplifies clip rendering by removing separate clip fill colors, edge color strips, and trim handle shading.
- Compacts clip duration labels under one hour from `HH:MM:SS:FF` to `MM:SS:FF`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and labeling changes only; trim interaction constants remain for hit-testing elsewhere.
> 
> **Overview**
> **Timeline clips** get a flatter look: fill is the full **source-type** `themeColor` (no separate tinted fill or left color strip), thumbnails/waveforms use the **full clip width** (layout no longer reserves space for edge strip and trim-handle shading), and **drawn trim-handle bars** in detail chrome are removed.
> 
> **Borders and selection**: clips at least **8px** wide get a thin **black** outline (`AppTheme.Border.timelineClip`); selection adds a **primary-text** medium stroke on top instead of the previous white-heavy selected-only border.
> 
> **Waveform bars** switch from type-tinted color to **primary text** at **70%** opacity. **Track/clip palette** in `AppTheme.TrackColor` is updated to darker, more muted hues; corner radius ties to **`AppTheme.Radius.xsSm`**.
> 
> **Duration labels** use new **`formatClipDuration`**: under one hour, timecode drops the leading hours field (`MM:SS:FF` instead of `HH:MM:SS:FF`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a3994ec7d7d7d38badd0f1487ac28b22b3e451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->