### PR TITLE
[analytics] track tools called

### DIFF
--- a/Sources/PalmierPro/Agent/MCP/MCPService.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPService.swift
@@ -92,7 +92,7 @@ final class MCPService {
     // Convert args on the main actor so the non-Sendable dict never crosses the hop.
     private static func dispatchCall(_ params: CallTool.Parameters, executor: ToolExecutor) async -> CallTool.Result {
         let args = ToolArgsBridge.argsFromMCP(params.arguments ?? [:])
-        let result = await executor.execute(name: params.name, args: args)
+        let result = await executor.execute(name: params.name, args: args, source: "mcp")
         return result.toMCPResult()
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -21,24 +21,50 @@ final class ToolExecutor {
     var feedbackState = FeedbackState()
     var lastTranscriptContext: TranscriptionToolContext?
 
-    func execute(name: String, args: [String: Any]) async -> ToolResult {
+    func execute(name: String, args: [String: Any], source: String = "agent") async -> ToolResult {
+        let started = ContinuousClock.now
         guard let tool = ToolName(rawValue: name) else {
+            captureToolAnalytics(
+                toolName: name,
+                source: source,
+                projectId: editor?.projectId,
+                status: "failed",
+                started: started,
+                failureReason: "unknown_tool"
+            )
             return .error("Unknown tool: \(name)")
         }
 
         // project tools act on AppState before editor is available
         switch tool {
         case .getProjects, .openProject, .newProject, .closeProject:
-            return await runProjectTool(tool, args)
+            let result = await runProjectTool(tool, args)
+            captureToolAnalytics(
+                toolName: tool.rawValue,
+                source: source,
+                projectId: editor?.projectId,
+                status: result.isError ? "failed" : "finished",
+                started: started
+            )
+            return result
         default:
             break
         }
 
-        guard let editor else { return .error("Editor not available") }
+        guard let editor else {
+            captureToolAnalytics(
+                toolName: tool.rawValue,
+                source: source,
+                projectId: nil,
+                status: "failed",
+                started: started,
+                failureReason: "editor_unavailable"
+            )
+            return .error("Editor not available")
+        }
         let before = editor.timelines
         let idsBefore = currentIdUniverse(editor)
         let result: ToolResult
-        let started = ContinuousClock.now
         Log.agent.notice(
             "tool start name=\(tool.rawValue)",
             telemetry: "Agent tool started",
@@ -77,8 +103,48 @@ final class ToolExecutor {
                 data: payload
             )
         }
+        captureToolAnalytics(
+            toolName: tool.rawValue,
+            source: source,
+            projectId: editor.projectId,
+            status: result.isError ? "failed" : "finished",
+            started: started,
+            timelineChanged: editor.timelines != before
+        )
         // Shorten on pre ∪ post ids: new ids and just-removed ids both stay short.
         return await shorteningIds(in: result, editor: editor, alsoKnown: idsBefore)
+    }
+
+    private func captureToolAnalytics(
+        toolName: String,
+        source: String,
+        projectId: String?,
+        status: String,
+        started: ContinuousClock.Instant? = nil,
+        timelineChanged: Bool? = nil,
+        failureReason: String? = nil
+    ) {
+        var payload: [String: Any] = [
+            "tool_name": toolName,
+            "source": source,
+            "project_id": projectId ?? "unknown",
+            "status": status,
+        ]
+        if let started {
+            payload["tool_duration_seconds"] = durationSeconds(since: started)
+        }
+        if let timelineChanged {
+            payload["timeline_changed"] = timelineChanged
+        }
+        if let failureReason {
+            payload["failure_reason"] = failureReason
+        }
+        Analytics.capture(.agentToolCalled, properties: payload)
+    }
+
+    private func durationSeconds(since started: ContinuousClock.Instant) -> Double {
+        let duration = started.duration(to: .now)
+        return Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
     }
 
     private func run(_ tool: ToolName, _ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -13,6 +13,7 @@ enum Analytics {
         case exportFinished = "export finished"
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
+        case agentToolCalled = "agent tool called"
         case mcpSessionStarted = "mcp session started"
     }
 
@@ -113,6 +114,7 @@ enum Analytics {
             Event.exportFinished.rawValue,
             Event.exportFailed.rawValue,
             Event.agentSessionStarted.rawValue,
+            Event.agentToolCalled.rawValue,
             Event.mcpSessionStarted.rawValue,
             "$identify",
         ])
@@ -169,12 +171,17 @@ enum Analytics {
         Set([
             "active_day",
             "export_duration_seconds",
+            "failure_reason",
             "format",
             "mode",
             "model",
             "project_id",
             "resolution",
             "source",
+            "status",
+            "timeline_changed",
+            "tool_name",
+            "tool_duration_seconds",
         ])
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Telemetry-only changes on existing tool paths; no behavior change beyond analytics capture when enabled.
> 
> **Overview**
> Adds PostHog **`agent tool called`** events whenever `ToolExecutor` runs a tool, for both the in-app agent (default `source: "agent"`) and MCP (`source: "mcp"`).
> 
> Each capture includes **`tool_name`**, **`status`** (`finished` / `failed`), **`tool_duration_seconds`**, optional **`timeline_changed`**, and **`failure_reason`** on early failures (unknown tool, editor unavailable). Project-navigation tools and the main editor path are covered on every return path.
> 
> `Analytics` registers the new event and allowlists the related property keys so they pass the existing `beforeSend` filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 039b1fec48d2d3fa960b124eebff6a48a967ce50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->