### PR TITLE
[fix] agent manage_tracks tool stable track addressing

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -9,8 +9,8 @@ enum AgentInstructions {
         - Timing: TIMELINE positions are project frames (startFrame, frames pairs, gaps, \
           ranges); SOURCE positions are seconds (source spans, search hits, asset transcripts \
           and durations). Tools convert between them — never multiply by fps yourself.
-        - Tracks are ordered and typed (video or audio); index 0 renders on top. Video clips, \
-          images, and text overlays all live on video tracks.
+        - Tracks are ordered and typed (video or audio); index 0 renders on top. For manage_tracks, \
+          use stable trackId values because indexes change. Video, images, and text use video tracks.
         - A clip occupies frames [start, end). Placement takes startFrame + endFrame or \
           source: [startSeconds, endSeconds]; lengths elsewhere are durationFrames. A video \
           clip's linked audio is folded into it as audio: {id, track, …} — use that nested id \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -79,7 +79,7 @@ enum ToolDefinitions {
     static let all: [AgentTool] = [
         AgentTool(
             name: .getTimeline,
-            description: "Always call at the start of a session. Returns project settings (fps, resolution, totalFrames, durationSeconds), tracks with their index (what every trackIndex parameter takes), type, and clips, plus canGenerate (if false, generation/upscale tools will fail — tell the user to sign in to Palmier and subscribe before attempting them). The clipId values here are what every other tool accepts.\n\nEvery clip occupies frames: [start, end) — timeline frames, end exclusive, duration = end − start. gaps on a track lists its empty [start, end) spans; no gaps key means contiguous. A video clip's linked audio partner is folded into it as audio: {id, track, …} carrying only what deviates (volume, effects, differing trims); the partner is not repeated on its own track, which instead reports linkedClips (its folded count). Address the audio side by its nested id.\n\nFields equal to their defaults are omitted: mediaType 'video', sourceClipType = mediaType, speed 1, volume 1, opacity 1, trims/fades 0, identity transform/crop, default textStyle, track muted/hidden false. Text clips never report trims. Keyframe tracks that animate nothing are shown as what they are: identity tracks are dropped, constant ones appear as the static field (e.g. crop: {left: 0.31}). A graded clip carries `color` — its grade in apply_color's own vocabulary, pasteable to other clips via apply_color's color parameter. Other effects appear as effects: [{type, params}], the exact shape apply_effect accepts.\n\nCaption clips (sharing a captionGroupId) come back per track as captionGroups summaries: clipCount, frameRange, shared style, and a textPreview — individual caption clips and their ids are NOT listed. That summary is all you need to restyle (update_text with captionGroupId) or judge coverage; the spoken words live in get_transcript. Only when you must touch individual caption clips (retime one, delete one, fix one word's style), re-read with captionDetail:true — ideally windowed — to get [clipId, startFrame, endFrame, text] rows, capped at 200 per group. Caption clips whose properties deviate from the group always appear individually in clips.",
+            description: "Always call at the start of a session. Returns project settings (fps, resolution, totalFrames, durationSeconds), tracks with a stable trackId, their current index (what every trackIndex parameter takes), type, and clips, plus canGenerate (if false, generation/upscale tools will fail — tell the user to sign in to Palmier and subscribe before attempting them). Clip ids are accepted by clip mutation tools; trackId is accepted by manage_tracks.\n\nEvery clip occupies frames: [start, end) — timeline frames, end exclusive, duration = end − start. gaps on a track lists its empty [start, end) spans; no gaps key means contiguous. A video clip's linked audio partner is folded into it as audio: {id, track, …} carrying only what deviates (volume, effects, differing trims); the partner is not repeated on its own track, which instead reports linkedClips (its folded count). Address the audio side by its nested id.\n\nFields equal to their defaults are omitted: mediaType 'video', sourceClipType = mediaType, speed 1, volume 1, opacity 1, trims/fades 0, identity transform/crop, default textStyle, track muted/hidden false. Text clips never report trims. Keyframe tracks that animate nothing are shown as what they are: identity tracks are dropped, constant ones appear as the static field (e.g. crop: {left: 0.31}). A graded clip carries `color` — its grade in apply_color's own vocabulary, pasteable to other clips via apply_color's color parameter. Other effects appear as effects: [{type, params}], the exact shape apply_effect accepts.\n\nCaption clips (sharing a captionGroupId) come back per track as captionGroups summaries: clipCount, frameRange, shared style, and a textPreview — individual caption clips and their ids are NOT listed. That summary is all you need to restyle (update_text with captionGroupId) or judge coverage; the spoken words live in get_transcript. Only when you must touch individual caption clips (retime one, delete one, fix one word's style), re-read with captionDetail:true — ideally windowed — to get [clipId, startFrame, endFrame, text] rows, capped at 200 per group. Caption clips whose properties deviate from the group always appear individually in clips.",
             inputSchema: objectSchema(
                 properties: [
                     "startFrame": ["type": "integer", "description": "Optional. Window start (inclusive); only clips intersecting [startFrame, endFrame) are returned. Tracks report totalClips when the window hides some."],
@@ -368,7 +368,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .manageTracks,
-            description: "Track-level operations in one undoable action: reorder (stacking order — index 0 renders on top; a video track can only move within the video zone, audio within audio), set flags (muted silences an audio track; hidden excludes a video track from the render; syncLocked controls whether ripple edits shift it), and remove (deletes tracks with every clip on them; linked partners on OTHER tracks stay). Arrays run reorder → set → remove; every index refers to the track order at call time (resolved up front). Returns the resulting track order — remaining indexes shift after reorder/remove. Tracks holding multicam clips can't be removed or sync-unlocked (mute/hide stay free).",
+            description: "Reorders, configures, or removes tracks in one undoable action. Prefer stable trackId selectors; numeric indexes use the order at call time. Index 0 renders on top, and reorder destinations must stay within the track's video/audio zone. Arrays run reorder → set → remove. Returns receipts and the resulting track order. Tracks holding multicam clips can't be removed or sync-unlocked.",
             inputSchema: objectSchema(
                 properties: [
                     "reorder": [
@@ -377,10 +377,11 @@ enum ToolDefinitions {
                         "items": [
                             "type": "object",
                             "properties": [
+                                "trackId": ["type": "string", "description": "Stable track ID from get_timeline."],
                                 "index": ["type": "integer", "description": "Track to move (0-based, current order)."],
-                                "to": ["type": "integer", "description": "Destination index; clamped to the track's type zone."],
+                                "to": ["type": "integer", "description": "Exact destination index in the same type zone."],
                             ],
-                            "required": ["index", "to"],
+                            "required": ["to"],
                         ],
                     ],
                     "set": [
@@ -388,18 +389,18 @@ enum ToolDefinitions {
                         "items": [
                             "type": "object",
                             "properties": [
+                                "trackId": ["type": "string", "description": "Stable track ID from get_timeline."],
                                 "index": ["type": "integer", "description": "Track to change (0-based, current order)."],
                                 "muted": ["type": "boolean", "description": "Silence/unsilence the track's audio."],
                                 "hidden": ["type": "boolean", "description": "Exclude/include a video track in the render."],
                                 "syncLocked": ["type": "boolean", "description": "Whether ripple edits shift this track along."],
                             ],
-                            "required": ["index"],
                         ],
                     ],
                     "remove": [
                         "type": "array",
-                        "items": ["type": "integer"],
-                        "description": "Track indexes to remove, with all their clips.",
+                        "description": "Tracks to remove with all their clips. Prefer {trackId}; bare integers are legacy current indexes.",
+                        "items": ["type": ["integer", "object"], "properties": ["trackId": ["type": "string"]]],
                     ],
                 ]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -858,6 +858,11 @@ extension ToolExecutor {
 
     // MARK: manage_tracks
 
+    private static func exactTrackIndex(_ raw: Any?) -> Int? {
+        guard let value = (raw as? NSNumber)?.doubleValue, !(raw is Bool), value.rounded() == value else { return nil }
+        return Int(exactly: value)
+    }
+
     func manageTracks(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         try validateUnknownKeys(args, allowed: ["reorder", "set", "remove"], path: "manage_tracks")
         let tracks = editor.timeline.tracks
@@ -869,36 +874,61 @@ extension ToolExecutor {
             return tracks[index].id
         }
 
+        func trackId(_ entry: [String: Any], _ path: String) throws -> String {
+            if let id = entry["trackId"] as? String {
+                guard entry["index"] == nil, tracks.contains(where: { $0.id == id }) else {
+                    throw ToolError("\(path): pass one current trackId or index")
+                }
+                return id
+            }
+            guard entry["trackId"] == nil, let index = Self.exactTrackIndex(entry["index"]) else {
+                throw ToolError("\(path): pass one current trackId or index")
+            }
+            return try trackId(index, path)
+        }
+
         var reorders: [(id: String, to: Int)] = []
         for (i, raw) in (args["reorder"] as? [Any] ?? []).enumerated() {
             guard let entry = raw as? [String: Any] else { throw ToolError("reorder[\(i)] must be an object") }
-            try validateUnknownKeys(entry, allowed: ["index", "to"], path: "reorder[\(i)]")
-            guard let index = entry.int("index"), let to = entry.int("to") else {
-                throw ToolError("reorder[\(i)]: 'index' and 'to' are required")
+            let path = "reorder[\(i)]"
+            try validateUnknownKeys(entry, allowed: ["trackId", "index", "to"], path: path)
+            guard let to = Self.exactTrackIndex(entry["to"]) else {
+                throw ToolError("\(path): 'to' is required and must be an integer")
             }
-            reorders.append((try trackId(index, "reorder[\(i)]"), to))
+            let id = try trackId(entry, path)
+            guard let from = tracks.firstIndex(where: { $0.id == id }),
+                  tracks.indices.contains(to), tracks[from].type == tracks[to].type else {
+                throw ToolError("\(path): destination index \(to) is outside the track's type zone")
+            }
+            reorders.append((id, to))
         }
 
         var flagSets: [(id: String, muted: Bool?, hidden: Bool?, syncLocked: Bool?)] = []
         for (i, raw) in (args["set"] as? [Any] ?? []).enumerated() {
             guard let entry = raw as? [String: Any] else { throw ToolError("set[\(i)] must be an object") }
-            try validateUnknownKeys(entry, allowed: ["index", "muted", "hidden", "syncLocked"], path: "set[\(i)]")
-            guard let index = entry.int("index") else { throw ToolError("set[\(i)]: 'index' is required") }
+            let path = "set[\(i)]"
+            try validateUnknownKeys(entry, allowed: ["trackId", "index", "muted", "hidden", "syncLocked"], path: path)
             let muted = entry["muted"] as? Bool
             let hidden = entry["hidden"] as? Bool
             let syncLocked = entry["syncLocked"] as? Bool
             guard muted != nil || hidden != nil || syncLocked != nil else {
-                throw ToolError("set[\(i)]: pass at least one of muted, hidden, syncLocked")
+                throw ToolError("\(path): pass at least one of muted, hidden, syncLocked")
             }
-            flagSets.append((try trackId(index, "set[\(i)]"), muted, hidden, syncLocked))
+            flagSets.append((try trackId(entry, path), muted, hidden, syncLocked))
         }
 
         var removeIds: [String] = []
         for (i, raw) in (args["remove"] as? [Any] ?? []).enumerated() {
-            guard let index = (raw as? Int) ?? (raw as? NSNumber)?.intValue else {
-                throw ToolError("remove[\(i)] must be a track index")
+            let path = "remove[\(i)]"
+            if let entry = raw as? [String: Any] {
+                try validateUnknownKeys(entry, allowed: ["trackId", "index"], path: path)
+                removeIds.append(try trackId(entry, path))
+                continue
             }
-            removeIds.append(try trackId(index, "remove[\(i)]"))
+            guard let index = Self.exactTrackIndex(raw) else {
+                throw ToolError("\(path) must be an integer index or track selector object")
+            }
+            removeIds.append(try trackId(index, path))
         }
 
         guard !reorders.isEmpty || !flagSets.isEmpty || !removeIds.isEmpty else {
@@ -916,10 +946,22 @@ extension ToolExecutor {
         }
 
         let snapshot = timelineSnapshot(editor)
+        let removeIdSet = Set(removeIds)
+        let removedTracks = tracks.indices.compactMap { i -> [String: Any]? in
+            let track = tracks[i]
+            guard removeIdSet.contains(track.id) else { return nil }
+            return ["trackId": track.id, "index": i, "label": editor.timelineTrackDisplayLabel(at: i), "type": track.type.rawValue]
+        }
+        var reorderResults: [(trackId: String, from: Int, to: Int)] = []
         withUndoGroup(editor, actionName: "Manage Tracks (Agent)") {
             if !reorders.isEmpty {
                 let before = editor.timeline
-                for r in reorders { editor.reorderTrackLive(id: r.id, to: r.to) }
+                for r in reorders {
+                    guard let from = editor.timeline.tracks.firstIndex(where: { $0.id == r.id }) else { continue }
+                    editor.reorderTrackLive(id: r.id, to: r.to)
+                    let destination = editor.timeline.tracks.firstIndex(where: { $0.id == r.id }) ?? from
+                    reorderResults.append((r.id, from, destination))
+                }
                 editor.commitTrackReorder(before: before)
             }
             for f in flagSets {
@@ -933,17 +975,18 @@ extension ToolExecutor {
         }
 
         let order = editor.timeline.tracks.indices.map { i -> [String: Any] in
-            let t = editor.timeline.tracks[i]
-            var entry: [String: Any] = ["index": i, "label": editor.timelineTrackDisplayLabel(at: i), "type": t.type.rawValue]
-            if t.muted { entry["muted"] = true }
-            if t.hidden { entry["hidden"] = true }
-            if !t.syncLocked { entry["syncLocked"] = false }
+            let track = editor.timeline.tracks[i]
+            var entry: [String: Any] = ["trackId": track.id, "index": i, "label": editor.timelineTrackDisplayLabel(at: i), "type": track.type.rawValue]
+            if track.muted { entry["muted"] = true }
+            if track.hidden { entry["hidden"] = true }
+            if !track.syncLocked { entry["syncLocked"] = false }
             return entry
         }
-        var notes: [String] = []
-        if !reorders.isEmpty || !removeIds.isEmpty {
-            notes.append("Track indices changed — 'tracks' is the new order; index 0 renders on top.")
+        var extra: [String: Any] = ["tracks": order]
+        if !reorderResults.isEmpty {
+            extra["reordered"] = reorderResults.map { ["trackId": $0.trackId, "from": $0.from, "to": $0.to, "changed": $0.from != $0.to] }
         }
-        return mutationResult(editor, since: snapshot, extra: ["tracks": order], notes: notes)
+        if !removedTracks.isEmpty { extra["removedTracks"] = removedTracks }
+        return mutationResult(editor, since: snapshot, extra: extra)
     }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
@@ -8,7 +8,7 @@ extension ToolExecutor {
         "clipId", "sourceClipId", "referenceClipId", "targetClipId",
         "mediaRef", "startFrameMediaRef", "endFrameMediaRef",
         "sourceVideoMediaRef", "videoSourceMediaRef", "sourceMediaRef",
-        "captionGroupId", "timelineId", "item", "from", "reference",
+        "captionGroupId", "timelineId", "trackId", "item", "from", "reference",
         "groupId", "memberId",
     ]
     private static let arrayIdKeys: Set<String> = [
@@ -22,6 +22,7 @@ extension ToolExecutor {
         var ids = Set<String>()
         for timeline in editor.timelines { ids.insert(timeline.id) }
         for track in editor.timeline.tracks {
+            ids.insert(track.id)
             for clip in track.clips {
                 ids.insert(clip.id)
                 if let captionGroupId = clip.captionGroupId { ids.insert(captionGroupId) }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -151,7 +151,7 @@ extension ToolExecutor {
             // Report the displayed label (mirrored video numbering), not the stored seed.
             track["label"] = editor.timelineTrackDisplayLabel(at: i)
             track["index"] = i
-            track.removeValue(forKey: "id")
+            track["trackId"] = track.removeValue(forKey: "id")
             track.removeValue(forKey: "displayHeight")
             if let count = fold.foldedCountByTrack[i] { track["linkedClips"] = count }
             let gaps = trackGaps(editor.timeline.tracks[i])

--- a/Tests/PalmierProTests/Agent/ManageTracksTests.swift
+++ b/Tests/PalmierProTests/Agent/ManageTracksTests.swift
@@ -33,6 +33,9 @@ struct ManageTracksTests {
 
     @Test func reordersWithinTypeZoneWithoutClipChurn() async throws {
         let h = harness()
+        let timeline = try await h.runOK("get_timeline") as? [String: Any]
+        let tracks = try #require(timeline?["tracks"] as? [[String: Any]])
+        let textRef = try #require(tracks[0]["trackId"] as? String)
         let movedId = h.editor.timeline.tracks[1].id
         let json = try await h.runOK("manage_tracks", args: ["reorder": [["index": 1, "to": 0]]]) as? [String: Any]
         #expect(h.editor.timeline.tracks[0].id == movedId)
@@ -41,7 +44,19 @@ struct ManageTracksTests {
         #expect(json?["shifted"] == nil)
         let order = json?["tracks"] as? [[String: Any]]
         #expect(order?.count == 3)
-        #expect(((json?["notes"] as? [String])?.first ?? "").contains("Track indices changed"))
+        let receipt = (json?["reordered"] as? [[String: Any]])?.first
+        #expect(receipt?["to"] as? Int == 0)
+        #expect(receipt?["changed"] as? Bool == true)
+        let movedRef = try #require(order?.first?["trackId"] as? String)
+        let noOp = try await h.runOK("manage_tracks", args: [
+            "reorder": [["trackId": movedRef, "to": 0]],
+        ]) as? [String: Any]
+        #expect(((noOp?["reordered"] as? [[String: Any]])?.first?["changed"] as? Bool) == false)
+
+        let remove = try await h.runOK("manage_tracks", args: ["remove": [["trackId": textRef]]]) as? [String: Any]
+        #expect(h.editor.timeline.tracks.contains { $0.id == movedId })
+        #expect(!h.editor.timeline.tracks.contains { $0.clips.contains { $0.mediaType == .text } })
+        #expect(((remove?["removedTracks"] as? [[String: Any]])?.first?["trackId"] as? String) == textRef)
     }
 
     @Test func setsMuteHiddenAndSyncLock() async throws {
@@ -63,8 +78,12 @@ struct ManageTracksTests {
 
     @Test func rejectsOutOfRangeIndexAndEmptyCall() async throws {
         let h = harness()
+        let before = h.editor.timeline
         #expect(await h.runRaw("manage_tracks", args: ["remove": [5]]).isError)
-        #expect(h.editor.timeline.tracks.count == 3)
+        #expect(await h.runRaw("manage_tracks", args: ["remove": [1.5]]).isError)
+        #expect(await h.runRaw("manage_tracks", args: ["reorder": [["index": 2, "to": 0]]]).isError)
+        #expect(await h.runRaw("manage_tracks", args: ["reorder": [["index": 1, "to": 99]]]).isError)
+        #expect(h.editor.timeline == before)
         #expect(await h.runRaw("manage_tracks", args: [:]).isError)
     }
 }

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -330,7 +330,7 @@ struct ToolExecutorReadOnlyTests {
         #expect(track?["hidden"] == nil)
         #expect(track?["syncLocked"] == nil)
         #expect(track?["label"] as? String == "V1")
-        // No tool consumes track ids or UI fields; the index is what tools take.
+        #expect(track?["trackId"] != nil)
         #expect(track?["id"] == nil)
         #expect(track?["displayHeight"] == nil)
         #expect(track?["index"] as? Int == 0)


### PR DESCRIPTION
fixes part of #302 

## Before

`get_timeline` and `manage_tracks` exposed track indexes and positional labels, but stripped the underlying track ID. Because labels are recalculated from stacking order, a reorder between same-type tracks could return a success-shaped response that looked unchanged. Reusing an index after an edit could then target a different track, making unattended reorder/remove workflows unsafe.

Reorder destinations were also silently clamped to the video or audio track zone, so an invalid request could appear successful without landing at the requested index.

## After

- `get_timeline` and `manage_tracks` return a stable `trackId` alongside each current index and label.
- `manage_tracks` accepts `trackId` for reorder/set and `{trackId: ...}` for removal; legacy numeric indexes remain supported and resolve against the pre-call order.
- Track ID prefixes round-trip through the existing short-ID layer.
- Reorder destinations and numeric selectors must be exact integers and valid for the track's type zone; invalid requests fail instead of clamping.
- Reorders return `{trackId, from, to, changed}` receipts, including `changed: false` for an explicit no-op.
- Removes return `removedTracks`, identifying the exact track that was deleted.

Track labels remain positional by design; `trackId` is now the stable identity automation can retain across edits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-facing timeline/track APIs and validation for `manage_tracks`; wrong clients could break on stricter reorder errors, but legacy index selectors remain and tests cover the new paths.
> 
> **Overview**
> **Stable track identity for the agent** — `get_timeline` and `manage_tracks` now expose **`trackId`** on each track (with current `index` and label), so automation can target tracks after reorders instead of relying on shifting indexes or positional labels.
> 
> **`manage_tracks` behavior** accepts **`trackId`** (or `{trackId}`) for reorder, set, and remove; legacy integer indexes still resolve against pre-call order. Reorder **`to`** must be an exact integer inside the track’s video/audio zone — invalid destinations **error** rather than silently clamp. Responses add **`reordered`** receipts (`from`, `to`, **`changed`**, including explicit no-ops) and **`removedTracks`** on delete. Track IDs participate in the existing short-ID round-trip layer.
> 
> Agent **tool descriptions** and **instructions** steer the model toward `trackId` for `manage_tracks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5541856e1bcc870f7a118a798bec9a44efc72a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->