### PR TITLE
[fix] Prevent MLX crash during app termination

### DIFF
--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -2,6 +2,8 @@ import AppKit
 import ClerkKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var isTerminating = false
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Activate the app (required when launched from CLI, not a .app bundle)
         NSApp.setActivationPolicy(.regular)
@@ -29,6 +31,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             AppState.shared.showHome()
         }
         return true
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if isTerminating { return .terminateLater }
+        isTerminating = true
+        if MLXRuntime.beginTermination() { return .terminateNow }
+
+        Task { @MainActor in
+            await MLXRuntime.waitUntilIdle()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {

--- a/Sources/PalmierPro/Audio/Analysis/SpeakerIdentity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeakerIdentity.swift
@@ -37,8 +37,9 @@ enum SpeakerIdentity {
     private actor ModelBox {
         private var model: WeSpeakerModel?
         func embed(_ samples: [Float]) async throws -> [Float] {
+            try MLXRuntime.beginOperation()
+            defer { MLXRuntime.endOperation() }
             if model == nil {
-                try MLXRuntime.requireAvailable()
                 model = try await WeSpeakerModel.fromPretrained()
             }
             return model!.embed(audio: samples, sampleRate: 16000)

--- a/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
@@ -37,22 +37,46 @@ enum VoiceActivity {
         private var model: SileroVADModel?
 
         func analyze(samples: [Float]) async throws -> Analysis {
+            guard !samples.isEmpty else { return Analysis(chunkCount: 0, segments: []) }
+            try MLXRuntime.beginOperation()
+            defer { MLXRuntime.endOperation() }
+
             // .mlx pinned: the CoreML engine soft-fails per chunk on ANE errors, caching empty segments as truth.
             let vad: SileroVADModel
             if let model {
                 vad = model
             } else {
-                try MLXRuntime.requireAvailable()
                 vad = try await SileroVADModel.fromPretrained(engine: .mlx)
                 model = vad
             }
-            guard !samples.isEmpty else { return Analysis(chunkCount: 0, segments: []) }
-            let segments = vad.detectSpeech(audio: samples, sampleRate: SileroVADModel.sampleRate)
             let chunkCount = (samples.count + SileroVADModel.chunkSize - 1) / SileroVADModel.chunkSize
+            let segments = try detectSpeech(vad: vad, samples: samples)
             return Analysis(
                 chunkCount: chunkCount,
-                segments: segments.map { Span(start: Double($0.startTime), end: Double($0.endTime)) }
+                segments: segments
             )
+        }
+
+        private func detectSpeech(vad: SileroVADModel, samples: [Float]) throws -> [Span] {
+            vad.resetState()
+            var probabilities: [Float] = []
+            for offset in stride(from: 0, to: samples.count, by: SileroVADModel.chunkSize) {
+                try Task.checkCancellation()
+                guard !MLXRuntime.shouldStop else { throw CancellationError() }
+                let end = min(offset + SileroVADModel.chunkSize, samples.count)
+                var chunk = Array(samples[offset..<end])
+                chunk.append(contentsOf: repeatElement(0, count: SileroVADModel.chunkSize - chunk.count))
+                probabilities.append(vad.processChunk(chunk))
+            }
+            var config = VADConfig.sileroDefault
+            let chunkDuration = Float(SileroVADModel.chunkSize) / Float(SileroVADModel.sampleRate)
+            config.windowDuration = Float(probabilities.count) * chunkDuration
+            let pipeline = VADPipeline(
+                config: config, sampleRate: SileroVADModel.sampleRate, framesPerChunk: probabilities.count
+            )
+            return pipeline.binarize(probs: probabilities).map {
+                Span(start: Double($0.startTime), end: Double($0.endTime))
+            }
         }
     }
 

--- a/Sources/PalmierPro/Utilities/MLXRuntime.swift
+++ b/Sources/PalmierPro/Utilities/MLXRuntime.swift
@@ -1,8 +1,10 @@
 import Foundation
+import os
 
 // Skip MLX model loads in unbundled builds to avoid a fatal mlx.metallib error.
 enum MLXRuntime {
     static let isAvailable = Bundle.main.bundleURL.pathExtension == "app"
+    private static let gate = MLXOperationGate()
 
     struct Unavailable: Error, LocalizedError {
         var errorDescription: String? {
@@ -12,5 +14,39 @@ enum MLXRuntime {
 
     static func requireAvailable() throws {
         guard isAvailable else { throw Unavailable() }
+    }
+
+    static func beginOperation() throws {
+        try requireAvailable()
+        guard gate.begin() else { throw CancellationError() }
+    }
+    static func endOperation() { gate.end() }
+    static var shouldStop: Bool { gate.shouldStop }
+    static func beginTermination() -> Bool { gate.stop() }
+    static func waitUntilIdle() async { await gate.waitUntilIdle() }
+}
+
+final class MLXOperationGate: @unchecked Sendable {
+    private let stopping = OSAllocatedUnfairLock(initialState: false)
+    private let operations = DispatchGroup()
+    func begin() -> Bool {
+        stopping.withLock { stopping in
+            guard !stopping else { return false }
+            operations.enter()
+            return true
+        }
+    }
+    func end() { operations.leave() }
+    var shouldStop: Bool { stopping.withLock { $0 } }
+    func stop() -> Bool {
+        stopping.withLock { $0 = true }
+        return operations.wait(timeout: .now()) == .success
+    }
+    func waitUntilIdle() async {
+        await withCheckedContinuation { continuation in
+            operations.notify(queue: .global(qos: .utility)) {
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Tests/PalmierProTests/Utilities/MLXOperationGateTests.swift
+++ b/Tests/PalmierProTests/Utilities/MLXOperationGateTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import PalmierPro
+
+@Test func mlxGateRejectsNewWorkAndDrainsActiveWork() async {
+    let gate = MLXOperationGate()
+    #expect(gate.begin())
+    #expect(!gate.stop())
+    #expect(!gate.begin())
+    async let drained: Void = gate.waitUntilIdle()
+    gate.end()
+    await drained
+    #expect(gate.stop())
+}


### PR DESCRIPTION
## Summary

- gate active Silero VAD and WeSpeaker MLX operations during app termination
- stop admitting new MLX work once quitting begins and delay AppKit termination until active work drains
- process VAD in cancellable 512-sample chunks while preserving Silero's thresholds and segmentation pipeline

## Root cause

Palmier Pro could terminate while background Silero inference was still using MLX. App teardown then destroyed MLX and Metal resources underneath the active operation, causing a native crash.

The upstream whole-file VAD helper is synchronous and does not observe task cancellation between chunks, so cancelling the surrounding task was not sufficient.

## Impact

Quitting during speech analysis now stops VAD between chunks and waits for admitted MLX work to drain safely. Normal speech detection results are unchanged, and quitting while MLX is idle remains immediate.

## Validation

- `swift build`
- `swift build -c release`
- `swift test` — 1,032 tests passed, 1 skipped
- focused MLX operation-gate test
- manually cleared analysis caches and quit at the start and during speech detection; the app exited cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app shutdown and native MLX inference paths; incorrect draining or cancellation could delay quit or leave analysis in a bad state, but scope is narrow and tested.
> 
> **Overview**
> Adds an **MLX operation gate** so quitting no longer tears down Metal/MLX while Silero VAD or WeSpeaker work is still running.
> 
> `MLXRuntime` now tracks admitted work via `beginOperation`/`endOperation`, rejects new work after `beginTermination()`, and exposes `shouldStop` for in-flight cancellation. **`AppDelegate.applicationShouldTerminate`** returns `.terminateLater` when MLX is busy, then calls `reply(toApplicationShouldTerminate: true)` after `waitUntilIdle()` (immediate quit when idle).
> 
> **Voice activity** no longer uses the synchronous whole-file helper; it runs **512-sample chunks** with `Task.checkCancellation()` and `shouldStop`, then keeps the same Silero `VADPipeline` binarization. **Speaker embeddings** wrap inference in the same gate. A small **`MLXOperationGate`** unit test covers stop/reject/drain behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79406db12496556d000670d3fe5cdc7f4faadab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->