### PR TITLE
[fix/perf] Isolate media index status updates

### DIFF
--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+IndexStatus.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+IndexStatus.swift
@@ -1,9 +1,17 @@
 import SwiftUI
 
 extension MediaTab {
-    @ViewBuilder
     var searchIndexStatus: some View {
-        let search = editor.searchIndex
+        MediaSearchIndexStatus(search: editor.searchIndex, mediaAssets: editor.mediaAssets)
+    }
+}
+
+private struct MediaSearchIndexStatus: View {
+    let search: SearchIndexCoordinator
+    let mediaAssets: [MediaAsset]
+
+    @ViewBuilder
+    var body: some View {
         let model = VisualModelLoader.shared
         switch model.state {
         case .notInstalled where model.enabled && hasIndexableAssets:
@@ -30,7 +38,7 @@ extension MediaTab {
     }
 
     private var hasIndexableAssets: Bool {
-        editor.mediaAssets.contains { $0.type == .video || $0.type == .image }
+        mediaAssets.contains { $0.type == .video || $0.type == .image }
     }
 
     private var modelSizeLabel: String {


### PR DESCRIPTION
## Summary

- move the media indexing status into its own SwiftUI view
- keep high-frequency indexing progress observations out of the full media panel
- preserve the existing status, progress, download, and retry UI

## Why

Index progress updates were observed by `MediaTab`, invalidating the entire media panel for every progress change. Large libraries then repeatedly reevaluated and laid out their grids on the main thread while background indexing was active.

The new child view owns those observations, limiting updates to the small status indicator.

## User impact

The media panel remains responsive while large folders are indexed. There is no intended visual or interaction change.

## Validation

- `swift build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only SwiftUI view extraction with no API or behavior change beyond update scoping; low risk to correctness.
> 
> **Overview**
> **Isolates smart-search / indexing status UI** so high-frequency `SearchIndexCoordinator` progress updates no longer invalidate all of `MediaTab`.
> 
> `searchIndexStatus` now only embeds a private **`MediaSearchIndexStatus`** view, passing `editor.searchIndex` and `editor.mediaAssets`. The status UI (model download, preparing, indexing progress ring, retry) is unchanged; **`hasIndexableAssets`** reads the passed-in `mediaAssets` instead of `editor.mediaAssets` directly inside the former inline body.
> 
> **Intent:** limit SwiftUI body re-evaluation to the small toolbar indicator while large media grids index in the background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd12d5691d2ae71e43a98a368d32bc54f894e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->