### PR TITLE
Fix NSUndoManager crash from forced event-group closing

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -104,8 +104,8 @@ extension ToolExecutor {
         let snapshot = timelineSnapshot(editor)
         editor.undoManager?.beginUndoGrouping()
         let outcome = editor.rippleDeleteRangesOnTrack(trackIndex: primaryTrack, ranges: primaryRanges)
-        editor.undoManager?.endUndoGrouping()
         editor.undoManager?.setActionName("Remove Words (Agent)")
+        editor.undoManager?.endUndoGrouping()
         guard case .ok(let report) = outcome else {
             if case .refused(let reason) = outcome { throw ToolError("Ripple delete refused: \(reason)") }
             throw ToolError("Ripple delete refused.")

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -97,6 +97,7 @@ final class ToolExecutor {
             )
             return .error("Editor not available")
         }
+        await settlePendingUndoGrouping(editor.undoManager)
         let before = editor.timelines
         let idsBefore = currentIdUniverse(editor)
         let result: ToolResult
@@ -211,6 +212,28 @@ final class ToolExecutor {
     }
 
     private func run(_ tool: ToolName, _ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        guard Self.wrapsToolInUndoGroup(tool), let undoManager = editor.undoManager else {
+            return try await dispatch(tool, editor, args)
+        }
+        undoManager.beginUndoGrouping()
+        defer { undoManager.endUndoGrouping() }
+        return try await dispatch(tool, editor, args)
+    }
+
+    private static func wrapsToolInUndoGroup(_ tool: ToolName) -> Bool {
+        switch tool {
+        case .applyColor, .applyEffect, .denoiseAudio, .addClips, .insertClips, .removeClips,
+             .manageTracks, .moveClips, .applyLayout, .setClipProperties, .setKeyframes,
+             .splitClips, .rippleDeleteRanges, .removeSilence, .changeCam, .addTexts,
+             .updateText, .organizeMedia, .setProjectSettings, .createTimeline,
+             .generateVideo, .generateImage, .upscaleMedia:
+            true
+        default:
+            false
+        }
+    }
+
+    private func dispatch(_ tool: ToolName, _ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         switch tool {
         case .getTimeline:   return try getTimeline(editor, args)
         case .getMedia:      return try getMedia(editor, args)
@@ -281,6 +304,9 @@ final class ToolExecutor {
             agentUndoStack.removeAll()
             throw ToolError("Nothing to undo.")
         }
+        guard undoManager.groupingLevel == 0 else {
+            throw ToolError("An undo group is still open (an edit is in progress) — try again.")
+        }
         guard undoManager.undoActionName == expected else {
             throw ToolError("The most recent change ('\(undoManager.undoActionName)') wasn't made by the assistant — not undoing it.")
         }
@@ -327,18 +353,23 @@ final class ToolExecutor {
 
     func withUndoGroup<T>(_ editor: EditorViewModel, actionName: String, _ work: () throws -> T) rethrows -> T {
         guard let undoManager = editor.undoManager else { return try work() }
-        let restoresEventGrouping = undoManager.groupsByEvent && undoManager.groupingLevel <= 1
-        if restoresEventGrouping {
-            undoManager.groupsByEvent = false
-            if undoManager.groupingLevel == 1 { undoManager.endUndoGrouping() }
-        }
         undoManager.beginUndoGrouping()
         defer {
             undoManager.setActionName(actionName)
             undoManager.endUndoGrouping()
-            if restoresEventGrouping { undoManager.groupsByEvent = true }
         }
         return try work()
+    }
+
+    func settlePendingUndoGrouping(_ undoManager: UndoManager?) async {
+        guard let undoManager else { return }
+        var turns = 0
+        while undoManager.groupsByEvent, undoManager.groupingLevel > 0, turns < 3 {
+            turns += 1
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                DispatchQueue.main.async { cont.resume() }
+            }
+        }
     }
 }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Folders.swift
@@ -173,10 +173,12 @@ extension EditorViewModel {
             inverse.append((change.id, get(self, change.id)))
             set(self, change.id, change.newValue)
         }
+        undoManager?.beginUndoGrouping()
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.applyParentChanges(inverse, actionName: actionName, get: get, set: set)
         }
         undoManager?.setActionName(actionName)
+        undoManager?.endUndoGrouping()
     }
 
     func mediaLibraryUndoSnapshot() -> MediaLibraryUndoSnapshot {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -277,10 +277,12 @@ extension EditorViewModel {
             folderCount: mediaManifest.folders.count - before.mediaManifest.folders.count
         )
         guard summary.assetCount != 0 || summary.folderCount != 0 else { return summary }
+        undoManager?.beginUndoGrouping()
         undoManager?.registerUndo(withTarget: self) { vm in
             vm.restoreMediaLibraryUndoSnapshot(before, actionName: "Import Media")
         }
         undoManager?.setActionName("Import Media")
+        undoManager?.endUndoGrouping()
         for asset in importedAssets {
             Task { await finalizeImportedAsset(asset, batchManifestUpdate: true) }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -246,8 +246,8 @@ extension EditorViewModel {
         if !moves.isEmpty {
             undoManager?.beginUndoGrouping()
             moveClips(moves)
-            undoManager?.endUndoGrouping()
             undoManager?.setActionName("Synchronize")
+            undoManager?.endUndoGrouping()
         }
         return report
     }

--- a/Tests/PalmierProTests/Agent/UndoToolTests.swift
+++ b/Tests/PalmierProTests/Agent/UndoToolTests.swift
@@ -41,7 +41,7 @@ struct UndoToolTests {
         #expect(h.editor.timeline.tracks[0].clips.map(\.durationFrames) == [30, 70])
     }
 
-    @Test func undoKeepsNewTimelineWhenAutomaticEventGroupStaysOpen() async throws {
+    @Test func toolsNestSafelyWhenAutomaticEventGroupStaysOpen() async throws {
         let (h, um) = harness()
         um.runLoopModes = [RunLoop.Mode("AgentUndoBoundaryTests")]
         um.registerUndo(withTarget: h.editor) { _ in }
@@ -51,17 +51,32 @@ struct UndoToolTests {
         _ = await h.runRaw("create_timeline", args: ["from": sourceTimelineId])
         let createdTimelineId = h.editor.activeTimelineId
         let createdClipId = h.editor.timeline.tracks[0].clips[0].id
-        _ = await h.runRaw("set_clip_properties", args: [
+        let edit = await h.runRaw("set_clip_properties", args: [
             "clipIds": [createdClipId],
             "volume": 0.25,
         ])
+        #expect(edit.isError == false)
+        #expect(um.groupsByEvent == true)
+        #expect(um.groupingLevel == 1)
 
         let result = await h.runRaw("undo")
 
-        #expect(result.isError == false)
+        #expect(result.isError == true)
         #expect(h.editor.timelines.count == 2)
         #expect(h.editor.activeTimelineId == createdTimelineId)
-        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 0.25)
+    }
+
+    @Test func eachToolClosesItsOwnNamedUndoGroup() async throws {
+        let (h, um) = harness()
+        _ = await h.runRaw("split_clips", args: ["trackIndex": 0, "frames": [30]])
+        #expect(um.groupingLevel == 0)
+        #expect(um.undoActionName == "Split Clip")
+
+        let clipId = h.editor.timeline.tracks[0].clips[0].id
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": [clipId], "volume": 0.5])
+        #expect(um.groupingLevel == 0)
+        #expect(um.undoActionName == "Set Clip Property (Agent)")
     }
 
     @Test func refusesWhenAssistantHasNotEdited() async throws {


### PR DESCRIPTION
Ending the automatic event group manually (#318) corrupted NSUndoManager's bookkeeping, crashing in _endTopLevelGroupings and _prepareEventGrouping under sustained MCP editing. Wrap each mutating tool in its own explicit top-level undo group instead, group the remaining top-level registrations, and let the run loop close any pending event group before a tool runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core undo bookkeeping for agent/MCP editing and user media/timeline operations; incorrect nesting could affect undo granularity or assistant undo behavior, but changes are targeted and covered by updated undo tests.
> 
> **Overview**
> Replaces the prior approach of **manually ending** `NSUndoManager` automatic event groups—which could crash under sustained MCP editing—with **explicit top-level undo groups** around agent mutations and safer boundaries elsewhere.
> 
> **Agent tools:** Before each tool runs, `settlePendingUndoGrouping` yields up to a few main-run-loop turns so any pending event grouping can finish. Mutating tools listed in `wrapsToolInUndoGroup` get an outer `beginUndoGrouping` / `endUndoGrouping` in `run()`; `withUndoGroup` no longer toggles `groupsByEvent` or force-closes open groups. The assistant `undo` tool now **errors** when `groupingLevel > 0` instead of undoing while a group is still open.
> 
> **Editor undo registration:** Media import, folder parent moves (`applyParentChanges`), clip sync moves, and `remove_words` now set the action name and close an explicit group around `registerUndo` (action name before `endUndoGrouping` where applicable).
> 
> **Tests:** Expectations change when an automatic event group stays open—`undo` is refused and edits remain; a new test asserts each tool leaves `groupingLevel == 0` with the correct named undo step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58632758eb03bc6315b4e2656d3151cb2e7244f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->