### PR TITLE
[fix] Reduce production logging overhead

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -585,11 +585,7 @@ extension EditorViewModel {
 
     @discardableResult
     func finalizeImportedAsset(_ asset: MediaAsset) async -> Bool {
-        Log.project.notice(
-            "media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
-            telemetry: "Media asset finalize started",
-            data: ["assetId": Telemetry.shortId(asset.id), "type": asset.type.rawValue]
-        )
+        Log.project.debug("media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)")
         let metadataLoaded = await asset.loadMetadata()
         guard metadataLoaded else {
             if FileManager.default.fileExists(atPath: asset.url.path) {
@@ -633,18 +629,8 @@ extension EditorViewModel {
             break
         }
         refreshPreviewForFinalizedAsset(asset)
-        Log.project.notice(
-            "media finalize ok asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)",
-            telemetry: "Media asset finalize finished",
-            data: [
-                "assetId": Telemetry.shortId(asset.id),
-                "type": asset.type.rawValue,
-                "duration": asset.duration,
-                "width": asset.sourceWidth ?? 0,
-                "height": asset.sourceHeight ?? 0,
-                "fps": asset.sourceFPS ?? 0,
-                "hasAudio": asset.hasAudio
-            ]
+        Log.project.debug(
+            "media finalize ok asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue) duration=\(asset.duration)"
         )
         return true
     }

--- a/Sources/PalmierPro/Search/SearchIndexCoordinator.swift
+++ b/Sources/PalmierPro/Search/SearchIndexCoordinator.swift
@@ -187,12 +187,12 @@ final class SearchIndexCoordinator {
             currentAssetFraction = visualShare
             try await transcriptDone
             let totalSeconds = start.duration(to: .now).seconds
-            Log.search.notice("""
+            Log.search.debug("""
                 indexed \(asset.id.prefix(8)) visual=\(String(format: "%.1f", visualSeconds))s \
                 total=\(String(format: "%.1f", totalSeconds))s transcribed=\(transcribe)
                 """)
         } catch is CancellationError {
-            Log.search.notice("index cancelled asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)")
+            Log.search.debug("index cancelled asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)")
         } catch {
             failedIds.insert(asset.id)
             Log.search.warning("index failed asset=\(asset.id.prefix(8)): \(error.localizedDescription)")

--- a/Sources/PalmierPro/Utilities/Log.swift
+++ b/Sources/PalmierPro/Utilities/Log.swift
@@ -55,7 +55,13 @@ struct CategoryLog {
         self.category = category
     }
 
-    func debug(_ m: String) { logger.debug("\(m, privacy: .public)") }
+    func debug(_ message: @autoclosure () -> String) {
+        #if DEBUG
+        let value = message()
+        mirror("DEBUG", value)
+        logger.debug("\(value, privacy: .public)")
+        #endif
+    }
     func info(_ m: String) { logger.info("\(m, privacy: .public)") }
     func notice(_ m: String, telemetry: String? = nil, data: Telemetry.Payload? = nil) {
         mirror("NOTICE", m)
@@ -81,7 +87,9 @@ struct CategoryLog {
     }
 
     private func mirror(_ level: String, _ msg: String) {
+        #if DEBUG
         FileHandle.standardError.write(Data("[\(category)] \(level): \(msg)\n".utf8))
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary

- compile debug logging out of release builds, including message evaluation and stderr mirroring
- keep per-asset import and indexing success messages available in debug builds
- retain production warnings, failures, and batch-level summaries for diagnostics and Sentry

## Why

Large imports generated a log entry for every finalized and indexed asset. Those success messages ran in production and could add I/O overhead while crowding out more useful Sentry breadcrumbs.

This keeps detailed per-asset visibility during development without paying that cost in release builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes; production warnings and batch summaries remain, with slightly less per-asset detail in release logs and Sentry.
> 
> **Overview**
> Cuts **release-build logging cost** by making `CategoryLog.debug` a **DEBUG-only** path: messages use `@autoclosure` so strings are not built in release, and stderr mirroring runs only under `#if DEBUG`.
> 
> **Per-asset success noise** on large imports is moved off production telemetry: media finalize start/ok and search index success/cancel lines go from `notice` (with Sentry breadcrumbs on finalize) to `debug`. **Warnings, errors, and batch-level `notice` calls** (e.g. import applied, index sweep/worker) are unchanged for diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 464abe7d8c97d7818c05d0108d6cfcc3d391b202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->