### PR TITLE
fix(mcp): persist timeline when closing an edited project

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -80,6 +80,9 @@ final class ToolExecutor {
                let actionName = editor.undoManager?.undoActionName {
                 agentUndoStack.append(actionName)
             }
+            if !result.isError, tool != .undo, editor.timelines != before {
+                editor.onDocumentEdited?()
+            }
         } catch let err as ToolError {
             result = .error(err.message)
         } catch {

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -93,12 +93,11 @@ final class AppState {
         project.showWindows()
     }
 
-    // Save and close project; switch to next open or show Home. Throws (without closing) if the save fails.
     func closeProject(_ project: VideoProject) async throws {
         if let url = project.fileURL { ProjectRegistry.shared.register(url) }
-        if project.isDocumentEdited {
+        if let url = project.fileURL {
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                project.autosave(withImplicitCancellability: false) { error in
+                project.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
                     if let error { cont.resume(throwing: error) } else { cont.resume() }
                 }
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -108,6 +108,10 @@ extension EditorViewModel {
             }
             handler(vm)
         }
+        let undoing = undoManager?.isUndoing == true || undoManager?.isRedoing == true
+        if !undoing {
+            onDocumentEdited?()
+        }
     }
 
     // MARK: - CRUD
@@ -222,6 +226,10 @@ extension EditorViewModel {
             vm.deleteTimeline(id)
         }
         undoManager?.setActionName(actionName)
+        let undoing = undoManager?.isUndoing == true || undoManager?.isRedoing == true
+        if !undoing {
+            onDocumentEdited?()
+        }
     }
 
     /// Removes every clip referencing `assetIds` from every timeline; prunes emptied tracks.

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -291,6 +291,7 @@ final class EditorViewModel {
 
     weak var undoManager: UndoManager?
     @ObservationIgnored var onProjectCheckpointRequired: (() -> Void)?
+    @ObservationIgnored var onDocumentEdited: (() -> Void)?
     var isDocumentEdited: Bool = false
 
     func telemetrySnapshot() -> [String: Any] {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -298,6 +298,7 @@ final class VideoProject: NSDocument {
             guard let self else { return }
             self.projectCheckpointAutosaveScheduled = false
             guard self.fileURL != nil else { return }
+            self.updateChangeCount(.changeDone)
             self.autosave(withImplicitCancellability: false) { error in
                 if let error {
                     Log.project.error("project checkpoint autosave failed: \(error.localizedDescription)")
@@ -347,6 +348,9 @@ final class VideoProject: NSDocument {
         editorViewModel.projectURL = fileURL
         editorViewModel.agentService.loadSessions(from: fileURL)
         editorViewModel.agentService.onSessionsChanged = { [weak self] in
+            self?.updateChangeCount(.changeDone)
+        }
+        editorViewModel.onDocumentEdited = { [weak self] in
             self?.updateChangeCount(.changeDone)
         }
         editorViewModel.onProjectCheckpointRequired = { [weak self] in

--- a/Tests/PalmierProTests/Media/ProjectDocumentIOTests.swift
+++ b/Tests/PalmierProTests/Media/ProjectDocumentIOTests.swift
@@ -37,6 +37,45 @@ struct ProjectDocumentIOTests {
         #expect(fm.fileExists(atPath: destination.appendingPathComponent(Project.manifestFilename).path))
     }
 
+    @Test func savePersistsTimelineWhenDocumentNotMarkedEdited() async throws {
+        let root = fm.temporaryDirectory.appendingPathComponent("pp-close-\(UUID().uuidString)", isDirectory: true)
+        let package = root.appendingPathComponent("Edited.palmier", isDirectory: true)
+        try fm.createDirectory(at: package, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let doc = VideoProject()
+        doc.fileURL = package
+        doc.fileType = VideoProject.typeIdentifier
+        let track = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 90)])
+        doc.editorViewModel.timeline = Fixtures.timeline(tracks: [track])
+        #expect(doc.isDocumentEdited == false)
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            doc.save(to: package, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            }
+        }
+
+        let reloaded = try VideoProject.readProjectPackage(at: package)
+        #expect(reloaded.projectFile.timelines.first?.tracks.count == 1)
+        #expect(reloaded.projectFile.timelines.first?.tracks.first?.clips.count == 1)
+        #expect(reloaded.projectFile.timelines.first?.tracks.first?.clips.first?.durationFrames == 90)
+    }
+
+    @Test func timelineUndoMarksDocumentEditedCallback() {
+        let editor = EditorViewModel()
+        let um = UndoManager()
+        um.groupsByEvent = false
+        editor.undoManager = um
+        var edited = 0
+        editor.onDocumentEdited = { edited += 1 }
+
+        um.beginUndoGrouping()
+        editor.registerTimelineUndo { _ in }
+        um.endUndoGrouping()
+        #expect(edited == 1)
+    }
+
     private func makePackage(at url: URL) throws {
         let media = url.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
         try fm.createDirectory(at: media, withIntermediateDirectories: true)


### PR DESCRIPTION
close_project only autosaved when isDocumentEdited was set, so agent edits that never closed an undo group were discarded on reopen.

Tested by running:
new_project with a unique name.
import_media something, then add_clips / manage_tracks until get_timeline shows tracks + clips.
close_project (no args).
open_project with that same name.
get_timeline — tracks/clips were still there 