### PR TITLE
[fix] avoid redundant audio meter invalidation

### DIFF
--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -1,7 +1,6 @@
 import Accelerate
 import AVFoundation
 import Foundation
-import Observation
 
 struct AudioMeterAnalysis: Sendable, Equatable {
     let leftPeak, rightPeak: Float
@@ -62,7 +61,6 @@ struct AudioMeterChannelState: Sendable {
     }
 }
 
-@Observable
 @MainActor
 final class AudioMeterHub {
     private var left = AudioMeterChannelState()


### PR DESCRIPTION
## Summary

- stop `AudioMeterHub` from publishing observation invalidations on every ingest
- keep the existing 30 Hz `TimelineView` as the meter's sole UI refresh driver

## Why

The meter view already pulls the latest display state every 33 ms. Making the hub observable caused playback and scrub ingestion to request additional SwiftUI updates between those scheduled frames, duplicating invalidation work without improving the intended visual cadence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small observation-layer change in audio metering UI with no auth, data, or API impact; visual behavior should match the prior TimelineView-driven cadence.
> 
> **Overview**
> **`AudioMeterHub` is no longer `@Observable`**, and the `Observation` import is removed. Ingest still updates internal channel state the same way; it just no longer triggers SwiftUI observation invalidations on every audio buffer during playback or scrubbing.
> 
> The meter UI already refreshes on a fixed cadence via **`TimelineView`** (~30 Hz), which calls `display()` each tick. Relying on that timer alone avoids duplicate view updates between scheduled frames without changing how levels are computed or shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002c127de3a6f449c807b3f1ab79a593f65a0701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->