### PR TITLE
[agent] Fix agent undo boundaries

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -74,14 +74,18 @@ extension ToolExecutor {
             guard let source = editor.timeline(for: fromRef) else {
                 throw ToolError("No timeline with id '\(fromRef)'. get_media lists the project's timelines.")
             }
-            guard let newId = editor.duplicateTimeline(fromRef) else {
-                throw ToolError("Couldn't duplicate \"\(source.name)\".")
+            id = try withUndoGroup(editor, actionName: "Duplicate Timeline (Agent)") {
+                guard let newId = editor.duplicateTimeline(fromRef) else {
+                    throw ToolError("Couldn't duplicate \"\(source.name)\".")
+                }
+                if let name = args.string("name") { editor.renameTimeline(newId, to: name) }
+                return newId
             }
-            id = newId
-            if let name = args.string("name") { editor.renameTimeline(id, to: name) }
             note = "Duplicated \"\(source.name)\" and switched to the copy. Its clip and track ids are new — re-read get_timeline before editing."
         } else {
-            id = editor.createTimeline(name: args.string("name"))
+            id = withUndoGroup(editor, actionName: "Create Timeline (Agent)") {
+                editor.createTimeline(name: args.string("name"))
+            }
             note = "Empty and now active; all edit tools target it."
         }
         let payload: [String: Any] = [

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -316,10 +316,17 @@ final class ToolExecutor {
     }
 
     func withUndoGroup<T>(_ editor: EditorViewModel, actionName: String, _ work: () throws -> T) rethrows -> T {
-        editor.undoManager?.beginUndoGrouping()
+        guard let undoManager = editor.undoManager else { return try work() }
+        let restoresEventGrouping = undoManager.groupsByEvent && undoManager.groupingLevel <= 1
+        if restoresEventGrouping {
+            undoManager.groupsByEvent = false
+            if undoManager.groupingLevel == 1 { undoManager.endUndoGrouping() }
+        }
+        undoManager.beginUndoGrouping()
         defer {
-            editor.undoManager?.endUndoGrouping()
-            editor.undoManager?.setActionName(actionName)
+            undoManager.setActionName(actionName)
+            undoManager.endUndoGrouping()
+            if restoresEventGrouping { undoManager.groupsByEvent = true }
         }
         return try work()
     }

--- a/Tests/PalmierProTests/Agent/UndoToolTests.swift
+++ b/Tests/PalmierProTests/Agent/UndoToolTests.swift
@@ -41,6 +41,29 @@ struct UndoToolTests {
         #expect(h.editor.timeline.tracks[0].clips.map(\.durationFrames) == [30, 70])
     }
 
+    @Test func undoKeepsNewTimelineWhenAutomaticEventGroupStaysOpen() async throws {
+        let (h, um) = harness()
+        um.runLoopModes = [RunLoop.Mode("AgentUndoBoundaryTests")]
+        um.registerUndo(withTarget: h.editor) { _ in }
+        um.setActionName("Earlier Tool")
+        let sourceTimelineId = h.editor.activeTimelineId
+
+        _ = await h.runRaw("create_timeline", args: ["from": sourceTimelineId])
+        let createdTimelineId = h.editor.activeTimelineId
+        let createdClipId = h.editor.timeline.tracks[0].clips[0].id
+        _ = await h.runRaw("set_clip_properties", args: [
+            "clipIds": [createdClipId],
+            "volume": 0.25,
+        ])
+
+        let result = await h.runRaw("undo")
+
+        #expect(result.isError == false)
+        #expect(h.editor.timelines.count == 2)
+        #expect(h.editor.activeTimelineId == createdTimelineId)
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+    }
+
     @Test func refusesWhenAssistantHasNotEdited() async throws {
         let (h, um) = harness()
         _ = um


### PR DESCRIPTION
behavior change: undo by agent should undo just one event like UI, instead of undoing the agent's stack (can cause unexpected behavior)

## Summary

- isolate each agent mutation from Foundation's automatic per-event undo grouping
- make timeline creation and duplicate-plus-rename explicit agent undo actions
- add a regression for undoing a clip edit without deleting its newly created timeline

## Root cause

`UndoManager` can leave an automatic event group open while multiple MCP tool calls register their own nested groups. Those nested groups are committed together when the outer event closes, so a single undo can revert several tool calls, including timeline creation.

The shared helper now temporarily suspends automatic event grouping, closes a pending automatic group, commits exactly one explicit agent group, and restores event grouping afterward. User-owned nested groups are left untouched.

## Impact

One agent undo now reverts only the latest agent mutation. A clip-property undo keeps the current timeline and does not silently remove earlier timeline work. Creating a timeline remains independently undoable.

## Validation

- `swift test --filter 'UndoToolTests|TimelineToolsTests|SetClipPropertiesTests'` — 19 tests in 3 suites passed
- ran the worktree app and MCP server on an isolated local port
- issued 70 MCP calls covering timeline creation, clip insertion, repeated reads, duplicate-and-rename, clip properties, movement, invalid edits, identical action names, multi-clip batches, active-timeline switching, and concurrent HTTP edits
- verified concurrent calls serialize into distinct undo steps and unwind in exact reverse application order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared undo grouping used by many agent edit tools; wrong boundary logic could split or merge undo steps incorrectly, though scope is undo registration rather than timeline data paths.
> 
> **Overview**
> **Agent undo now matches one UI step per `undo` call** by fixing how MCP tool mutations register with `UndoManager`.
> 
> `withUndoGroup` temporarily turns off **`groupsByEvent`**, closes a pending automatic event group when needed, commits a single named agent group, then restores event grouping. That stops several tool calls from landing in one outer event group so one undo no longer rewinds a whole batch (including timeline creation).
> 
> **`create_timeline`** wraps blank create and duplicate-plus-rename in explicit undo groups (`Create Timeline (Agent)` / `Duplicate Timeline (Agent)`).
> 
> A new **`undoKeepsNewTimelineWhenAutomaticEventGroupStaysOpen`** test checks that undoing a clip edit after duplicating a timeline reverts volume only and keeps both timelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f314b4b03aeaa305957b27bb41c3182a795f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->