### PR TITLE
Slip Edit in UI

### DIFF
--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -129,6 +129,13 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             }
             return false
 
+        case 17: // T key
+            if !cmd {
+                editorViewModel.toolMode = .trim
+                return true
+            }
+            return false
+
         case 34: // I key
             if rangeMarkShortcut {
                 editorViewModel.markTimelineRangeStart()

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -195,6 +195,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
                 editorViewModel.maximizedPanel = nil
                 return true
             }
+            editorViewModel.slipPreview = nil
             editorViewModel.selectedClipIds.removeAll()
             editorViewModel.clearTimelineRange()
             editorViewModel.toolMode = .pointer

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -195,6 +195,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
                 editorViewModel.maximizedPanel = nil
                 return true
             }
+            editorViewModel.onCancelTimelineDrag?()
             editorViewModel.slipPreview = nil
             editorViewModel.selectedClipIds.removeAll()
             editorViewModel.clearTimelineRange()

--- a/Sources/PalmierPro/Editor/ToolMode.swift
+++ b/Sources/PalmierPro/Editor/ToolMode.swift
@@ -2,4 +2,5 @@
 enum ToolMode: CaseIterable {
     case pointer  // V key — default selection/move/trim
     case razor    // C key — click to split clips
+    case trim     // T key — drag clip body to slip source in/out; edges trim as usual
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -195,18 +195,27 @@ extension EditorViewModel {
 
     /// Slip: shift which source range plays without moving the clip on the timeline.
     /// Positive delta (drag right) reveals earlier material: trimStart -= d, trimEnd += d.
+    /// A clip's trim can be slipped only if it has bounded source material and isn't part of a multicam group.
+    func isSlipEligible(_ clip: Clip) -> Bool {
+        clip.mediaType != .image && clip.mediaType != .text && clip.multicamGroupId == nil
+    }
+
+    /// Linked partners of `clipId` whose trim should slip along with it — the same
+    /// eligibility filter `commitSlip` applies, so live preview and commit agree.
+    func slipPropagationPartnerIds(of clipId: String) -> [String] {
+        linkedPartnerIds(of: clipId).filter { clipFor(id: $0).map(isSlipEligible) ?? false }
+    }
+
     func commitSlip(clipId: String, deltaFrames: Int, propagateToLinked: Bool) {
         guard let loc = findClip(id: clipId) else { return }
         let lead = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
         var targets = [lead]
         if propagateToLinked {
-            targets += linkedPartnerIds(of: clipId).compactMap { pid in
+            targets += slipPropagationPartnerIds(of: clipId).compactMap { pid in
                 findClip(id: pid).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] }
             }
         }
-        targets = targets.filter {
-            $0.mediaType != .image && $0.mediaType != .text && $0.multicamGroupId == nil
-        }
+        targets = targets.filter(isSlipEligible)
         guard !targets.isEmpty else { return }
 
         // Clamp the shared timeline delta to the tightest headroom in the group.

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -227,11 +227,18 @@ extension EditorViewModel {
         }
         guard delta != 0 else { return }
 
+        // Per-clip source shift, clamped to each clip's live trim headroom (nested
+        // tail room, not stale trimEndFrame) so rounding through speed never drives a
+        // trim negative. Slow-motion clips can round a non-zero delta to zero here.
+        func appliedSourceDelta(for c: Clip) -> Int {
+            let sourceDelta = Int((Double(delta) * c.speed).rounded())
+            return max(-effectiveTrimEnd(for: c), min(c.trimStartFrame, sourceDelta))
+        }
+        guard targets.contains(where: { appliedSourceDelta(for: $0) != 0 }) else { return }
+
         mutateClips(ids: Set(targets.map(\.id)),
                     actionName: targets.count == 1 ? "Slip Clip" : "Slip Clips") { c in
-            let sourceDelta = Int((Double(delta) * c.speed).rounded())
-            // Lockstep clamp so rounding through speed never drives a trim negative.
-            let applied = max(-c.trimEndFrame, min(c.trimStartFrame, sourceDelta))
+            let applied = appliedSourceDelta(for: c)
             c.trimStartFrame -= applied
             c.trimEndFrame += applied
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -185,6 +185,49 @@ extension EditorViewModel {
         trimClips(edits)
     }
 
+    /// Nest trim limits come from the child's live length, not creation time.
+    func effectiveTrimEnd(for clip: Clip) -> Int {
+        guard clip.sourceClipType == .sequence, let child = timeline(for: clip.mediaRef) else {
+            return clip.trimEndFrame
+        }
+        return max(0, child.totalFrames - clip.trimStartFrame - clip.durationFrames)
+    }
+
+    /// Slip: shift which source range plays without moving the clip on the timeline.
+    /// Positive delta (drag right) reveals earlier material: trimStart -= d, trimEnd += d.
+    func commitSlip(clipId: String, deltaFrames: Int, propagateToLinked: Bool) {
+        guard let loc = findClip(id: clipId) else { return }
+        let lead = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        var targets = [lead]
+        if propagateToLinked {
+            targets += linkedPartnerIds(of: clipId).compactMap { pid in
+                findClip(id: pid).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] }
+            }
+        }
+        targets = targets.filter {
+            $0.mediaType != .image && $0.mediaType != .text && $0.multicamGroupId == nil
+        }
+        guard !targets.isEmpty else { return }
+
+        // Clamp the shared timeline delta to the tightest headroom in the group.
+        var delta = deltaFrames
+        for t in targets {
+            let speed = max(t.speed, 0.001)
+            delta = min(delta, Int((Double(t.trimStartFrame) / speed).rounded(.down)))
+            delta = max(delta, -Int((Double(effectiveTrimEnd(for: t)) / speed).rounded(.down)))
+        }
+        guard delta != 0 else { return }
+
+        mutateClips(ids: Set(targets.map(\.id)),
+                    actionName: targets.count == 1 ? "Slip Clip" : "Slip Clips") { c in
+            let sourceDelta = Int((Double(delta) * c.speed).rounded())
+            // Lockstep clamp so rounding through speed never drives a trim negative.
+            let applied = max(-c.trimEndFrame, min(c.trimStartFrame, sourceDelta))
+            c.trimStartFrame -= applied
+            c.trimEndFrame += applied
+        }
+    }
+
     func trimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int) {
         let sourceDelta = Int((Double(delta) * clip.speed).rounded())
         // Image/Text clips have no source-material bound, so their trim fields can go negative

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -131,6 +131,8 @@ final class EditorViewModel {
     var pendingReplacements: Set<String> = []
     var cropEditingActive: Bool = false
     var chromaKeySamplingClipId: String?
+    /// Two-up in/out frames shown in the viewer while a slip drag is active.
+    var slipPreview: SlipPreviewState?
     var cropAspectLock: CropAspectLock = .free
     var previewTabs: [PreviewTab] = [.timeline]
     var activePreviewTabId: String = PreviewTab.timeline.id

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -297,6 +297,7 @@ final class EditorViewModel {
     @ObservationIgnored let undo = EditorUndo()
     @ObservationIgnored let projectPackageCoordinator = ProjectPackageCoordinator()
     @ObservationIgnored var onProjectCheckpointRequired: (() -> Void)?
+    @ObservationIgnored var onCancelTimelineDrag: (() -> Void)?
     var isDocumentEdited: Bool = false
 
     func telemetrySnapshot() -> [String: Any] {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -45,6 +45,9 @@ struct PreviewContainerView: View {
                     } else {
                         TransformOverlayView()
                     }
+                    if let slip = editor.slipPreview, isTimeline {
+                        SlipTwoUpView(state: slip)
+                    }
                 }
                 .frame(width: scaledWidth, height: scaledHeight)
                 .simultaneousGesture(

--- a/Sources/PalmierPro/Preview/SlipTwoUpView.swift
+++ b/Sources/PalmierPro/Preview/SlipTwoUpView.swift
@@ -16,6 +16,8 @@ struct SlipTwoUpView: View {
     @State private var loader = SlipFrameLoader()
     @State private var inImage: CGImage?
     @State private var outImage: CGImage?
+    @State private var pendingState: SlipPreviewState?
+    @State private var loaderTask: Task<Void, Never>?
 
     var body: some View {
         ZStack {
@@ -25,16 +27,42 @@ struct SlipTwoUpView: View {
                 pane(image: outImage, label: "End", frame: state.outSourceFrame)
             }
         }
-        .task(id: state) {
-            loader.prepare(url: state.url, fps: state.fps)
-            async let start = loader.frame(at: state.inSourceFrame)
-            async let end = loader.frame(at: state.outSourceFrame)
-            let (i, o) = await (start, end)
-            // Keep the previous frame while the next decode is in flight.
-            if let i { inImage = i }
-            if let o { outImage = o }
+        .onAppear {
+            enqueue(state)
+        }
+        .onChange(of: state) { _, newState in
+            enqueue(newState)
+        }
+        .onDisappear {
+            loaderTask?.cancel()
+            loaderTask = nil
+            pendingState = nil
         }
         .allowsHitTesting(false)
+    }
+
+    private func enqueue(_ state: SlipPreviewState) {
+        pendingState = state
+        guard loaderTask == nil else { return }
+        loaderTask = Task { @MainActor in
+            while let state = pendingState {
+                pendingState = nil
+                await load(state)
+                try? await Task.sleep(for: AppTheme.Anim.slipPreviewRefresh)
+                guard !Task.isCancelled else { break }
+            }
+            loaderTask = nil
+        }
+    }
+
+    private func load(_ state: SlipPreviewState) async {
+        loader.prepare(url: state.url, fps: state.fps)
+        async let start = loader.frame(at: state.inSourceFrame)
+        async let end = loader.frame(at: state.outSourceFrame)
+        let (i, o) = await (start, end)
+        guard !Task.isCancelled else { return }
+        if let i { inImage = i }
+        if let o { outImage = o }
     }
 
     private func pane(image: CGImage?, label: String, frame: Int) -> some View {

--- a/Sources/PalmierPro/Preview/SlipTwoUpView.swift
+++ b/Sources/PalmierPro/Preview/SlipTwoUpView.swift
@@ -13,7 +13,6 @@ struct SlipPreviewState: Equatable {
 struct SlipTwoUpView: View {
     let state: SlipPreviewState
 
-    @State private var loader = SlipFrameLoader()
     @State private var inImage: CGImage?
     @State private var outImage: CGImage?
     @State private var pendingState: SlipPreviewState?
@@ -56,13 +55,15 @@ struct SlipTwoUpView: View {
     }
 
     private func load(_ state: SlipPreviewState) async {
-        loader.prepare(url: state.url, fps: state.fps)
-        async let start = loader.frame(at: state.inSourceFrame)
-        async let end = loader.frame(at: state.outSourceFrame)
-        let (i, o) = await (start, end)
+        let (start, end) = await SlipFrameLoader.frames(
+            inSourceFrame: state.inSourceFrame,
+            outSourceFrame: state.outSourceFrame,
+            url: state.url,
+            fps: state.fps
+        )
         guard !Task.isCancelled else { return }
-        if let i { inImage = i }
-        if let o { outImage = o }
+        if let start { inImage = start }
+        if let end { outImage = end }
     }
 
     private func pane(image: CGImage?, label: String, frame: Int) -> some View {
@@ -91,28 +92,27 @@ struct SlipTwoUpView: View {
     }
 }
 
-@MainActor
-private final class SlipFrameLoader {
-    private var url: URL?
-    private var fps: Int = 30
-    private var asset: AVURLAsset?
-
-    func prepare(url: URL, fps: Int) {
-        guard url != self.url || fps != self.fps else { return }
-        self.url = url
-        self.fps = fps
-        asset = AVURLAsset(url: url)
-    }
-
-    func frame(at sourceFrame: Int) async -> CGImage? {
-        guard let asset, fps > 0 else { return nil }
-        // Fresh generator per request: AVAssetImageGenerator isn't Sendable, a local stays region-isolated.
-        let generator = AVAssetImageGenerator(asset: asset)
+/// Decodes the slip two-up preview frames. Nonisolated so the AVFoundation setup and decode
+/// run on the cooperative pool, never the UI executor, and both frames come from a single
+/// generator per refresh.
+private enum SlipFrameLoader {
+    static func frames(inSourceFrame: Int, outSourceFrame: Int, url: URL, fps: Int) async -> (start: CGImage?, end: CGImage?) {
+        guard fps > 0 else { return (nil, nil) }
+        let timescale = CMTimeScale(fps)
+        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
         generator.appliesPreferredTrackTransform = true
         generator.maximumSize = CGSize(width: 960, height: 960)
         generator.requestedTimeToleranceBefore = .zero
-        generator.requestedTimeToleranceAfter = CMTime(value: 1, timescale: CMTimeScale(fps))
-        let time = CMTime(value: CMTimeValue(max(0, sourceFrame)), timescale: CMTimeScale(fps))
-        return try? await generator.image(at: time).image
+        generator.requestedTimeToleranceAfter = CMTime(value: 1, timescale: timescale)
+        let inTime = CMTime(value: CMTimeValue(max(0, inSourceFrame)), timescale: timescale)
+        let outTime = CMTime(value: CMTimeValue(max(0, outSourceFrame)), timescale: timescale)
+        var start: CGImage?
+        var end: CGImage?
+        for await result in generator.images(for: [inTime, outTime]) {
+            guard case let .success(requestedTime, image, _) = result else { continue }
+            if CMTimeCompare(requestedTime, inTime) == 0 { start = image }
+            if CMTimeCompare(requestedTime, outTime) == 0 { end = image }
+        }
+        return (start, end)
     }
 }

--- a/Sources/PalmierPro/Preview/SlipTwoUpView.swift
+++ b/Sources/PalmierPro/Preview/SlipTwoUpView.swift
@@ -1,0 +1,90 @@
+import AVFoundation
+import SwiftUI
+
+/// Viewer two-up state published while a slip drag is active.
+struct SlipPreviewState: Equatable {
+    let url: URL
+    let inSourceFrame: Int
+    let outSourceFrame: Int
+    let fps: Int
+}
+
+/// FCP-style two-up: the slipped clip's new first and last frame, updating live during the drag.
+struct SlipTwoUpView: View {
+    let state: SlipPreviewState
+
+    @State private var loader = SlipFrameLoader()
+    @State private var inImage: CGImage?
+    @State private var outImage: CGImage?
+
+    var body: some View {
+        ZStack {
+            Color.black
+            HStack(spacing: AppTheme.Spacing.xxs) {
+                pane(image: inImage, label: "Start", frame: state.inSourceFrame)
+                pane(image: outImage, label: "End", frame: state.outSourceFrame)
+            }
+        }
+        .task(id: state) {
+            loader.prepare(url: state.url, fps: state.fps)
+            async let start = loader.frame(at: state.inSourceFrame)
+            async let end = loader.frame(at: state.outSourceFrame)
+            let (i, o) = await (start, end)
+            // Keep the previous frame while the next decode is in flight.
+            if let i { inImage = i }
+            if let o { outImage = o }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func pane(image: CGImage?, label: String, frame: Int) -> some View {
+        ZStack(alignment: .topLeading) {
+            Color.black
+            if let image {
+                Image(decorative: image, scale: 1)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Text(label)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                Text(formatTimecode(frame: frame, fps: state.fps))
+                    .font(.system(size: AppTheme.FontSize.xs).monospacedDigit())
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+            }
+            .padding(.horizontal, AppTheme.Spacing.sm)
+            .padding(.vertical, AppTheme.Spacing.xxs)
+            .background(Color.black.opacity(AppTheme.Opacity.strong), in: RoundedRectangle(cornerRadius: AppTheme.Radius.xs))
+            .padding(AppTheme.Spacing.sm)
+        }
+        .clipped()
+    }
+}
+
+@MainActor
+private final class SlipFrameLoader {
+    private var url: URL?
+    private var fps: Int = 30
+    private var asset: AVURLAsset?
+
+    func prepare(url: URL, fps: Int) {
+        guard url != self.url || fps != self.fps else { return }
+        self.url = url
+        self.fps = fps
+        asset = AVURLAsset(url: url)
+    }
+
+    func frame(at sourceFrame: Int) async -> CGImage? {
+        guard let asset, fps > 0 else { return nil }
+        // Fresh generator per request: AVAssetImageGenerator isn't Sendable, a local stays region-isolated.
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 960, height: 960)
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = CMTime(value: 1, timescale: CMTimeScale(fps))
+        let time = CMTime(value: CMTimeValue(max(0, sourceFrame)), timescale: CMTimeScale(fps))
+        return try? await generator.image(at: time).image
+    }
+}

--- a/Sources/PalmierPro/Timeline/DragState.swift
+++ b/Sources/PalmierPro/Timeline/DragState.swift
@@ -85,7 +85,6 @@ enum DragState {
 
     struct SlipDrag {
         let clipId: String
-        let trackIndex: Int
         let grabFrame: Int
         /// Timeline-frame caps from source headroom across the slip group:
         /// dragging right consumes head material, left consumes tail material.

--- a/Sources/PalmierPro/Timeline/DragState.swift
+++ b/Sources/PalmierPro/Timeline/DragState.swift
@@ -6,6 +6,7 @@ enum DragState {
     case moveClip(MoveClipDrag)
     case trimLeft(TrimDrag)
     case trimRight(TrimDrag)
+    case slip(SlipDrag)
     case audioVolumeKf(AudioVolumeKfDrag)
     case fadeKnee(FadeKneeDrag)
     case marquee(MarqueeDrag)
@@ -79,6 +80,18 @@ enum DragState {
         /// When true, trim applies to link-group partners too.
         let propagateToLinked: Bool
         let isRipple: Bool
+        var deltaFrames: Int = 0
+    }
+
+    struct SlipDrag {
+        let clipId: String
+        let trackIndex: Int
+        let grabFrame: Int
+        /// Timeline-frame caps from source headroom across the slip group:
+        /// dragging right consumes head material, left consumes tail material.
+        let maxRightDelta: Int
+        let maxLeftDelta: Int
+        let propagateToLinked: Bool
         var deltaFrames: Int = 0
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -245,7 +245,6 @@ final class TimelineInputController {
                     let headroom = slipHeadroom(for: clip, linked: linkedOn)
                     dragState = .slip(DragState.SlipDrag(
                         clipId: clip.id,
-                        trackIndex: hit.trackIndex,
                         grabFrame: geometry.frameAt(x: point.x),
                         maxRightDelta: headroom.right,
                         maxLeftDelta: headroom.left,

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -629,6 +629,18 @@ final class TimelineInputController {
         view.needsDisplay = true
     }
 
+    /// Escape during an in-progress slip drag: drop the preview and the pending
+    /// drag so the eventual mouse-up commits nothing. Only slip is cancellable;
+    /// other drags have no uncommitted live mutation to unwind here.
+    func cancelActiveDrag() {
+        guard case .slip = dragState else { return }
+        editor.slipPreview = nil
+        dragState = .idle
+        snapIndicatorX = nil
+        stopPlayheadAutoScroll()
+        view.needsDisplay = true
+    }
+
     // MARK: - Mouse moved (cursor updates)
 
     func mouseMoved(with event: NSEvent, geometry: TimelineGeometry) {

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -75,6 +75,31 @@ final class TimelineInputController {
         return (right == .max ? 0 : right, left == .max ? 0 : left)
     }
 
+    /// Viewer two-up for a slip drag: the previewed in/out source frames of the
+    /// slipped clip (or its linked video partner when the grab is on audio).
+    private func slipPreviewState(for clip: Clip, deltaFrames: Int, linked: Bool) -> SlipPreviewState? {
+        var display = clip
+        if display.mediaType != .video || display.sourceClipType == .sequence {
+            guard linked,
+                  let partner = editor.linkedPartnerIds(of: clip.id)
+                    .compactMap({ editor.clipFor(id: $0) })
+                    .first(where: { $0.mediaType == .video && $0.sourceClipType != .sequence })
+            else { return nil }
+            display = partner
+        }
+        guard let url = editor.mediaResolver.expectedURL(for: display.mediaRef) else { return nil }
+        let sourceDelta = Int((Double(deltaFrames) * display.speed).rounded())
+        let applied = max(-display.trimEndFrame, min(display.trimStartFrame, sourceDelta))
+        let inFrame = display.trimStartFrame - applied
+        let outFrame = inFrame + max(0, display.sourceFramesConsumed - 1)
+        return SlipPreviewState(
+            url: url,
+            inSourceFrame: inFrame,
+            outSourceFrame: outFrame,
+            fps: editor.timeline.fps
+        )
+    }
+
     func mouseDown(with event: NSEvent, geometry: TimelineGeometry) {
         let point = view.convert(event.locationInWindow, from: nil)
         let scrollOffsetY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
@@ -216,6 +241,7 @@ final class TimelineInputController {
                     dragState = .idle
                 } else {
                     Self.slipCursor.set()
+                    if editor.isPlaying { editor.pause() }
                     let headroom = slipHeadroom(for: clip, linked: linkedOn)
                     dragState = .slip(DragState.SlipDrag(
                         clipId: clip.id,
@@ -225,6 +251,7 @@ final class TimelineInputController {
                         maxLeftDelta: headroom.left,
                         propagateToLinked: linkedOn
                     ))
+                    editor.slipPreview = slipPreviewState(for: clip, deltaFrames: 0, linked: linkedOn)
                 }
             } else {
                 let grabFrame = geometry.frameAt(x: point.x)
@@ -421,8 +448,11 @@ final class TimelineInputController {
 
         case .slip(var drag):
             snapIndicatorX = nil
-            let delta = frame - drag.grabFrame
-            drag.deltaFrames = max(-drag.maxLeftDelta, min(drag.maxRightDelta, delta))
+            let delta = max(-drag.maxLeftDelta, min(drag.maxRightDelta, frame - drag.grabFrame))
+            if delta != drag.deltaFrames, let clip = editor.clipFor(id: drag.clipId) {
+                editor.slipPreview = slipPreviewState(for: clip, deltaFrames: delta, linked: drag.propagateToLinked)
+            }
+            drag.deltaFrames = delta
             dragState = .slip(drag)
 
         case .audioVolumeKf(let drag):
@@ -558,6 +588,7 @@ final class TimelineInputController {
             }
 
         case .slip(let drag):
+            editor.slipPreview = nil
             if drag.deltaFrames != 0 {
                 editor.commitSlip(
                     clipId: drag.clipId,

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -67,7 +67,7 @@ final class TimelineInputController {
         }
         var right = Int.max
         var left = Int.max
-        for c in clips where c.mediaType != .image && c.mediaType != .text {
+        for c in clips where editor.isSlipEligible(c) {
             let speed = max(c.speed, 0.001)
             right = min(right, Int((Double(c.trimStartFrame) / speed).rounded(.down)))
             left = min(left, Int((Double(editor.effectiveTrimEnd(for: c)) / speed).rounded(.down)))

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -28,6 +28,7 @@ final class TimelineInputController {
     private static let timelineRangeEdgeHitSlop: CGFloat = 8
     private static let trimLeftCursor = makeTrimCursor(edge: .left)
     private static let trimRightCursor = makeTrimCursor(edge: .right)
+    private static let slipCursor = makeSlipCursor()
 
     init(editor: EditorViewModel, view: TimelineView) {
         self.editor = editor
@@ -50,19 +51,28 @@ final class TimelineInputController {
                 right = min(right, bounds.right)
             } else if c.id == clip.id {
                 left = min(left, c.trimStartFrame)
-                right = min(right, effectiveTrimEnd(for: c))
+                right = min(right, editor.effectiveTrimEnd(for: c))
             }
         }
         return (left == .max ? clip.trimStartFrame : left,
-                right == .max ? effectiveTrimEnd(for: clip) : right)
+                right == .max ? editor.effectiveTrimEnd(for: clip) : right)
     }
 
-    /// Nest trim limits come from the child's live length, not creation time.
-    private func effectiveTrimEnd(for clip: Clip) -> Int {
-        guard clip.sourceClipType == .sequence, let child = editor.timeline(for: clip.mediaRef) else {
-            return clip.trimEndFrame
+    /// Timeline-frame slip caps: the tightest source headroom across the clip
+    /// and (when linked) its partners, through each clip's own speed.
+    private func slipHeadroom(for clip: Clip, linked: Bool) -> (right: Int, left: Int) {
+        var clips = [clip]
+        if linked {
+            clips += editor.linkedPartnerIds(of: clip.id).compactMap { editor.clipFor(id: $0) }
         }
-        return max(0, child.totalFrames - clip.trimStartFrame - clip.durationFrames)
+        var right = Int.max
+        var left = Int.max
+        for c in clips where c.mediaType != .image && c.mediaType != .text {
+            let speed = max(c.speed, 0.001)
+            right = min(right, Int((Double(c.trimStartFrame) / speed).rounded(.down)))
+            left = min(left, Int((Double(editor.effectiveTrimEnd(for: c)) / speed).rounded(.down)))
+        }
+        return (right == .max ? 0 : right, left == .max ? 0 : left)
     }
 
     func mouseDown(with event: NSEvent, geometry: TimelineGeometry) {
@@ -198,6 +208,24 @@ final class TimelineInputController {
                     isRipple: rippleTrim
                 )
                 dragState = edge == .left ? .trimLeft(drag) : .trimRight(drag)
+            } else if editor.toolMode == .trim {
+                if clip.multicamGroupId != nil {
+                    editor.refuseWithToast("Can't slip a multicam clip — it would go out of sync with the group.")
+                    dragState = .idle
+                } else if clip.mediaType == .image || clip.mediaType == .text {
+                    dragState = .idle
+                } else {
+                    Self.slipCursor.set()
+                    let headroom = slipHeadroom(for: clip, linked: linkedOn)
+                    dragState = .slip(DragState.SlipDrag(
+                        clipId: clip.id,
+                        trackIndex: hit.trackIndex,
+                        grabFrame: geometry.frameAt(x: point.x),
+                        maxRightDelta: headroom.right,
+                        maxLeftDelta: headroom.left,
+                        propagateToLinked: linkedOn
+                    ))
+                }
             } else {
                 let grabFrame = geometry.frameAt(x: point.x)
                 var companions: [DragState.Participant] = []
@@ -391,6 +419,12 @@ final class TimelineInputController {
             }
             dragState = .trimRight(drag)
 
+        case .slip(var drag):
+            snapIndicatorX = nil
+            let delta = frame - drag.grabFrame
+            drag.deltaFrames = max(-drag.maxLeftDelta, min(drag.maxRightDelta, delta))
+            dragState = .slip(drag)
+
         case .audioVolumeKf(let drag):
             dragState = .audioVolumeKf(applyVolumeKfDrag(drag, cursorFrame: frame, cursorY: point.y, geometry: geometry))
 
@@ -523,6 +557,15 @@ final class TimelineInputController {
                 }
             }
 
+        case .slip(let drag):
+            if drag.deltaFrames != 0 {
+                editor.commitSlip(
+                    clipId: drag.clipId,
+                    deltaFrames: drag.deltaFrames,
+                    propagateToLinked: drag.propagateToLinked
+                )
+            }
+
         case .audioVolumeKf(let drag):
             if drag.currentFrame != drag.originalFrame || drag.currentDb != drag.originalDb {
                 editor.commitMoveVolumeKeyframe(clipId: drag.clipId)
@@ -622,6 +665,14 @@ final class TimelineInputController {
                 NSCursor.openHand.set()
                 return
             }
+            if editor.toolMode == .trim {
+                if clip.multicamGroupId == nil, clip.mediaType != .image, clip.mediaType != .text {
+                    Self.slipCursor.set()
+                } else {
+                    NSCursor.operationNotAllowed.set()
+                }
+                return
+            }
         } else {
             view.setHoveredClipId(nil)
         }
@@ -672,6 +723,48 @@ final class TimelineInputController {
             arrow.move(to: NSPoint(x: arrowTipX, y: midY))
             arrow.line(to: NSPoint(x: arrowBaseX, y: midY + AppTheme.Spacing.sm))
             arrow.line(to: NSPoint(x: arrowBaseX, y: midY - AppTheme.Spacing.sm))
+            arrow.close()
+            arrow.lineJoinStyle = .round
+            arrow.lineWidth = AppTheme.BorderWidth.thick
+            AppTheme.Text.primary.setStroke()
+            arrow.stroke()
+            AppTheme.Status.error.setFill()
+            arrow.fill()
+            return true
+        }
+        return NSCursor(image: image, hotSpot: NSPoint(x: size.width / 2, y: size.height / 2))
+    }
+
+    /// Slip glyph: two fixed edge ticks with a double-headed arrow between them —
+    /// content slides while the clip edges stay put.
+    private static func makeSlipCursor() -> NSCursor {
+        let size = NSSize(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let midX = rect.midX
+            let midY = rect.midY
+            let ticks = NSBezierPath()
+            for direction: CGFloat in [-1, 1] {
+                let x = midX + direction * AppTheme.Spacing.md
+                ticks.move(to: NSPoint(x: x, y: midY - AppTheme.Spacing.smMd))
+                ticks.line(to: NSPoint(x: x, y: midY + AppTheme.Spacing.smMd))
+            }
+            ticks.lineCapStyle = .square
+
+            AppTheme.Background.base.setStroke()
+            ticks.lineWidth = AppTheme.BorderWidth.thick + AppTheme.BorderWidth.thin
+            ticks.stroke()
+            AppTheme.Status.error.setStroke()
+            ticks.lineWidth = AppTheme.BorderWidth.thick
+            ticks.stroke()
+
+            let arrow = NSBezierPath()
+            arrow.move(to: NSPoint(x: midX - AppTheme.Spacing.sm, y: midY))
+            arrow.line(to: NSPoint(x: midX - AppTheme.Spacing.xxs, y: midY + AppTheme.Spacing.xs))
+            arrow.line(to: NSPoint(x: midX - AppTheme.Spacing.xxs, y: midY - AppTheme.Spacing.xs))
+            arrow.close()
+            arrow.move(to: NSPoint(x: midX + AppTheme.Spacing.sm, y: midY))
+            arrow.line(to: NSPoint(x: midX + AppTheme.Spacing.xxs, y: midY + AppTheme.Spacing.xs))
+            arrow.line(to: NSPoint(x: midX + AppTheme.Spacing.xxs, y: midY - AppTheme.Spacing.xs))
             arrow.close()
             arrow.lineJoinStyle = .round
             arrow.lineWidth = AppTheme.BorderWidth.thick

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -451,9 +451,11 @@ final class TimelineInputController {
             let delta = max(-drag.maxLeftDelta, min(drag.maxRightDelta, frame - drag.grabFrame))
             if delta != drag.deltaFrames, let clip = editor.clipFor(id: drag.clipId) {
                 editor.slipPreview = slipPreviewState(for: clip, deltaFrames: delta, linked: drag.propagateToLinked)
+                invalidateSlipRects(for: drag, newDeltaFrames: delta, geometry: geometry)
             }
             drag.deltaFrames = delta
             dragState = .slip(drag)
+            return
 
         case .audioVolumeKf(let drag):
             dragState = .audioVolumeKf(applyVolumeKfDrag(drag, cursorFrame: frame, cursorY: point.y, geometry: geometry))
@@ -503,6 +505,38 @@ final class TimelineInputController {
         }
 
         view.needsDisplay = true
+    }
+
+    private func invalidateSlipRects(for drag: DragState.SlipDrag, newDeltaFrames: Int, geometry: TimelineGeometry) {
+        var ids = [drag.clipId]
+        if drag.propagateToLinked {
+            ids += editor.slipPropagationPartnerIds(of: drag.clipId)
+        }
+        let pad = AppTheme.BorderWidth.thick
+        for id in ids {
+            guard let loc = editor.findClip(id: id) else { continue }
+            let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+            let activeRect = geometry.clipRect(for: clip, trackIndex: loc.trackIndex)
+            let oldRect = slipSourceRect(for: clip, deltaFrames: drag.deltaFrames, activeRect: activeRect, geometry: geometry)
+            let newRect = slipSourceRect(for: clip, deltaFrames: newDeltaFrames, activeRect: activeRect, geometry: geometry)
+            view.setNeedsDisplay(oldRect.union(newRect).union(activeRect).insetBy(dx: -pad, dy: -pad))
+        }
+    }
+
+    private func slipSourceRect(for clip: Clip, deltaFrames: Int, activeRect: NSRect, geometry: TimelineGeometry) -> NSRect {
+        let speed = max(clip.speed, 0.001)
+        let sourceDelta = Int((Double(deltaFrames) * speed).rounded())
+        let applied = max(-editor.effectiveTrimEnd(for: clip), min(clip.trimStartFrame, sourceDelta))
+        let trimStart = clip.trimStartFrame - applied
+        let sourceFrames = trimStart + clip.sourceFramesConsumed + editor.effectiveTrimEnd(for: clip) + applied
+        let sourceTimelineFrames = max(1, Double(sourceFrames) / speed)
+        let headTimelineFrames = Double(trimStart) / speed
+        return NSRect(
+            x: activeRect.minX - headTimelineFrames * geometry.pixelsPerFrame,
+            y: activeRect.minY,
+            width: sourceTimelineFrames * geometry.pixelsPerFrame,
+            height: activeRect.height
+        )
     }
 
     // MARK: - Mouse up

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -321,7 +321,7 @@ final class TimelineView: NSView {
         }()
         let slipPartnerIds: Set<String> = {
             guard let drag = slipDrag, drag.propagateToLinked else { return [] }
-            return Set(editor.linkedPartnerIds(of: drag.clipId))
+            return Set(editor.slipPropagationPartnerIds(of: drag.clipId))
         }()
 
         // Live ripple-trim layout: downstream clips shift while the edge is dragged.

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -468,6 +468,19 @@ final class TimelineView: NSView {
                     // Slip never moves the clip: rect is the resting rect, only content shifts.
                     let rect = geo.clipRect(for: clip, trackIndex: ti)
                     clipDisplayRects[clip.id] = rect
+                    let sourceRect = slipSourceRect(for: previewClip, activeRect: rect, geometry: geo)
+                    if sourceRect.intersects(dirtyRect) {
+                        drawSlipSourceRange(
+                            clip: previewClip,
+                            sourceRect: sourceRect,
+                            activeRect: rect,
+                            isSelected: isSelected,
+                            isMissing: clipMissing,
+                            isGenerating: clipGenerating,
+                            angleLabel: angleLabel(clip),
+                            context: ctx
+                        )
+                    }
                     if rect.intersects(dirtyRect) {
                         let chip = angleLabel(clip)
                         let cache = editor.mediaVisualCache
@@ -524,6 +537,86 @@ final class TimelineView: NSView {
                 ctx.setFillColor(AppTheme.Status.error.cgColor)
                 ctx.fill(line)
             }
+        }
+    }
+
+    private func slipSourceRect(for clip: Clip, activeRect: NSRect, geometry geo: TimelineGeometry) -> NSRect {
+        let speed = max(clip.speed, 0.001)
+        let sourceFrames = clip.trimStartFrame + clip.sourceFramesConsumed + editor.effectiveTrimEnd(for: clip)
+        let sourceTimelineFrames = max(1, Double(sourceFrames) / speed)
+        let headTimelineFrames = Double(clip.trimStartFrame) / speed
+        return NSRect(
+            x: activeRect.minX - headTimelineFrames * geo.pixelsPerFrame,
+            y: activeRect.minY,
+            width: sourceTimelineFrames * geo.pixelsPerFrame,
+            height: activeRect.height
+        )
+    }
+
+    private func drawSlipSourceRange(
+        clip: Clip,
+        sourceRect: NSRect,
+        activeRect: NSRect,
+        isSelected: Bool,
+        isMissing: Bool,
+        isGenerating: Bool,
+        angleLabel: String?,
+        context ctx: CGContext
+    ) {
+        var sourceClip = clip
+        let speed = max(sourceClip.speed, 0.001)
+        let sourceFrames = sourceClip.trimStartFrame + sourceClip.sourceFramesConsumed + editor.effectiveTrimEnd(for: sourceClip)
+        sourceClip.durationFrames = max(1, Int((Double(sourceFrames) / speed).rounded()))
+        sourceClip.trimStartFrame = 0
+        sourceClip.trimEndFrame = 0
+
+        ClipRenderer.draw(
+            sourceClip,
+            type: clip.mediaType,
+            in: sourceRect,
+            isSelected: false,
+            opacity: CGFloat(AppTheme.Opacity.medium),
+            context: ctx,
+            cache: editor.mediaVisualCache,
+            displayName: editor.clipDisplayLabel(for: clip),
+            multicamAngleLabel: angleLabel,
+            fps: editor.timeline.fps,
+            isMissing: isMissing,
+            isGenerating: isGenerating
+        )
+
+        ctx.saveGState()
+        defer { ctx.restoreGState() }
+
+        let outside = CGMutablePath()
+        outside.addRect(sourceRect)
+        outside.addRect(activeRect)
+        ctx.addPath(outside)
+        ctx.setFillColor(AppTheme.Background.base.withAlphaComponent(AppTheme.Opacity.medium).cgColor)
+        ctx.drawPath(using: .eoFill)
+
+        let sourcePath = CGPath(
+            roundedRect: sourceRect.insetBy(dx: AppTheme.BorderWidth.hairline, dy: AppTheme.BorderWidth.hairline),
+            cornerWidth: Trim.clipCornerRadius,
+            cornerHeight: Trim.clipCornerRadius,
+            transform: nil
+        )
+        ctx.addPath(sourcePath)
+        ctx.setStrokeColor(AppTheme.Text.primary.withAlphaComponent(AppTheme.Opacity.prominent).cgColor)
+        ctx.setLineWidth(AppTheme.BorderWidth.medium)
+        ctx.strokePath()
+
+        ctx.setStrokeColor(AppTheme.Text.primary.cgColor)
+        ctx.setLineWidth(AppTheme.BorderWidth.thick)
+        ctx.stroke(activeRect.insetBy(dx: AppTheme.BorderWidth.hairline, dy: AppTheme.BorderWidth.hairline))
+
+        guard isSelected else { return }
+        ctx.setFillColor(AppTheme.Text.primary.cgColor)
+        let handleWidth = AppTheme.BorderWidth.thick
+        let handleHeight = min(activeRect.height, AppTheme.IconSize.md)
+        let y = activeRect.minY
+        for x in [activeRect.minX - handleWidth / 2, activeRect.maxX - handleWidth / 2] {
+            ctx.fill(NSRect(x: x, y: y, width: handleWidth, height: handleHeight))
         }
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -22,6 +22,7 @@ final class TimelineView: NSView {
         super.init(frame: .zero)
         self.inputController = TimelineInputController(editor: editor, view: self)
         editor.mediaVisualCache.timelineView = self
+        editor.onCancelTimelineDrag = { [weak self] in self?.inputController.cancelActiveDrag() }
         wantsLayer = true
         layer?.backgroundColor = AppTheme.Background.surface.cgColor
         canvas.wantsLayer = true

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -315,6 +315,15 @@ final class TimelineView: NSView {
             return Set(editor.linkedPartnerIds(of: drag.clipId))
         }()
 
+        let slipDrag: DragState.SlipDrag? = {
+            if case .slip(let drag) = inputController.dragState { return drag }
+            return nil
+        }()
+        let slipPartnerIds: Set<String> = {
+            guard let drag = slipDrag, drag.propagateToLinked else { return [] }
+            return Set(editor.linkedPartnerIds(of: drag.clipId))
+        }()
+
         // Live ripple-trim layout: downstream clips shift while the edge is dragged.
         let ripplePlan: EditorViewModel.RippleTrimPlan? = {
             guard let (drag, isLeft) = trimDrag, drag.isRipple else { return nil }
@@ -440,6 +449,31 @@ final class TimelineView: NSView {
                         let fps = editor.timeline.fps
                         deferredDraws.append {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
+                                              isSelected: isSelected, context: ctx,
+                                              cache: cache, displayName: name,
+                                              multicamAngleLabel: chip,
+                                              fps: fps, isMissing: clipMissing, isGenerating: clipGenerating)
+                        }
+                    }
+                    continue
+                }
+
+                if let drag = slipDrag, clip.id == drag.clipId || slipPartnerIds.contains(clip.id) {
+                    var previewClip = clip
+                    let sourceDelta = Int((Double(drag.deltaFrames) * clip.speed).rounded())
+                    let applied = max(-clip.trimEndFrame, min(clip.trimStartFrame, sourceDelta))
+                    previewClip.trimStartFrame = clip.trimStartFrame - applied
+                    previewClip.trimEndFrame = clip.trimEndFrame + applied
+                    // Slip never moves the clip: rect is the resting rect, only content shifts.
+                    let rect = geo.clipRect(for: clip, trackIndex: ti)
+                    clipDisplayRects[clip.id] = rect
+                    if rect.intersects(dirtyRect) {
+                        let chip = angleLabel(clip)
+                        let cache = editor.mediaVisualCache
+                        let name = editor.clipDisplayLabel(for: clip)
+                        let fps = editor.timeline.fps
+                        deferredDraws.append {
+                            ClipRenderer.draw(previewClip, type: clip.mediaType, in: rect,
                                               isSelected: isSelected, context: ctx,
                                               cache: cache, displayName: name,
                                               multicamAngleLabel: chip,

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -19,6 +19,7 @@ struct ToolbarView: View {
             HStack(spacing: AppTheme.Spacing.md) {
                 toolModeButton("cursorarrow", mode: .pointer, help: "Pointer (V)")
                 toolModeButton("scissors", mode: .razor, help: "Razor (C)")
+                toolModeButton("arrow.left.and.right", mode: .trim, help: "Trim (T)")
             }
 
             Divider()

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -398,6 +398,7 @@ enum AppTheme {
         static let hover: Double = 0.15
         static let transition: Double = 0.2
         static let pulse: Double = 0.8
+        static let slipPreviewRefresh: Duration = .milliseconds(67)
     }
 }
 

--- a/Tests/PalmierProTests/Timeline/SlipTests.swift
+++ b/Tests/PalmierProTests/Timeline/SlipTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// Slip edits shift the source in/out window while the clip's timeline footprint stays fixed.
+@MainActor
+private func editor(_ tracks: [Track] = []) -> EditorViewModel {
+    let e = EditorViewModel()
+    e.timeline = Fixtures.timeline(tracks: tracks)
+    return e
+}
+
+@Suite("EditorViewModel — commitSlip")
+@MainActor
+struct SlipTests {
+
+    @Test func slipRightRevealsEarlierMaterial() {
+        let clip = Fixtures.clip(id: "c1", start: 100, duration: 60, trimStart: 30, trimEnd: 20)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 20)
+        #expect(updated.trimEndFrame == 30)
+        #expect(updated.startFrame == 100)
+        #expect(updated.durationFrames == 60)
+        #expect(updated.sourceDurationFrames == clip.sourceDurationFrames)
+    }
+
+    @Test func slipLeftRevealsLaterMaterial() {
+        let clip = Fixtures.clip(id: "c1", start: 100, duration: 60, trimStart: 30, trimEnd: 20)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: -10, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 40)
+        #expect(updated.trimEndFrame == 10)
+    }
+
+    @Test func slipClampsAtHeadMaterial() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 5, trimEnd: 20)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: 30, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 0)
+        #expect(updated.trimEndFrame == 25)
+    }
+
+    @Test func slipClampsAtTailMaterial() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 20, trimEnd: 5)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: -30, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 25)
+        #expect(updated.trimEndFrame == 0)
+    }
+
+    @Test func slipScalesTimelineDeltaThroughSpeed() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 40, trimEnd: 40, speed: 2.0)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 20)
+        #expect(updated.trimEndFrame == 60)
+    }
+
+    @Test func slipSpeedAwareClampKeepsTrimsNonNegative() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 10, trimEnd: 40, speed: 2.0)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
+        let updated = e.timeline.tracks[0].clips[0]
+        #expect(updated.trimStartFrame == 0)
+        #expect(updated.trimEndFrame == 50)
+    }
+
+    @Test func slipPropagatesToLinkedPartnerAndTightestHeadroomWins() {
+        var v = Fixtures.clip(id: "v1", start: 0, duration: 60, trimStart: 30, trimEnd: 30)
+        var a = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60, trimStart: 8, trimEnd: 30)
+        v.linkGroupId = "g1"
+        a.linkGroupId = "g1"
+        let e = editor([Fixtures.videoTrack(clips: [v]), Fixtures.audioTrack(clips: [a])])
+        e.commitSlip(clipId: "v1", deltaFrames: 20, propagateToLinked: true)
+        let video = e.timeline.tracks[0].clips[0]
+        let audio = e.timeline.tracks[1].clips[0]
+        #expect(video.trimStartFrame == 22)
+        #expect(video.trimEndFrame == 38)
+        #expect(audio.trimStartFrame == 0)
+        #expect(audio.trimEndFrame == 38)
+    }
+
+    @Test func slipWithoutPropagationMovesOnlyLead() {
+        var v = Fixtures.clip(id: "v1", start: 0, duration: 60, trimStart: 30, trimEnd: 30)
+        var a = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60, trimStart: 30, trimEnd: 30)
+        v.linkGroupId = "g1"
+        a.linkGroupId = "g1"
+        let e = editor([Fixtures.videoTrack(clips: [v]), Fixtures.audioTrack(clips: [a])])
+        e.commitSlip(clipId: "v1", deltaFrames: 10, propagateToLinked: false)
+        #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 20)
+        #expect(e.timeline.tracks[1].clips[0].trimStartFrame == 30)
+    }
+
+    @Test func slipRefusesMulticamAndImageClips() {
+        var mc = Fixtures.clip(id: "mc", start: 0, duration: 60, trimStart: 30, trimEnd: 30)
+        mc.multicamGroupId = "group"
+        let img = Fixtures.clip(id: "img", mediaType: .image, start: 100, duration: 60)
+        let e = editor([Fixtures.videoTrack(clips: [mc, img])])
+        e.commitSlip(clipId: "mc", deltaFrames: 10, propagateToLinked: true)
+        e.commitSlip(clipId: "img", deltaFrames: 10, propagateToLinked: true)
+        #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 30)
+        #expect(e.timeline.tracks[0].clips[1].trimStartFrame == 0)
+    }
+
+    @Test func slipUndoRestoresOriginalTrims() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 30, trimEnd: 20)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let undoManager = UndoManager()
+        e.undoManager = undoManager
+        e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
+        #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 20)
+        undoManager.undo()
+        let restored = e.timeline.tracks[0].clips[0]
+        #expect(restored.trimStartFrame == 30)
+        #expect(restored.trimEndFrame == 20)
+    }
+
+    @Test func slipLeavesKeyframesUntouched() {
+        var clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 30, trimEnd: 20)
+        clip.opacityTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 1.0),
+            Keyframe(frame: 30, value: 0.5),
+        ])
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
+        #expect(e.timeline.tracks[0].clips[0].opacityTrack?.keyframes.map(\.frame) == [0, 30])
+    }
+
+    @Test func slipZeroDeltaIsNoOp() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 30, trimEnd: 20)
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let undoManager = UndoManager()
+        e.undoManager = undoManager
+        e.commitSlip(clipId: "c1", deltaFrames: 0, propagateToLinked: true)
+        #expect(undoManager.canUndo == false)
+        #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 30)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/SlipTests.swift
+++ b/Tests/PalmierProTests/Timeline/SlipTests.swift
@@ -112,7 +112,7 @@ struct SlipTests {
         let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 30, trimEnd: 20)
         let e = editor([Fixtures.videoTrack(clips: [clip])])
         let undoManager = UndoManager()
-        e.undoManager = undoManager
+        e.undo.attach(undoManager)
         e.commitSlip(clipId: "c1", deltaFrames: 10, propagateToLinked: true)
         #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 20)
         undoManager.undo()
@@ -136,7 +136,7 @@ struct SlipTests {
         let clip = Fixtures.clip(id: "c1", start: 0, duration: 60, trimStart: 30, trimEnd: 20)
         let e = editor([Fixtures.videoTrack(clips: [clip])])
         let undoManager = UndoManager()
-        e.undoManager = undoManager
+        e.undo.attach(undoManager)
         e.commitSlip(clipId: "c1", deltaFrames: 0, propagateToLinked: true)
         #expect(undoManager.canUndo == false)
         #expect(e.timeline.tracks[0].clips[0].trimStartFrame == 30)


### PR DESCRIPTION
- **Slip Edit: First working version**
- **Slip Edit: Preview start and end frame**

(Closes #300)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core trim/slip timeline logic and clip mutation paths; behavior is well-tested but mistakes could corrupt clip trims or A/V sync when linked.
> 
> **Overview**
> Adds **slip editing** so users can shift which source frames play inside a clip without moving it on the timeline. The new **Trim (T)** tool mode keeps edge trims on the handles and starts a **slip drag** from the clip body; **Escape** cancels an in-progress slip without committing.
> 
> `commitSlip` and related helpers move `trimStart`/`trimEnd` in opposite directions with clamps for speed, linked partners, nested sequences (`effectiveTrimEnd`), and exclusions for multicam, image, and text clips. The timeline shows a live **source-range** overlay while dragging, and the viewer shows an FCP-style **two-up** (`SlipTwoUpView`) of start/end source frames during the drag.
> 
> Toolbar and **T** shortcut select the tool; unit tests cover slip behavior, propagation, and undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a58e34db3ed1e742f2fa1d6eec3c94e675018eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->