### PR TITLE
[fix] Batch manifest metadata updates

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -283,14 +283,14 @@ extension ToolExecutor {
             return
         }
         asset.importInput = nil
-        editor.updateManifestMetadata(for: asset)
+        editor.updateManifestMetadata(for: [asset])
         editor.onProjectCheckpointRequired?()
     }
 
     @MainActor
     private static func failImportedAsset(_ asset: MediaAsset, editor: EditorViewModel, message: String) {
         asset.generationStatus = .failed(message)
-        editor.updateManifestMetadata(for: asset)
+        editor.updateManifestMetadata(for: [asset])
         editor.onProjectCheckpointRequired?()
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -180,7 +180,8 @@ extension EditorViewModel {
     }
 
     func mediaLibraryUndoSnapshot() -> MediaLibraryUndoSnapshot {
-        MediaLibraryUndoSnapshot(
+        flushPendingManifestMetadataUpdates()
+        return MediaLibraryUndoSnapshot(
             timelines: timelines,
             activeTimelineId: activeTimelineId,
             openTimelineIds: openTimelineIds,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -132,7 +132,7 @@ extension EditorViewModel {
         if !skipAppend, !mediaAssets.contains(where: { $0.id == asset.id }) {
             mediaAssets.append(asset)
         }
-        updateManifestMetadata(for: asset)
+        updateManifestMetadata(for: [asset])
         Log.project.notice(
             "media imported asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
             telemetry: "Media asset imported",
@@ -282,7 +282,7 @@ extension EditorViewModel {
         }
         undoManager?.setActionName("Import Media")
         for asset in importedAssets {
-            Task { await finalizeImportedAsset(asset) }
+            Task { await finalizeImportedAsset(asset, batchManifestUpdate: true) }
         }
         return summary
     }
@@ -500,13 +500,47 @@ extension EditorViewModel {
         undoManager?.setActionName("Rename Asset")
     }
 
-    func updateManifestMetadata(for asset: MediaAsset) {
-        let entry = asset.toManifestEntry(projectURL: projectURL)
-        if let idx = mediaManifest.entries.firstIndex(where: { $0.id == asset.id }) {
-            mediaManifest.entries[idx] = entry
-        } else {
-            mediaManifest.entries.append(entry)
+    func updateManifestMetadata(for assets: [MediaAsset]) {
+        guard !assets.isEmpty else { return }
+        var manifest = mediaManifest
+        var indices: [String: Int] = [:]
+        for index in manifest.entries.indices {
+            indices[manifest.entries[index].id] = index
         }
+        for asset in assets {
+            let entry = asset.toManifestEntry(projectURL: projectURL)
+            if let index = indices[asset.id] {
+                manifest.entries[index] = entry
+            } else {
+                indices[asset.id] = manifest.entries.count
+                manifest.entries.append(entry)
+            }
+        }
+        mediaManifest = manifest
+    }
+
+    func queueManifestMetadataUpdate(for asset: MediaAsset) {
+        pendingManifestMetadataUpdates[asset.id] = asset
+        if pendingManifestMetadataUpdates.count >= 64 {
+            flushPendingManifestMetadataUpdates()
+        } else if pendingManifestMetadataFlushTask == nil {
+            pendingManifestMetadataFlushTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(20))
+                guard !Task.isCancelled, let self else { return }
+                pendingManifestMetadataFlushTask = nil
+                flushPendingManifestMetadataUpdates()
+            }
+        }
+    }
+
+    func flushPendingManifestMetadataUpdates() {
+        pendingManifestMetadataFlushTask?.cancel()
+        pendingManifestMetadataFlushTask = nil
+        let assets = pendingManifestMetadataUpdates.values.filter {
+            mediaAssetsById[$0.id] === $0
+        }
+        pendingManifestMetadataUpdates.removeAll(keepingCapacity: true)
+        updateManifestMetadata(for: assets)
     }
 
     /// Text is composited via `CALayer.render` — `AVAssetImageGenerator`
@@ -584,7 +618,10 @@ extension EditorViewModel {
     }
 
     @discardableResult
-    func finalizeImportedAsset(_ asset: MediaAsset) async -> Bool {
+    func finalizeImportedAsset(
+        _ asset: MediaAsset,
+        batchManifestUpdate: Bool = false
+    ) async -> Bool {
         Log.project.notice(
             "media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
             telemetry: "Media asset finalize started",
@@ -600,7 +637,7 @@ extension EditorViewModel {
             if asset.isGenerating || asset.isGenerated || asset.importInput != nil {
                 asset.generationStatus = .failed("Could not read media file.")
             }
-            updateManifestMetadata(for: asset)
+            recordManifestMetadata(for: asset, batching: batchManifestUpdate)
             Log.project.warning(
                 "media finalize unreadable asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
                 telemetry: "Media asset finalize unreadable",
@@ -613,7 +650,7 @@ extension EditorViewModel {
         if asset.isGenerating {
             asset.generationStatus = .none
         }
-        updateManifestMetadata(for: asset)
+        recordManifestMetadata(for: asset, batching: batchManifestUpdate)
         if FileManager.default.fileExists(atPath: asset.url.path) {
             missingMediaRefs.remove(asset.id)
             offlineMediaRefs.remove(asset.id)
@@ -647,6 +684,14 @@ extension EditorViewModel {
             ]
         )
         return true
+    }
+
+    private func recordManifestMetadata(for asset: MediaAsset, batching: Bool) {
+        if batching {
+            queueManifestMetadataUpdate(for: asset)
+        } else {
+            updateManifestMetadata(for: [asset])
+        }
     }
 
     private func refreshPreviewForFinalizedAsset(_ asset: MediaAsset) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -246,6 +246,8 @@ final class EditorViewModel {
     var mediaPanelToast: MediaPanelToast?
     @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Never>?
     @ObservationIgnored var mediaImportSequence: Int = 0
+    @ObservationIgnored var pendingManifestMetadataUpdates: [String: MediaAsset] = [:]
+    @ObservationIgnored var pendingManifestMetadataFlushTask: Task<Void, Never>?
 
     func showMediaPanelMediaTab() {
         mediaPanelShowMediaTabTick += 1

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -330,7 +330,7 @@ final class GenerationService {
             mutateInput(&input)
             asset.generationInput = input
         }
-        editor.updateManifestMetadata(for: asset)
+        editor.updateManifestMetadata(for: [asset])
     }
 
     /// Uploads each reference and returns the hosted URLs.

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -217,6 +217,7 @@ final class VideoProject: NSDocument {
     }
 
     private func captureSaveSnapshot() {
+        editorViewModel.flushPendingManifestMetadataUpdates()
         snapshotProjectFile = editorViewModel.projectFileSnapshot()
         snapshotManifest = Self.manifestSnapshot(manifest: editorViewModel.mediaManifest, loadFailed: manifestLoadFailed)
         snapshotGenerationLog = editorViewModel.generationLog
@@ -588,6 +589,7 @@ final class VideoProject: NSDocument {
         var restored = 0
         var missing = initialMissingCount
         var missingRefs = initialMissingRefs
+        var manifestUpdates: [MediaAsset] = []
 
         for candidate in candidates {
             guard let asset = assetsByID[candidate.id] else { continue }
@@ -598,13 +600,13 @@ final class VideoProject: NSDocument {
                         break
                     default:
                         asset.generationStatus = .failed("Import interrupted")
-                        editorViewModel.updateManifestMetadata(for: asset)
+                        manifestUpdates.append(asset)
                     }
                     continue
                 }
                 if asset.isRecoveringGeneration {
                     asset.generationStatus = .generating
-                    editorViewModel.updateManifestMetadata(for: asset)
+                    manifestUpdates.append(asset)
                     continue
                 }
                 Log.project.warning("restore: media file missing id=\(candidate.id) name=\(candidate.name) path=\(candidate.url.path)")
@@ -618,11 +620,11 @@ final class VideoProject: NSDocument {
                 }
                 asset.importInput = nil
                 asset.generationStatus = .none
-                editorViewModel.updateManifestMetadata(for: asset)
+                manifestUpdates.append(asset)
             }
             if asset.generationStatus != .none, !asset.canResumeGeneration {
                 asset.generationStatus = .none
-                editorViewModel.updateManifestMetadata(for: asset)
+                manifestUpdates.append(asset)
             }
             restored += 1
             if asset.type == .audio || asset.type == .video {
@@ -637,6 +639,7 @@ final class VideoProject: NSDocument {
             Task { await asset.loadMetadata() }
         }
 
+        editorViewModel.updateManifestMetadata(for: manifestUpdates)
         editorViewModel.missingMediaRefs = missingRefs
         editorViewModel.generationService.resumePendingGenerations(editor: editorViewModel)
         Log.project.notice(

--- a/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
+++ b/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+@MainActor struct ManifestMetadataTests {
+    private func asset(_ id: String) -> MediaAsset {
+        MediaAsset(id: id, url: URL(fileURLWithPath: "/tmp/\(id).mp4"), type: .video, name: id, duration: 1)
+    }
+    @Test func largeBatchUpdatesInPlace() {
+        let editor = EditorViewModel()
+        let assets = (0..<1_000).map { asset("asset-\($0)") }
+        editor.updateManifestMetadata(for: assets)
+        for (index, asset) in assets.enumerated() { asset.duration = Double(index) }
+        editor.updateManifestMetadata(for: Array(assets.reversed()))
+        #expect(editor.mediaManifest.entries[731].duration == 731)
+    }
+    @Test func queuedFlushUsesLatestLiveAssets() async {
+        let editor = EditorViewModel()
+        let renamed = asset("renamed")
+        let deleted = asset("deleted")
+        editor.mediaAssets = [renamed, deleted]
+        editor.updateManifestMetadata(for: [renamed, deleted])
+        editor.queueManifestMetadataUpdate(for: renamed)
+        editor.queueManifestMetadataUpdate(for: deleted)
+        renamed.name = "Latest"
+        editor.mediaAssets = [renamed]
+        editor.mediaManifest.entries.removeAll { $0.id == deleted.id }
+        await editor.pendingManifestMetadataFlushTask?.value
+        #expect(editor.mediaManifest.entries.map(\.name) == ["Latest"])
+    }
+}


### PR DESCRIPTION
## Summary

- Merge manifest metadata updates through one ID-indexed pass and one observed assignment.
- Coalesce Finder import finalizations for 20 ms or until 64 assets are pending.
- Batch project-restore mutations and flush pending metadata before save and undo snapshots.

## Root cause

Import finalization and project restoration updated each manifest entry separately on the main actor. Every update performed a linear search and mutated the observed manifest array, repeatedly triggering copy-on-write allocation and observation invalidation. Large projects therefore approached quadratic work and could freeze while allocating manifest copies.

## Impact

Live media asset state still updates immediately. Finder-import metadata is reflected in the serialized manifest after a short coalescing window, while persistence and undo boundaries force an immediate flush.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manifest persistence, undo snapshots, and import/restore timing; coalescing delays serialized manifest updates by up to ~20ms during bulk Finder imports unless save/undo forces a flush.
> 
> **Overview**
> Fixes **main-thread freezes** during large Finder imports and project restore by avoiding per-asset manifest rewrites that repeatedly triggered observation and copy-on-write on `mediaManifest`.
> 
> **`updateManifestMetadata`** now takes an array of assets, builds an ID→index map, applies all entry updates in one local copy, and assigns **`mediaManifest` once**. Call sites pass `[asset]`; project restore collects mutations and flushes in a single batch.
> 
> **Coalesced updates** for Finder import finalization: `finalizeImportedAsset(..., batchManifestUpdate: true)` queues via `queueManifestMetadataUpdate`, flushing after **20 ms** or when **64** assets are pending. `flushPendingManifestMetadataUpdates` drops stale/deleted assets (identity check against `mediaAssetsById`) before applying.
> 
> **Consistency boundaries**: pending metadata is flushed before **save snapshots**, **undo** media-library snapshots, and after batched import finalize paths so persisted/undo state matches live assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a49a1f5c7c812bc650c6b0693966dd11b6a1f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->