### PR TITLE
[fix/perf] Defer unused media hydration

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -631,6 +631,9 @@ extension EditorViewModel {
         guard let loc = findClip(id: clipId) else { return }
         let oldMediaRef = timeline.tracks[loc.trackIndex].clips[loc.clipIndex].mediaRef
         guard oldMediaRef != newAssetId else { return }
+        if let asset = mediaAssetsById[newAssetId] {
+            prepareMediaVisuals(for: asset)
+        }
 
         let targetIds = linkedClipIdsSharingMedia(anchor: clipId)
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -633,7 +633,7 @@ extension EditorViewModel {
         batchManifestUpdate: Bool = false
     ) async -> Bool {
         Log.project.debug("media finalize start asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue)")
-        let metadataLoaded = await asset.loadMetadata()
+        let metadataLoaded = await asset.loadMetadata(includeThumbnail: !batchManifestUpdate)
         guard metadataLoaded else {
             if FileManager.default.fileExists(atPath: asset.url.path) {
                 unprocessableMediaRefs.insert(asset.id)
@@ -664,6 +664,17 @@ extension EditorViewModel {
         }
         refreshMissingMediaCache()
         searchIndex.schedule(asset)
+        if !batchManifestUpdate {
+            prepareMediaVisuals(for: asset)
+        }
+        refreshPreviewForFinalizedAsset(asset)
+        Log.project.debug(
+            "media finalize ok asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue) duration=\(asset.duration)"
+        )
+        return true
+    }
+
+    func prepareMediaVisuals(for asset: MediaAsset) {
         switch asset.type {
         case .video:
             mediaVisualCache.generateWaveform(for: asset)
@@ -675,11 +686,6 @@ extension EditorViewModel {
         case .text, .lottie, .sequence:
             break
         }
-        refreshPreviewForFinalizedAsset(asset)
-        Log.project.debug(
-            "media finalize ok asset=\(asset.id.prefix(8)) type=\(asset.type.rawValue) duration=\(asset.duration)"
-        )
-        return true
     }
 
     private func recordManifestMetadata(for asset: MediaAsset, batching: Bool) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -464,6 +464,7 @@ final class EditorViewModel {
         trimEndFrame: Int? = nil
     ) -> [String] {
         guard timeline.tracks.indices.contains(trackIndex) else { return [] }
+        prepareMediaVisuals(for: asset)
         let targetIsVideo = timeline.tracks[trackIndex].type == .video
         let shouldLink = addLinkedAudio && targetIsVideo && asset.hasAudio
             && (asset.type == .video || asset.type == .sequence)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -69,8 +69,8 @@ struct AssetThumbnailView: View {
         .contextMenu { contextMenuItems }
         .opacity(isSwapDimmed ? AppTheme.Opacity.muted : 1)
         .allowsHitTesting(!isSwapDimmed)
-        .task(id: asset.url) {
-            guard !isMissing, !asset.isGenerating else { return }
+        .task(id: "\(asset.id)|\(asset.url.path)|\(asset.generationStatus.serialized)|\(isMissing)") {
+            guard case .none = asset.generationStatus, !isMissing else { return }
             await asset.loadLibraryThumbnail()
         }
     }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -69,6 +69,10 @@ struct AssetThumbnailView: View {
         .contextMenu { contextMenuItems }
         .opacity(isSwapDimmed ? AppTheme.Opacity.muted : 1)
         .allowsHitTesting(!isSwapDimmed)
+        .task(id: asset.url) {
+            guard !isMissing, !asset.isGenerating else { return }
+            await asset.loadLibraryThumbnail()
+        }
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -121,15 +121,18 @@ extension MediaTab {
 
     @ViewBuilder
     private func momentThumb(_ asset: MediaAsset?, time: Double) -> some View {
-        if asset?.type == .image {
+        if let asset, asset.type == .image {
             ZStack {
                 Rectangle().fill(Color.black)
-                if let thumb = asset?.thumbnail {
+                if let thumb = asset.thumbnail {
                     Image(nsImage: thumb).resizable().aspectRatio(contentMode: .fit)
                 } else {
                     Image(systemName: "photo")
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
                 }
+            }
+            .task(id: searchThumbnailTaskID(for: asset)) {
+                await loadSearchThumbnail(asset)
             }
         } else {
             MomentThumbnail(url: asset?.url, time: time)
@@ -187,6 +190,18 @@ extension MediaTab {
         }
         .draggable(dragPayload(for: asset)) { dragPreview(for: asset) }
         .onTapGesture { editor.selectMediaPanelItem(asset.id) }
+        .task(id: searchThumbnailTaskID(for: asset)) {
+            await loadSearchThumbnail(asset)
+        }
+    }
+
+    private func searchThumbnailTaskID(for asset: MediaAsset) -> String {
+        "\(asset.id)|\(asset.url.path)|\(asset.generationStatus.serialized)|\(editor.isMediaOffline(asset.id))"
+    }
+
+    private func loadSearchThumbnail(_ asset: MediaAsset) async {
+        guard case .none = asset.generationStatus, !editor.isMediaOffline(asset.id) else { return }
+        await asset.loadLibraryThumbnail()
     }
 
     private func previewMoment(assetID: String, atSeconds seconds: Double) {

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -192,6 +192,7 @@ final class MediaAsset: Identifiable {
                     thumbnailMaxPixelSize: includeThumbnail ? ImageEncoder.maxLongestEdge : nil
                 )
             }.value
+            guard !Task.isCancelled, url == imageURL else { return false }
             if let width = metadata.width { sourceWidth = width }
             if let height = metadata.height { sourceHeight = height }
             if let image = metadata.thumbnail,
@@ -203,12 +204,14 @@ final class MediaAsset: Identifiable {
         }
 
         if type == .lottie {
-            guard let info = try? await LottieVideoGenerator.inspect(fileAt: url) else { return false }
+            let lottieURL = url
+            guard let info = try? await LottieVideoGenerator.inspect(fileAt: lottieURL),
+                  !Task.isCancelled, url == lottieURL else { return false }
             duration = info.meta.duration
             sourceWidth = Int(info.meta.size.width)
             sourceHeight = Int(info.meta.size.height)
             sourceFPS = info.meta.framerate
-            if let cg = info.thumbnail {
+            if includeThumbnail, let cg = info.thumbnail {
                 thumbnail = NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
             }
             return true
@@ -273,7 +276,7 @@ final class MediaAsset: Identifiable {
         let metadata = await Task.detached(priority: .utility) {
             ImageEncoder.metadata(url: imageURL, thumbnailMaxPixelSize: maxPixelSize)
         }.value
-        guard !Task.isCancelled, maxPixelSize > thumbnailMaxPixelSize else { return }
+        guard !Task.isCancelled, url == imageURL, maxPixelSize > thumbnailMaxPixelSize else { return }
         duration = Defaults.imageDurationSeconds
         if let width = metadata.width { sourceWidth = width }
         if let height = metadata.height { sourceHeight = height }

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -4,8 +4,19 @@ import AVFoundation
 @Observable
 @MainActor
 final class MediaAsset: Identifiable {
+    private nonisolated static let metadataLoadGate = AsyncSemaphore(value: 4)
+    private nonisolated static let thumbnailLoadGate = AsyncSemaphore(value: 4)
+    private nonisolated static let libraryThumbnailMaxPixelSize = 320
+    private nonisolated static let previewThumbnailMaxPixelSize = ImageEncoder.maxLongestEdge
+
     let id: String
-    var url: URL
+    var url: URL {
+        didSet {
+            guard url != oldValue else { return }
+            thumbnail = nil
+            thumbnailMaxPixelSize = 0
+        }
+    }
     let type: ClipType
     var name: String
     var duration: Double
@@ -21,6 +32,7 @@ final class MediaAsset: Identifiable {
     var pendingDownloadURL: URL?
     var cachedRemoteURL: String?
     var cachedRemoteURLExpiresAt: Date?
+    private var thumbnailMaxPixelSize = 0
 
     /// Returns the cached URL if it's set AND not expired; else nil.
     var freshRemoteURL: String? {
@@ -103,6 +115,7 @@ final class MediaAsset: Identifiable {
         self.thumbnail = thumbnail
         self.generationInput = generationInput
         self.hasAudio = (type == .video)
+        if thumbnail != nil { thumbnailMaxPixelSize = .max }
     }
 
     /// Reconstruct from a manifest entry + resolved URL.
@@ -142,18 +155,64 @@ final class MediaAsset: Identifiable {
         )
     }
 
+    var needsMetadataRefresh: Bool {
+        switch type {
+        case .image:
+            sourceWidth == nil || sourceHeight == nil
+        case .video:
+            duration <= 0 || sourceWidth == nil || sourceHeight == nil || sourceFPS == nil
+        case .audio:
+            duration <= 0
+        case .lottie:
+            duration <= 0 || sourceWidth == nil || sourceHeight == nil || sourceFPS == nil
+        case .text, .sequence:
+            false
+        }
+    }
+
+    func loadLibraryThumbnail() async {
+        switch type {
+        case .image:
+            await loadImageThumbnail(maxPixelSize: Self.libraryThumbnailMaxPixelSize)
+        case .video, .lottie:
+            guard thumbnail == nil, await acquireThumbnailPermit() else { return }
+            defer { releaseThumbnailPermit() }
+            guard thumbnail == nil, !Task.isCancelled else { return }
+            _ = await loadMetadata()
+        case .audio, .text, .sequence:
+            break
+        }
+    }
+
+    func loadPreviewThumbnail() async {
+        guard type == .image else { return }
+        await loadImageThumbnail(maxPixelSize: Self.previewThumbnailMaxPixelSize)
+    }
+
     @discardableResult
-    func loadMetadata() async -> Bool {
+    func loadMetadata(includeThumbnail: Bool = true) async -> Bool {
+        do {
+            try await Self.metadataLoadGate.wait()
+        } catch {
+            return false
+        }
+        defer { Task { await Self.metadataLoadGate.signal() } }
+
         if type == .image {
             duration = Defaults.imageDurationSeconds
             let imageURL = url
             let metadata = await Task.detached(priority: .utility) {
-                ImageEncoder.metadata(url: imageURL, thumbnailMaxPixelSize: 1568)
+                ImageEncoder.metadata(
+                    url: imageURL,
+                    thumbnailMaxPixelSize: includeThumbnail ? ImageEncoder.maxLongestEdge : nil
+                )
             }.value
             if let width = metadata.width { sourceWidth = width }
             if let height = metadata.height { sourceHeight = height }
-            if let image = metadata.thumbnail {
+            if let image = metadata.thumbnail,
+               ImageEncoder.maxLongestEdge >= thumbnailMaxPixelSize {
                 thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+                thumbnailMaxPixelSize = ImageEncoder.maxLongestEdge
             }
             return metadata.width != nil && metadata.height != nil
         }
@@ -201,13 +260,15 @@ final class MediaAsset: Identifiable {
                 hasAudio = !audioTracks.isEmpty
             }
             if hasVideoTrack {
-                let gen = AVAssetImageGenerator(asset: avAsset)
-                gen.maximumSize = CGSize(width: 320, height: 320)   // square budget — portrait gets full res too
-                gen.appliesPreferredTrackTransform = true
-                if let cgImage = try? await gen.image(at: .zero).image {
-                    // Use the generated frame's true pixel size — a hardcoded 16:9 size makes
-                    // SwiftUI's aspectRatio squeeze non-16:9 (e.g. vertical) thumbnails.
-                    thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                if includeThumbnail {
+                    let gen = AVAssetImageGenerator(asset: avAsset)
+                    gen.maximumSize = CGSize(width: 320, height: 320)   // square budget — portrait gets full res too
+                    gen.appliesPreferredTrackTransform = true
+                    if let cgImage = try? await gen.image(at: .zero).image {
+                        // Use the generated frame's true pixel size — a hardcoded 16:9 size makes
+                        // SwiftUI's aspectRatio squeeze non-16:9 (e.g. vertical) thumbnails.
+                        thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                    }
                 }
             }
             return hasVideoTrack
@@ -216,5 +277,37 @@ final class MediaAsset: Identifiable {
             return (try? await avAsset.loadTracks(withMediaType: .audio).first) != nil
         }
         return true
+    }
+
+    private func loadImageThumbnail(maxPixelSize: Int) async {
+        guard maxPixelSize > thumbnailMaxPixelSize, await acquireThumbnailPermit() else { return }
+        defer { releaseThumbnailPermit() }
+        guard maxPixelSize > thumbnailMaxPixelSize, !Task.isCancelled else { return }
+
+        let imageURL = url
+        let metadata = await Task.detached(priority: .utility) {
+            ImageEncoder.metadata(url: imageURL, thumbnailMaxPixelSize: maxPixelSize)
+        }.value
+        guard !Task.isCancelled, maxPixelSize > thumbnailMaxPixelSize else { return }
+        duration = Defaults.imageDurationSeconds
+        if let width = metadata.width { sourceWidth = width }
+        if let height = metadata.height { sourceHeight = height }
+        if let image = metadata.thumbnail {
+            thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+            thumbnailMaxPixelSize = maxPixelSize
+        }
+    }
+
+    private func acquireThumbnailPermit() async -> Bool {
+        do {
+            try await Self.thumbnailLoadGate.wait()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func releaseThumbnailPermit() {
+        Task { await Self.thumbnailLoadGate.signal() }
     }
 }

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -155,21 +155,6 @@ final class MediaAsset: Identifiable {
         )
     }
 
-    var needsMetadataRefresh: Bool {
-        switch type {
-        case .image:
-            sourceWidth == nil || sourceHeight == nil
-        case .video:
-            duration <= 0 || sourceWidth == nil || sourceHeight == nil || sourceFPS == nil
-        case .audio:
-            duration <= 0
-        case .lottie:
-            duration <= 0 || sourceWidth == nil || sourceHeight == nil || sourceFPS == nil
-        case .text, .sequence:
-            false
-        }
-    }
-
     func loadLibraryThumbnail() async {
         switch type {
         case .image:

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -207,15 +207,21 @@ struct PreviewContainerView: View {
 
     private var imagePreview: some View {
         Group {
-            if let asset = activeMediaAsset, let image = asset.thumbnail ?? NSImage(contentsOf: asset.url) {
+            if let asset = activeMediaAsset, let image = asset.thumbnail {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.black)
         .allowsHitTesting(false)
+        .task(id: activeMediaAsset.map { "\($0.id)|\($0.url.path)" }) {
+            await activeMediaAsset?.loadPreviewThumbnail()
+        }
     }
 
     private func fitSize(in container: CGSize, aspect: CGFloat) -> CGSize {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -8,6 +8,7 @@ struct PreviewContainerView: View {
     private var isImage: Bool { editor.activePreviewTab.clipType == .image }
 
     @State private var hoveredTabId: String?
+    @State private var failedImagePreviewKey: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -206,11 +207,18 @@ struct PreviewContainerView: View {
     // MARK: - Image preview
 
     private var imagePreview: some View {
-        Group {
+        let assetKey = activeMediaAsset.map {
+            "\($0.id)|\($0.url.path)|\($0.generationStatus.serialized)|\(editor.isMediaOffline($0.id))"
+        }
+        return Group {
             if let asset = activeMediaAsset, let image = asset.thumbnail {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+            } else if let assetKey, failedImagePreviewKey == assetKey {
+                Image(systemName: "photo")
+                    .font(.system(size: AppTheme.FontSize.xl))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
             } else {
                 ProgressView()
                     .controlSize(.small)
@@ -219,8 +227,12 @@ struct PreviewContainerView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.black)
         .allowsHitTesting(false)
-        .task(id: activeMediaAsset.map { "\($0.id)|\($0.url.path)" }) {
-            await activeMediaAsset?.loadPreviewThumbnail()
+        .task(id: assetKey) {
+            failedImagePreviewKey = nil
+            guard let asset = activeMediaAsset else { return }
+            await asset.loadPreviewThumbnail()
+            guard !Task.isCancelled, asset.thumbnail == nil else { return }
+            failedImagePreviewKey = assetKey
         }
     }
 

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -636,9 +636,10 @@ final class VideoProject: NSDocument {
                 manifestUpdates.append(asset)
             }
             restored += 1
-            guard timelineMediaRefs.contains(asset.id) else { continue }
+            let usedOnTimeline = timelineMediaRefs.contains(asset.id)
             Task { [weak self] in
-                guard await asset.loadMetadata(includeThumbnail: false), let self else { return }
+                _ = await asset.loadMetadata(includeThumbnail: false)
+                guard usedOnTimeline, let self else { return }
                 self.editorViewModel.prepareMediaVisuals(for: asset)
             }
         }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -588,7 +588,6 @@ final class VideoProject: NSDocument {
         initialMissingCount: Int,
         manifestEntries: Int
     ) {
-        let cache = editorViewModel.mediaVisualCache
         var assetsByID: [String: MediaAsset] = [:]
         for asset in editorViewModel.mediaAssets {
             assetsByID[asset.id] = asset
@@ -597,6 +596,9 @@ final class VideoProject: NSDocument {
         var missing = initialMissingCount
         var missingRefs = initialMissingRefs
         var manifestUpdates: [MediaAsset] = []
+        let timelineMediaRefs = Set(editorViewModel.timelines.flatMap { timeline in
+            timeline.tracks.flatMap { track in track.clips.map(\.mediaRef) }
+        })
 
         for candidate in candidates {
             guard let asset = assetsByID[candidate.id] else { continue }
@@ -634,16 +636,15 @@ final class VideoProject: NSDocument {
                 manifestUpdates.append(asset)
             }
             restored += 1
-            if asset.type == .audio || asset.type == .video {
-                cache.generateWaveform(for: asset)
+            guard timelineMediaRefs.contains(asset.id) else { continue }
+            if asset.needsMetadataRefresh {
+                Task { [weak self] in
+                    guard await asset.loadMetadata(includeThumbnail: false), let self else { return }
+                    self.editorViewModel.prepareMediaVisuals(for: asset)
+                }
+            } else {
+                editorViewModel.prepareMediaVisuals(for: asset)
             }
-            if asset.type == .video {
-                cache.generateVideoThumbnails(for: asset)
-            }
-            if asset.type == .image {
-                cache.generateImageThumbnail(for: asset)
-            }
-            Task { await asset.loadMetadata() }
         }
 
         editorViewModel.updateManifestMetadata(for: manifestUpdates)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -637,13 +637,9 @@ final class VideoProject: NSDocument {
             }
             restored += 1
             guard timelineMediaRefs.contains(asset.id) else { continue }
-            if asset.needsMetadataRefresh {
-                Task { [weak self] in
-                    guard await asset.loadMetadata(includeThumbnail: false), let self else { return }
-                    self.editorViewModel.prepareMediaVisuals(for: asset)
-                }
-            } else {
-                editorViewModel.prepareMediaVisuals(for: asset)
+            Task { [weak self] in
+                guard await asset.loadMetadata(includeThumbnail: false), let self else { return }
+                self.editorViewModel.prepareMediaVisuals(for: asset)
             }
         }
 

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -39,6 +39,7 @@ final class MediaVisualCache {
 
     private var videoThumbnails: [String: [(time: Double, image: CGImage)]] = [:]
     private var videoThumbnailInFlight: Set<String> = []
+    private static let videoThumbnailGate = AsyncSemaphore(value: 2)
 
     // MARK: - Image thumbnails (single still per asset)
 
@@ -147,6 +148,14 @@ final class MediaVisualCache {
 
         let url = asset.url
         Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try await Self.videoThumbnailGate.wait()
+            } catch {
+                await MainActor.run { [weak self] in _ = self?.videoThumbnailInFlight.remove(key) }
+                return
+            }
+            defer { Task { await Self.videoThumbnailGate.signal() } }
+
             let cacheKey = Self.diskCacheKey(for: url)
             var results = cacheKey.flatMap(Self.loadThumbnails(key:)) ?? []
 

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -141,7 +141,7 @@ struct VideoProjectLoadTests {
     }
 
     @MainActor
-    @Test func manifestRestoreRefreshesOnlyTimelineMetadataWithoutThumbnail() async throws {
+    @Test func manifestRestoreRefreshesTimelineMetadataWithoutThumbnail() async throws {
         let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
         let document = VideoProject()
         document.editorViewModel.timeline = Fixtures.timeline(tracks: [
@@ -159,21 +159,25 @@ struct VideoProjectLoadTests {
                 name: "Used Image",
                 type: .image,
                 source: .external(absolutePath: imageURL.path),
-                duration: Defaults.imageDurationSeconds
+                duration: Defaults.imageDurationSeconds,
+                sourceWidth: 1,
+                sourceHeight: 1
             ),
             MediaManifestEntry(
                 id: "unused-image",
                 name: "Unused Image",
                 type: .image,
                 source: .external(absolutePath: imageURL.path),
-                duration: Defaults.imageDurationSeconds
+                duration: Defaults.imageDurationSeconds,
+                sourceWidth: 2,
+                sourceHeight: 2
             ),
         ]
         document.editorViewModel.mediaManifest = manifest
 
         document.restoreAssetsFromManifest()
         for _ in 0..<100 {
-            if document.editorViewModel.mediaAssets.first(where: { $0.id == "used-image" })?.sourceWidth != nil {
+            if document.editorViewModel.mediaAssets.first(where: { $0.id == "used-image" })?.sourceWidth == 640 {
                 break
             }
             try await Task.sleep(for: .milliseconds(10))
@@ -184,8 +188,8 @@ struct VideoProjectLoadTests {
         #expect(used.sourceWidth == 640)
         #expect(used.sourceHeight == 360)
         #expect(used.thumbnail == nil)
-        #expect(unused.sourceWidth == nil)
-        #expect(unused.sourceHeight == nil)
+        #expect(unused.sourceWidth == 2)
+        #expect(unused.sourceHeight == 2)
         #expect(unused.thumbnail == nil)
     }
 

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -118,7 +118,7 @@ struct VideoProjectLoadTests {
     }
 
     @MainActor
-    @Test func manifestRestoreDefersUnusedImageHydration() async throws {
+    @Test func manifestRestoreLoadsUnusedMetadataWithoutVisuals() async throws {
         let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
         let document = VideoProject()
         var manifest = MediaManifest()
@@ -132,12 +132,16 @@ struct VideoProjectLoadTests {
         document.editorViewModel.mediaManifest = manifest
 
         document.restoreAssetsFromManifest()
-        try await Task.sleep(for: .milliseconds(100))
+        for _ in 0..<100 {
+            if document.editorViewModel.mediaAssets.first?.sourceWidth == 640 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
 
         let asset = try #require(document.editorViewModel.mediaAssets.first)
-        #expect(asset.sourceWidth == nil)
-        #expect(asset.sourceHeight == nil)
+        #expect(asset.sourceWidth == 640)
+        #expect(asset.sourceHeight == 360)
         #expect(asset.thumbnail == nil)
+        #expect(document.editorViewModel.mediaVisualCache.imageThumbnail(for: asset.id) == nil)
     }
 
     @MainActor
@@ -177,7 +181,9 @@ struct VideoProjectLoadTests {
 
         document.restoreAssetsFromManifest()
         for _ in 0..<100 {
-            if document.editorViewModel.mediaAssets.first(where: { $0.id == "used-image" })?.sourceWidth == 640 {
+            let usedReady = document.editorViewModel.mediaVisualCache.imageThumbnail(for: "used-image") != nil
+            let unusedReady = document.editorViewModel.mediaAssets.first(where: { $0.id == "unused-image" })?.sourceWidth == 640
+            if usedReady && unusedReady {
                 break
             }
             try await Task.sleep(for: .milliseconds(10))
@@ -188,9 +194,11 @@ struct VideoProjectLoadTests {
         #expect(used.sourceWidth == 640)
         #expect(used.sourceHeight == 360)
         #expect(used.thumbnail == nil)
-        #expect(unused.sourceWidth == 2)
-        #expect(unused.sourceHeight == 2)
+        #expect(unused.sourceWidth == 640)
+        #expect(unused.sourceHeight == 360)
         #expect(unused.thumbnail == nil)
+        #expect(document.editorViewModel.mediaVisualCache.imageThumbnail(for: used.id) != nil)
+        #expect(document.editorViewModel.mediaVisualCache.imageThumbnail(for: unused.id) == nil)
     }
 
     @MainActor

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -117,6 +117,108 @@ struct VideoProjectLoadTests {
         #expect(document.editorViewModel.mediaAssetsById.count == manifest.entries.count)
     }
 
+    @MainActor
+    @Test func manifestRestoreDefersUnusedImageHydration() async throws {
+        let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
+        let document = VideoProject()
+        var manifest = MediaManifest()
+        manifest.entries = [MediaManifestEntry(
+            id: "unused-image",
+            name: "Unused Image",
+            type: .image,
+            source: .external(absolutePath: imageURL.path),
+            duration: Defaults.imageDurationSeconds
+        )]
+        document.editorViewModel.mediaManifest = manifest
+
+        document.restoreAssetsFromManifest()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let asset = try #require(document.editorViewModel.mediaAssets.first)
+        #expect(asset.sourceWidth == nil)
+        #expect(asset.sourceHeight == nil)
+        #expect(asset.thumbnail == nil)
+    }
+
+    @MainActor
+    @Test func manifestRestoreRefreshesOnlyTimelineMetadataWithoutThumbnail() async throws {
+        let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
+        let document = VideoProject()
+        document.editorViewModel.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(
+                mediaRef: "used-image",
+                mediaType: .image,
+                start: 0,
+                duration: 30
+            )])
+        ])
+        var manifest = MediaManifest()
+        manifest.entries = [
+            MediaManifestEntry(
+                id: "used-image",
+                name: "Used Image",
+                type: .image,
+                source: .external(absolutePath: imageURL.path),
+                duration: Defaults.imageDurationSeconds
+            ),
+            MediaManifestEntry(
+                id: "unused-image",
+                name: "Unused Image",
+                type: .image,
+                source: .external(absolutePath: imageURL.path),
+                duration: Defaults.imageDurationSeconds
+            ),
+        ]
+        document.editorViewModel.mediaManifest = manifest
+
+        document.restoreAssetsFromManifest()
+        for _ in 0..<100 {
+            if document.editorViewModel.mediaAssets.first(where: { $0.id == "used-image" })?.sourceWidth != nil {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let used = try #require(document.editorViewModel.mediaAssets.first { $0.id == "used-image" })
+        let unused = try #require(document.editorViewModel.mediaAssets.first { $0.id == "unused-image" })
+        #expect(used.sourceWidth == 640)
+        #expect(used.sourceHeight == 360)
+        #expect(used.thumbnail == nil)
+        #expect(unused.sourceWidth == nil)
+        #expect(unused.sourceHeight == nil)
+        #expect(unused.thumbnail == nil)
+    }
+
+    @MainActor
+    @Test func libraryThumbnailLoadsOnDemand() async throws {
+        let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
+        let asset = MediaAsset(url: imageURL, type: .image, name: "Lazy Image")
+
+        await asset.loadLibraryThumbnail()
+
+        let thumbnail = try #require(asset.thumbnail)
+        #expect(asset.sourceWidth == 640)
+        #expect(asset.sourceHeight == 360)
+        #expect(max(thumbnail.size.width, thumbnail.size.height) <= 320)
+    }
+
+    @MainActor
+    @Test func placingDeferredImageStartsTimelineThumbnail() async throws {
+        let imageURL = try CompositorFixtures.patternPNG(size: CGSize(width: 640, height: 360))
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+        let asset = MediaAsset(url: imageURL, type: .image, name: "Deferred Image")
+        editor.importMediaAsset(asset)
+
+        _ = editor.placeClip(asset: asset, trackIndex: 0, startFrame: 0, durationFrames: 30)
+        for _ in 0..<100 {
+            if editor.mediaVisualCache.imageThumbnail(for: asset.id) != nil { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(editor.mediaVisualCache.imageThumbnail(for: asset.id) != nil)
+    }
+
     @Test func missingTimelineStillThrows() throws {
         // project.json is the required file — degrading it would hide real corruption.
         let bundle = fm.temporaryDirectory


### PR DESCRIPTION
## Summary

- restore unused media from the manifest without eagerly loading metadata or timeline visuals
- load small library thumbnails and higher-resolution image previews on demand
- generate timeline visuals when media is restored on a timeline, placed, or used as a replacement
- bound concurrent metadata, image-thumbnail, and video-thumbnail work

## Root cause

Project restoration hydrated every media asset, including unused assets. Large folders could start hundreds or thousands of metadata, image-decoding, waveform, and video-thumbnail operations while retaining preview-sized decoded images in memory.

## Impact

Large projects open with bounded background work and substantially lower initial memory pressure. Library thumbnails can appear progressively, while single-file imports and timeline media retain immediate visual preparation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core media load/restore and preview paths across many call sites; behavior shifts (e.g. thumbnails appearing later) are intentional but could surface edge cases around offline assets, relink, or batch import timing despite new tests.
> 
> **Overview**
> **Defers heavy media work on project open** so unused manifest assets no longer eagerly decode preview-sized images or kick off timeline waveforms/video filmstrips. Restore now loads **metadata only** (`loadMetadata(includeThumbnail: false)`); **timeline-referenced** assets still get `prepareMediaVisuals` afterward.
> 
> **On-demand UI thumbnails**: library grid, search, and image preview use SwiftUI `.task` hooks calling `loadLibraryThumbnail()` (~320px) or `loadPreviewThumbnail()` (full preview edge) instead of syncing full files in the preview pane. Batch Finder imports skip thumbnails during finalize and skip timeline visuals until needed.
> 
> **Timeline visuals when media becomes “hot”**: `prepareMediaVisuals` is centralized and invoked on **place clip**, **replace clip source**, and single-file finalize (not batch).
> 
> **Concurrency caps**: `AsyncSemaphore` limits parallel metadata (4), image thumbnail (4), and video timeline thumbnail (2) work; `MediaAsset` tracks `thumbnailMaxPixelSize` for progressive image upgrades and clears cache on `url` change.
> 
> **Tests** cover unused restore without visuals, timeline-used restore with cache thumbs, lazy library load, and place-clip triggering timeline thumbnails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cb81de742975d32ab2e9b2684deba7f74cdd52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->