### PR TITLE
[fix] agent undo boundaries

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -61,7 +61,9 @@ extension ToolExecutor {
         try await Self.validateCloudTranscriptionAccess(for: request, in: editor)
 
         let snapshot = timelineSnapshot(editor)
-        let ids = try await editor.generateCaptions(for: request)
+        let ids = try await editor.generateCaptions(for: request, applying: { mutation in
+            try await self.withUndoBoundary(editor, actionName: "Generate Captions (Agent)", mutation)
+        })
         guard !ids.isEmpty else { throw ToolError("No speech detected to caption.") }
         return mutationResult(editor, since: snapshot)
     }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -330,7 +330,9 @@ extension ToolExecutor {
         }
 
         let snapshot = timelineSnapshot(editor)
-        let ids = editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
+        let ids = try withUndoGroup(editor, actionName: specs.count == 1 ? "Insert Clip (Agent)" : "Insert Clips (Agent)") {
+            editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
+        }
         guard !ids.isEmpty else {
             throw ToolError("Insert failed on track \(input.trackIndex) at frame \(input.atFrame)")
         }
@@ -348,7 +350,9 @@ extension ToolExecutor {
         }
         let expanded = editor.expandToLinkGroup(Set(clipIds))
         let snapshot = timelineSnapshot(editor)
-        editor.removeClips(ids: expanded)
+        try withUndoGroup(editor, actionName: clipIds.count == 1 ? "Remove Clip (Agent)" : "Remove Clips (Agent)") {
+            editor.removeClips(ids: expanded)
+        }
         return mutationResult(editor, since: snapshot)
     }
 
