### PR TITLE
[fix] Move search index preflight off main actor

### DIFF
--- a/Sources/PalmierPro/Search/Models/VisualEmbedder.swift
+++ b/Sources/PalmierPro/Search/Models/VisualEmbedder.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 import Foundation
 
 final class VisualEmbedder: @unchecked Sendable {
-    struct Spec: Codable, Sendable {
+    struct Spec: Codable, Equatable, Sendable {
         let model: String
         let version: Int
         let embeddingDim: Int

--- a/Sources/PalmierPro/Search/SearchIndexCoordinator.swift
+++ b/Sources/PalmierPro/Search/SearchIndexCoordinator.swift
@@ -4,6 +4,34 @@ import Foundation
 @MainActor
 @Observable
 final class SearchIndexCoordinator {
+    struct PreflightRequest: Sendable {
+        let url: URL
+        let type: ClipType
+        let hasAudio: Bool
+        let spec: VisualEmbedder.Spec
+    }
+
+    struct PreflightResult: Equatable, Sendable {
+        let needsVisual: Bool
+        let needsTranscript: Bool
+
+        var needsIndex: Bool { needsVisual || needsTranscript }
+    }
+
+    private struct AssetSnapshot: Equatable, Sendable {
+        let id: String
+        let url: URL
+        let type: ClipType
+        let duration: Double
+        let hasAudio: Bool
+        let isGenerating: Bool
+    }
+
+    private struct IndexWork: Sendable {
+        let asset: AssetSnapshot
+        let spec: VisualEmbedder.Spec
+    }
+
     private(set) var batchTotal = 0
     private(set) var batchCompleted = 0
     private(set) var currentAssetFraction: Double = 0
@@ -16,7 +44,9 @@ final class SearchIndexCoordinator {
 
     var assetsProvider: () -> [MediaAsset] = { [] }
 
-    private var queue: [String] = []
+    private var queue: [IndexWork] = []
+    private var scheduledIds: Set<String> = []
+    private var isCancelling = false
     private var failedIds: Set<String> = []
     private var worker: Task<Void, Never>?
     /// Bumped whenever `worker` is replaced or cancelled, so a stale worker's
@@ -84,12 +114,14 @@ final class SearchIndexCoordinator {
     }
 
     func schedule(_ asset: MediaAsset) {
-        guard VisualModelLoader.shared.enabled, let model = VisualModelLoader.shared.embedder, !asset.isGenerating else { return }
-        guard !queue.contains(asset.id), !failedIds.contains(asset.id) else { return }
-        let needsVisual = (asset.type == .video || asset.type == .image)
-            && VisualIndexer.needsIndex(url: asset.url, spec: model.spec)
-        guard needsVisual || needsTranscript(asset) else { return }
-        queue.append(asset.id)
+        guard !isCancelling,
+              VisualModelLoader.shared.enabled,
+              let model = VisualModelLoader.shared.embedder,
+              !asset.isGenerating else { return }
+        guard !scheduledIds.contains(asset.id), !failedIds.contains(asset.id) else { return }
+        let snapshot = Self.snapshot(asset)
+        queue.append(IndexWork(asset: snapshot, spec: model.spec))
+        scheduledIds.insert(snapshot.id)
         batchTotal += 1
         ensureWorker()
     }
@@ -98,19 +130,37 @@ final class SearchIndexCoordinator {
         asset.type == .audio || (asset.type == .video && asset.hasAudio)
     }
 
-    private func needsTranscript(_ asset: MediaAsset) -> Bool {
-        Self.wantsTranscript(asset) && !TranscriptCache.hasCachedOnDisk(for: asset.url)
+    nonisolated static func preflight(_ request: PreflightRequest) -> PreflightResult {
+        let needsVisual = (request.type == .video || request.type == .image)
+            && VisualIndexer.needsIndex(url: request.url, spec: request.spec)
+        let needsTranscript = (request.type == .audio || (request.type == .video && request.hasAudio))
+            && !TranscriptCache.hasCachedOnDisk(for: request.url)
+        return PreflightResult(needsVisual: needsVisual, needsTranscript: needsTranscript)
     }
 
-    /// Stops the worker and waits for the in-flight asset to actually stop.
     private func cancelIndexing() async {
+        isCancelling = true
+        defer { isCancelling = false }
         let current = worker
         workerGeneration += 1
         worker = nil
         queue.removeAll()
+        scheduledIds.removeAll()
         resetBatch()
         current?.cancel()
         await current?.value
+        resetBatch()
+    }
+
+    private static func snapshot(_ asset: MediaAsset) -> AssetSnapshot {
+        AssetSnapshot(
+            id: asset.id,
+            url: asset.url,
+            type: asset.type,
+            duration: asset.duration,
+            hasAudio: asset.hasAudio,
+            isGenerating: asset.isGenerating
+        )
     }
 
     // MARK: - Worker
@@ -125,12 +175,9 @@ final class SearchIndexCoordinator {
             data: ["generation": generation, "queueDepth": queue.count, "batchTotal": batchTotal]
         )
         worker = Task(priority: .utility) { [weak self] in
-            while let self, !Task.isCancelled, let asset = self.dequeue() {
-                while ExportQueue.shared.isExportActive, !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(2))
-                }
+            while let self, !Task.isCancelled, let work = self.dequeue() {
                 self.currentAssetFraction = 0
-                await self.indexOne(asset)
+                await self.process(work)
             }
             if let self, self.workerGeneration == generation {
                 self.worker = nil
@@ -138,14 +185,58 @@ final class SearchIndexCoordinator {
         }
     }
 
-    private func dequeue() -> MediaAsset? {
-        while !queue.isEmpty {
-            let id = queue.removeFirst()
-            if let asset = assetsProvider().first(where: { $0.id == id }) { return asset }
-            batchCompleted += 1
+    private func dequeue() -> IndexWork? {
+        guard !queue.isEmpty else {
+            resetBatch()
+            return nil
         }
-        resetBatch()
-        return nil
+        return queue.removeFirst()
+    }
+
+    private func process(_ work: IndexWork) async {
+        var retry: MediaAsset?
+        defer {
+            scheduledIds.remove(work.asset.id)
+            batchCompleted += 1
+            if let retry { schedule(retry) }
+        }
+
+        let request = PreflightRequest(
+            url: work.asset.url,
+            type: work.asset.type,
+            hasAudio: work.asset.hasAudio,
+            spec: work.spec
+        )
+        let task = Task.detached(priority: .utility) { Self.preflight(request) }
+        let result = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard !Task.isCancelled else { return }
+
+        guard isCurrent(work) else {
+            retry = assetsProvider().first { $0.id == work.asset.id }
+            return
+        }
+        guard result.needsIndex else { return }
+
+        while ExportQueue.shared.isExportActive, !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(2))
+        }
+        guard !Task.isCancelled else { return }
+        guard isCurrent(work), let model = VisualModelLoader.shared.embedder else {
+            retry = assetsProvider().first { $0.id == work.asset.id }
+            return
+        }
+        await indexOne(work.asset, model: model, transcribe: result.needsTranscript)
+    }
+
+    private func isCurrent(_ work: IndexWork) -> Bool {
+        guard VisualModelLoader.shared.enabled,
+              VisualModelLoader.shared.embedder?.spec == work.spec,
+              let asset = assetsProvider().first(where: { $0.id == work.asset.id }) else { return false }
+        return Self.snapshot(asset) == work.asset
     }
 
     private func resetBatch() {
@@ -154,10 +245,11 @@ final class SearchIndexCoordinator {
         currentAssetFraction = 0
     }
 
-    private func indexOne(_ asset: MediaAsset) async {
-        defer { batchCompleted += 1 }
-        guard let model = VisualModelLoader.shared.embedder else { return }
-        let transcribe = needsTranscript(asset)
+    private func indexOne(
+        _ asset: AssetSnapshot,
+        model: VisualEmbedder,
+        transcribe: Bool
+    ) async {
         let visualShare = transcribe ? 0.5 : 1.0
         let onProgress: @Sendable (Double) -> Void = { [weak self] fraction in
             Task { @MainActor [weak self] in self?.currentAssetFraction = fraction * visualShare }

--- a/Tests/PalmierProTests/Search/SearchIndexCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Search/SearchIndexCoordinatorTests.swift
@@ -25,3 +25,51 @@ struct TranscriptGatingTests {
         #expect(!TranscriptCache.hasCachedOnDisk(for: url))
     }
 }
+
+@Suite("SearchIndexCoordinator — disk preflight")
+struct SearchIndexPreflightTests {
+    private let spec = VisualEmbedder.Spec(
+        model: "preflight-test",
+        version: 1,
+        embeddingDim: 4,
+        imageSize: 8,
+        contextLength: 8
+    )
+
+    @Test func visualAndTranscriptEligibilityAreComputedTogether() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preflight-\(UUID().uuidString).mov")
+        try Data("media".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let request = SearchIndexCoordinator.PreflightRequest(
+            url: url,
+            type: .video,
+            hasAudio: true,
+            spec: spec
+        )
+        let result = await Task.detached { SearchIndexCoordinator.preflight(request) }.value
+
+        #expect(result.needsVisual)
+        #expect(result.needsTranscript)
+        #expect(result.needsIndex)
+    }
+
+    @Test func imagePreflightDoesNotRequestTranscript() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preflight-\(UUID().uuidString).png")
+        try Data("image".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let request = SearchIndexCoordinator.PreflightRequest(
+            url: url,
+            type: .image,
+            hasAudio: true,
+            spec: spec
+        )
+        let result = await Task.detached { SearchIndexCoordinator.preflight(request) }.value
+
+        #expect(result.needsVisual)
+        #expect(!result.needsTranscript)
+    }
+}


### PR DESCRIPTION
## Summary

- Move visual-index and transcript-cache preflight checks off the main actor.
- Reuse the existing serial indexing worker for preflight and indexing.
- Revalidate queued asset snapshots and the visual model before starting work.

## Root cause

`SearchIndexCoordinator.schedule()` ran synchronous filesystem checks while isolated to the main actor. Project sweeps call it for every media asset, so opening a large project could block the UI while index and transcript caches were inspected.

## Impact

The main actor now only coordinates queue, progress, and observable state. Filesystem preflight runs in a detached utility task, while existing indexing and transcription behavior remains unchanged.

## Validation

- `swift build`
- `swift test --filter 'SearchIndexPreflightTests|TranscriptGatingTests'` (4 tests)
- `swift test` (1,033 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches indexing queue lifecycle, cancellation, and when work is skipped vs retried; behavior should match prior gating but race/retry paths are more complex.
> 
> **Overview**
> **Moves filesystem-heavy “do we need to index?” checks off the main actor** so project sweeps no longer block the UI when many assets are enqueued.
> 
> `schedule` now only snapshots each asset and appends `IndexWork` (with `scheduledIds` deduping); **visual and transcript eligibility run later** via `nonisolated static preflight` in a detached utility task inside the serial worker’s `process` path. Before indexing, **`isCurrent`** re-checks that the embedder spec still matches and the live asset still matches the queued snapshot, **rescheduling** if the asset changed or the model isn’t ready. Cancel paths set **`isCancelling`** and clear **`scheduledIds`**; **`VisualEmbedder.Spec`** gains **`Equatable`** for spec comparison. New **`SearchIndexPreflightTests`** cover combined visual/transcript gating for video vs image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6739bdf494920dfba39f97e3ab06811ad305ad22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->