### PR TITLE
[feat] add audio scrubbing and timeline meter

### DIFF
--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -1,6 +1,7 @@
 import Accelerate
 import AVFoundation
 import Foundation
+import Observation
 
 struct AudioMeterAnalysis: Sendable, Equatable {
     let leftPeak, rightPeak: Float
@@ -61,6 +62,7 @@ struct AudioMeterChannelState: Sendable {
     }
 }
 
+@Observable
 @MainActor
 final class AudioMeterHub {
     private var left = AudioMeterChannelState()

--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -1,0 +1,126 @@
+import Accelerate
+import AVFoundation
+import Foundation
+import Observation
+
+struct AudioMeterAnalysis: Sendable, Equatable {
+    struct Channel: Sendable, Equatable {
+        let peak, rms: Float
+    }
+    let left, right: Channel
+    static let silence = AudioMeterAnalysis(
+        left: Channel(peak: 0, rms: 0),
+        right: Channel(peak: 0, rms: 0)
+    )
+}
+
+struct AudioMeterChannelDisplay: Sendable, Equatable {
+    let levelDb, peakDb: Float
+    let clipped: Bool
+}
+
+struct StereoAudioMeterDisplay: Sendable, Equatable {
+    let left, right: AudioMeterChannelDisplay
+}
+
+struct AudioMeterChannelState: Sendable {
+    nonisolated static let floorDb: Float = -60
+    nonisolated static let ceilingDb: Float = 0
+    nonisolated static let levelDecayDbPerSecond: Float = 24
+    nonisolated static let peakDecayDbPerSecond: Float = 18
+    nonisolated static let peakHoldSeconds: TimeInterval = 1.5
+
+    private var levelDb = floorDb
+    private var levelTime: TimeInterval = 0
+    private var peakDb = floorDb
+    private var peakHoldUntil: TimeInterval = 0
+    private(set) var clipped = false
+
+    mutating func ingest(rms: Float, peak: Float, at time: TimeInterval) {
+        let current = display(at: time)
+        levelDb = max(Self.decibels(rms), current.levelDb)
+        levelTime = time
+
+        let incomingPeak = Self.decibels(peak)
+        if incomingPeak >= current.peakDb {
+            peakDb = incomingPeak
+            peakHoldUntil = time + Self.peakHoldSeconds
+        } else if time > peakHoldUntil {
+            peakDb = current.peakDb
+            peakHoldUntil = time
+        }
+        clipped = clipped || peak >= 1
+    }
+
+    func display(at time: TimeInterval) -> AudioMeterChannelDisplay {
+        let levelElapsed = Float(max(0, time - levelTime))
+        let peakElapsed = Float(max(0, time - peakHoldUntil))
+        return AudioMeterChannelDisplay(
+            levelDb: max(Self.floorDb, levelDb - levelElapsed * Self.levelDecayDbPerSecond),
+            peakDb: max(Self.floorDb, peakDb - peakElapsed * Self.peakDecayDbPerSecond),
+            clipped: clipped
+        )
+    }
+
+    mutating func resetClipping() { clipped = false }
+    nonisolated static func decibels(_ amplitude: Float) -> Float {
+        amplitude > 0 ? max(floorDb, 20 * log10(amplitude)) : floorDb
+    }
+}
+
+@Observable
+@MainActor
+final class AudioMeterHub {
+    private var left = AudioMeterChannelState()
+    private var right = AudioMeterChannelState()
+
+    func ingest(_ analysis: AudioMeterAnalysis, at time: TimeInterval = ProcessInfo.processInfo.systemUptime) {
+        left.ingest(rms: analysis.left.rms, peak: analysis.left.peak, at: time)
+        right.ingest(rms: analysis.right.rms, peak: analysis.right.peak, at: time)
+    }
+    func display(at time: TimeInterval = ProcessInfo.processInfo.systemUptime) -> StereoAudioMeterDisplay {
+        StereoAudioMeterDisplay(left: left.display(at: time), right: right.display(at: time))
+    }
+    func resetClipping() {
+        left.resetClipping()
+        right.resetClipping()
+    }
+    func reset() {
+        left = AudioMeterChannelState()
+        right = AudioMeterChannelState()
+    }
+}
+
+enum AudioLevelAnalyzer {
+    nonisolated static func analyze(left: [Float], right: [Float], range: Range<Int>) -> AudioMeterAnalysis {
+        let upper = min(range.upperBound, min(left.count, right.count))
+        let lower = max(0, min(range.lowerBound, upper))
+        guard lower < upper else { return .silence }
+        let leftResult = left.withUnsafeBufferPointer { metrics($0.baseAddress! + lower, count: upper - lower) }
+        let rightResult = right.withUnsafeBufferPointer { metrics($0.baseAddress! + lower, count: upper - lower) }
+        return AudioMeterAnalysis(left: leftResult, right: rightResult)
+    }
+
+    nonisolated static func analyze(_ buffer: AVAudioPCMBuffer) -> AudioMeterAnalysis {
+        guard buffer.format.commonFormat == .pcmFormatFloat32,
+              !buffer.format.isInterleaved,
+              buffer.format.channelCount > 0,
+              let channels = buffer.floatChannelData,
+              buffer.frameLength > 0
+        else { return .silence }
+        let count = Int(buffer.frameLength)
+        let right = min(1, Int(buffer.format.channelCount) - 1)
+        return AudioMeterAnalysis(
+            left: metrics(channels[0], count: count),
+            right: metrics(channels[right], count: count)
+        )
+    }
+
+    nonisolated private static func metrics(_ samples: UnsafePointer<Float>, count: Int) -> AudioMeterAnalysis.Channel {
+        var peak: Float = 0
+        var rms: Float = 0
+        vDSP_maxmgv(samples, 1, &peak, vDSP_Length(count))
+        vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
+        return AudioMeterAnalysis.Channel(peak: peak, rms: rms)
+    }
+}

--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -1,17 +1,10 @@
 import Accelerate
 import AVFoundation
 import Foundation
-import Observation
 
 struct AudioMeterAnalysis: Sendable, Equatable {
-    struct Channel: Sendable, Equatable {
-        let peak, rms: Float
-    }
-    let left, right: Channel
-    static let silence = AudioMeterAnalysis(
-        left: Channel(peak: 0, rms: 0),
-        right: Channel(peak: 0, rms: 0)
-    )
+    let leftPeak, rightPeak: Float
+    static let silence = AudioMeterAnalysis(leftPeak: 0, rightPeak: 0)
 }
 
 struct AudioMeterChannelDisplay: Sendable, Equatable {
@@ -36,12 +29,12 @@ struct AudioMeterChannelState: Sendable {
     private var peakHoldUntil: TimeInterval = 0
     private(set) var clipped = false
 
-    mutating func ingest(rms: Float, peak: Float, at time: TimeInterval) {
+    mutating func ingest(peak: Float, at time: TimeInterval) {
         let current = display(at: time)
-        levelDb = max(Self.decibels(rms), current.levelDb)
+        let incomingPeak = Self.decibels(peak)
+        levelDb = max(incomingPeak, current.levelDb)
         levelTime = time
 
-        let incomingPeak = Self.decibels(peak)
         if incomingPeak >= current.peakDb {
             peakDb = incomingPeak
             peakHoldUntil = time + Self.peakHoldSeconds
@@ -68,15 +61,14 @@ struct AudioMeterChannelState: Sendable {
     }
 }
 
-@Observable
 @MainActor
 final class AudioMeterHub {
     private var left = AudioMeterChannelState()
     private var right = AudioMeterChannelState()
 
     func ingest(_ analysis: AudioMeterAnalysis, at time: TimeInterval = ProcessInfo.processInfo.systemUptime) {
-        left.ingest(rms: analysis.left.rms, peak: analysis.left.peak, at: time)
-        right.ingest(rms: analysis.right.rms, peak: analysis.right.peak, at: time)
+        left.ingest(peak: analysis.leftPeak, at: time)
+        right.ingest(peak: analysis.rightPeak, at: time)
     }
     func display(at time: TimeInterval = ProcessInfo.processInfo.systemUptime) -> StereoAudioMeterDisplay {
         StereoAudioMeterDisplay(left: left.display(at: time), right: right.display(at: time))
@@ -96,9 +88,11 @@ enum AudioLevelAnalyzer {
         let upper = min(range.upperBound, min(left.count, right.count))
         let lower = max(0, min(range.lowerBound, upper))
         guard lower < upper else { return .silence }
-        let leftResult = left.withUnsafeBufferPointer { metrics($0.baseAddress! + lower, count: upper - lower) }
-        let rightResult = right.withUnsafeBufferPointer { metrics($0.baseAddress! + lower, count: upper - lower) }
-        return AudioMeterAnalysis(left: leftResult, right: rightResult)
+        let count = upper - lower
+        return AudioMeterAnalysis(
+            leftPeak: left.withUnsafeBufferPointer { peak($0.baseAddress! + lower, count: count) },
+            rightPeak: right.withUnsafeBufferPointer { peak($0.baseAddress! + lower, count: count) }
+        )
     }
 
     nonisolated static func analyze(_ buffer: AVAudioPCMBuffer) -> AudioMeterAnalysis {
@@ -111,16 +105,14 @@ enum AudioLevelAnalyzer {
         let count = Int(buffer.frameLength)
         let right = min(1, Int(buffer.format.channelCount) - 1)
         return AudioMeterAnalysis(
-            left: metrics(channels[0], count: count),
-            right: metrics(channels[right], count: count)
+            leftPeak: peak(channels[0], count: count),
+            rightPeak: peak(channels[right], count: count)
         )
     }
 
-    nonisolated private static func metrics(_ samples: UnsafePointer<Float>, count: Int) -> AudioMeterAnalysis.Channel {
-        var peak: Float = 0
-        var rms: Float = 0
-        vDSP_maxmgv(samples, 1, &peak, vDSP_Length(count))
-        vDSP_rmsqv(samples, 1, &rms, vDSP_Length(count))
-        return AudioMeterAnalysis.Channel(peak: peak, rms: rms)
+    nonisolated private static func peak(_ samples: UnsafePointer<Float>, count: Int) -> Float {
+        var result: Float = 0
+        vDSP_maxmgv(samples, 1, &result, vDSP_Length(count))
+        return result
     }
 }

--- a/Sources/PalmierPro/Audio/AudioMeterView.swift
+++ b/Sources/PalmierPro/Audio/AudioMeterView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+struct AudioMeterView: View {
+    @Environment(EditorViewModel.self) private var editor
+
+    private static let barsWidth = AppTheme.AudioMeter.barWidth * 2
+    private static let contentWidth = barsWidth + AppTheme.AudioMeter.scaleGap + AppTheme.AudioMeter.majorTickWidth
+    private static let rulerMarks = stride(
+        from: AudioMeterChannelState.ceilingDb,
+        through: AudioMeterChannelState.floorDb,
+        by: -AppTheme.AudioMeter.rulerStepDb
+    ).map { $0 }
+
+    var body: some View {
+        SwiftUI.TimelineView(.animation(minimumInterval: AppTheme.AudioMeter.refreshInterval)) { _ in
+            let display = editor.audioMeter.display()
+            Canvas { context, size in
+                drawChannel(display.left, x: 0, height: size.height, context: &context)
+                drawChannel(display.right, x: AppTheme.AudioMeter.barWidth, height: size.height, context: &context)
+                fill(
+                    CGRect(
+                        x: AppTheme.AudioMeter.barWidth - AppTheme.BorderWidth.thin / 2,
+                        y: 0,
+                        width: AppTheme.BorderWidth.thin,
+                        height: size.height
+                    ),
+                    color: AppTheme.Background.previewCanvasColor,
+                    context: &context
+                )
+
+                let rulerX = Self.barsWidth + AppTheme.AudioMeter.scaleGap
+                for db in Self.rulerMarks {
+                    let major = db.truncatingRemainder(dividingBy: AppTheme.AudioMeter.rulerMajorStepDb) == 0
+                    fill(
+                        CGRect(
+                            x: rulerX,
+                            y: tickY(for: db, height: size.height),
+                            width: major ? AppTheme.AudioMeter.majorTickWidth : AppTheme.AudioMeter.minorTickWidth,
+                            height: AppTheme.BorderWidth.hairline
+                        ),
+                        color: AppTheme.Text.mutedColor,
+                        context: &context
+                    )
+                }
+            }
+            .frame(width: Self.contentWidth)
+            .frame(maxHeight: .infinity)
+            .padding(.horizontal, AppTheme.Spacing.xs)
+            .padding(.vertical, AppTheme.AudioMeter.verticalPadding)
+            .contentShape(Rectangle())
+            .onTapGesture { editor.audioMeter.resetClipping() }
+            .help("Reset Clipping Indicators")
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Master Audio Meter")
+            .accessibilityValue(accessibilityValue(display))
+            .accessibilityAction(named: "Reset Clipping Indicators") {
+                editor.audioMeter.resetClipping()
+            }
+        }
+        .frame(width: AppTheme.AudioMeter.panelWidth)
+        .background(AppTheme.Background.baseColor)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(AppTheme.Border.primaryColor)
+                .frame(width: AppTheme.BorderWidth.thin)
+        }
+    }
+
+    private func drawChannel(
+        _ channel: AudioMeterChannelDisplay,
+        x: CGFloat,
+        height: CGFloat,
+        context: inout GraphicsContext
+    ) {
+        let gap = AppTheme.AudioMeter.segmentGap
+        let count = max(1, Int((height + gap) / (AppTheme.AudioMeter.segmentHeight + gap)))
+        let segmentHeight = (height - CGFloat(count - 1) * gap) / CGFloat(count)
+        guard segmentHeight > 0 else { return }
+        let activeCount = min(count, max(0, Int(ceil(normalized(channel.levelDb) * CGFloat(count)))))
+
+        for index in 0..<count {
+            let color: Color
+            if channel.clipped && index == count - 1 {
+                color = AppTheme.Status.errorColor
+            } else if index < activeCount {
+                color = segmentColor(for: decibels(at: index, count: count))
+            } else {
+                color = AppTheme.Background.previewCanvasColor
+            }
+            let y = height - CGFloat(index + 1) * segmentHeight - CGFloat(index) * gap
+            fill(
+                CGRect(x: x, y: y, width: AppTheme.AudioMeter.barWidth, height: segmentHeight),
+                color: color,
+                context: &context
+            )
+        }
+
+        guard channel.peakDb > AudioMeterChannelState.floorDb else { return }
+        let lineHeight = AppTheme.AudioMeter.peakLineHeight
+        let y = min(
+            height - lineHeight,
+            max(0, height * (1 - normalized(channel.peakDb)) - lineHeight / 2)
+        )
+        fill(
+            CGRect(x: x, y: y, width: AppTheme.AudioMeter.barWidth, height: lineHeight),
+            color: segmentColor(for: channel.peakDb),
+            context: &context
+        )
+    }
+
+    private func fill(_ rect: CGRect, color: Color, context: inout GraphicsContext) {
+        context.fill(Path(rect), with: .color(color))
+    }
+
+    private func normalized(_ db: Float) -> CGFloat {
+        let floor = AudioMeterChannelState.floorDb
+        let ceiling = AudioMeterChannelState.ceilingDb
+        return CGFloat(min(1, max(0, (db - floor) / (ceiling - floor))))
+    }
+
+    private func decibels(at index: Int, count: Int) -> Float {
+        let floor = AudioMeterChannelState.floorDb
+        let position = (Float(index) + 0.5) / Float(count)
+        return floor + position * (AudioMeterChannelState.ceilingDb - floor)
+    }
+
+    private func segmentColor(for db: Float) -> Color {
+        if db >= AppTheme.AudioMeter.redThresholdDb { return AppTheme.AudioMeter.redSegment }
+        if db >= AppTheme.AudioMeter.yellowThresholdDb { return AppTheme.AudioMeter.yellowSegment }
+        return AppTheme.AudioMeter.greenSegment
+    }
+
+    private func tickY(for db: Float, height: CGFloat) -> CGFloat {
+        let y = height * (1 - normalized(db)) - AppTheme.BorderWidth.hairline / 2
+        return min(height - AppTheme.BorderWidth.hairline, max(0, y))
+    }
+
+    private func accessibilityValue(_ display: StereoAudioMeterDisplay) -> String {
+        "Left \(Int(display.left.levelDb.rounded())) dBFS, right \(Int(display.right.levelDb.rounded())) dBFS"
+    }
+}

--- a/Sources/PalmierPro/Audio/AudioMeterView.swift
+++ b/Sources/PalmierPro/Audio/AudioMeterView.swift
@@ -4,7 +4,7 @@ struct AudioMeterView: View {
     @Environment(EditorViewModel.self) private var editor
 
     private static let barsWidth = AppTheme.AudioMeter.barWidth * 2
-    private static let contentWidth = barsWidth + AppTheme.AudioMeter.scaleGap + AppTheme.AudioMeter.majorTickWidth
+    private static let contentWidth = barsWidth + AppTheme.Spacing.xxs + AppTheme.Spacing.xs
     private static let rulerMarks = stride(
         from: AudioMeterChannelState.ceilingDb,
         through: AudioMeterChannelState.floorDb,
@@ -28,14 +28,14 @@ struct AudioMeterView: View {
                     context: &context
                 )
 
-                let rulerX = Self.barsWidth + AppTheme.AudioMeter.scaleGap
+                let rulerX = Self.barsWidth + AppTheme.Spacing.xxs
                 for db in Self.rulerMarks {
                     let major = db.truncatingRemainder(dividingBy: AppTheme.AudioMeter.rulerMajorStepDb) == 0
                     fill(
                         CGRect(
                             x: rulerX,
                             y: tickY(for: db, height: size.height),
-                            width: major ? AppTheme.AudioMeter.majorTickWidth : AppTheme.AudioMeter.minorTickWidth,
+                            width: major ? AppTheme.Spacing.xs : AppTheme.BorderWidth.thick,
                             height: AppTheme.BorderWidth.hairline
                         ),
                         color: AppTheme.Text.mutedColor,
@@ -46,7 +46,7 @@ struct AudioMeterView: View {
             .frame(width: Self.contentWidth)
             .frame(maxHeight: .infinity)
             .padding(.horizontal, AppTheme.Spacing.xs)
-            .padding(.vertical, AppTheme.AudioMeter.verticalPadding)
+            .padding(.vertical, AppTheme.Spacing.sm)
             .contentShape(Rectangle())
             .onTapGesture { editor.audioMeter.resetClipping() }
             .help("Reset Clipping Indicators")
@@ -72,8 +72,8 @@ struct AudioMeterView: View {
         height: CGFloat,
         context: inout GraphicsContext
     ) {
-        let gap = AppTheme.AudioMeter.segmentGap
-        let count = max(1, Int((height + gap) / (AppTheme.AudioMeter.segmentHeight + gap)))
+        let gap = AppTheme.BorderWidth.thin
+        let count = max(1, Int((height + gap) / (AppTheme.BorderWidth.thin + gap)))
         let segmentHeight = (height - CGFloat(count - 1) * gap) / CGFloat(count)
         guard segmentHeight > 0 else { return }
         let activeCount = min(count, max(0, Int(ceil(normalized(channel.levelDb) * CGFloat(count)))))
@@ -96,7 +96,7 @@ struct AudioMeterView: View {
         }
 
         guard channel.peakDb > AudioMeterChannelState.floorDb else { return }
-        let lineHeight = AppTheme.AudioMeter.peakLineHeight
+        let lineHeight = AppTheme.BorderWidth.thin
         let y = min(
             height - lineHeight,
             max(0, height * (1 - normalized(channel.peakDb)) - lineHeight / 2)

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -76,7 +76,10 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
                 .overlay(alignment: .bottom) {
                     Rectangle().fill(AppTheme.Border.primaryColor).frame(height: AppTheme.BorderWidth.thin)
                 }
-            TimelineContainerView()
+            HStack(spacing: 0) {
+                TimelineContainerView()
+                AudioMeterView()
+            }
         },
         panel: .timeline
     )

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -398,10 +398,10 @@ final class EditorViewModel {
         videoEngine?.togglePlayback()
     }
 
-    func stepForward() { seekToFrame(currentFrame + 1) }
-    func stepBackward() { seekToFrame(currentFrame - 1) }
-    func skipForward(frames: Int = 5) { seekToFrame(currentFrame + frames) }
-    func skipBackward(frames: Int = 5) { seekToFrame(currentFrame - frames) }
+    func stepForward() { seekToFrame(currentFrame + 1, mode: .audibleStep) }
+    func stepBackward() { seekToFrame(currentFrame - 1, mode: .audibleStep) }
+    func skipForward(frames: Int = 5) { seekToFrame(currentFrame + frames, mode: .audibleStep) }
+    func skipBackward(frames: Int = 5) { seekToFrame(currentFrame - frames, mode: .audibleStep) }
 
     // MARK: - Shared infrastructure
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -326,6 +326,8 @@ final class EditorViewModel {
     /// Preview playback bridge.
     var videoEngine: VideoEngine?
 
+    let audioMeter = AudioMeterHub()
+
     @ObservationIgnored
     let playheadState = PreviewPlayheadState()
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -398,10 +398,10 @@ final class EditorViewModel {
         videoEngine?.togglePlayback()
     }
 
-    func stepForward() { seekToFrame(currentFrame + 1, mode: .audibleStep) }
-    func stepBackward() { seekToFrame(currentFrame - 1, mode: .audibleStep) }
-    func skipForward(frames: Int = 5) { seekToFrame(currentFrame + frames, mode: .audibleStep) }
-    func skipBackward(frames: Int = 5) { seekToFrame(currentFrame - frames, mode: .audibleStep) }
+    func stepForward() { seekToFrame(currentFrame + 1, mode: .audibleStepForward) }
+    func stepBackward() { seekToFrame(currentFrame - 1, mode: .audibleStepBackward) }
+    func skipForward(frames: Int = 5) { seekToFrame(currentFrame + frames, mode: .audibleStepForward) }
+    func skipBackward(frames: Int = 5) { seekToFrame(currentFrame - frames, mode: .audibleStepBackward) }
 
     // MARK: - Shared infrastructure
 

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -69,6 +69,7 @@ final class ScrubAudioEngine {
         cache = nil
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
         if resetMeter { meter.reset() }
+        if asset != nil { startEngineIfNeeded() }
     }
 
     func scrub(to time: CMTime) {
@@ -258,7 +259,8 @@ final class ScrubAudioEngine {
         return min(fadeIn, fadeOut)
     }
 
-    nonisolated private static func decodeWindow(
+    @concurrent
+    private static func decodeWindow(
         source: Source,
         startSample: Int64,
         frameCount: Int

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -38,9 +38,12 @@ final class ScrubAudioEngine {
     nonisolated private static let cacheFrameCount = 96_000
     nonisolated private static let grainFrameCount = 2_400
     nonisolated private static let fadeFrameCount = 144
+    nonisolated private static let meterFrameCount = 960
+    nonisolated private static let meterPrefetchFrameCount = 12_000
 
     private let engine = AVAudioEngine()
     private let playerNode = AVAudioPlayerNode()
+    private let meter: AudioMeterHub
     private let format = AVAudioFormat(
         commonFormat: .pcmFormatFloat32,
         sampleRate: ScrubAudioEngine.sampleRate,
@@ -52,12 +55,14 @@ final class ScrubAudioEngine {
     private var sourceGeneration = 0
     private var cache: PCMWindow?
     private var latestRequest: Request?
+    private var latestMeterSample: Int64?
     private var lastRequestedSample: Int64?
     private var lastDirection: Direction = .forward
     private var decodeTask: Task<Void, Never>?
     private var pendingDecodeRange: Range<Int64>?
 
-    init() {
+    init(meter: AudioMeterHub) {
+        self.meter = meter
         engine.attach(playerNode)
         engine.connect(playerNode, to: engine.mainMixerNode, format: format)
         engine.prepare()
@@ -68,6 +73,7 @@ final class ScrubAudioEngine {
         sourceGeneration &+= 1
         cache = nil
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
+        meter.reset()
         if asset != nil { startEngineIfNeeded() }
     }
 
@@ -85,6 +91,7 @@ final class ScrubAudioEngine {
             direction = lastDirection
         }
         lastRequestedSample = sample
+        latestMeterSample = nil
 
         let request = Request(sample: sample, direction: direction, generation: source.generation)
         latestRequest = request
@@ -95,11 +102,29 @@ final class ScrubAudioEngine {
         }
     }
 
+    func meterPlayback(at time: CMTime) {
+        guard let source, time.isValid else { return }
+        let seconds = time.seconds
+        guard seconds.isFinite else { return }
+
+        let sample = Int64((seconds * Self.sampleRate).rounded())
+        latestMeterSample = sample
+        if let cache, canMeter(sample: sample, from: cache) {
+            publishMeter(sample: sample, from: cache)
+            if sample + Int64(Self.meterPrefetchFrameCount) >= cache.endSample {
+                requestWindow(around: sample, source: source)
+            }
+        } else {
+            requestWindow(around: sample, source: source)
+        }
+    }
+
     func stopScrubbing() {
         decodeTask?.cancel()
         decodeTask = nil
         pendingDecodeRange = nil
         latestRequest = nil
+        latestMeterSample = nil
         lastRequestedSample = nil
         lastDirection = .forward
         playerNode.stop()
@@ -133,11 +158,20 @@ final class ScrubAudioEngine {
             guard source.generation == self.source?.generation, let window else { return }
             self.cache = window
 
-            guard let request = self.latestRequest, request.generation == source.generation else { return }
-            if self.canServe(sample: request.sample, from: window) {
-                self.play(request: request, from: window)
-            } else {
-                self.requestWindow(around: request.sample, source: source)
+            if let request = self.latestRequest, request.generation == source.generation {
+                if self.canServe(sample: request.sample, from: window) {
+                    self.play(request: request, from: window)
+                } else {
+                    self.requestWindow(around: request.sample, source: source)
+                }
+                return
+            }
+            if let meterSample = self.latestMeterSample {
+                if self.canMeter(sample: meterSample, from: window) {
+                    self.publishMeter(sample: meterSample, from: window)
+                } else {
+                    self.requestWindow(around: meterSample, source: source)
+                }
             }
         }
     }
@@ -146,10 +180,12 @@ final class ScrubAudioEngine {
         guard window.hasAudioTracks,
               let buffer = makeGrain(request: request, from: window)
         else {
+            meter.ingest(.silence)
             playerNode.stop()
             return
         }
 
+        meter.ingest(AudioLevelAnalyzer.analyze(buffer))
         startEngineIfNeeded()
         playerNode.scheduleBuffer(buffer, at: nil, options: .interrupts)
         if !playerNode.isPlaying { playerNode.play() }
@@ -159,6 +195,20 @@ final class ScrubAudioEngine {
         let halfGrain = Int64(Self.grainFrameCount / 2)
         let hasLeftContext = window.startSample == 0 || sample - halfGrain >= window.startSample
         return window.contains(sample) && hasLeftContext && sample + halfGrain < window.endSample
+    }
+
+    private func canMeter(sample: Int64, from window: PCMWindow) -> Bool {
+        sample >= window.startSample
+            && sample + Int64(Self.meterFrameCount) <= window.endSample
+    }
+
+    private func publishMeter(sample: Int64, from window: PCMWindow) {
+        let start = Int(sample - window.startSample)
+        let range = start..<(start + Self.meterFrameCount)
+        let analysis = window.hasAudioTracks
+            ? AudioLevelAnalyzer.analyze(left: window.left, right: window.right, range: range)
+            : .silence
+        meter.ingest(analysis)
     }
 
     private func makeGrain(request: Request, from window: PCMWindow) -> AVAudioPCMBuffer? {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -72,7 +72,7 @@ final class ScrubAudioEngine {
         if asset != nil { startEngineIfNeeded() }
     }
 
-    func scrub(to time: CMTime) {
+    func scrub(to time: CMTime, movingForward: Bool? = nil) {
         guard let source, time.isValid else { return }
         let seconds = time.seconds
         guard seconds.isFinite else { return }
@@ -80,7 +80,10 @@ final class ScrubAudioEngine {
         let sample = Int64((seconds * Self.sampleRate).rounded())
         guard sample != lastRequestedSample else { return }
         let direction: Direction
-        if let previous = lastRequestedSample {
+        if let movingForward {
+            direction = movingForward ? .forward : .reverse
+            lastDirection = direction
+        } else if let previous = lastRequestedSample {
             direction = sample > previous ? .forward : .reverse
             lastDirection = direction
         } else {
@@ -177,6 +180,7 @@ final class ScrubAudioEngine {
     }
 
     private func play(request: Request, from window: PCMWindow) {
+        latestRequest = nil
         guard window.hasAudioTracks,
               let buffer = makeGrain(request: request, from: window)
         else {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -147,7 +147,7 @@ final class ScrubAudioEngine {
     }
 
     private func requestWindow(around sample: Int64, source: Source) {
-        if let pendingDecodeRange, pendingDecodeRange.contains(sample) { return }
+        if let pendingDecodeRange, canServe(sample: sample, from: pendingDecodeRange) { return }
 
         decodeTask?.cancel()
         let halfWindow = Int64(Self.cacheFrameCount / 2)
@@ -164,7 +164,13 @@ final class ScrubAudioEngine {
             guard !Task.isCancelled, let self else { return }
             self.decodeTask = nil
             self.pendingDecodeRange = nil
-            guard source.generation == self.source?.generation, let window else { return }
+            guard source.generation == self.source?.generation else { return }
+            guard let window else {
+                if self.latestRequest?.generation == source.generation {
+                    self.lastRequestedSample = nil
+                }
+                return
+            }
             self.cache = window
 
             if let request = self.latestRequest, request.generation == source.generation {
@@ -201,9 +207,13 @@ final class ScrubAudioEngine {
     }
 
     private func canServe(sample: Int64, from window: PCMWindow) -> Bool {
+        canServe(sample: sample, from: window.startSample..<window.endSample)
+    }
+
+    private func canServe(sample: Int64, from range: Range<Int64>) -> Bool {
         let halfGrain = Int64(Self.grainFrameCount / 2)
-        let hasLeftContext = window.startSample == 0 || sample - halfGrain >= window.startSample
-        return window.contains(sample) && hasLeftContext && sample + halfGrain < window.endSample
+        let hasLeftContext = range.lowerBound == 0 || sample - halfGrain >= range.lowerBound
+        return range.contains(sample) && hasLeftContext && sample + halfGrain < range.upperBound
     }
 
     private func canMeter(sample: Int64, from window: PCMWindow) -> Bool {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -1,0 +1,300 @@
+import AVFoundation
+
+@MainActor
+final class ScrubAudioEngine {
+    private enum Direction: Sendable {
+        case forward
+        case reverse
+    }
+
+    private struct Source: @unchecked Sendable {
+        let asset: AVAsset
+        let audioMix: AVAudioMix?
+        let generation: Int
+    }
+
+    private struct Request: Sendable {
+        let sample: Int64
+        let direction: Direction
+        let generation: Int
+    }
+
+    private struct PCMWindow: Sendable {
+        let startSample: Int64
+        let left: [Float]
+        let right: [Float]
+        let hasAudioTracks: Bool
+
+        var endSample: Int64 { startSample + Int64(left.count) }
+
+        func contains(_ sample: Int64) -> Bool {
+            sample >= startSample && sample < endSample
+        }
+    }
+
+    nonisolated private static let sampleRate = 48_000.0
+    nonisolated private static let sampleTimescale: CMTimeScale = 48_000
+    nonisolated private static let channelCount: AVAudioChannelCount = 2
+    nonisolated private static let cacheFrameCount = 96_000
+    nonisolated private static let grainFrameCount = 2_400
+    nonisolated private static let fadeFrameCount = 144
+
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+    private let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: ScrubAudioEngine.sampleRate,
+        channels: ScrubAudioEngine.channelCount,
+        interleaved: false
+    )!
+
+    private var source: Source?
+    private var sourceGeneration = 0
+    private var cache: PCMWindow?
+    private var latestRequest: Request?
+    private var lastRequestedSample: Int64?
+    private var lastDirection: Direction = .forward
+    private var decodeTask: Task<Void, Never>?
+    private var pendingDecodeRange: Range<Int64>?
+
+    init() {
+        engine.attach(playerNode)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: format)
+        engine.prepare()
+    }
+
+    func configure(asset: AVAsset?, audioMix: AVAudioMix?) {
+        stopScrubbing()
+        sourceGeneration &+= 1
+        cache = nil
+        source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
+        if asset != nil { startEngineIfNeeded() }
+    }
+
+    func scrub(to time: CMTime) {
+        guard let source, time.isValid else { return }
+        let seconds = time.seconds
+        guard seconds.isFinite else { return }
+
+        let sample = Int64((seconds * Self.sampleRate).rounded())
+        let direction: Direction
+        if let previous = lastRequestedSample, sample != previous {
+            direction = sample > previous ? .forward : .reverse
+            lastDirection = direction
+        } else {
+            direction = lastDirection
+        }
+        lastRequestedSample = sample
+
+        let request = Request(sample: sample, direction: direction, generation: source.generation)
+        latestRequest = request
+        if let cache, canServe(sample: sample, from: cache) {
+            play(request: request, from: cache)
+        } else {
+            requestWindow(around: sample, source: source)
+        }
+    }
+
+    func stopScrubbing() {
+        decodeTask?.cancel()
+        decodeTask = nil
+        pendingDecodeRange = nil
+        latestRequest = nil
+        lastRequestedSample = nil
+        lastDirection = .forward
+        playerNode.stop()
+    }
+
+    func teardown() {
+        stopScrubbing()
+        source = nil
+        cache = nil
+        engine.stop()
+    }
+
+    private func requestWindow(around sample: Int64, source: Source) {
+        if let pendingDecodeRange, pendingDecodeRange.contains(sample) { return }
+
+        decodeTask?.cancel()
+        let halfWindow = Int64(Self.cacheFrameCount / 2)
+        let startSample = max(0, sample - halfWindow)
+        let range = startSample..<(startSample + Int64(Self.cacheFrameCount))
+        pendingDecodeRange = range
+
+        decodeTask = Task { [weak self] in
+            let window = await Self.decodeWindow(
+                source: source,
+                startSample: startSample,
+                frameCount: Self.cacheFrameCount
+            )
+            guard !Task.isCancelled, let self else { return }
+            self.decodeTask = nil
+            self.pendingDecodeRange = nil
+            guard source.generation == self.source?.generation, let window else { return }
+            self.cache = window
+
+            guard let request = self.latestRequest, request.generation == source.generation else { return }
+            if self.canServe(sample: request.sample, from: window) {
+                self.play(request: request, from: window)
+            } else {
+                self.requestWindow(around: request.sample, source: source)
+            }
+        }
+    }
+
+    private func play(request: Request, from window: PCMWindow) {
+        guard window.hasAudioTracks,
+              let buffer = makeGrain(request: request, from: window)
+        else {
+            playerNode.stop()
+            return
+        }
+
+        startEngineIfNeeded()
+        playerNode.scheduleBuffer(buffer, at: nil, options: .interrupts)
+        if !playerNode.isPlaying { playerNode.play() }
+    }
+
+    private func canServe(sample: Int64, from window: PCMWindow) -> Bool {
+        let halfGrain = Int64(Self.grainFrameCount / 2)
+        let hasLeftContext = window.startSample == 0 || sample - halfGrain >= window.startSample
+        return window.contains(sample) && hasLeftContext && sample + halfGrain < window.endSample
+    }
+
+    private func makeGrain(request: Request, from window: PCMWindow) -> AVAudioPCMBuffer? {
+        let frameCount = Self.grainFrameCount
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frameCount)
+        ), let channels = buffer.floatChannelData else { return nil }
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+
+        let halfGrain = Int64(frameCount / 2)
+        for outputIndex in 0..<frameCount {
+            let sourceSample: Int64 = switch request.direction {
+            case .forward:
+                request.sample - halfGrain + Int64(outputIndex)
+            case .reverse:
+                request.sample + halfGrain - 1 - Int64(outputIndex)
+            }
+            let cacheIndex = Int(sourceSample - window.startSample)
+            let gain = Self.edgeGain(at: outputIndex, frameCount: frameCount)
+            if window.left.indices.contains(cacheIndex) {
+                channels[0][outputIndex] = window.left[cacheIndex] * gain
+                channels[1][outputIndex] = window.right[cacheIndex] * gain
+            } else {
+                channels[0][outputIndex] = 0
+                channels[1][outputIndex] = 0
+            }
+        }
+        return buffer
+    }
+
+    private func startEngineIfNeeded() {
+        guard !engine.isRunning else { return }
+        do {
+            try engine.start()
+        } catch {
+            Log.preview.error("scrub audio engine failed: \(error.localizedDescription)")
+        }
+    }
+
+    private static func edgeGain(at index: Int, frameCount: Int) -> Float {
+        let fadeIn = min(1, Float(index + 1) / Float(fadeFrameCount))
+        let fadeOut = min(1, Float(frameCount - index) / Float(fadeFrameCount))
+        return min(fadeIn, fadeOut)
+    }
+
+    nonisolated private static func decodeWindow(
+        source: Source,
+        startSample: Int64,
+        frameCount: Int
+    ) async -> PCMWindow? {
+        let tracks: [AVAssetTrack]
+        do {
+            tracks = try await source.asset.loadTracks(withMediaType: .audio)
+        } catch {
+            return nil
+        }
+
+        var left = [Float](repeating: 0, count: frameCount)
+        var right = [Float](repeating: 0, count: frameCount)
+        guard !tracks.isEmpty else {
+            return PCMWindow(startSample: startSample, left: left, right: right, hasAudioTracks: false)
+        }
+
+        let reader: AVAssetReader
+        do {
+            reader = try AVAssetReader(asset: source.asset)
+        } catch {
+            return nil
+        }
+
+        let output = AVAssetReaderAudioMixOutput(audioTracks: tracks, audioSettings: [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: Int(channelCount),
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: true,
+        ])
+        output.audioMix = source.audioMix
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else { return nil }
+        reader.add(output)
+        reader.timeRange = CMTimeRange(
+            start: CMTime(value: startSample, timescale: sampleTimescale),
+            duration: CMTime(value: CMTimeValue(frameCount), timescale: sampleTimescale)
+        )
+        guard reader.startReading() else { return nil }
+
+        var runningOffset = 0
+        while let sampleBuffer = output.copyNextSampleBuffer() {
+            if Task.isCancelled {
+                reader.cancelReading()
+                return nil
+            }
+            guard let description = CMSampleBufferGetFormatDescription(sampleBuffer),
+                  let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description),
+                  let sampleFormat = AVAudioFormat(streamDescription: streamDescription)
+            else { continue }
+
+            let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
+            guard sampleCount > 0,
+                  let pcm = AVAudioPCMBuffer(
+                    pcmFormat: sampleFormat,
+                    frameCapacity: AVAudioFrameCount(sampleCount)
+                  )
+            else { continue }
+            pcm.frameLength = AVAudioFrameCount(sampleCount)
+            guard CMSampleBufferCopyPCMDataIntoAudioBufferList(
+                sampleBuffer,
+                at: 0,
+                frameCount: Int32(sampleCount),
+                into: pcm.mutableAudioBufferList
+            ) == noErr, let channels = pcm.floatChannelData else { continue }
+
+            let presentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            let destinationOffset: Int
+            if presentationTime.isValid {
+                let delta = presentationTime - CMTime(value: startSample, timescale: sampleTimescale)
+                destinationOffset = Int((delta.seconds * sampleRate).rounded())
+            } else {
+                destinationOffset = runningOffset
+            }
+
+            let sourceChannelCount = Int(sampleFormat.channelCount)
+            for sourceIndex in 0..<sampleCount {
+                let destinationIndex = destinationOffset + sourceIndex
+                guard left.indices.contains(destinationIndex) else { continue }
+                left[destinationIndex] = channels[0][sourceIndex]
+                right[destinationIndex] = channels[min(1, sourceChannelCount - 1)][sourceIndex]
+            }
+            runningOffset = max(runningOffset, destinationOffset + sampleCount)
+        }
+
+        guard reader.status != .failed else { return nil }
+        return PCMWindow(startSample: startSample, left: left, right: right, hasAudioTracks: true)
+    }
+}

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -77,14 +77,23 @@ final class ScrubAudioEngine {
         if asset != nil { startEngineIfNeeded() }
     }
 
+    func updateAudioMix(_ audioMix: AVAudioMix?) {
+        guard let source else { return }
+        stopScrubbing()
+        sourceGeneration &+= 1
+        cache = nil
+        self.source = Source(asset: source.asset, audioMix: audioMix, generation: sourceGeneration)
+    }
+
     func scrub(to time: CMTime) {
         guard let source, time.isValid else { return }
         let seconds = time.seconds
         guard seconds.isFinite else { return }
 
         let sample = Int64((seconds * Self.sampleRate).rounded())
+        guard sample != lastRequestedSample else { return }
         let direction: Direction
-        if let previous = lastRequestedSample, sample != previous {
+        if let previous = lastRequestedSample {
             direction = sample > previous ? .forward : .reverse
             lastDirection = direction
         } else {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -16,7 +16,6 @@ final class ScrubAudioEngine {
     private struct Request: Sendable {
         let sample: Int64
         let direction: Direction
-        let generation: Int
     }
 
     private struct PCMWindow: Sendable {
@@ -26,10 +25,6 @@ final class ScrubAudioEngine {
         let hasAudioTracks: Bool
 
         var endSample: Int64 { startSample + Int64(left.count) }
-
-        func contains(_ sample: Int64) -> Bool {
-            sample >= startSample && sample < endSample
-        }
     }
 
     nonisolated private static let sampleRate = 48_000.0
@@ -68,21 +63,12 @@ final class ScrubAudioEngine {
         engine.prepare()
     }
 
-    func configure(asset: AVAsset?, audioMix: AVAudioMix?) {
+    func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
         stopScrubbing()
         sourceGeneration &+= 1
         cache = nil
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
-        meter.reset()
-        if asset != nil { startEngineIfNeeded() }
-    }
-
-    func updateAudioMix(_ audioMix: AVAudioMix?) {
-        guard let source else { return }
-        stopScrubbing()
-        sourceGeneration &+= 1
-        cache = nil
-        self.source = Source(asset: source.asset, audioMix: audioMix, generation: sourceGeneration)
+        if resetMeter { meter.reset() }
     }
 
     func scrub(to time: CMTime) {
@@ -102,7 +88,7 @@ final class ScrubAudioEngine {
         lastRequestedSample = sample
         latestMeterSample = nil
 
-        let request = Request(sample: sample, direction: direction, generation: source.generation)
+        let request = Request(sample: sample, direction: direction)
         latestRequest = request
         if let cache, canServe(sample: sample, from: cache) {
             play(request: request, from: cache)
@@ -166,14 +152,12 @@ final class ScrubAudioEngine {
             self.pendingDecodeRange = nil
             guard source.generation == self.source?.generation else { return }
             guard let window else {
-                if self.latestRequest?.generation == source.generation {
-                    self.lastRequestedSample = nil
-                }
+                if self.latestRequest != nil { self.lastRequestedSample = nil }
                 return
             }
             self.cache = window
 
-            if let request = self.latestRequest, request.generation == source.generation {
+            if let request = self.latestRequest {
                 if self.canServe(sample: request.sample, from: window) {
                     self.play(request: request, from: window)
                 } else {
@@ -279,12 +263,7 @@ final class ScrubAudioEngine {
         startSample: Int64,
         frameCount: Int
     ) async -> PCMWindow? {
-        let tracks: [AVAssetTrack]
-        do {
-            tracks = try await source.asset.loadTracks(withMediaType: .audio)
-        } catch {
-            return nil
-        }
+        guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio) else { return nil }
 
         var left = [Float](repeating: 0, count: frameCount)
         var right = [Float](repeating: 0, count: frameCount)
@@ -292,12 +271,7 @@ final class ScrubAudioEngine {
             return PCMWindow(startSample: startSample, left: left, right: right, hasAudioTracks: false)
         }
 
-        let reader: AVAssetReader
-        do {
-            reader = try AVAssetReader(asset: source.asset)
-        } catch {
-            return nil
-        }
+        guard let reader = try? AVAssetReader(asset: source.asset) else { return nil }
 
         let output = AVAssetReaderAudioMixOutput(audioTracks: tracks, audioSettings: [
             AVFormatIDKey: kAudioFormatLinearPCM,

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -5,6 +5,7 @@ import CoreImage
 enum PreviewSeekMode: String {
     case exact
     case interactiveScrub
+    case audibleStep
 }
 
 @MainActor
@@ -89,6 +90,10 @@ final class VideoEngine {
         case .interactiveScrub:
             scrubAudioEngine.scrub(to: time)
             enqueueInteractiveSeek(time: time, tolerance: tolerance)
+        case .audibleStep:
+            scrubAudioEngine.scrub(to: time)
+            cancelInteractiveSeek()
+            performSeek(time: time, tolerance: tolerance)
         }
     }
 

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -5,7 +5,8 @@ import CoreImage
 enum PreviewSeekMode: String {
     case exact
     case interactiveScrub
-    case audibleStep
+    case audibleStepForward
+    case audibleStepBackward
 }
 
 @MainActor
@@ -90,8 +91,9 @@ final class VideoEngine {
         case .interactiveScrub:
             scrubAudioEngine.scrub(to: time)
             enqueueInteractiveSeek(time: time, tolerance: tolerance)
-        case .audibleStep:
-            scrubAudioEngine.scrub(to: time)
+        case .audibleStepForward, .audibleStepBackward:
+            if editor.isPlaying { pause() }
+            scrubAudioEngine.scrub(to: time, movingForward: mode == .audibleStepForward)
             cancelInteractiveSeek()
             performSeek(time: time, tolerance: tolerance)
         }

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -10,7 +10,7 @@ enum PreviewSeekMode: String {
 @MainActor
 final class VideoEngine {
     private(set) var player = AVPlayer()
-    private let scrubAudioEngine = ScrubAudioEngine()
+    private let scrubAudioEngine: ScrubAudioEngine
 
     weak var previewView: PreviewNSView?
 
@@ -31,6 +31,7 @@ final class VideoEngine {
 
     init(editor: EditorViewModel) {
         self.editor = editor
+        scrubAudioEngine = ScrubAudioEngine(meter: editor.audioMeter)
         setupTimeObserver()
     }
 
@@ -427,6 +428,7 @@ final class VideoEngine {
             MainActor.assumeIsolated {
                 guard let self, let editor = self.editor else { return }
                 guard editor.isPlaying, !editor.isScrubbing else { return }
+                self.scrubAudioEngine.meterPlayback(at: time)
 
                 let frame = secondsToFrame(seconds: time.seconds, fps: editor.timeline.fps)
                 let duration = editor.activePreviewDurationFrames

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -10,6 +10,7 @@ enum PreviewSeekMode: String {
 @MainActor
 final class VideoEngine {
     private(set) var player = AVPlayer()
+    private let scrubAudioEngine = ScrubAudioEngine()
 
     weak var previewView: PreviewNSView?
 
@@ -38,6 +39,7 @@ final class VideoEngine {
         rebuildTask = nil
         compositionCache.removeAll()
         invalidateSeekState()
+        scrubAudioEngine.teardown()
         if let timeObserver { player.removeTimeObserver(timeObserver) }
         timeObserver = nil
     }
@@ -46,6 +48,7 @@ final class VideoEngine {
 
     func play() {
         guard let editor else { return }
+        scrubAudioEngine.stopScrubbing()
         editor.isPlaying = true
         guard rebuildTask == nil else { return }
         let frame = playbackStartFrame(for: editor)
@@ -54,11 +57,13 @@ final class VideoEngine {
     }
 
     func pause() {
+        scrubAudioEngine.stopScrubbing()
         editor?.isPlaying = false
         player.pause()
     }
 
     func resumePlayback() {
+        scrubAudioEngine.stopScrubbing()
         editor?.isPlaying = true
         player.play()
     }
@@ -77,9 +82,11 @@ final class VideoEngine {
 
         switch mode {
         case .exact:
+            scrubAudioEngine.stopScrubbing()
             cancelInteractiveSeek()
             performSeek(time: time, tolerance: tolerance)
         case .interactiveScrub:
+            scrubAudioEngine.scrub(to: time)
             enqueueInteractiveSeek(time: time, tolerance: tolerance)
         }
     }
@@ -126,6 +133,7 @@ final class VideoEngine {
 
     private func replacePlayerItem(_ item: AVPlayerItem?, reason: String) {
         invalidateSeekState()
+        scrubAudioEngine.configure(asset: item?.asset, audioMix: item?.audioMix)
         player.replaceCurrentItem(with: item)
         Log.preview.debug("seek state invalidated reason=\(reason)")
     }
@@ -241,6 +249,7 @@ final class VideoEngine {
         )
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
+        scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix)
     }
 
     // MARK: - Scopes

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -250,7 +250,7 @@ final class VideoEngine {
         )
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
-        scrubAudioEngine.updateAudioMix(audioMix)
+        scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix, resetMeter: false)
         if editor.isPlaying {
             scrubAudioEngine.meterPlayback(at: player.currentTime())
         }

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -250,7 +250,10 @@ final class VideoEngine {
         )
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
-        scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix)
+        scrubAudioEngine.updateAudioMix(audioMix)
+        if editor.isPlaying {
+            scrubAudioEngine.meterPlayback(at: player.currentTime())
+        }
     }
 
     // MARK: - Scopes

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -89,7 +89,7 @@ enum AppTheme {
         static let refreshInterval: Double = 1.0 / 30.0
         static let rulerStepDb: Float = 6
         static let rulerMajorStepDb: Float = 12
-        static let yellowThresholdDb: Float = -12
+        static let yellowThresholdDb: Float = -20
         static let redThresholdDb: Float = -6
 
         static let greenSegment = Color(red: 0.08, green: 0.78, blue: 0.22)

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -83,6 +83,27 @@ enum AppTheme {
         static let lumaGradient = [Color(white: 0.05), Color(white: 0.95)]
     }
 
+    enum AudioMeter {
+        static let panelWidth: CGFloat = 32
+        static let barWidth: CGFloat = 8
+        static let scaleGap: CGFloat = 2
+        static let verticalPadding: CGFloat = 6
+        static let segmentHeight: CGFloat = 1
+        static let segmentGap: CGFloat = 1
+        static let peakLineHeight: CGFloat = 1
+        static let minorTickWidth: CGFloat = 2
+        static let majorTickWidth: CGFloat = 4
+        static let refreshInterval: Double = 1.0 / 30.0
+        static let rulerStepDb: Float = 6
+        static let rulerMajorStepDb: Float = 12
+        static let yellowThresholdDb: Float = -12
+        static let redThresholdDb: Float = -6
+
+        static let greenSegment = Color(red: 0.08, green: 0.78, blue: 0.22)
+        static let yellowSegment = Color(red: 0.98, green: 0.84, blue: 0.10)
+        static let redSegment = Color(red: 0.90, green: 0.24, blue: 0.20)
+    }
+
     // MARK: - Color wheels
 
     enum Wheels {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -86,13 +86,6 @@ enum AppTheme {
     enum AudioMeter {
         static let panelWidth: CGFloat = 32
         static let barWidth: CGFloat = 8
-        static let scaleGap: CGFloat = 2
-        static let verticalPadding: CGFloat = 6
-        static let segmentHeight: CGFloat = 1
-        static let segmentGap: CGFloat = 1
-        static let peakLineHeight: CGFloat = 1
-        static let minorTickWidth: CGFloat = 2
-        static let majorTickWidth: CGFloat = 4
         static let refreshInterval: Double = 1.0 / 30.0
         static let rulerStepDb: Float = 6
         static let rulerMajorStepDb: Float = 12

--- a/Tests/PalmierProTests/Audio/AudioMeterTests.swift
+++ b/Tests/PalmierProTests/Audio/AudioMeterTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Audio meter")
+struct AudioMeterTests {
+    @Test func analyzesStereoAndClampsRanges() {
+        let analysis = AudioLevelAnalyzer.analyze(
+            left: [0, -0.5, 0.25, -1],
+            right: [0.25, -0.25, 0.25, -0.25],
+            range: -4..<20
+        )
+        let empty = AudioLevelAnalyzer.analyze(left: [], right: [], range: 0..<1)
+
+        #expect(abs(analysis.left.peak - 1) < 0.0001)
+        #expect(abs(analysis.left.rms - 0.57282) < 0.0001)
+        #expect(abs(analysis.right.peak - 0.25) < 0.0001)
+        #expect(abs(analysis.right.rms - 0.25) < 0.0001)
+        #expect(empty == .silence)
+    }
+
+    @Test func holdsPeakAndDecaysLevel() {
+        var state = AudioMeterChannelState()
+        state.ingest(rms: 0.25, peak: 0.5, at: 10)
+        let initial = state.display(at: 10)
+        let afterOneSecond = state.display(at: 11)
+        let afterTwoSeconds = state.display(at: 12)
+
+        #expect(abs(initial.levelDb - -12.0412) < 0.001)
+        #expect(abs(initial.peakDb - -6.0206) < 0.001)
+        #expect(abs(afterOneSecond.levelDb - -36.0412) < 0.001)
+        #expect(abs(afterOneSecond.peakDb - initial.peakDb) < 0.001)
+        #expect(abs(afterTwoSeconds.peakDb - -15.0206) < 0.001)
+    }
+
+    @Test func latchesClippingUntilReset() {
+        var state = AudioMeterChannelState()
+        state.ingest(rms: 0.5, peak: 1.01, at: 0)
+        state.ingest(rms: 0, peak: 0, at: 3)
+        #expect(state.display(at: 3).clipped)
+        state.resetClipping()
+        #expect(!state.display(at: 3).clipped)
+    }
+}

--- a/Tests/PalmierProTests/Audio/AudioMeterTests.swift
+++ b/Tests/PalmierProTests/Audio/AudioMeterTests.swift
@@ -11,31 +11,29 @@ struct AudioMeterTests {
         )
         let empty = AudioLevelAnalyzer.analyze(left: [], right: [], range: 0..<1)
 
-        #expect(abs(analysis.left.peak - 1) < 0.0001)
-        #expect(abs(analysis.left.rms - 0.57282) < 0.0001)
-        #expect(abs(analysis.right.peak - 0.25) < 0.0001)
-        #expect(abs(analysis.right.rms - 0.25) < 0.0001)
+        #expect(abs(analysis.leftPeak - 1) < 0.0001)
+        #expect(abs(analysis.rightPeak - 0.25) < 0.0001)
         #expect(empty == .silence)
     }
 
     @Test func holdsPeakAndDecaysLevel() {
         var state = AudioMeterChannelState()
-        state.ingest(rms: 0.25, peak: 0.5, at: 10)
+        state.ingest(peak: 0.5, at: 10)
         let initial = state.display(at: 10)
         let afterOneSecond = state.display(at: 11)
         let afterTwoSeconds = state.display(at: 12)
 
-        #expect(abs(initial.levelDb - -12.0412) < 0.001)
+        #expect(abs(initial.levelDb - -6.0206) < 0.001)
         #expect(abs(initial.peakDb - -6.0206) < 0.001)
-        #expect(abs(afterOneSecond.levelDb - -36.0412) < 0.001)
+        #expect(abs(afterOneSecond.levelDb - -30.0206) < 0.001)
         #expect(abs(afterOneSecond.peakDb - initial.peakDb) < 0.001)
         #expect(abs(afterTwoSeconds.peakDb - -15.0206) < 0.001)
     }
 
     @Test func latchesClippingUntilReset() {
         var state = AudioMeterChannelState()
-        state.ingest(rms: 0.5, peak: 1.01, at: 0)
-        state.ingest(rms: 0, peak: 0, at: 3)
+        state.ingest(peak: 1.01, at: 0)
+        state.ingest(peak: 0, at: 3)
         #expect(state.display(at: 3).clipped)
         state.resetClipping()
         #expect(!state.display(at: 3).clipped)


### PR DESCRIPTION
## Summary

- add responsive audio feedback while scrubbing the timeline
- cache and play short direction-aware audio grains through AVAudioEngine
- add a compact stereo dBFS meter beside the timeline for scrubbing and playback
- show fixed green, yellow, and red level ranges with peak hold and clipping reset
<img width="1458" height="484" alt="Screenshot 2026-07-10 at 4 03 05 PM" src="https://github.com/user-attachments/assets/9c8fa414-7195-4191-b3e8-2eb53f8a75f4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core preview seek/playback and runs async PCM decode plus a second audio engine alongside AVPlayer; regressions could affect scrubbing feel or audio during edit, but scope is localized to preview.
> 
> **Overview**
> Adds **audible timeline scrubbing** and a **compact stereo dBFS meter** next to the timeline, wired through preview playback and seek paths.
> 
> **Scrub audio:** New `ScrubAudioEngine` decodes cached PCM windows from the current composition (with `audioMix`), plays short direction-aware grains via `AVAudioEngine`, and feeds level analysis. `VideoEngine` routes **interactive scrub** and new **audible step** seek modes (`audibleStepForward` / `audibleStepBackward`); frame step/skip in `EditorViewModel` now use those modes so stepping plays a brief audio cue while still seeking the player.
> 
> **Meter UI:** `AudioMeterHub` / `AudioLevelAnalyzer` hold peak, decay, and clipping state; `AudioMeterView` draws green/yellow/red segments, peak lines, and a dB ruler (tap to reset clipping). `AppTheme.AudioMeter` defines sizing and thresholds. During playback, the periodic time observer drives `meterPlayback` so levels update without scrub grains.
> 
> **Layout:** Timeline panel is an `HStack` of `TimelineContainerView` + `AudioMeterView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd6e857a397ab1843f3e3ce7c21e92d80b64425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->