### PR TITLE
Validate video-to-audio span in agent path; shrink scoring renders

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 extension ToolExecutor {
@@ -248,6 +249,9 @@ extension ToolExecutor {
             guard let fileURL = editor.mediaResolver.resolveURL(for: videoAsset.id) else {
                 throw ToolError("Could not read the video source file.")
             }
+            if let err = model.validate(spanSeconds: videoAsset.duration) {
+                throw ToolError(err)
+            }
             videoURL = try await GenerationBackend.uploadReference(fileURL: fileURL, contentType: "video/mp4")
             spanSeconds = videoAsset.duration
         } else if let start = args.int("videoSourceStartFrame"), let end = args.int("videoSourceEndFrame") {
@@ -257,12 +261,16 @@ extension ToolExecutor {
             guard start >= 0, end > start else {
                 throw ToolError("videoSourceEndFrame must be greater than videoSourceStartFrame (>= 0).")
             }
+            if let err = model.validate(spanSeconds: Double(end - start) / Double(max(1, editor.timeline.fps))) {
+                throw ToolError(err)
+            }
             let mp4 = try await TimelineRenderer.render(
                 timeline: editor.timeline, resolver: editor.mediaResolver,
                 resolveTimeline: editor.timelineResolver(),
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: start, frameCount: end - start,
-                shortSide: 360, includeAudio: false
+                shortSide: 240, includeAudio: false,
+                preset: AVAssetExportPresetLowQuality
             )
             defer { try? FileManager.default.removeItem(at: mp4) }
             videoURL = try await GenerationBackend.uploadReference(fileURL: mp4, contentType: "video/mp4")

--- a/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
@@ -81,7 +81,7 @@ struct AudioModelConfig: Identifiable, Sendable {
     var inputs: [Input] { (caps.inputs ?? ["text"]).compactMap(Input.init(rawValue:)) }
     var promptLabel: String { caps.promptLabel ?? "Describe the sound" }
     var minSeconds: Int { caps.minSeconds ?? 1 }
-    var maxSeconds: Int { caps.maxSeconds ?? 900 }
+    var maxSeconds: Int { caps.maxSeconds ?? 600 }
 
     func validate(spanSeconds: Double) -> String? {
         let s = Int(spanSeconds.rounded())

--- a/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 /// Generates music from music tab and places it on the timeline
@@ -41,8 +42,9 @@ struct MusicGenerationSubmission {
                 missingMediaRefs: editor.missingMediaRefs,
                 startFrame: source.startFrame,
                 frameCount: source.frameCount,
-                shortSide: 360,
-                includeAudio: false
+                shortSide: 240,
+                includeAudio: false,
+                preset: AVAssetExportPresetLowQuality
             )
             defer { try? FileManager.default.removeItem(at: mp4) }
             onPhase(.uploading)


### PR DESCRIPTION
## Changes

- `generate_audio` (agent tool) now runs `model.validate(spanSeconds:)` before rendering/uploading, for both `videoSourceMediaRef` and timeline-span inputs. This check previously only existed in the UI paths, so over-limit spans were rendered, uploaded, and submitted before failing at the provider.
- Video-to-music scoring renders (agent tool + Music tab) drop from 360p medium quality to 240p `AVAssetExportPresetLowQuality`. Music scoring doesn't need visual fidelity; this cuts upload size several-fold, keeping long spans inside the staging upload's 2-minute POST window and away from 413s.
- `AudioModelConfig.maxSeconds` fallback lowered 900 → 600 to match the provider's actual video-duration limit.

Companion catalog change: palmier-io/palmier-pro-backend#11 (clients read `maxSeconds` live from `models:list`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the generation upload pipeline and duration limits; wrong limits could block valid agent requests, but changes are narrow and align agent behavior with existing UI validation.
> 
> **Overview**
> **Agent `generate_audio`** now runs **`AudioModelConfig.validate(spanSeconds:)`** before uploading a media ref or rendering a timeline span, matching the UI paths so over-limit selections fail immediately instead of after render/upload.
> 
> **Video-to-music scoring exports** (agent timeline span + Music tab) switch from **360p** to **240p** with **`AVAssetExportPresetLowQuality`** to shrink reference MP4s and reduce upload timeouts/413s.
> 
> The **`maxSeconds`** catalog fallback is tightened **900 → 600** when the backend omits a limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b434acb952fdbbd34222f40a8cf3c49b20d5ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->