@@ -424,7 +428,7 @@ extension ToolExecutor {
 
         let snapshot = timelineSnapshot(editor)
         let moveActionName = parsed.count == 1 ? "Move Clip (Agent)" : "Move Clips (Agent)"
-        withUndoGroup(editor, actionName: moveActionName) {
+        try withUndoGroup(editor, actionName: moveActionName) {
             if !moves.isEmpty { editor.moveClips(moves) }
         }
 
@@ -508,7 +512,7 @@ extension ToolExecutor {
 
         let snapshot = timelineSnapshot(editor)
         let setActionName = clipIds.count == 1 ? "Set Clip Property (Agent)" : "Set Clip Properties (Agent)"
-        withUndoGroup(editor, actionName: setActionName) {
+        try withUndoGroup(editor, actionName: setActionName) {
             for id in clipIds {
                 let changed = Self.applyPropertyChanges(
                     durationFrames: input.durationFrames,
@@ -692,7 +696,9 @@ extension ToolExecutor {
 
         guard !points.isEmpty else { throw ToolError("No valid split points") }
         let snapshot = timelineSnapshot(editor)
-        _ = editor.splitClips(at: points)
+        try withUndoGroup(editor, actionName: points.count == 1 ? "Split Clip (Agent)" : "Split Clips (Agent)") {
+            _ = editor.splitClips(at: points)
+        }
         return mutationResult(editor, since: snapshot)
     }
 
@@ -762,7 +768,10 @@ extension ToolExecutor {
 
         let ignoreSyncLocked = Set(input.ignoreSyncLockedTracks ?? [])
         let snapshot = timelineSnapshot(editor)
-        switch editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked) {
+        let outcome = try withUndoGroup(editor, actionName: "Ripple Delete (Agent)") {
+            editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked)
+        }
+        switch outcome {
         case .refused(let reason):
             throw ToolError(reason)
         case .ok(let report):
@@ -953,7 +962,7 @@ extension ToolExecutor {
             return ["trackId": track.id, "index": i, "label": editor.timelineTrackDisplayLabel(at: i), "type": track.type.rawValue]
         }
         var reorderResults: [(trackId: String, from: Int, to: Int)] = []
-        withUndoGroup(editor, actionName: "Manage Tracks (Agent)") {
+        try withUndoGroup(editor, actionName: "Manage Tracks (Agent)") {
             if !reorders.isEmpty {
                 let before = editor.timeline
                 for r in reorders {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -330,9 +330,7 @@ extension ToolExecutor {
         }
 
         let snapshot = timelineSnapshot(editor)
-        let ids = try withUndoGroup(editor, actionName: specs.count == 1 ? "Insert Clip (Agent)" : "Insert Clips (Agent)") {
-            editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
-        }
+        let ids = editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
         guard !ids.isEmpty else {
             throw ToolError("Insert failed on track \(input.trackIndex) at frame \(input.atFrame)")
         }
@@ -350,9 +348,7 @@ extension ToolExecutor {
         }
         let expanded = editor.expandToLinkGroup(Set(clipIds))
         let snapshot = timelineSnapshot(editor)
-        try withUndoGroup(editor, actionName: clipIds.count == 1 ? "Remove Clip (Agent)" : "Remove Clips (Agent)") {
-            editor.removeClips(ids: expanded)
-        }
+        editor.removeClips(ids: expanded)
         return mutationResult(editor, since: snapshot)
     }
 
@@ -696,9 +692,7 @@ extension ToolExecutor {
 
         guard !points.isEmpty else { throw ToolError("No valid split points") }
         let snapshot = timelineSnapshot(editor)
-        try withUndoGroup(editor, actionName: points.count == 1 ? "Split Clip (Agent)" : "Split Clips (Agent)") {
-            _ = editor.splitClips(at: points)
-        }
+        _ = editor.splitClips(at: points)
         return mutationResult(editor, since: snapshot)
     }
 
@@ -768,10 +762,7 @@ extension ToolExecutor {
 
         let ignoreSyncLocked = Set(input.ignoreSyncLockedTracks ?? [])
         let snapshot = timelineSnapshot(editor)
-        let outcome = try withUndoGroup(editor, actionName: "Ripple Delete (Agent)") {
-            editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked)
-        }
-        switch outcome {
+        switch editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked) {
         case .refused(let reason):
             throw ToolError(reason)
         case .ok(let report):

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -330,7 +330,9 @@ extension ToolExecutor {
         }
 
         let snapshot = timelineSnapshot(editor)
-        let ids = editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
+        let ids = try withUndoGroup(editor, actionName: specs.count == 1 ? "Insert Clip (Agent)" : "Insert Clips (Agent)") {
+            editor.rippleInsertClips(specs: specs, trackIndex: input.trackIndex, atFrame: input.atFrame)
+        }
         guard !ids.isEmpty else {
             throw ToolError("Insert failed on track \(input.trackIndex) at frame \(input.atFrame)")
         }
@@ -348,7 +350,9 @@ extension ToolExecutor {
         }
         let expanded = editor.expandToLinkGroup(Set(clipIds))
         let snapshot = timelineSnapshot(editor)
-        editor.removeClips(ids: expanded)
+        try withUndoGroup(editor, actionName: clipIds.count == 1 ? "Remove Clip (Agent)" : "Remove Clips (Agent)") {
+            editor.removeClips(ids: expanded)
+        }
         return mutationResult(editor, since: snapshot)
     }
 
@@ -692,7 +696,9 @@ extension ToolExecutor {
 
         guard !points.isEmpty else { throw ToolError("No valid split points") }
         let snapshot = timelineSnapshot(editor)
-        _ = editor.splitClips(at: points)
+        try withUndoGroup(editor, actionName: points.count == 1 ? "Split Clip (Agent)" : "Split Clips (Agent)") {
+            _ = editor.splitClips(at: points)
+        }
         return mutationResult(editor, since: snapshot)
     }
 
@@ -762,7 +768,10 @@ extension ToolExecutor {
 
         let ignoreSyncLocked = Set(input.ignoreSyncLockedTracks ?? [])
         let snapshot = timelineSnapshot(editor)
-        switch editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked) {
+        let outcome = try withUndoGroup(editor, actionName: "Ripple Delete (Agent)") {
+            editor.rippleDeleteRangesOnTrack(trackIndex: resolvedTrackIndex, ranges: frameRanges, ignoreSyncLockTrackIndices: ignoreSyncLocked)
+        }
+        switch outcome {
         case .refused(let reason):
             throw ToolError(reason)
         case .ok(let report):

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Color.swift
@@ -139,7 +139,7 @@ extension ToolExecutor {
         let reset = input.reset ?? false
         let snapshot = timelineSnapshot(editor)
         let actionName = input.clipIds.count == 1 ? "Color Grade (Agent)" : "Color Grade ×\(input.clipIds.count) (Agent)"
-        withUndoGroup(editor, actionName: actionName) {
+        try withUndoGroup(editor, actionName: actionName) {
             editor.mutateClips(ids: Set(input.clipIds), actionName: actionName) { clip in
                 let nonColor = (clip.effects ?? []).filter { !$0.type.hasPrefix("color.") }
                 if let pastedStack {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Denoise.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Denoise.swift
@@ -24,7 +24,7 @@ extension ToolExecutor {
         let enabled = input.enabled ?? true
         let snapshot = timelineSnapshot(editor)
         let actionName = enabled ? "Denoise Audio (Agent)" : "Disable Denoise (Agent)"
-        withUndoGroup(editor, actionName: actionName) {
+        try withUndoGroup(editor, actionName: actionName) {
             editor.setDenoise(
                 clipIds: Set(input.clipIds),
                 enabled: enabled,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Effect.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Effect.swift
@@ -47,7 +47,7 @@ extension ToolExecutor {
 
         let snapshot = timelineSnapshot(editor)
         let actionName = input.clipIds.count == 1 ? "Apply Effect (Agent)" : "Apply Effect ×\(input.clipIds.count) (Agent)"
-        withUndoGroup(editor, actionName: actionName) {
+        try withUndoGroup(editor, actionName: actionName) {
             editor.mutateClips(ids: Set(input.clipIds), actionName: actionName) { clip in
                 var stack = clip.effects ?? []
                 for type in removes { stack.removeAll { $0.type == type } }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -340,18 +340,21 @@ extension ToolExecutor {
 
         if let startFrame = placementStartFrame, let sourceSpan = spanSeconds {
             let outputSpan = requestedDurationSeconds.map(Double.init) ?? sourceSpan
-            let placeholderId = submission.submit(
-                service: editor.generationService,
-                projectURL: editor.projectURL,
-                editor: editor,
-                onComplete: { asset in
-                    editor.finalizeGeneratingClip(placeholderId: asset.id, asset: asset)
-                }
-            )
-            editor.placeGeneratingAudioClip(
-                placeholderId: placeholderId, startFrame: startFrame,
-                spanSeconds: outputSpan, actionName: "Add \(model.category.label)"
-            )
+            let placeholderId = try await withUndoBoundary(editor, actionName: "Add \(model.category.label) (Agent)") {
+                let placeholderId = submission.submit(
+                    service: editor.generationService,
+                    projectURL: editor.projectURL,
+                    editor: editor,
+                    onComplete: { asset in
+                        editor.finalizeGeneratingClip(placeholderId: asset.id, asset: asset)
+                    }
+                )
+                editor.placeGeneratingAudioClip(
+                    placeholderId: placeholderId, startFrame: startFrame,
+                    spanSeconds: outputSpan, actionName: "Add \(model.category.label)"
+                )
+                return placeholderId
+            }
             return .ok("Generation started and placed on the timeline at frame \(startFrame). Placeholder asset ID: \(placeholderId). Model: \(model.displayName), \(model.category.label) (scored from video).")
         }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -67,7 +67,9 @@ extension ToolExecutor {
             throw ToolError("File not found: \(path)")
         }
         if status.isDirectory {
-            let summary = await editor.importFinderItems([fileURL], into: folderId)
+            let summary = try await editor.importFinderItems([fileURL], into: folderId, applying: { mutation in
+                try await self.withUndoBoundary(editor, actionName: "Import Media (Agent)", mutation)
+            })
             guard summary.assetCount > 0 else {
                 throw ToolError("No supported media found in folder: \(path)")
             }
@@ -123,13 +125,21 @@ extension ToolExecutor {
         let imported = try await Task.detached(priority: .userInitiated) {
             try Self.writeImportedBytes(base64: base64, mimeType: mimeType, projectURL: projectURL)
         }.value
-        guard let asset = editor.addMediaAsset(from: imported.url) else {
+        let asset: MediaAsset
+        do {
+            asset = try await withUndoBoundary(editor, actionName: "Import Media (Agent)") {
+                guard let asset = editor.addMediaAsset(from: imported.url) else {
+                    throw ToolError("Failed to register imported asset")
+                }
+                applyImportMetadata(editor: editor, asset: asset, name: name, folderId: folderId)
+                return asset
+            }
+        } catch {
             try? await Task.detached(priority: .utility) {
                 try FileManager.default.removeItem(at: imported.url)
             }.value
-            throw ToolError("Failed to register imported asset")
+            throw error
         }
-        applyImportMetadata(editor: editor, asset: asset, name: name, folderId: folderId)
         return .ok(Self.jsonString([
             "mediaRef": asset.id,
             "name": asset.name,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Layout.swift
@@ -43,6 +43,12 @@ extension ToolExecutor {
     }
 
     func applyLayout(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try withUndoGroup(editor, actionName: "Apply Layout (Agent)") {
+            try applyLayoutMutation(editor, args)
+        }
+    }
+
+    private func applyLayoutMutation(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: ApplyLayoutInput = try decodeToolArgs(args, path: "apply_layout")
         for (i, raw) in (args["slots"] as? [Any] ?? []).enumerated() {
             if let d = raw as? [String: Any] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Multicam.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Multicam.swift
@@ -41,7 +41,7 @@ extension ToolExecutor {
             searchWindowSeconds: args.double("searchWindowSeconds") ?? EditorViewModel.SyncDefaults.memberSearchWindowSeconds
         )
 
-        let (groupId, clipIds) = try withUndoGroup(editor, actionName: "Create Multicam (Agent)") {
+        let (groupId, clipIds) = try await withUndoBoundary(editor, actionName: "Create Multicam (Agent)") {
             try editor.createMulticamGroup(
                 specs: specs, syncMaps: sync.maps, masterRef: masterRef,
                 name: args.string("name"), startFrame: args.int("startFrame")
@@ -64,7 +64,7 @@ extension ToolExecutor {
     private func ungroupSection(_ editor: EditorViewModel, _ args: [String: Any]) throws -> String {
         try validateUnknownKeys(args, allowed: ["groupId"], path: "manage_multicam.ungroup")
         let groupId = try requireGroup(editor, args.string("groupId"))
-        withUndoGroup(editor, actionName: "Ungroup Multicam (Agent)") {
+        try withUndoGroup(editor, actionName: "Ungroup Multicam (Agent)") {
             editor.ungroupMulticam(groupId: groupId)
         }
         return groupId

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ProjectSettings.swift
@@ -60,7 +60,9 @@ extension ToolExecutor {
 
     func setProjectSettings(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let settings = try validateProjectSettings(args)
-        return try setProjectSettings(editor, settings)
+        return try withUndoGroup(editor, actionName: "Set Project Settings (Agent)") {
+            try setProjectSettings(editor, settings)
+        }
     }
 
     func setProjectSettings(_ editor: EditorViewModel, _ settings: ValidatedProjectSettings) throws -> ToolResult {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
@@ -27,12 +27,15 @@ extension ToolExecutor {
         guard searchWindow > 0 else { throw ToolError("sync_clips: searchWindowSeconds must be > 0.") }
 
         let snapshot = timelineSnapshot(editor)
-        let report = await editor.syncClips(
+        let report = try await editor.syncClips(
             referenceClipId: referenceClipId,
             targetClipIds: targets,
             mode: mode,
             searchWindowSeconds: searchWindow,
-            minConfidence: args.double("minConfidence") ?? EditorViewModel.SyncDefaults.minConfidence
+            minConfidence: args.double("minConfidence") ?? EditorViewModel.SyncDefaults.minConfidence,
+            applying: { mutation in
+                try await self.withUndoBoundary(editor, actionName: "Synchronize Clips (Agent)", mutation)
+            }
         )
         guard !report.synced.isEmpty else {
             throw ToolError("sync_clips: \(report.failures.first?.message ?? "no clips aligned")")

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -297,7 +297,7 @@ extension ToolExecutor {
         let shouldFitToContent = transform == nil && (hasContent || textStylePatch.affectsLayout)
         let canvasW = Double(editor.timeline.width)
         let canvasH = Double(editor.timeline.height)
-        withUndoGroup(editor, actionName: actionName) {
+        try withUndoGroup(editor, actionName: actionName) {
             editor.commitClipProperties(clipIds: clipIds) { clip in
                 if let content {
                     if clip.textContent != content {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -83,7 +83,7 @@ extension ToolExecutor {
             }
             note = "Duplicated \"\(source.name)\" and switched to the copy. Its clip and track ids are new — re-read get_timeline before editing."
         } else {
-            id = withUndoGroup(editor, actionName: "Create Timeline (Agent)") {
+            id = try withUndoGroup(editor, actionName: "Create Timeline (Agent)") {
                 editor.createTimeline(name: args.string("name"))
             }
             note = "Empty and now active; all edit tools target it."

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -102,10 +102,9 @@ extension ToolExecutor {
         let primaryRanges = rangesByTrack[primaryTrack]!
 
         let snapshot = timelineSnapshot(editor)
-        editor.undoManager?.beginUndoGrouping()
-        let outcome = editor.rippleDeleteRangesOnTrack(trackIndex: primaryTrack, ranges: primaryRanges)
-        editor.undoManager?.endUndoGrouping()
-        editor.undoManager?.setActionName("Remove Words (Agent)")
+        let outcome = try await withUndoBoundary(editor, actionName: "Remove Words (Agent)") {
+            editor.rippleDeleteRangesOnTrack(trackIndex: primaryTrack, ranges: primaryRanges)
+        }
         guard case .ok(let report) = outcome else {
             if case .refused(let reason) = outcome { throw ToolError("Ripple delete refused: \(reason)") }
             throw ToolError("Ripple delete refused.")
@@ -128,13 +127,12 @@ extension ToolExecutor {
     func removeSilence(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         try validateUnknownKeys(args, allowed: [], path: "remove_silence")
         let snapshot = timelineSnapshot(editor)
-        editor.undoManager?.beginUndoGrouping()
-        let result = editor.removeAllDeadAir()
-        editor.undoManager?.endUndoGrouping()
+        let result = try withUndoGroup(editor, actionName: "Remove Silence (Agent)") {
+            editor.removeAllDeadAir()
+        }
         guard let result else {
             throw ToolError("No dead air on the timeline. Speech analysis may still be running, or the audio has no quiet non-speech sections.")
         }
-        editor.undoManager?.setActionName("Remove Silence (Agent)")
         if let refusal = result.refusal, result.sections == 0 {
             throw ToolError("Ripple delete refused: \(refusal)")
         }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -47,7 +47,7 @@ final class ToolExecutor {
         boundProject = project
     }
 
-    private var agentUndoStack: [String] = []
+    private let undoSessionID = UUID().uuidString
     var feedbackState = FeedbackState()
     var lastTranscriptContext: TranscriptionToolContext?
 
@@ -97,6 +97,10 @@ final class ToolExecutor {
             )
             return .error("Editor not available")
         }
+        if Self.isMutating(tool), let undoManager = editor.undoManager,
+           await !undoManager.awaitTopLevelUndoBoundary() {
+            return .error("An editor action is in progress. Try again.")
+        }
         let before = editor.timelines
         let idsBefore = currentIdUniverse(editor)
         let result: ToolResult
@@ -108,10 +112,6 @@ final class ToolExecutor {
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
             result = try await run(tool, editor, resolved)
-            if tool != .undo, tool != .setActiveTimeline, !result.isError, editor.timelines != before,
-               let actionName = editor.undoManager?.undoActionName {
-                agentUndoStack.append(actionName)
-            }
         } catch let err as ToolError {
             result = .error(err.message)
         } catch {
@@ -166,6 +166,18 @@ final class ToolExecutor {
         let sessionName = session?.displayName ?? boundProject?.displayName ?? "no project"
         let frontmostName = frontmost?.displayName ?? "no project"
         return "This session is on '\(sessionName)', but '\(frontmostName)' is active in Palmier Pro. Activate '\(sessionName)' or call manage_project with action='open' before making changes."
+    }
+
+    private static func isMutating(_ tool: ToolName) -> Bool {
+        switch tool {
+        case .manageProject, .getTimeline, .inspectTimeline, .setActiveTimeline,
+             .exportProject, .manageExports, .getMedia, .inspectMedia, .searchMedia,
+             .getMulticam, .getTranscript, .detectBeats, .inspectColor, .listModels,
+             .sendFeedback, .readSkill:
+            false
+        default:
+            true
+        }
     }
 
     private static func canReadInactiveProject(_ tool: ToolName) -> Bool {
@@ -228,7 +240,8 @@ final class ToolExecutor {
         case .removeClips:      return try removeClips(editor, args)
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
-        case .applyLayout:      return try applyLayout(editor, args)
+        case .applyLayout:
+            return try withUndoGroup(editor, actionName: "Apply Layout (Agent)") { try applyLayout(editor, args) }
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)
@@ -253,7 +266,8 @@ final class ToolExecutor {
         case .listModels:    return listModels(args)
         case .organizeMedia: return try organizeMedia(editor, args)
         case .sendFeedback:  return try await sendFeedback(editor, args)
-        case .setProjectSettings: return try setProjectSettings(editor, args)
+        case .setProjectSettings:
+            return try withUndoGroup(editor, actionName: "Set Project Settings (Agent)") { try setProjectSettings(editor, args) }
         case .createTimeline:     return try createTimeline(editor, args)
         case .setActiveTimeline:  return try setActiveTimeline(editor, args)
         case .readSkill:     return readSkill(args)
@@ -274,19 +288,15 @@ final class ToolExecutor {
 
     /// Reverts the assistant's most recent timeline edit. Refuses to undo the user's own edits.
     func undo(_ editor: EditorViewModel) throws -> ToolResult {
-        guard let expected = agentUndoStack.last else {
-            throw ToolError("No assistant edit to undo this session. The user's own edits are theirs to undo.")
-        }
         guard let undoManager = editor.undoManager, undoManager.canUndo else {
-            agentUndoStack.removeAll()
             throw ToolError("Nothing to undo.")
         }
-        guard undoManager.undoActionName == expected else {
-            throw ToolError("The most recent change ('\(undoManager.undoActionName)') wasn't made by the assistant — not undoing it.")
+        guard undoManager.topAgentSessionID == undoSessionID else {
+            throw ToolError("The most recent change ('\(undoManager.undoActionName)') wasn't made by this assistant session — not undoing it.")
         }
+        let actionName = undoManager.undoActionName
         undoManager.undo()
-        agentUndoStack.removeLast()
-        return .ok("Undid: \(expected). The timeline is restored to its state before that edit; re-read with get_timeline or get_transcript before editing again.")
+        return .ok("Undid: \(actionName). The timeline is restored to its state before that edit; re-read with get_timeline or get_transcript before editing again.")
     }
 
     // Shared helpers used by tool extensions in other files.
@@ -325,20 +335,18 @@ final class ToolExecutor {
         return String(data: data, encoding: .utf8)
     }
 
-    func withUndoGroup<T>(_ editor: EditorViewModel, actionName: String, _ work: () throws -> T) rethrows -> T {
+    func withUndoGroup<T>(_ editor: EditorViewModel, actionName: String, _ work: () throws -> T) throws -> T {
         guard let undoManager = editor.undoManager else { return try work() }
-        let restoresEventGrouping = undoManager.groupsByEvent && undoManager.groupingLevel <= 1
-        if restoresEventGrouping {
-            undoManager.groupsByEvent = false
-            if undoManager.groupingLevel == 1 { undoManager.endUndoGrouping() }
+        return try undoManager.withTopLevelGroup(actionName: actionName, sessionID: undoSessionID, work)
+    }
+
+    /// Ensures undo boundary is closed before mutating after async work.
+    func withUndoBoundary<T>(_ editor: EditorViewModel, actionName: String, _ work: () throws -> T) async throws -> T {
+        guard let undoManager = editor.undoManager else { return try work() }
+        guard await undoManager.awaitTopLevelUndoBoundary() else {
+            throw ToolError("An editor action is in progress. Try again.")
         }
-        undoManager.beginUndoGrouping()
-        defer {
-            undoManager.setActionName(actionName)
-            undoManager.endUndoGrouping()
-            if restoresEventGrouping { undoManager.groupsByEvent = true }
-        }
-        return try work()
+        return try undoManager.withTopLevelGroup(actionName: actionName, sessionID: undoSessionID, work)
     }
 }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -236,16 +236,16 @@ final class ToolExecutor {
         case .denoiseAudio:  return try denoiseAudio(editor, args)
         case .inspectColor:  return try await inspectColor(editor, args)
         case .addClips:         return try addClips(editor, args)
-        case .insertClips:      return try insertClips(editor, args)
-        case .removeClips:      return try removeClips(editor, args)
+        case .insertClips:      return try withUndoGroup(editor, actionName: "Insert Clips (Agent)") { try insertClips(editor, args) }
+        case .removeClips:      return try withUndoGroup(editor, actionName: "Remove Clips (Agent)") { try removeClips(editor, args) }
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
         case .applyLayout:
             return try withUndoGroup(editor, actionName: "Apply Layout (Agent)") { try applyLayout(editor, args) }
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
-        case .splitClips:       return try splitClips(editor, args)
-        case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)
+        case .splitClips:       return try withUndoGroup(editor, actionName: "Split Clips (Agent)") { try splitClips(editor, args) }
+        case .rippleDeleteRanges: return try withUndoGroup(editor, actionName: "Ripple Delete (Agent)") { try rippleDeleteRanges(editor, args) }
         case .removeWords:   return try await removeWords(editor, args)
         case .removeSilence: return try removeSilence(editor, args)
         case .syncClips:     return try await syncClips(editor, args)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -236,16 +236,15 @@ final class ToolExecutor {
         case .denoiseAudio:  return try denoiseAudio(editor, args)
         case .inspectColor:  return try await inspectColor(editor, args)
         case .addClips:         return try addClips(editor, args)
-        case .insertClips:      return try withUndoGroup(editor, actionName: "Insert Clips (Agent)") { try insertClips(editor, args) }
-        case .removeClips:      return try withUndoGroup(editor, actionName: "Remove Clips (Agent)") { try removeClips(editor, args) }
+        case .insertClips:      return try insertClips(editor, args)
+        case .removeClips:      return try removeClips(editor, args)
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
-        case .applyLayout:
-            return try withUndoGroup(editor, actionName: "Apply Layout (Agent)") { try applyLayout(editor, args) }
+        case .applyLayout:      return try applyLayout(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
-        case .splitClips:       return try withUndoGroup(editor, actionName: "Split Clips (Agent)") { try splitClips(editor, args) }
-        case .rippleDeleteRanges: return try withUndoGroup(editor, actionName: "Ripple Delete (Agent)") { try rippleDeleteRanges(editor, args) }
+        case .splitClips:       return try splitClips(editor, args)
+        case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)
         case .removeWords:   return try await removeWords(editor, args)
         case .removeSilence: return try removeSilence(editor, args)
         case .syncClips:     return try await syncClips(editor, args)
@@ -266,8 +265,7 @@ final class ToolExecutor {
         case .listModels:    return listModels(args)
         case .organizeMedia: return try organizeMedia(editor, args)
         case .sendFeedback:  return try await sendFeedback(editor, args)
-        case .setProjectSettings:
-            return try withUndoGroup(editor, actionName: "Set Project Settings (Agent)") { try setProjectSettings(editor, args) }
+        case .setProjectSettings: return try setProjectSettings(editor, args)
         case .createTimeline:     return try createTimeline(editor, args)
         case .setActiveTimeline:  return try setActiveTimeline(editor, args)
         case .readSkill:     return readSkill(args)

--- a/Sources/PalmierPro/Editor/UndoManager+Boundary.swift
+++ b/Sources/PalmierPro/Editor/UndoManager+Boundary.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@MainActor
+private final class UndoBoundaryWaiter: NSObject {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(_ continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    @objc func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+extension UndoManager {
+    private static let agentSessionKey = UserInfoKey(rawValue: "io.palmier.agent.session")
+
+    /// True once Foundation's automatic per-event group is closed; bounded, never blocks past ~0.5s.
+    @MainActor
+    func awaitTopLevelUndoBoundary() async -> Bool {
+        var attempts = 0
+        while groupingLevel > 0, attempts < 3 {
+            attempts += 1
+            await withCheckedContinuation { continuation in
+                let waiter = UndoBoundaryWaiter(continuation)
+                // Runs after Foundation's NSUndoCloseGroupingRunLoopOrdering observer.
+                RunLoop.main.perform(
+                    #selector(UndoBoundaryWaiter.resume),
+                    target: waiter,
+                    argument: nil,
+                    order: NSUndoCloseGroupingRunLoopOrdering + 1,
+                    modes: runLoopModes
+                )
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { waiter.resume() }
+            }
+        }
+        return groupingLevel == 0
+    }
+
+    /// One top-level named group; suspends per-event grouping while open, never closes a group it didn't begin.
+    @MainActor
+    func withTopLevelGroup<T>(actionName: String, sessionID: String, _ work: () throws -> T) throws -> T {
+        guard groupingLevel == 0 else { throw UndoBoundaryError.actionInProgress }
+        let restoresEventGrouping = groupsByEvent
+        if restoresEventGrouping { groupsByEvent = false }
+        beginUndoGrouping()
+        defer {
+            if undoActionName != actionName { setActionName(actionName) }
+            setActionUserInfoValue(sessionID, forKey: Self.agentSessionKey)
+            endUndoGrouping()
+            if restoresEventGrouping { groupsByEvent = true }
+        }
+        return try work()
+    }
+
+    @MainActor
+    var topAgentSessionID: String? {
+        undoActionUserInfoValue(forKey: Self.agentSessionKey) as? String
+    }
+}
+
+enum UndoBoundaryError: LocalizedError {
+    case actionInProgress
+
+    var errorDescription: String? { "An editor action is in progress. Try again." }
+}

--- a/Sources/PalmierPro/Editor/UndoManager+Boundary.swift
+++ b/Sources/PalmierPro/Editor/UndoManager+Boundary.swift
@@ -4,37 +4,29 @@ import Foundation
 private final class UndoBoundaryWaiter: NSObject {
     private var continuation: CheckedContinuation<Void, Never>?
 
-    init(_ continuation: CheckedContinuation<Void, Never>) {
-        self.continuation = continuation
-    }
+    init(_ continuation: CheckedContinuation<Void, Never>) { self.continuation = continuation }
 
-    @objc func resume() {
-        continuation?.resume()
-        continuation = nil
-    }
+    @objc func resume() { continuation?.resume(); continuation = nil }
 }
 
 extension UndoManager {
     private static let agentSessionKey = UserInfoKey(rawValue: "io.palmier.agent.session")
 
-    /// True once Foundation's automatic per-event group is closed; bounded, never blocks past ~0.5s.
+    /// True once Foundation's automatic per-event group is closed; bounded to one run-loop pass.
     @MainActor
     func awaitTopLevelUndoBoundary() async -> Bool {
-        var attempts = 0
-        while groupingLevel > 0, attempts < 3 {
-            attempts += 1
-            await withCheckedContinuation { continuation in
-                let waiter = UndoBoundaryWaiter(continuation)
-                // Runs after Foundation's NSUndoCloseGroupingRunLoopOrdering observer.
-                RunLoop.main.perform(
-                    #selector(UndoBoundaryWaiter.resume),
-                    target: waiter,
-                    argument: nil,
-                    order: NSUndoCloseGroupingRunLoopOrdering + 1,
-                    modes: runLoopModes
-                )
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { waiter.resume() }
-            }
+        guard groupingLevel > 0 else { return true }
+        await withCheckedContinuation { continuation in
+            let waiter = UndoBoundaryWaiter(continuation)
+            // Runs after Foundation's NSUndoCloseGroupingRunLoopOrdering observer.
+            RunLoop.main.perform(
+                #selector(UndoBoundaryWaiter.resume),
+                target: waiter,
+                argument: nil,
+                order: NSUndoCloseGroupingRunLoopOrdering + 1,
+                modes: runLoopModes
+            )
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { waiter.resume() }
         }
         return groupingLevel == 0
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -116,7 +116,10 @@ extension EditorViewModel {
     }
 
     @discardableResult
-    func generateCaptions(for request: CaptionRequest) async throws -> [String] {
+    func generateCaptions(
+        for request: CaptionRequest,
+        applying mutation: (@MainActor (@MainActor () -> [String]) async throws -> [String])? = nil
+    ) async throws -> [String] {
         let owningTimelineId = activeTimelineId
         var targets = resolvedCaptionTargets(for: request)
         guard !targets.isEmpty else { throw CaptionError.noSource }
@@ -132,6 +135,9 @@ extension EditorViewModel {
 
         let specs = captionSpecs(targets, results: results, request: request)
         guard !specs.isEmpty else { return [] }
+        if let mutation {
+            return try await mutation { self.placeCaptionTrack(specs) }
+        }
         return placeCaptionTrack(specs)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -206,31 +206,41 @@ extension EditorViewModel {
 
     /// Import files and folders from the open panel or a Finder drop as one undo step
     @discardableResult
-    func importFinderItems(_ urls: [URL], into folderId: String?) async -> MediaImportSummary {
+    func importFinderItems(
+        _ urls: [URL],
+        into folderId: String?,
+        applying mutation: (@MainActor (@MainActor () -> MediaImportSummary) async throws -> MediaImportSummary)? = nil
+    ) async throws -> MediaImportSummary {
         let previous = mediaImportTail
         mediaImportSequence &+= 1
         let sequence = mediaImportSequence
         let task = Task { @MainActor in
-            _ = await previous?.value
-            return await performFinderImport(urls, into: folderId)
+            _ = try? await previous?.value
+            return try await performFinderImport(urls, into: folderId, applying: mutation)
         }
         mediaImportTail = task
 
-        let summary = await task.value
-        if mediaImportSequence == sequence {
-            mediaImportTail = nil
+        defer {
+            if mediaImportSequence == sequence { mediaImportTail = nil }
         }
-        return summary
+        return try await task.value
     }
 
     @discardableResult
-    private func performFinderImport(_ urls: [URL], into folderId: String?) async -> MediaImportSummary {
+    private func performFinderImport(
+        _ urls: [URL],
+        into folderId: String?,
+        applying mutation: (@MainActor (@MainActor () -> MediaImportSummary) async throws -> MediaImportSummary)?
+    ) async throws -> MediaImportSummary {
         let before = mediaLibraryUndoSnapshot()
         let roots = urls.map { MediaImportScanner.Root(url: $0, parentFolderId: folderId) }
 
         let plan = await Task.detached(priority: .userInitiated) {
             MediaImportScanner.scan(roots: roots)
         }.value
+        if let mutation {
+            return try await mutation { self.applyMediaImportPlan(plan, restoringFrom: before) }
+        }
         return applyMediaImportPlan(plan, restoringFrom: before)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -39,8 +39,9 @@ extension EditorViewModel {
         targetClipIds: [String],
         mode: SyncMode = .auto,
         searchWindowSeconds: Double = SyncDefaults.searchWindowSeconds,
-        minConfidence: Double = SyncDefaults.minConfidence
-    ) async -> SyncBatchReport {
+        minConfidence: Double = SyncDefaults.minConfidence,
+        applying mutation: (@MainActor (@MainActor () -> Void) async throws -> Void)? = nil
+    ) async throws -> SyncBatchReport {
         let fps = Double(timeline.fps)
         let targets = targetClipIds.filter { $0 != referenceClipId }
         var report = SyncBatchReport()
@@ -244,10 +245,14 @@ extension EditorViewModel {
             return (move.clipId, move.toTrack, move.toFrame + shift)
         }
         if !moves.isEmpty {
-            undoManager?.beginUndoGrouping()
-            moveClips(moves)
-            undoManager?.endUndoGrouping()
-            undoManager?.setActionName("Synchronize")
+            if let mutation {
+                try await mutation { self.moveClips(moves) }
+            } else {
+                undoManager?.beginUndoGrouping()
+                moveClips(moves)
+                undoManager?.endUndoGrouping()
+                undoManager?.setActionName("Synchronize")
+            }
         }
         return report
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -244,7 +244,7 @@ final class EditorViewModel {
     var mediaPanelPasteRequestTick: Int = 0
     var mediaPanelShowMediaTabTick: Int = 0
     var mediaPanelToast: MediaPanelToast?
-    @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Never>?
+    @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Error>?
     @ObservationIgnored var mediaImportSequence: Int = 0
     @ObservationIgnored var pendingManifestMetadataUpdates: [String: MediaAsset] = [:]
     @ObservationIgnored var pendingManifestMetadataFlushTask: Task<Void, Never>?

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
@@ -114,7 +114,7 @@ extension MediaTab {
 
     @MainActor
     static func handlePanelFinderDrop(urls: [URL], into destFolderId: String?, editor: EditorViewModel) async {
-        await editor.importFinderItems(urls, into: destFolderId)
+        _ = try? await editor.importFinderItems(urls, into: destFolderId)
     }
 
     func handleProviderDrop(_ providers: [NSItemProvider], into destFolderId: String?) {

--- a/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
@@ -8,11 +8,15 @@ extension TimelineView {
         let mode = (info["mode"] as? String).flatMap(EditorViewModel.SyncMode.init) ?? .auto
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let report = await editor.syncClips(referenceClipId: referenceClipId, targetClipIds: targetClipIds, mode: mode)
-            editor.mediaPanelToast = MediaPanelToast(
-                message: Self.synchronizeSummary(report),
-                kind: report.synced.isEmpty ? .warning : .success
-            )
+            do {
+                let report = try await editor.syncClips(referenceClipId: referenceClipId, targetClipIds: targetClipIds, mode: mode)
+                editor.mediaPanelToast = MediaPanelToast(
+                    message: Self.synchronizeSummary(report),
+                    kind: report.synced.isEmpty ? .warning : .success
+                )
+            } catch {
+                editor.mediaPanelToast = MediaPanelToast(message: error.localizedDescription, kind: .warning)
+            }
             needsDisplay = true
         }
     }

--- a/Tests/PalmierProTests/Agent/UndoToolTests.swift
+++ b/Tests/PalmierProTests/Agent/UndoToolTests.swift
@@ -43,9 +43,9 @@ struct UndoToolTests {
 
     @Test func undoKeepsNewTimelineWhenAutomaticEventGroupStaysOpen() async throws {
         let (h, um) = harness()
-        um.runLoopModes = [RunLoop.Mode("AgentUndoBoundaryTests")]
         um.registerUndo(withTarget: h.editor) { _ in }
         um.setActionName("Earlier Tool")
+        #expect(um.groupingLevel == 1)
         let sourceTimelineId = h.editor.activeTimelineId
 
         _ = await h.runRaw("create_timeline", args: ["from": sourceTimelineId])
@@ -62,6 +62,76 @@ struct UndoToolTests {
         #expect(h.editor.timelines.count == 2)
         #expect(h.editor.activeTimelineId == createdTimelineId)
         #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+    }
+
+    @Test func automaticGroupingRemainsUsableAfterAgentEdit() async throws {
+        let (h, um) = harness()
+        um.registerUndo(withTarget: h.editor) { _ in }
+        #expect(um.groupingLevel == 1)
+
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.5])
+        #expect(um.groupingLevel == 0)
+
+        // A later automatic event group must still open and register cleanly (#320).
+        um.registerUndo(withTarget: h.editor) { _ in }
+        #expect(um.groupingLevel == 1)
+        _ = await h.runRaw("ripple_delete_ranges", args: ["clipId": "c1", "ranges": [[40, 50]]])
+        #expect(um.canUndo)
+    }
+
+    @Test func concurrentAgentEditsRemainSeparateUndoSteps() async throws {
+        let (h, um) = harness()
+        _ = um
+
+        async let first = h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.25])
+        async let second = h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.5])
+        _ = await (first, second)
+
+        _ = await h.runRaw("undo")
+        #expect(h.editor.timeline.tracks[0].clips[0].volume != 1.0)
+        _ = await h.runRaw("undo")
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+    }
+
+    @Test func refusesWhileUserUndoGroupIsOpen() async throws {
+        let (h, um) = harness()
+        um.groupsByEvent = false
+        um.beginUndoGrouping()
+
+        let result = await h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.5])
+
+        #expect(result.isError)
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+        #expect(um.groupingLevel == 1)
+        um.endUndoGrouping()
+        um.groupsByEvent = true
+    }
+
+    @Test func sessionsCannotUndoIdenticallyNamedTransactions() async throws {
+        let (h, um) = harness()
+        let other = ToolExecutor(editor: h.editor)
+
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.25])
+        _ = await other.execute(
+            name: "set_clip_properties",
+            args: ["clipIds": ["c1"], "volume": 0.5]
+        )
+
+        #expect(await h.runRaw("undo").isError)
+        #expect(!(await other.execute(name: "undo", args: [:])).isError)
+        #expect(!(await h.runRaw("undo")).isError)
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+        _ = um
+    }
+
+    @Test func nativeUndoConsumesAgentTransaction() async throws {
+        let (h, um) = harness()
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": ["c1"], "volume": 0.5])
+
+        um.undo()
+
+        #expect(h.editor.timeline.tracks[0].clips[0].volume == 1.0)
+        #expect(await h.runRaw("undo").isError)
     }
 
     @Test func refusesWhenAssistantHasNotEdited() async throws {

--- a/Tests/PalmierProTests/Media/AudioImportTests.swift
+++ b/Tests/PalmierProTests/Media/AudioImportTests.swift
@@ -33,7 +33,7 @@ struct AudioImportTests {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         try Data().write(to: root.appendingPathComponent("voice.aifc"))
 
-        let summary = await e.importFinderItems([root], into: nil)
+        let summary = try await e.importFinderItems([root], into: nil)
 
         #expect(summary.assetCount == 1)
         let imported = try #require(e.mediaAssets.first { $0.name == "voice" })

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -69,7 +69,7 @@ struct FolderReadTests {
         try Data().write(to: nested.appendingPathComponent("child.wav"))
         try Data().write(to: nested.appendingPathComponent("ignored.txt"))
 
-        let summary = await e.importFinderItems([root], into: nil)
+        let summary = try await e.importFinderItems([root], into: nil)
 
         #expect(summary.assetCount == 2)
         #expect(summary.folderCount == 2)
@@ -91,7 +91,7 @@ struct FolderReadTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        let summary = await e.importFinderItems([root], into: nil)
+        let summary = try await e.importFinderItems([root], into: nil)
 
         #expect(summary.assetCount == 0)
         #expect(summary.folderCount == 0)


### PR DESCRIPTION
## Summary

- replace forced `NSUndoManager` event-group closure with a bounded run-loop boundary
- refuse agent mutations while a user-owned undo group remains open
- apply async tool results inside guarded synchronous undo transactions
- tag native undo entries with an agent session ID instead of matching action-name strings
- add coverage for automatic grouping, concurrent edits, cross-session ownership, and native UI undo

## Root cause

PR #318 disabled `groupsByEvent` and manually ended Foundation's automatic event group. Foundation still scheduled its own close at the end of the run-loop event, producing unmatched begin/end operations and the exceptions reported in #320.

This change never closes a group it did not open. It waits briefly for automatic grouping to finish, then either creates one explicit top-level transaction or returns a retryable error without mutating the document.

## Impact

Agent and MCP edits remain on the document's native undo stack, so toolbar Undo and Command-Z continue to work. User edits and edits from another agent session cannot be consumed by the current session's `undo` tool.

Closes #320.

## Validation

- `swift test --filter UndoToolTests` — 11 passed
- `swift test --filter ApplyLayoutTests` — 16 passed
- `swift test` — 1,045 passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every agent mutation interacts with NSUndoManager and blocks edits during in-flight undo groups; incorrect boundary timing could still affect Command-Z or tool undo, though the new tests target the prior crash/regression.
> 
> **Overview**
> Fixes **agent/MCP undo** so edits land as one native undo step without fighting Foundation’s automatic event groups (the root cause of #320).
> 
> **New undo boundary layer** (`UndoManager+Boundary`): briefly waits for any open automatic group to close, then opens a single named top-level group (only when `groupingLevel == 0`), tags it with an **agent session ID**, and refuses work if another undo group is already open. Mutating tools call this via `withUndoGroup` / `withUndoBoundary` instead of manually toggling `groupsByEvent` or ending groups the agent didn’t start.
> 
> **Tool behavior**: synchronous clip/timeline tools gain consistent `(Agent)` undo names and `try` propagation; async flows (**captions**, **sync**, **import**, **multicam create**, **audio generation** placement) apply timeline changes inside the boundary after async work. The agent **`undo` tool** no longer tracks action names in memory—it only reverses the stack top if its **session ID** matches; user or other-session edits are rejected. Mutating tools also bail early with “action in progress” when a boundary can’t be acquired.
> 
> **Tests** expand coverage for open event groups, concurrent agent edits, user-owned groups, cross-session undo, and native UI undo consuming agent transactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac45e2c1c084368f8b5b898db17f3d23af2a0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->