### PR TITLE
[fix] chroma key and add eyedropper

### DIFF
--- a/Metal/ChromaKey.metal
+++ b/Metal/ChromaKey.metal
@@ -21,7 +21,8 @@ extern "C" float4 chromaKey(coreimage::sample_t s, float keyHue, float tolerance
     hd = min(hd, 1.0 - hd);                                  // circular hue distance, 0…0.5
     float inner = tolerance * 0.25;                          // tolerance 1 ≈ ±90° band
     float key = (1.0 - smoothstep(inner, inner + softness * 0.3 + 0.02, hd))
-              * smoothstep(0.12, 0.32, sat);                 // near key hue AND saturated
+              * smoothstep(0.12, 0.32, sat)                  // near key hue AND saturated
+              * smoothstep(0.04, 0.12, dd);
     float y = dot(rgb, float3(0.2126, 0.7152, 0.0722));
     rgb = mix(rgb, float3(y), spill * key);                  // kill spill on the edges
     return float4(rgb, s.a * (1.0 - key));

--- a/Sources/PalmierPro/Compositing/EffectRegistry.swift
+++ b/Sources/PalmierPro/Compositing/EffectRegistry.swift
@@ -330,7 +330,7 @@ enum EffectRegistry {
             params: [
                 EffectParamSpec(key: "keyHue", label: "Key Hue", range: 0...1, defaultValue: 0.333, unit: ""),
                 EffectParamSpec(key: "tolerance", label: "Tolerance", range: 0...1, defaultValue: 0, unit: ""),
-                EffectParamSpec(key: "softness", label: "Softness", range: 0...1, defaultValue: 0.5, unit: ""),
+                EffectParamSpec(key: "softness", label: "Softness", range: 0...1, defaultValue: 0.1, unit: ""),
                 EffectParamSpec(key: "spill", label: "Spill", range: 0...1, defaultValue: 0.5, unit: ""),
             ],
             apply: { image, p, _ in

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -261,6 +261,7 @@ enum FrameRenderer {
         // Conjugate the AV top-left-origin mapping into CI's bottom-left space.
         let ci = flipY(srcHeight).concatenating(av).concatenating(flipY(renderSize.height))
         image = image.transformed(by: ci)
+        image = image.premultiplyingAlpha()
 
         if bakeOpacity, alpha < 1 {
             // Fade alpha only; scaling RGB would double-fade
@@ -291,6 +292,7 @@ enum FrameRenderer {
                 image = descriptor.render(image, effect: effect, atOffset: offset)
             }
         }
+        image = image.premultiplyingAlpha()
 
         if bakeOpacity, alpha < 1 {
             image = image.applyingFilter("CIColorMatrix", parameters: [

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -171,6 +171,10 @@ final class EditorWindowController: NSWindowController {
                 editorViewModel.cancelMediaSwap()
                 return true
             }
+            if editorViewModel.chromaKeySamplingClipId != nil {
+                editorViewModel.cancelChromaKeySampling()
+                return true
+            }
             if editorViewModel.cropEditingActive {
                 editorViewModel.cropEditingActive = false
                 return true

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ChromaKey.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ChromaKey.swift
@@ -1,0 +1,41 @@
+extension EditorViewModel {
+    func toggleChromaKeySampling(clipId: String) {
+        if chromaKeySamplingClipId == clipId {
+            cancelChromaKeySampling()
+            return
+        }
+        cancelChromaKeySampling()
+        guard activePreviewTab == .timeline, clipFor(id: clipId)?.mediaType.isVisual == true else { return }
+        pause()
+        applyClipProperty(clipId: clipId) { clip in
+            if let index = clip.effects?.firstIndex(where: { $0.type == "key.chroma" }) {
+                clip.effects?[index].enabled = false
+            }
+        }
+        chromaKeySamplingClipId = clipId
+    }
+
+    func cancelChromaKeySampling() {
+        guard let clipId = chromaKeySamplingClipId else { return }
+        chromaKeySamplingClipId = nil
+        revertClipProperty(clipId: clipId)
+    }
+
+    func commitChromaKeySample(hue: Double, clipId: String) {
+        guard chromaKeySamplingClipId == clipId, hue.isFinite else { return }
+        chromaKeySamplingClipId = nil
+        commitClipProperty(clipId: clipId) { clip in
+            guard let descriptor = EffectRegistry.descriptor(id: "key.chroma") else { return }
+            var effects = clip.effects ?? []
+            var effect = effects.first { $0.type == descriptor.id } ?? descriptor.makeEffect()
+            effect.enabled = true
+            effect.params["keyHue"] = EffectParam(value: hue)
+            effect.params["tolerance"] = EffectParam(value: 0.15)
+            effect.params["softness"] = EffectParam(value: 0.1)
+            effects.removeAll { $0.type == descriptor.id }
+            effects.insert(effect, at: EffectRegistry.insertIndex(effects, for: descriptor.id))
+            clip.effects = effects
+        }
+        undoManager?.setActionName("Sample Key Color")
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -130,6 +130,7 @@ final class EditorViewModel {
     /// Clip ids currently awaiting an AI-generated replacement.
     var pendingReplacements: Set<String> = []
     var cropEditingActive: Bool = false
+    var chromaKeySamplingClipId: String?
     var cropAspectLock: CropAspectLock = .free
     var previewTabs: [PreviewTab] = [.timeline]
     var activePreviewTabId: String = PreviewTab.timeline.id

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -41,6 +41,7 @@ struct InspectorView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onChange(of: editor.selectedClipIds) { _, _ in
+            editor.cancelChromaKeySampling()
             if !editor.isMarqueeSelecting { resolvePreferredTab() }
         }
         .onChange(of: editor.isMarqueeSelecting) { _, selecting in

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -73,9 +73,7 @@ extension InspectorView {
 
     private var chromaKeyControls: [EffectControl] {
         [
-            EffectControl(effectId: "key.chroma", paramKey: "keyHue", label: "Key Hue"),
-            EffectControl(effectId: "key.chroma", paramKey: "tolerance", label: "Tolerance"),
-            EffectControl(effectId: "key.chroma", paramKey: "softness", label: "Softness"),
+            EffectControl(effectId: "key.chroma", paramKey: "tolerance", label: "Range"),
             EffectControl(effectId: "key.chroma", paramKey: "spill", label: "Spill"),
         ]
     }
@@ -213,6 +211,17 @@ extension InspectorView {
                     .frame(width: AppTheme.IconSize.xxs, alignment: .center)
                 sectionTitleLabel(title: title)
                 Spacer(minLength: 0)
+                if title == "Chroma Key", clips.count == 1, let clip = clips.first {
+                    let sampling = editor.chromaKeySamplingClipId == clip.id
+                    Button { editor.toggleChromaKeySampling(clipId: clip.id) } label: {
+                        Image(systemName: "eyedropper")
+                            .foregroundStyle(sampling ? AppTheme.Accent.primary : AppTheme.Text.secondaryColor)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(editor.activePreviewTab != .timeline)
+                    .help(sampling ? "Cancel key color sampling" : "Sample key color")
+                    .accessibilityLabel(sampling ? "Cancel Key Color Sampling" : "Sample Key Color")
+                }
             }
             .contentShape(Rectangle())
             .onTapGesture {

--- a/Sources/PalmierPro/Preview/ChromaKeySamplerOverlayView.swift
+++ b/Sources/PalmierPro/Preview/ChromaKeySamplerOverlayView.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+struct ChromaKeySamplerOverlayView: View {
+    @Environment(EditorViewModel.self) private var editor
+
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(AppTheme.Background.clearColor)
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    (hovering ? NSCursor.crosshair : NSCursor.arrow).set()
+                }
+                .gesture(
+                    SpatialTapGesture().onEnded { value in
+                        sample(at: value.location, viewSize: geometry.size)
+                    }
+                )
+        }
+        .onDisappear { NSCursor.arrow.set() }
+    }
+
+    private func sample(at point: CGPoint, viewSize: CGSize) {
+        let rect = PreviewHitTester.videoContentRect(in: viewSize, timeline: editor.timeline)
+        guard let clipId = editor.chromaKeySamplingClipId,
+              let engine = editor.videoEngine, rect.contains(point) else {
+            NSSound.beep()
+            return
+        }
+        let normalizedPoint = CGPoint(
+            x: (point.x - rect.minX) / rect.width,
+            y: (point.y - rect.minY) / rect.height
+        )
+        Task { @MainActor in
+            guard let hue = await engine.sampleKeyHue(at: normalizedPoint, frame: editor.activeFrame) else {
+                NSSound.beep()
+                return
+            }
+            editor.commitChromaKeySample(hue: hue, clipId: clipId)
+        }
+    }
+}

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -37,7 +37,9 @@ struct PreviewContainerView: View {
                     if let overlay = offlineOverlay(timelineState: timelineState) {
                         offlinePreview(assetId: overlay.assetId, path: overlay.path, isUnprocessable: overlay.isUnprocessable)
                     }
-                    if editor.cropEditingActive {
+                    if editor.chromaKeySamplingClipId != nil {
+                        ChromaKeySamplerOverlayView()
+                    } else if editor.cropEditingActive {
                         CropOverlayView()
                     } else {
                         TransformOverlayView()
@@ -72,6 +74,9 @@ struct PreviewContainerView: View {
             }
         }
         .background(AppTheme.Background.surfaceColor)
+        .onChange(of: editor.activePreviewTabId) { _, _ in
+            editor.cancelChromaKeySampling()
+        }
     }
 
     // MARK: - Transport bar

--- a/Sources/PalmierPro/Preview/PreviewHitTester.swift
+++ b/Sources/PalmierPro/Preview/PreviewHitTester.swift
@@ -58,7 +58,7 @@ enum PreviewHitTester {
         return lx >= left && lx <= right && ly >= top && ly <= bottom
     }
 
-    private static func videoContentRect(in viewSize: CGSize, timeline: Timeline) -> CGRect {
+    static func videoContentRect(in viewSize: CGSize, timeline: Timeline) -> CGRect {
         guard viewSize.width > 0, viewSize.height > 0 else { return .zero }
         let videoAspect = CGFloat(timeline.width) / CGFloat(timeline.height)
         let viewAspect = viewSize.width / viewSize.height

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -346,6 +346,38 @@ final class VideoEngine {
         return bins
     }
 
+    func sampleKeyHue(at normalizedPoint: CGPoint, frame: Int? = nil) async -> Double? {
+        guard let item = player.currentItem else { return nil }
+        let time = frame.map { CMTime(value: CMTimeValue($0), timescale: CMTimeScale(editor?.timeline.fps ?? 30)) }
+            ?? player.currentTime()
+        let generator = AVAssetImageGenerator(asset: item.asset)
+        generator.videoComposition = item.videoComposition
+        guard let cg = try? await generator.image(at: time).image else { return nil }
+        return Self.sampleKeyHue(from: cg, at: normalizedPoint)
+    }
+
+    nonisolated static func sampleKeyHue(
+        from cg: CGImage,
+        at normalizedPoint: CGPoint,
+    ) -> Double? {
+        let image = CIImage(cgImage: cg)
+        let center = CGPoint(
+            x: normalizedPoint.x * image.extent.width,
+            y: (1 - normalizedPoint.y) * image.extent.height
+        )
+        let patch = CGRect(x: center.x - 4, y: center.y - 4, width: 9, height: 9)
+            .intersection(image.extent)
+        let average = image.applyingFilter("CIAreaAverage", parameters: [kCIInputExtentKey: CIVector(cgRect: patch)])
+        var rgba = [Float](repeating: 0, count: 4)
+        ColorScopes.context.render(
+            average, toBitmap: &rgba, rowBytes: 4 * MemoryLayout<Float>.size,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBAf, colorSpace: nil)
+        var hue: CGFloat = 0, saturation: CGFloat = 0, brightness: CGFloat = 0, alpha: CGFloat = 0
+        NSColor(red: CGFloat(rgba[0]), green: CGFloat(rgba[1]), blue: CGFloat(rgba[2]), alpha: 1)
+            .getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        return saturation >= 0.12 ? Double(hue) : nil
+    }
+
     // MARK: - Seek Coordinator
 
     private func enqueueInteractiveSeek(time: CMTime, tolerance: CMTime) {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -20,6 +20,7 @@ enum AppTheme {
         static var prominentColor: Color { Color(prominent) }
         static var previewCanvasColor: Color { .black }
         static var placeholderColor: Color { Color(placeholder) }
+        static var clearColor: Color { .clear }
     }
 
     // MARK: - Borders

--- a/Tests/PalmierProTests/Rendering/ChromaKeyKernelTests.swift
+++ b/Tests/PalmierProTests/Rendering/ChromaKeyKernelTests.swift
@@ -29,6 +29,7 @@ struct ChromaKeyKernelTests {
         #expect(alpha(0.8, 0.2, 0.2) > 0.95, "red stays opaque")
         #expect(alpha(0.7, 0.55, 0.45) > 0.95, "skin tone stays opaque")
         #expect(alpha(0.5, 0.5, 0.5) > 0.95, "gray stays opaque (not saturated)")
+        #expect(alpha(0.01, 0.05, 0.015) > 0.95, "near-black chroma noise stays opaque")
     }
 
     @Test func toleranceZeroIsNoOp() {

--- a/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorRenderTests.swift
@@ -253,6 +253,25 @@ extension CompositorRenderTests {
         #expect(isWhite(f.br), "transparent overlay region shows bg through: \(f.br)")
     }
 
+    @Test func chromaKeyRevealsBackground() async throws {
+        var keyed = CompositorFixtures.patternClip(id: "keyed")
+        keyed.effects = [Effect.make("key.chroma", [
+            "keyHue": 0.333,
+            "tolerance": 0.5,
+            "softness": 0.3,
+            "spill": 0,
+        ])]
+        var background = CompositorFixtures.patternClip(id: "background")
+        background.transform = Transform(flipHorizontal: true)
+
+        let f = try await Self.render(Self.timelineWith(
+            Fixtures.videoTrack(clips: [keyed]),
+            Fixtures.videoTrack(clips: [background])
+        ), frame: 15)
+
+        #expect(isRed(f.tr), "keyed green should reveal the red background: \(f.tr)")
+    }
+
     @Test func adjacentClipsBothRender() async throws {
         var second = CompositorFixtures.patternClip(id: "c2", start: 30, duration: 30)
         second.transform = Transform(flipHorizontal: true)

--- a/Tests/PalmierProTests/Rendering/HistogramTests.swift
+++ b/Tests/PalmierProTests/Rendering/HistogramTests.swift
@@ -43,4 +43,10 @@ struct HistogramTests {
         let h = try #require(VideoEngine.histogram(from: solid(0.5, 0.5, 0.5)))
         #expect((110...145).contains(argmax(h.r)), "mid-gray sits near bin 128, got \(argmax(h.r))")
     }
+
+    @Test func samplesChromaKeyHue() throws {
+        let hue = try #require(VideoEngine.sampleKeyHue(from: solid(0, 1, 0), at: CGPoint(x: 0.5, y: 0.5)))
+        #expect(abs(hue - 1.0 / 3.0) < 0.01)
+        #expect(VideoEngine.sampleKeyHue(from: solid(0.5, 0.5, 0.5), at: CGPoint(x: 0.5, y: 0.5)) == nil)
+    }
 }

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -398,6 +398,22 @@ struct WritePositionTests {
 @MainActor
 struct ClipPropertyCommitTests {
 
+    @Test func sampledChromaKeyUndoes() throws {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let undoManager = UndoManager()
+        e.undoManager = undoManager
+
+        e.toggleChromaKeySampling(clipId: clip.id)
+        e.commitChromaKeySample(hue: 1.0 / 3.0, clipId: clip.id)
+
+        let effect = try #require(e.clipFor(id: clip.id)?.effects?.first)
+        #expect(effect.params["tolerance"]?.value == 0.15)
+        #expect(effect.params["softness"]?.value == 0.1)
+        undoManager.undo()
+        #expect(e.clipFor(id: clip.id)?.effects == nil)
+    }
+
     @Test func commitClipPropertiesGroupsMultipleClipUndo() {
         var a = Fixtures.clip(id: "a", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
         var b = Fixtures.clip(id: "b", mediaRef: "text", mediaType: .text, start: 30, duration: 30)


### PR DESCRIPTION
## Summary

- Fix chroma-key transparency by premultiplying effect output before compositing.
- Add a preview eyedropper that samples the visible frame and applies a usable key in one undoable action.
- Simplify the inspector to Range and Spill, with safer defaults and protection for near-black chroma noise.

## Why

The chroma-key kernel produced correct alpha, but the compositor consumed unpremultiplied RGB. Fully keyed pixels could therefore remain visible during source-over compositing. The previous raw hue, tolerance, and softness controls also made it difficult to establish a working key.

## Impact

Users can select one visual clip, activate the eyedropper, and click the screen color in the timeline preview. Sampling resets the key to a conservative Range and Softness baseline, while dark clothing is protected from compressed chroma noise. Escape, selection changes, and preview-tab changes cancel sampling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compositing (`FrameRenderer` premultiply) and preview sampling paths; incorrect alpha handling could affect all layered clips, though changes are localized and covered by new render tests.
> 
> **Overview**
> Fixes **chroma key** so keyed areas actually show through in the compositor by **premultiplying alpha** on video and text layers after transform/effects, matching what source-over compositing expects. The Metal kernel also gates the key on **chroma delta** so near-black pixels are not keyed from compressed noise.
> 
> Adds a **timeline preview eyedropper**: from Adjust → Chroma Key (single clip), users pick a screen color; the app samples hue from the composited frame via `VideoEngine`, applies a conservative **Range** / softness baseline, and records one undoable **Sample Key Color** action. Sampling temporarily disables the existing key effect; **Escape**, selection/tab changes, and preview tab switches cancel it.
> 
> Inspector chroma controls are reduced to **Range** and **Spill** (hue comes from sampling); default softness is lower. Tests cover compositor keying, hue sampling, near-black protection, and undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedf276705f4ee02566cf2ac2d2a6f5c6d58d8f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->