### PR TITLE
[fix] prevent scrub audio from blocking the main thread

### DIFF
--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 
 @MainActor
@@ -36,15 +37,8 @@ final class ScrubAudioEngine {
     nonisolated private static let meterFrameCount = 960
     nonisolated private static let meterPrefetchFrameCount = 12_000
 
-    private let engine = AVAudioEngine()
-    private let playerNode = AVAudioPlayerNode()
     private let meter: AudioMeterHub
-    private let format = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: ScrubAudioEngine.sampleRate,
-        channels: ScrubAudioEngine.channelCount,
-        interleaved: false
-    )!
+    private let output = ScrubAudioOutput(sampleRate: sampleRate)
 
     private var source: Source?
     private var sourceGeneration = 0
@@ -55,12 +49,16 @@ final class ScrubAudioEngine {
     private var lastDirection: Direction = .forward
     private var decodeTask: Task<Void, Never>?
     private var pendingDecodeRange: Range<Int64>?
+    private var lifecycleObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     init(meter: AudioMeterHub) {
         self.meter = meter
-        engine.attach(playerNode)
-        engine.connect(playerNode, to: engine.mainMixerNode, format: format)
-        engine.prepare()
+        observeLifecycle()
+    }
+
+    isolated deinit {
+        removeLifecycleObservers()
+        output.invalidate()
     }
 
     func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
@@ -69,7 +67,6 @@ final class ScrubAudioEngine {
         cache = nil
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
         if resetMeter { meter.reset() }
-        if asset != nil { startEngineIfNeeded() }
     }
 
     func scrub(to time: CMTime, movingForward: Bool? = nil) {
@@ -119,6 +116,11 @@ final class ScrubAudioEngine {
     }
 
     func stopScrubbing() {
+        resetScrubState()
+        output.stop()
+    }
+
+    private func resetScrubState() {
         decodeTask?.cancel()
         decodeTask = nil
         pendingDecodeRange = nil
@@ -126,14 +128,21 @@ final class ScrubAudioEngine {
         latestMeterSample = nil
         lastRequestedSample = nil
         lastDirection = .forward
-        playerNode.stop()
     }
 
     func teardown() {
-        stopScrubbing()
+        resetScrubState()
         source = nil
         cache = nil
-        engine.stop()
+        output.invalidate()
+        removeLifecycleObservers()
+    }
+
+    private func removeLifecycleObservers() {
+        for observer in lifecycleObservers {
+            observer.center.removeObserver(observer.token)
+        }
+        lifecycleObservers.removeAll()
     }
 
     private func requestWindow(around sample: Int64, source: Source) {
@@ -181,18 +190,19 @@ final class ScrubAudioEngine {
 
     private func play(request: Request, from window: PCMWindow) {
         latestRequest = nil
-        guard window.hasAudioTracks,
-              let buffer = makeGrain(request: request, from: window)
-        else {
+        guard window.hasAudioTracks else {
             meter.ingest(.silence)
-            playerNode.stop()
+            output.stop()
             return
         }
 
-        meter.ingest(AudioLevelAnalyzer.analyze(buffer))
-        startEngineIfNeeded()
-        playerNode.scheduleBuffer(buffer, at: nil, options: .interrupts)
-        if !playerNode.isPlaying { playerNode.play() }
+        let grain = makeGrain(request: request, from: window)
+        meter.ingest(AudioLevelAnalyzer.analyze(
+            left: grain.left,
+            right: grain.right,
+            range: grain.left.indices
+        ))
+        output.play(grain)
     }
 
     private func canServe(sample: Int64, from window: PCMWindow) -> Bool {
@@ -219,13 +229,10 @@ final class ScrubAudioEngine {
         meter.ingest(analysis)
     }
 
-    private func makeGrain(request: Request, from window: PCMWindow) -> AVAudioPCMBuffer? {
+    private func makeGrain(request: Request, from window: PCMWindow) -> ScrubAudioGrain {
         let frameCount = Self.grainFrameCount
-        guard let buffer = AVAudioPCMBuffer(
-            pcmFormat: format,
-            frameCapacity: AVAudioFrameCount(frameCount)
-        ), let channels = buffer.floatChannelData else { return nil }
-        buffer.frameLength = AVAudioFrameCount(frameCount)
+        var left = [Float](repeating: 0, count: frameCount)
+        var right = [Float](repeating: 0, count: frameCount)
 
         let halfGrain = Int64(frameCount / 2)
         for outputIndex in 0..<frameCount {
@@ -238,23 +245,42 @@ final class ScrubAudioEngine {
             let cacheIndex = Int(sourceSample - window.startSample)
             let gain = Self.edgeGain(at: outputIndex, frameCount: frameCount)
             if window.left.indices.contains(cacheIndex) {
-                channels[0][outputIndex] = window.left[cacheIndex] * gain
-                channels[1][outputIndex] = window.right[cacheIndex] * gain
-            } else {
-                channels[0][outputIndex] = 0
-                channels[1][outputIndex] = 0
+                left[outputIndex] = window.left[cacheIndex] * gain
+                right[outputIndex] = window.right[cacheIndex] * gain
             }
         }
-        return buffer
+        return ScrubAudioGrain(left: left, right: right)
     }
 
-    private func startEngineIfNeeded() {
-        guard !engine.isRunning else { return }
-        do {
-            try engine.start()
-        } catch {
-            Log.preview.error("scrub audio engine failed: \(error.localizedDescription)")
+    private func observeLifecycle() {
+        let appCenter = NotificationCenter.default
+        let resignObserver = appCenter.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.suspendOutput()
+            }
         }
+        lifecycleObservers.append((appCenter, resignObserver))
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        let sleepObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.suspendOutput()
+            }
+        }
+        lifecycleObservers.append((workspaceCenter, sleepObserver))
+    }
+
+    private func suspendOutput() {
+        resetScrubState()
+        output.invalidate()
     }
 
     private static func edgeGain(at index: Int, frameCount: Int) -> Float {

--- a/Sources/PalmierPro/Preview/ScrubAudioOutput.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioOutput.swift
@@ -1,0 +1,269 @@
+import AVFoundation
+import os
+
+struct ScrubAudioGrain: Sendable {
+    let left: [Float]
+    let right: [Float]
+}
+
+struct ScrubAudioOutputState: Equatable, Sendable {
+    enum GraphState: Equatable, Sendable {
+        case missing
+        case stopped
+        case running
+    }
+
+    private(set) var graph: GraphState = .missing
+    private(set) var playerStarted = false
+
+    mutating func graphPrepared() {
+        graph = .stopped
+        playerStarted = false
+    }
+
+    mutating func engineStarted() {
+        graph = .running
+    }
+
+    mutating func startPlayerIfNeeded() -> Bool {
+        guard graph == .running, !playerStarted else { return false }
+        playerStarted = true
+        return true
+    }
+
+    mutating func stop() {
+        if graph != .missing { graph = .stopped }
+        playerStarted = false
+    }
+
+    mutating func invalidate() {
+        graph = .missing
+        playerStarted = false
+    }
+}
+
+struct ScrubAudioPendingState<Value: Sendable>: Sendable {
+    private(set) var generation: UInt = 0
+    private(set) var drainGeneration: UInt?
+    private var pending: Value?
+
+    mutating func submit(_ value: Value) -> UInt? {
+        pending = value
+        guard drainGeneration == nil else { return nil }
+        drainGeneration = generation
+        return generation
+    }
+
+    mutating func take(for generation: UInt) -> Value? {
+        guard self.generation == generation else { return nil }
+        defer { pending = nil }
+        return pending
+    }
+
+    mutating func finishDrain(for generation: UInt) -> UInt? {
+        guard drainGeneration == generation else { return nil }
+        drainGeneration = nil
+        guard pending != nil else { return nil }
+        drainGeneration = self.generation
+        return self.generation
+    }
+
+    mutating func cancel() {
+        generation &+= 1
+        pending = nil
+        // Keep the old drain claimed so replacement work runs after queued lifecycle operations.
+    }
+
+    func isCurrent(_ generation: UInt) -> Bool {
+        self.generation == generation
+    }
+}
+
+final class ScrubAudioOutput: @unchecked Sendable {
+    private static let channelCount: AVAudioChannelCount = 2
+
+    // Core Audio operations stay off the main thread because they may block.
+    private let queue = DispatchQueue(label: "io.palmier.pro.scrub-audio-output", qos: .userInteractive)
+    private let pending = OSAllocatedUnfairLock(initialState: ScrubAudioPendingState<ScrubAudioGrain>())
+    private let sampleRate: Double
+    private var state = ScrubAudioOutputState()
+    private var engine: AVAudioEngine?
+    private var player: AVAudioPlayerNode?
+    private var format: AVAudioFormat?
+    private var silenceBuffer: AVAudioPCMBuffer?
+    private var configurationObserver: NSObjectProtocol?
+
+    init(sampleRate: Double) {
+        self.sampleRate = sampleRate
+    }
+
+    deinit {
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+        }
+    }
+
+    func play(_ grain: ScrubAudioGrain) {
+        let generation = pending.withLock { state in
+            state.submit(grain)
+        }
+        guard let generation else { return }
+        scheduleDrain(generation: generation)
+    }
+
+    func stop() {
+        cancelPending()
+        queue.async { [self] in
+            stopOnQueue()
+        }
+    }
+
+    func invalidate() {
+        cancelPending()
+        queue.async { [self] in
+            invalidateOnQueue()
+        }
+    }
+
+    private func scheduleDrain(generation: UInt) {
+        queue.async { [self] in
+            drain(generation: generation)
+        }
+    }
+
+    private func drain(generation: UInt) {
+        while let grain = pending.withLock({ state in state.take(for: generation) }) {
+            let isCurrent = pending.withLock { state in state.isCurrent(generation) }
+            guard isCurrent else { break }
+            playOnQueue(grain)
+        }
+
+        let nextGeneration = pending.withLock { state in
+            state.finishDrain(for: generation)
+        }
+        if let nextGeneration {
+            scheduleDrain(generation: nextGeneration)
+        }
+    }
+
+    private func cancelPending() {
+        pending.withLock { state in
+            state.cancel()
+        }
+    }
+
+    private func playOnQueue(_ grain: ScrubAudioGrain) {
+        guard let player = prepareOutputIfNeeded(),
+              let format,
+              let silenceBuffer,
+              let buffer = makeBuffer(grain, format: format)
+        else { return }
+
+        player.scheduleBuffer(buffer, at: nil, options: .interrupts)
+        // Keep the player alive between grains so play() runs once per scrub session.
+        player.scheduleBuffer(silenceBuffer, at: nil, options: .loops)
+        if state.startPlayerIfNeeded() {
+            player.play()
+        }
+    }
+
+    private func prepareOutputIfNeeded() -> AVAudioPlayerNode? {
+        if state.graph == .missing {
+            guard prepareGraph() else { return nil }
+        }
+        guard let engine, let player else { return nil }
+        if state.graph != .running {
+            engine.prepare()
+            do {
+                try engine.start()
+                state.engineStarted()
+            } catch {
+                Log.preview.error("scrub audio engine failed: \(error.localizedDescription)")
+                cancelPending()
+                invalidateOnQueue()
+                return nil
+            }
+        }
+        return player
+    }
+
+    private func prepareGraph() -> Bool {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: Self.channelCount,
+            interleaved: false
+        ), let silenceBuffer = makeSilenceBuffer(format: format) else { return false }
+
+        let engine = AVAudioEngine()
+        let player = AVAudioPlayerNode()
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+
+        self.engine = engine
+        self.player = player
+        self.format = format
+        self.silenceBuffer = silenceBuffer
+        state.graphPrepared()
+
+        configurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] _ in
+            self?.invalidate()
+        }
+        return true
+    }
+
+    private func stopOnQueue() {
+        player?.stop()
+        engine?.stop()
+        state.stop()
+    }
+
+    private func invalidateOnQueue() {
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+            self.configurationObserver = nil
+        }
+        player?.stop()
+        engine?.stop()
+        engine?.reset()
+        player = nil
+        engine = nil
+        format = nil
+        silenceBuffer = nil
+        state.invalidate()
+    }
+
+    private func makeBuffer(_ grain: ScrubAudioGrain, format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frameCount = min(grain.left.count, grain.right.count)
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(frameCount)
+              ), let channels = buffer.floatChannelData
+        else { return nil }
+
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        grain.left.withUnsafeBufferPointer { source in
+            channels[0].update(from: source.baseAddress!, count: frameCount)
+        }
+        grain.right.withUnsafeBufferPointer { source in
+            channels[1].update(from: source.baseAddress!, count: frameCount)
+        }
+        return buffer
+    }
+
+    private func makeSilenceBuffer(format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frameCount = AVAudioFrameCount(256)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount),
+              let channels = buffer.floatChannelData else { return nil }
+        buffer.frameLength = frameCount
+        for channel in 0..<Int(Self.channelCount) {
+            channels[channel].initialize(repeating: 0, count: Int(frameCount))
+        }
+        return buffer
+    }
+}

--- a/Tests/PalmierProTests/Audio/ScrubAudioOutputStateTests.swift
+++ b/Tests/PalmierProTests/Audio/ScrubAudioOutputStateTests.swift
@@ -1,0 +1,105 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Scrub audio output state")
+struct ScrubAudioOutputStateTests {
+    @Test func startsPlayerOncePerRunningSession() {
+        var state = ScrubAudioOutputState()
+
+        state.graphPrepared()
+        state.engineStarted()
+
+        let firstStart = state.startPlayerIfNeeded()
+        let duplicateStart = state.startPlayerIfNeeded()
+
+        #expect(firstStart)
+        #expect(!duplicateStart)
+        #expect(state.graph == .running)
+        #expect(state.playerStarted)
+    }
+
+    @Test func stopRequiresEngineRestartAndAllowsPlayerRestart() {
+        var state = ScrubAudioOutputState()
+        state.graphPrepared()
+        state.engineStarted()
+        let initialStart = state.startPlayerIfNeeded()
+        #expect(initialStart)
+
+        state.stop()
+
+        #expect(state.graph == .stopped)
+        #expect(!state.playerStarted)
+        let stoppedStart = state.startPlayerIfNeeded()
+        #expect(!stoppedStart)
+
+        state.engineStarted()
+        let restarted = state.startPlayerIfNeeded()
+        #expect(restarted)
+    }
+
+    @Test func invalidationRequiresNewGraph() {
+        var state = ScrubAudioOutputState()
+        state.graphPrepared()
+        state.engineStarted()
+        let initialStart = state.startPlayerIfNeeded()
+        #expect(initialStart)
+
+        state.invalidate()
+
+        #expect(state.graph == .missing)
+        #expect(!state.playerStarted)
+        let invalidatedStart = state.startPlayerIfNeeded()
+        #expect(!invalidatedStart)
+    }
+}
+
+@Suite("Scrub audio pending state")
+struct ScrubAudioPendingStateTests {
+    @Test func keepsOnlyLatestPendingValue() {
+        var state = ScrubAudioPendingState<Int>()
+
+        let generation = state.submit(1)!
+        let firstValue = state.take(for: generation)
+        let duplicateDrain = state.submit(2)
+        let secondDuplicateDrain = state.submit(3)
+        let latestValue = state.take(for: generation)
+        let exhausted = state.take(for: generation)
+        let nextDrain = state.finishDrain(for: generation)
+
+        #expect(firstValue == 1)
+        #expect(duplicateDrain == nil)
+        #expect(secondDuplicateDrain == nil)
+        #expect(latestValue == 3)
+        #expect(exhausted == nil)
+        #expect(nextDrain == nil)
+    }
+
+    @Test func cancelDiscardsOldValuesAndReschedulesNewGeneration() {
+        var state = ScrubAudioPendingState<Int>()
+
+        let oldGeneration = state.submit(1)!
+        state.cancel()
+        let duplicateDrain = state.submit(2)
+        let staleValue = state.take(for: oldGeneration)
+        let newGeneration = state.finishDrain(for: oldGeneration)
+        let currentValue = state.take(for: newGeneration!)
+
+        #expect(duplicateDrain == nil)
+        #expect(staleValue == nil)
+        #expect(newGeneration == state.generation)
+        #expect(currentValue == 2)
+    }
+
+    @Test func cancelWithoutNewValueDoesNotScheduleAnotherDrain() {
+        var state = ScrubAudioPendingState<Int>()
+
+        let oldGeneration = state.submit(1)!
+        state.cancel()
+        let staleValue = state.take(for: oldGeneration)
+        let nextGeneration = state.finishDrain(for: oldGeneration)
+
+        #expect(staleValue == nil)
+        #expect(nextGeneration == nil)
+        #expect(state.drainGeneration == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- move scrub-audio graph creation, startup, playback, and teardown onto a dedicated serial queue
- keep the player alive for each scrub session and coalesce pending grains to the latest cursor position
- invalidate stale audio graphs after configuration changes, app deactivation, and system sleep
- add regression tests for graph lifecycle and pending-grain cancellation

## Root cause

Sentry issue `PALMIER-PRO-105` showed the main thread blocking in `AVAudioPlayerNode.play()` while waiting in `AVAudioClock.awaitIOCycle`. Scrub playback created and controlled the AVAudio graph from the main actor, repeatedly entering `play()` as short grains drained. The affected sessions were also strongly correlated with long uptime and prior backgrounding, leaving the graph vulnerable to stale audio-device state.

## Impact

Scrubbing no longer performs potentially blocking Core Audio work on the main thread. The graph is created lazily, stopped at the end of a scrub session, rebuilt after lifecycle or configuration changes, and protected from unbounded stale-grain queues if AVFoundation stalls.

## Validation

- `swift test --filter 'ScrubAudio.*StateTests'`
- `swift test` — 1,026 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time audio I/O and threading around AVAudioEngine; behavior changes (session lifetime, grain coalescing, sleep/background invalidation) could affect scrub audio edge cases but is scoped to preview scrubbing with regression tests.
> 
> **Overview**
> Fixes main-thread stalls during timeline scrubbing by **moving AVAudioEngine / `AVAudioPlayerNode` work off the main actor** into a new **`ScrubAudioOutput`** that runs graph setup, `play()`, and teardown on a dedicated serial queue.
> 
> **`ScrubAudioEngine`** now builds **`ScrubAudioGrain`** PCM on the main actor and hands playback to the output layer; it also **suspends and invalidates** the graph on app deactivation and system sleep, and tears down lifecycle observers in `deinit` / `teardown`.
> 
> **`ScrubAudioOutput`** lazily creates the audio graph, **coalesces rapid scrub grains** to the latest cursor via generation-based pending state, calls **`play()` once per scrub session** (with a looping silence buffer between grains), and **rebuilds** after `AVAudioEngineConfigurationChange` or explicit invalidation.
> 
> Adds unit tests for graph lifecycle (`ScrubAudioOutputState`) and pending-grain draining / cancellation (`ScrubAudioPendingState`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2048d9aabb04e48a90f1689f637ac587cf0fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->