### PR TITLE
fix: allow 65-point .cube LUTs

### DIFF
--- a/Sources/PalmierPro/Compositing/LUTLoader.swift
+++ b/Sources/PalmierPro/Compositing/LUTLoader.swift
@@ -87,7 +87,7 @@ enum LUTLoader {
             }
         }
 
-        guard dimension > 1, dimension <= 64,
+        guard dimension > 1, dimension <= 128,
               values.count == dimension * dimension * dimension * 3,
               domainMin.count == 3, domainMax.count == 3 else { return nil }
 

--- a/Tests/PalmierProTests/Rendering/LUTLoaderTests.swift
+++ b/Tests/PalmierProTests/Rendering/LUTLoaderTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("LUTLoader")
+struct LUTLoaderTests {
+
+    private func cubeText(size n: Int) -> String {
+        var lines = ["LUT_3D_SIZE \(n)"]
+        for b in 0..<n {
+            for g in 0..<n {
+                for r in 0..<n {
+                    let v = Double(r) / Double(n - 1)
+                    let vg = Double(g) / Double(n - 1)
+                    let vb = Double(b) / Double(n - 1)
+                    lines.append("\(v) \(vg) \(vb)")
+                }
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    @Test func parses33PointCube() {
+        let lut = LUTLoader.parse(cubeText(size: 33))
+        #expect(lut?.dimension == 33)
+    }
+
+    @Test func parses65PointCube() {
+        let lut = LUTLoader.parse(cubeText(size: 65))
+        #expect(lut?.dimension == 65)
+        #expect(lut?.data.count == 65 * 65 * 65 * 4 * MemoryLayout<Float>.size)
+    }
+
+    @Test func rejects1DLUT() {
+        #expect(LUTLoader.parse("LUT_1D_SIZE 16\n0 0 0") == nil)
+    }
+}


### PR DESCRIPTION
Closes #295

## Problem

A 65³ `.cube` 3D LUT silently fails to apply, while an identical 33³ LUT works. `LUTLoader.parse` capped the cube dimension at 64, so a 65-point LUT (a common Resolve export size — it exports 33 and 65 by default) tripped the guard, `parse` returned `nil`, and the LUT was rejected as invalid.

## Fix

The 64 limit was a holdover from Core Image's `CIColorCube` (`inputCubeDimension` max 64). This path doesn't use `CIColorCube` — it uploads the LUT as an `RGBAf` strip image into the custom `LUTTetraKernel` Metal kernel, which has no such constraint. Raised the cap to 128 to cover realistic LUT sizes with headroom.

## Test

Added `LUTLoaderTests` covering 33-point (passes before and after), 65-point (fails before, passes after), and 1D-LUT rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single validation constant change plus unit tests; larger LUTs may use more memory at apply time but follow the existing Metal LUT path.
> 
> **Overview**
> **Raises the maximum supported 3D LUT cube size** in `LUTLoader.parse` from **64 to 128**, so common exports (e.g. **65³** from DaVinci Resolve) are accepted instead of returning `nil` and skipping the effect.
> 
> Adds **`LUTLoaderTests`** with synthetic `.cube` text: **33** and **65** point cubes parse successfully (including expected RGBA float buffer size for 65), and **1D** LUTs still reject.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d818cc414cd6232e27275a325c15e3f45a21be22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->