### PR TITLE
[agent] Use Sonnet 5 for free chat

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -46,7 +46,7 @@ final class AgentService {
 
     var availableModels: [AnthropicModel] {
         if hasApiKey { return AnthropicModel.allCases }
-        return AccountService.shared.isPaid ? [.sonnet5] : [.haiku45]
+        return [.sonnet5]
     }
 
     private func selectClient() -> (any AgentClient)? {


### PR DESCRIPTION
haiku is giving bad experience

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Single-line policy change but increases model cost per free/credit chat and removes the paid-only Sonnet gate for hosted traffic.
> 
> **Overview**
> **Palmier-hosted agent chat** (signed-in users without their own Anthropic API key) now always uses **Sonnet 5** instead of tiering models by plan.
> 
> Previously, `availableModels` returned Haiku for non-paid accounts and Sonnet only for paid; that split is removed so every hosted session is limited to `[.sonnet5]`. Users with a BYOK still get `AnthropicModel.allCases` and the model picker in the agent panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2112320215b6bda5dfab241bc8b7b7094abe577d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->