### PR TITLE
[sentry fix] Batch project media restoration

### DIFF
--- a/Sources/PalmierPro/Models/MediaResolver.swift
+++ b/Sources/PalmierPro/Models/MediaResolver.swift
@@ -31,9 +31,13 @@ final class MediaResolver: @unchecked Sendable {
     }
 
     static func expectedURLMap(entries: [MediaManifestEntry], projectURL: URL?) -> [String: URL] {
-        Dictionary(uniqueKeysWithValues: entries.compactMap { entry in
-            expectedURL(for: entry, projectURL: projectURL).map { (entry.id, $0) }
-        })
+        var seenIds: Set<String> = []
+        var urls: [String: URL] = [:]
+        urls.reserveCapacity(entries.count)
+        for entry in entries where seenIds.insert(entry.id).inserted {
+            urls[entry.id] = expectedURL(for: entry, projectURL: projectURL)
+        }
+        return urls
     }
 
     private static func expectedURL(for entry: MediaManifestEntry, projectURL: URL?) -> URL? {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -532,28 +532,35 @@ final class VideoProject: NSDocument {
 
     // MARK: - Media restore
 
-    private func restoreAssetsFromManifest() {
-        let resolver = editorViewModel.mediaResolver
+    func restoreAssetsFromManifest() {
+        let entries = editorViewModel.mediaManifest.entries
+        let expectedURLs = MediaResolver.expectedURLMap(entries: entries, projectURL: editorViewModel.projectURL)
         var missing = 0
         var missingRefs: Set<String> = []
+        var restoredAssets: [MediaAsset] = []
         var candidates: [RestoredMediaCandidate] = []
-        for entry in editorViewModel.mediaManifest.entries {
-            guard let url = resolver.expectedURL(for: entry.id) else {
+        restoredAssets.reserveCapacity(entries.count)
+        candidates.reserveCapacity(entries.count)
+        for entry in entries {
+            guard let url = expectedURLs[entry.id] else {
                 Log.project.warning("restore: could not resolve URL for entry id=\(entry.id) name=\(entry.name)")
                 missing += 1
                 missingRefs.insert(entry.id)
                 continue
             }
             let asset = MediaAsset(entry: entry, resolvedURL: url)
-            editorViewModel.mediaAssets.append(asset)
+            restoredAssets.append(asset)
             candidates.append(RestoredMediaCandidate(id: entry.id, name: entry.name, url: url))
+        }
+        if !restoredAssets.isEmpty {
+            editorViewModel.mediaAssets.append(contentsOf: restoredAssets)
         }
         editorViewModel.missingMediaRefs = missingRefs
 
         let restoreCandidates = candidates
         let initialMissingRefs = missingRefs
         let initialMissingCount = missing
-        let manifestEntries = editorViewModel.mediaManifest.entries.count
+        let manifestEntries = entries.count
         Task { [weak self] in
             let existingRefs = await Task.detached(priority: .utility) {
                 Self.existingMediaRefs(restoreCandidates)

--- a/Tests/PalmierProTests/Media/MediaResolverTests.swift
+++ b/Tests/PalmierProTests/Media/MediaResolverTests.swift
@@ -102,6 +102,17 @@ struct MediaResolverTests {
         #expect(resolver.resolveURL(for: "a") == nil)
     }
 
+    @Test func expectedURLMapKeepsFirstDuplicateId() {
+        let entries = [
+            entry(id: "a", source: .external(absolutePath: "/tmp/first")),
+            entry(id: "a", source: .external(absolutePath: "/tmp/second"))
+        ]
+
+        let urls = MediaResolver.expectedURLMap(entries: entries, projectURL: nil)
+
+        #expect(urls["a"]?.path == "/tmp/first")
+    }
+
     // MARK: - Cache behavior
 
     // MARK: - missingAssetIds (off-main-thread offline computation)

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -1,6 +1,31 @@
 import Foundation
+import Observation
 import Testing
 @testable import PalmierPro
+
+@MainActor
+private final class MediaAssetsChangeCounter {
+    private weak var editor: EditorViewModel?
+    private(set) var count = 0
+
+    init(editor: EditorViewModel) {
+        self.editor = editor
+        observe()
+    }
+
+    private func observe() {
+        guard let editor else { return }
+        withObservationTracking {
+            _ = editor.mediaAssets.count
+        } onChange: { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.count += 1
+                self.observe()
+            }
+        }
+    }
+}
 
 /// A corrupt `media.json` must never make a project unopenable: the timeline lives in a
 /// separate file and is the real creative work. A bad manifest should degrade to "media
@@ -67,6 +92,29 @@ struct VideoProjectLoadTests {
 
         #expect(contents.manifest?.entries.count == 1)
         #expect(contents.manifestUnreadable == false)
+    }
+
+    @MainActor
+    @Test func manifestRestorePublishesMediaAssetsOnce() {
+        let document = VideoProject()
+        var manifest = MediaManifest()
+        manifest.entries = (0..<100).map { index in
+            MediaManifestEntry(
+                id: "asset-\(index)",
+                name: "Asset \(index)",
+                type: .video,
+                source: .external(absolutePath: "/tmp/asset-\(index).mp4"),
+                duration: 1
+            )
+        }
+        document.editorViewModel.mediaManifest = manifest
+        let changes = MediaAssetsChangeCounter(editor: document.editorViewModel)
+
+        document.restoreAssetsFromManifest()
+
+        #expect(changes.count == 1)
+        #expect(document.editorViewModel.mediaAssets.count == manifest.entries.count)
+        #expect(document.editorViewModel.mediaAssetsById.count == manifest.entries.count)
     }
 
     @Test func missingTimelineStillThrows() throws {


### PR DESCRIPTION
## Summary

- restore manifest media with one observed array mutation
- build the media URL lookup once instead of rescanning the manifest for every asset
- preserve first-entry behavior for duplicate manifest IDs and avoid duplicate-key traps

## Why

PALMIER-PRO-YP records project-open hangs of at least eight seconds inside `restoreAssetsFromManifest`. Each asset append rebuilt `mediaAssetsById` from the growing array, and each URL lookup scanned the manifest again, making restoration quadratic on the main thread.

## Impact

Large projects should become responsive sooner during open. This does not change project data or visible editor behavior.

## Validation

- `swift test --filter 'manifestRestorePublishesMediaAssetsOnce|expectedURLMapKeepsFirstDuplicateId'`
- `swift test` — 1,048 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor on project open with behavior pinned by tests; no auth, persistence format, or user-visible editor logic changes.
> 
> **Overview**
> Fixes main-thread project-open stalls by making manifest media restoration **linear** instead of quadratic on large libraries.
> 
> **`restoreAssetsFromManifest`** now builds one **`MediaResolver.expectedURLMap`** for all entries, accumulates **`MediaAsset`** instances in memory, then applies a single **`append(contentsOf:)`** to **`editorViewModel.mediaAssets`**. That cuts repeated manifest scans and repeated **`mediaAssetsById`** rebuilds (each append used to re-index the whole array). The method is **`internal`**/`func` (no longer **`private`**) so tests can call it directly.
> 
> **`MediaResolver.expectedURLMap`** no longer uses **`Dictionary(uniqueKeysWithValues:)`** over compact-mapped entries. It walks entries once, keeps the **first** URL per duplicate manifest ID, and skips later duplicates—avoiding duplicate-key failures while preserving first-wins semantics.
> 
> Tests lock in duplicate-ID map behavior and assert that restoring **100** manifest entries triggers **one** observation change on **`mediaAssets.count`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a9994986a24c715517a3dd6dd5d1b5713af2bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->