### PR TITLE
[fix/refactor] serialize project package media writes

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -122,19 +122,18 @@ extension ToolExecutor {
         let imported = try await Task.detached(priority: .userInitiated) {
             try Self.writeImportedBytes(base64: base64, mimeType: mimeType)
         }.value
+        defer { try? FileManager.default.removeItem(at: imported.url) }
+        guard let type = ClipType(fileExtension: imported.url.pathExtension.lowercased()) else {
+            throw ToolError("Unsupported mimeType '\(mimeType)'. \(Self.acceptedMimeTypesMessage)")
+        }
+        if type == .lottie, !LottieVideoGenerator.isLottie(at: imported.url) {
+            throw ToolError("source.bytes is not a valid Lottie animation")
+        }
         let committedURL = try await editor.commitStagedProjectMedia(imported.url, filename: imported.filename)
-        let asset: MediaAsset
-        do {
-            asset = try editor.undo.perform("Import Media (Agent)") {
-                guard let asset = editor.addMediaAsset(from: committedURL) else {
-                    throw ToolError("Failed to register imported asset")
-                }
-                applyImportMetadata(editor: editor, asset: asset, name: name, folderId: folderId)
-                return asset
-            }
-        } catch {
-            await editor.removeProjectMediaFile(committedURL)
-            throw error
+        let asset = editor.undo.perform("Import Media (Agent)") {
+            let asset = editor.addMediaAsset(from: committedURL, type: type)
+            applyImportMetadata(editor: editor, asset: asset, name: name, folderId: folderId)
+            return asset
         }
         return .ok(Self.jsonString([
             "mediaRef": asset.id,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Import.swift
@@ -16,7 +16,7 @@ extension ToolExecutor {
 
     private struct ImportedBytesFile: Sendable {
         let url: URL
-        let byteCount: Int
+        let filename: String
     }
 
     func importMedia(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -119,25 +119,24 @@ extension ToolExecutor {
         guard base64.utf8.count <= Self.importBytesMaxBase64Length else {
             throw ToolError("source.bytes is too large (\(base64.utf8.count) chars; max \(Self.importBytesMaxBase64Length)). Use source.url or source.path for larger files.")
         }
-        guard let projectURL = editor.projectURL else {
+        guard editor.projectURL != nil else {
             throw ToolError("No project is open; cannot import bytes")
         }
         let imported = try await Task.detached(priority: .userInitiated) {
-            try Self.writeImportedBytes(base64: base64, mimeType: mimeType, projectURL: projectURL)
+            try Self.writeImportedBytes(base64: base64, mimeType: mimeType)
         }.value
+        let committedURL = try await editor.commitStagedProjectMedia(imported.url, filename: imported.filename)
         let asset: MediaAsset
         do {
             asset = try editor.undo.perform("Import Media (Agent)") {
-                guard let asset = editor.addMediaAsset(from: imported.url) else {
+                guard let asset = editor.addMediaAsset(from: committedURL) else {
                     throw ToolError("Failed to register imported asset")
                 }
                 applyImportMetadata(editor: editor, asset: asset, name: name, folderId: folderId)
                 return asset
             }
         } catch {
-            try? await Task.detached(priority: .utility) {
-                try FileManager.default.removeItem(at: imported.url)
-            }.value
+            await editor.removeProjectMediaFile(committedURL)
             throw error
         }
         return .ok(Self.jsonString([
@@ -251,14 +250,7 @@ extension ToolExecutor {
                 throw ToolError("server returned HTTP \(httpResp.statusCode)")
             }
 
-            let destinationURL = asset.url
-            _ = try await Task.detached(priority: .userInitiated) {
-                try FileIO.moveReplacingDestination(
-                    from: tempURL,
-                    to: destinationURL,
-                    maxBytes: remoteImportMaxBytes
-                )
-            }.value
+            asset.url = try await editor.commitStagedProjectMedia(tempURL, filename: asset.url.lastPathComponent, maxBytes: remoteImportMaxBytes)
             await finishImportedAsset(asset, editor: editor)
         } catch {
             let message = (error as? ToolError)?.message ?? error.localizedDescription
@@ -270,13 +262,7 @@ extension ToolExecutor {
     @MainActor
     private static func copyImportedAsset(asset: MediaAsset, sourceURL: URL, editor: EditorViewModel) async {
         do {
-            let destinationURL = asset.url
-            _ = try await Task.detached(priority: .userInitiated) {
-                try FileIO.copyReplacingDestination(
-                    from: sourceURL,
-                    to: destinationURL
-                )
-            }.value
+            asset.url = try await editor.commitStagedProjectMedia(sourceURL, filename: asset.url.lastPathComponent, removeSource: false)
             await finishImportedAsset(asset, editor: editor)
         } catch {
             let message = (error as? ToolError)?.message ?? error.localizedDescription
@@ -322,22 +308,20 @@ extension ToolExecutor {
         return ImportPathStatus(exists: exists, isDirectory: isDirectory.boolValue)
     }
 
-    private nonisolated static func writeImportedBytes(base64: String, mimeType: String, projectURL: URL) throws -> ImportedBytesFile {
+    private nonisolated static func writeImportedBytes(base64: String, mimeType: String) throws -> ImportedBytesFile {
         guard let fileExt = fileExtension(forMime: mimeType) else {
             throw ToolError("Unsupported mimeType '\(mimeType)'. \(acceptedMimeTypesMessage)")
         }
         guard let data = Data(base64Encoded: base64, options: [.ignoreUnknownCharacters]), !data.isEmpty else {
             throw ToolError("source.bytes is not valid non-empty base64")
         }
-        let mediaDir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
         let filename = "imported-\(UUID().uuidString.prefix(8)).\(fileExt)"
-        let destURL = mediaDir.appendingPathComponent(filename)
         do {
-            try FileIO.writeData(data, to: destURL)
+            let stagedURL = try FileIO.stageData(data, pathExtension: fileExt)
+            return ImportedBytesFile(url: stagedURL, filename: filename)
         } catch {
             throw ToolError("Failed to write bytes to disk: \(error.localizedDescription)")
         }
-        return ImportedBytesFile(url: destURL, byteCount: data.count)
     }
 
     private nonisolated static func fileExtension(forMime mime: String) -> String? {

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -36,11 +36,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         if isTerminating { return .terminateLater }
         isTerminating = true
-        if MLXRuntime.beginTermination() { return .terminateNow }
+        let projects = AppState.shared.openProjects
 
         Task { @MainActor in
-            await MLXRuntime.waitUntilIdle()
-            sender.reply(toApplicationShouldTerminate: true)
+            do {
+                for project in projects {
+                    try await project.saveBeforeClosing()
+                }
+                if !MLXRuntime.beginTermination() {
+                    await MLXRuntime.waitUntilIdle()
+                }
+                sender.reply(toApplicationShouldTerminate: true)
+            } catch {
+                projects.forEach { $0.editorViewModel.projectPackageCoordinator.cancelClosing() }
+                isTerminating = false
+                sender.presentError(error)
+                sender.reply(toApplicationShouldTerminate: false)
+            }
         }
         return .terminateLater
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Matte.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Matte.swift
@@ -7,16 +7,14 @@ extension EditorViewModel {
         folderId: String? = nil,
         name: String? = nil
     ) async throws -> MediaAsset {
-        guard let projectURL else { throw Matte.Error.noProject }
+        guard projectURL != nil else { throw Matte.Error.noProject }
         let d = aspect.pixelSize(timelineWidth: timeline.width, timelineHeight: timeline.height)
-        let dest = projectURL
-            .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-            .appendingPathComponent("matte-\(UUID().uuidString.prefix(8)).png")
-        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let filename = "matte-\(UUID().uuidString.prefix(8)).png"
         let data = try Matte.png(hex: hex, width: d.width, height: d.height)
-        try await Task.detached(priority: .userInitiated) { try FileIO.writeData(data, to: dest) }.value
+        let stagedURL = try await Task.detached(priority: .userInitiated) { try FileIO.stageData(data, pathExtension: "png") }.value
+        let destinationURL = try await commitStagedProjectMedia(stagedURL, filename: filename)
         let asset = MediaAsset(
-            url: dest, type: .image,
+            url: destinationURL, type: .image,
             name: name ?? (aspect == .project ? "Matte · \(d.width)×\(d.height)" : "Matte · \(aspect.rawValue)")
         )
         asset.folderId = folderId

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -128,8 +128,13 @@ private enum MediaImportScanner {
 
 extension EditorViewModel {
 
-    func commitStagedProjectMedia(_ stagedURL: URL, filename: String, maxBytes: Int64? = nil, removeSource: Bool = true) async throws -> URL {
-        defer { if removeSource { try? FileManager.default.removeItem(at: stagedURL) } }
+    func commitStagedProjectMedia(
+        _ stagedURL: URL,
+        filename: String,
+        maxBytes: Int64? = nil,
+        workAlreadyAdmitted: Bool = false
+    ) async throws -> URL {
+        defer { try? FileManager.default.removeItem(at: stagedURL) }
         guard projectURL != nil else {
             let destination = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
             return try await Task.detached(priority: .userInitiated) {
@@ -146,8 +151,14 @@ extension EditorViewModel {
                 }.value
                 defer { try? FileManager.default.removeItem(at: preparedURL) }
                 try Task.checkCancellation()
-                try projectPackageCoordinator.beginMutation()
-                defer { projectPackageCoordinator.endMutation() }
+                if !workAlreadyAdmitted {
+                    try projectPackageCoordinator.beginMutation()
+                }
+                defer {
+                    if !workAlreadyAdmitted {
+                        projectPackageCoordinator.endMutation()
+                    }
+                }
                 if let destination = try await projectPackageCoordinator.performMutation({ () -> URL? in
                     guard self.projectURL?.standardizedFileURL == targetProjectURL.standardizedFileURL else { return nil }
                     let destination = targetProjectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
@@ -173,24 +184,6 @@ extension EditorViewModel {
         }
         projectURL = newRoot
         refreshMissingMediaCache()
-    }
-
-    func removeProjectMediaFile(_ url: URL) async {
-        guard (try? projectPackageCoordinator.beginMutation(allowDuringClosing: true)) != nil else { return }
-        defer { projectPackageCoordinator.endMutation() }
-        for _ in 0..<2 {
-            do {
-                try await projectPackageCoordinator.performMutation {
-                    guard let projectURL = self.projectURL else { return }
-                    try FileManager.default.removeItem(at: projectURL
-                        .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-                        .appendingPathComponent(url.lastPathComponent, isDirectory: false))
-                }
-                return
-            } catch {
-                guard error is CancellationError, !Task.isCancelled else { return }
-            }
-        }
     }
 
     func importMediaAsset(_ asset: MediaAsset, skipAppend: Bool = false) {
@@ -255,7 +248,7 @@ extension EditorViewModel {
     }
 
     @discardableResult
-    private func addMediaAsset(from url: URL, type: ClipType, folderId: String? = nil, finalize: Bool = true) -> MediaAsset {
+    func addMediaAsset(from url: URL, type: ClipType, folderId: String? = nil, finalize: Bool = true) -> MediaAsset {
         let name = url.deletingPathExtension().lastPathComponent
         let asset = MediaAsset(url: url, type: type, name: name)
         asset.folderId = folderId

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -128,6 +128,64 @@ private enum MediaImportScanner {
 
 extension EditorViewModel {
 
+    func commitStagedProjectMedia(_ stagedURL: URL, filename: String, maxBytes: Int64? = nil, removeSource: Bool = true) async throws -> URL {
+        defer { if removeSource { try? FileManager.default.removeItem(at: stagedURL) } }
+        guard projectURL != nil else {
+            let destination = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+            return try await Task.detached(priority: .userInitiated) {
+                try FileIO.moveReplacingDestination(from: stagedURL, to: destination, maxBytes: maxBytes)
+                return destination
+            }.value
+        }
+        for _ in 0..<3 {
+            guard let targetProjectURL = projectURL else { break }
+            try Task.checkCancellation()
+            do {
+                let preparedURL = try await Task.detached(priority: .userInitiated) {
+                    try FileIO.prepareStagedFile(from: stagedURL, nextTo: targetProjectURL, maxBytes: maxBytes)
+                }.value
+                defer { try? FileManager.default.removeItem(at: preparedURL) }
+                try Task.checkCancellation()
+                try projectPackageCoordinator.beginMutation()
+                defer { projectPackageCoordinator.endMutation() }
+                if let destination = try await projectPackageCoordinator.performMutation({ () -> URL? in
+                    guard self.projectURL?.standardizedFileURL == targetProjectURL.standardizedFileURL else { return nil }
+                    let destination = targetProjectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+                        .appendingPathComponent(filename, isDirectory: false)
+                    try FileIO.installPreparedFile(from: preparedURL, to: destination)
+                    return destination
+                }) {
+                    return destination
+                }
+            }
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+
+    func rebaseProjectURL(from oldURL: URL, to newURL: URL) {
+        guard projectURL?.standardizedFileURL == oldURL.standardizedFileURL else { return }
+        let oldPrefix = oldURL.standardizedFileURL.path + "/"
+        let newRoot = newURL.standardizedFileURL
+        for asset in mediaAssets {
+            let path = asset.url.standardizedFileURL.path
+            guard path.hasPrefix(oldPrefix) else { continue }
+            asset.url = newRoot.appendingPathComponent(String(path.dropFirst(oldPrefix.count)))
+        }
+        projectURL = newRoot
+        refreshMissingMediaCache()
+    }
+
+    func removeProjectMediaFile(_ url: URL) async {
+        guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
+        defer { projectPackageCoordinator.endMutation() }
+        try? await projectPackageCoordinator.performMutation {
+            guard let projectURL = self.projectURL else { return }
+            try FileManager.default.removeItem(at: projectURL
+                .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+                .appendingPathComponent(url.lastPathComponent, isDirectory: false))
+        }
+    }
+
     func importMediaAsset(_ asset: MediaAsset, skipAppend: Bool = false) {
         if !skipAppend, !mediaAssets.contains(where: { $0.id == asset.id }) {
             mediaAssets.append(asset)
@@ -308,22 +366,14 @@ extension EditorViewModel {
     @discardableResult
     func importPastedImageData(_ data: Data, fileExtension: String = "png") async -> MediaAsset? {
         let filename = "pasted-\(UUID().uuidString.prefix(8)).\(fileExtension)"
-        let destURL: URL
-        if let projectURL {
-            let dir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-            destURL = dir.appendingPathComponent(filename)
-        } else {
-            destURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
-        }
         do {
-            try await Task.detached(priority: .userInitiated) {
-                try FileIO.writeData(data, to: destURL)
-            }.value
+            let stagedURL = try await Task.detached(priority: .userInitiated) { try FileIO.stageData(data, pathExtension: fileExtension) }.value
+            let destinationURL = try await commitStagedProjectMedia(stagedURL, filename: filename)
+            return addMediaAsset(from: destinationURL)
         } catch {
             Log.project.error("importPastedImageData: write failed \(error.localizedDescription)")
             return nil
         }
-        return addMediaAsset(from: destURL)
     }
 
     func fitTextClipToContent(clipId: String) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -176,13 +176,20 @@ extension EditorViewModel {
     }
 
     func removeProjectMediaFile(_ url: URL) async {
-        guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
+        guard (try? projectPackageCoordinator.beginMutation(allowDuringClosing: true)) != nil else { return }
         defer { projectPackageCoordinator.endMutation() }
-        try? await projectPackageCoordinator.performMutation {
-            guard let projectURL = self.projectURL else { return }
-            try FileManager.default.removeItem(at: projectURL
-                .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-                .appendingPathComponent(url.lastPathComponent, isDirectory: false))
+        for _ in 0..<2 {
+            do {
+                try await projectPackageCoordinator.performMutation {
+                    guard let projectURL = self.projectURL else { return }
+                    try FileManager.default.removeItem(at: projectURL
+                        .appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+                        .appendingPathComponent(url.lastPathComponent, isDirectory: false))
+                }
+                return
+            } catch {
+                guard error is CancellationError, !Task.isCancelled else { return }
+            }
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -13,6 +13,7 @@ extension EditorViewModel {
             return
         }
         let sourceName = mediaResolver.displayName(for: clip.mediaRef)
+        guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
 
         let filename = Self.uniqueClipFilename(for: clip.mediaType)
         let mediaDir = projectURL?.appendingPathComponent(Project.mediaDirectoryName) ?? FileManager.default.temporaryDirectory
@@ -30,6 +31,7 @@ extension EditorViewModel {
         let mediaType = clip.mediaType
 
         Task { @MainActor in
+            defer { self.projectPackageCoordinator.endMutation() }
             let stagedURL = FileIO.temporaryFileURL(pathExtension: mediaType == .video ? "mp4" : "m4a")
             defer { try? FileManager.default.removeItem(at: stagedURL) }
             do {
@@ -43,12 +45,17 @@ extension EditorViewModel {
                     speed: speed,
                     mediaType: mediaType
                 )
-                placeholder.url = try await self.commitStagedProjectMedia(stagedURL, filename: filename)
+                placeholder.url = try await self.commitStagedProjectMedia(
+                    stagedURL,
+                    filename: filename,
+                    workAlreadyAdmitted: true
+                )
                 placeholder.generationStatus = .none
                 await self.finalizeImportedAsset(placeholder)
                 Log.project.notice("saveClipAsMedia ok clip=\(clipId) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)
+                self.updateManifestMetadata(for: [placeholder])
                 Log.project.error("saveClipAsMedia failed clip=\(clipId): \(error.localizedDescription)")
             }
         }
@@ -60,6 +67,7 @@ extension EditorViewModel {
         let startFrame = range.startFrame
         let frameCount = range.endFrame - range.startFrame
         guard frameCount > 0 else { return }
+        guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
 
         let filename = Self.uniqueClipFilename(for: .video)
         let mediaDir = projectURL?.appendingPathComponent(Project.mediaDirectoryName) ?? FileManager.default.temporaryDirectory
@@ -75,6 +83,7 @@ extension EditorViewModel {
         let resolveTimeline = timelineResolver()
 
         Task { @MainActor in
+            defer { self.projectPackageCoordinator.endMutation() }
             do {
                 let tempURL = try await TimelineRenderer.render(
                     timeline: timeline,
@@ -85,12 +94,17 @@ extension EditorViewModel {
                     frameCount: frameCount,
                     preset: AVAssetExportPresetHighestQuality
                 )
-                placeholder.url = try await self.commitStagedProjectMedia(tempURL, filename: filename)
+                placeholder.url = try await self.commitStagedProjectMedia(
+                    tempURL,
+                    filename: filename,
+                    workAlreadyAdmitted: true
+                )
                 placeholder.generationStatus = .none
                 await self.finalizeImportedAsset(placeholder)
                 Log.project.notice("saveTimelineRangeAsMedia ok frames=\(startFrame)..<\(startFrame + frameCount) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)
+                self.updateManifestMetadata(for: [placeholder])
                 Log.project.error("saveTimelineRangeAsMedia failed: \(error.localizedDescription)")
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -14,14 +14,9 @@ extension EditorViewModel {
         }
         let sourceName = mediaResolver.displayName(for: clip.mediaRef)
 
-        let mediaDir: URL
-        if let projectURL {
-            mediaDir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-            try? FileManager.default.createDirectory(at: mediaDir, withIntermediateDirectories: true)
-        } else {
-            mediaDir = FileManager.default.temporaryDirectory
-        }
-        let destURL = mediaDir.appendingPathComponent(Self.uniqueClipFilename(for: clip.mediaType))
+        let filename = Self.uniqueClipFilename(for: clip.mediaType)
+        let mediaDir = projectURL?.appendingPathComponent(Project.mediaDirectoryName) ?? FileManager.default.temporaryDirectory
+        let destURL = mediaDir.appendingPathComponent(filename)
 
         let placeholder = MediaAsset(url: destURL, type: clip.mediaType, name: "\(sourceName) (clip)")
         placeholder.generationStatus = .generating
@@ -35,10 +30,12 @@ extension EditorViewModel {
         let mediaType = clip.mediaType
 
         Task { @MainActor [weak self] in
+            let stagedURL = FileIO.temporaryFileURL(pathExtension: mediaType == .video ? "mp4" : "m4a")
+            defer { try? FileManager.default.removeItem(at: stagedURL) }
             do {
                 try await Self.exportClipRange(
                     sourceURL: sourceURL,
-                    destURL: destURL,
+                    destURL: stagedURL,
                     fps: fps,
                     trimStartFrame: trimStartFrame,
                     sourceFramesConsumed: sourceFramesConsumed,
@@ -46,9 +43,10 @@ extension EditorViewModel {
                     speed: speed,
                     mediaType: mediaType
                 )
+                if let self { placeholder.url = try await self.commitStagedProjectMedia(stagedURL, filename: filename) }
                 placeholder.generationStatus = .none
                 await self?.finalizeImportedAsset(placeholder)
-                Log.project.notice("saveClipAsMedia ok clip=\(clipId) out=\(destURL.lastPathComponent)")
+                Log.project.notice("saveClipAsMedia ok clip=\(clipId) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)
                 Log.project.error("saveClipAsMedia failed clip=\(clipId): \(error.localizedDescription)")
@@ -63,14 +61,9 @@ extension EditorViewModel {
         let frameCount = range.endFrame - range.startFrame
         guard frameCount > 0 else { return }
 
-        let mediaDir: URL
-        if let projectURL {
-            mediaDir = projectURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
-            try? FileManager.default.createDirectory(at: mediaDir, withIntermediateDirectories: true)
-        } else {
-            mediaDir = FileManager.default.temporaryDirectory
-        }
-        let destURL = mediaDir.appendingPathComponent(Self.uniqueClipFilename(for: .video))
+        let filename = Self.uniqueClipFilename(for: .video)
+        let mediaDir = projectURL?.appendingPathComponent(Project.mediaDirectoryName) ?? FileManager.default.temporaryDirectory
+        let destURL = mediaDir.appendingPathComponent(filename)
 
         let placeholder = MediaAsset(url: destURL, type: .video, name: "Timeline range")
         placeholder.generationStatus = .rendering
@@ -92,11 +85,10 @@ extension EditorViewModel {
                     frameCount: frameCount,
                     preset: AVAssetExportPresetHighestQuality
                 )
-                try? FileManager.default.removeItem(at: destURL)
-                try FileManager.default.moveItem(at: tempURL, to: destURL)
+                if let self { placeholder.url = try await self.commitStagedProjectMedia(tempURL, filename: filename) }
                 placeholder.generationStatus = .none
                 await self?.finalizeImportedAsset(placeholder)
-                Log.project.notice("saveTimelineRangeAsMedia ok frames=\(startFrame)..<\(startFrame + frameCount) out=\(destURL.lastPathComponent)")
+                Log.project.notice("saveTimelineRangeAsMedia ok frames=\(startFrame)..<\(startFrame + frameCount) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)
                 Log.project.error("saveTimelineRangeAsMedia failed: \(error.localizedDescription)")

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -29,7 +29,7 @@ extension EditorViewModel {
         let speed = clip.speed
         let mediaType = clip.mediaType
 
-        Task { @MainActor [weak self] in
+        Task { @MainActor in
             let stagedURL = FileIO.temporaryFileURL(pathExtension: mediaType == .video ? "mp4" : "m4a")
             defer { try? FileManager.default.removeItem(at: stagedURL) }
             do {
@@ -43,9 +43,9 @@ extension EditorViewModel {
                     speed: speed,
                     mediaType: mediaType
                 )
-                if let self { placeholder.url = try await self.commitStagedProjectMedia(stagedURL, filename: filename) }
+                placeholder.url = try await self.commitStagedProjectMedia(stagedURL, filename: filename)
                 placeholder.generationStatus = .none
-                await self?.finalizeImportedAsset(placeholder)
+                await self.finalizeImportedAsset(placeholder)
                 Log.project.notice("saveClipAsMedia ok clip=\(clipId) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)
@@ -74,7 +74,7 @@ extension EditorViewModel {
         let missingMediaRefs = self.missingMediaRefs
         let resolveTimeline = timelineResolver()
 
-        Task { @MainActor [weak self] in
+        Task { @MainActor in
             do {
                 let tempURL = try await TimelineRenderer.render(
                     timeline: timeline,
@@ -85,9 +85,9 @@ extension EditorViewModel {
                     frameCount: frameCount,
                     preset: AVAssetExportPresetHighestQuality
                 )
-                if let self { placeholder.url = try await self.commitStagedProjectMedia(tempURL, filename: filename) }
+                placeholder.url = try await self.commitStagedProjectMedia(tempURL, filename: filename)
                 placeholder.generationStatus = .none
-                await self?.finalizeImportedAsset(placeholder)
+                await self.finalizeImportedAsset(placeholder)
                 Log.project.notice("saveTimelineRangeAsMedia ok frames=\(startFrame)..<\(startFrame + frameCount) out=\(placeholder.url.lastPathComponent)")
             } catch {
                 placeholder.generationStatus = .failed(error.localizedDescription)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -292,6 +292,7 @@ final class EditorViewModel {
     // MARK: - Document bridge
 
     @ObservationIgnored let undo = EditorUndo()
+    @ObservationIgnored let projectPackageCoordinator = ProjectPackageCoordinator()
     @ObservationIgnored var onProjectCheckpointRequired: (() -> Void)?
     var isDocumentEdited: Bool = false
 

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -245,10 +245,7 @@ final class GenerationService {
                ClipType(fileExtension: realExt) != nil {
                 asset.url = asset.url.deletingPathExtension().appendingPathExtension(realExt)
             }
-            let destinationURL = asset.url
-            try await Task.detached(priority: .utility) {
-                _ = try FileIO.moveReplacingDestination(from: tempURL, to: destinationURL)
-            }.value
+            asset.url = try await editor.commitStagedProjectMedia(tempURL, filename: asset.url.lastPathComponent)
 
             asset.pendingDownloadURL = nil
             editor.importMediaAsset(asset, skipAppend: true)

--- a/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
+++ b/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
@@ -3,7 +3,6 @@ import Foundation
 @MainActor
 final class ProjectPackageCoordinator {
     private var savesInProgress = 0
-    private var saveFailed = false
     private var activeMutations = 0
     private var nextMutationID = 0
     private var pendingMutations: [(id: Int, run: () -> Void, cancel: () -> Void)] = []
@@ -17,14 +16,12 @@ final class ProjectPackageCoordinator {
             assertionFailure("Unbalanced project save completion")
             return
         }
-        if !success { saveFailed = true }
         savesInProgress -= 1
         guard savesInProgress == 0 else { return }
+        if !success { isClosing = false }
         let mutations = pendingMutations
         pendingMutations.removeAll()
-        let shouldCancel = saveFailed
-        saveFailed = false
-        if shouldCancel {
+        if !success {
             mutations.forEach { $0.cancel() }
         } else {
             mutations.forEach { $0.run() }

--- a/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
+++ b/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 final class ProjectPackageCoordinator {
     private var savesInProgress = 0
+    private var saveFailed = false
     private var activeMutations = 0
     private var nextMutationID = 0
     private var pendingMutations: [(id: Int, run: () -> Void, cancel: () -> Void)] = []
@@ -11,22 +12,29 @@ final class ProjectPackageCoordinator {
 
     func saveStarted() { savesInProgress += 1 }
 
-    func saveFinished() {
+    func saveFinished(success: Bool) {
         guard savesInProgress > 0 else {
             assertionFailure("Unbalanced project save completion")
             return
         }
+        if !success { saveFailed = true }
         savesInProgress -= 1
         guard savesInProgress == 0 else { return }
         let mutations = pendingMutations
         pendingMutations.removeAll()
-        mutations.forEach { $0.run() }
+        let shouldCancel = saveFailed
+        saveFailed = false
+        if shouldCancel {
+            mutations.forEach { $0.cancel() }
+        } else {
+            mutations.forEach { $0.run() }
+        }
         resumeIdleWaitersIfNeeded()
     }
 
-    func beginMutation() throws {
+    func beginMutation(allowDuringClosing: Bool = false) throws {
         try Task.checkCancellation()
-        guard !isClosing else { throw CancellationError() }
+        guard allowDuringClosing || !isClosing else { throw CancellationError() }
         activeMutations += 1
     }
 

--- a/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
+++ b/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
@@ -18,7 +18,6 @@ final class ProjectPackageCoordinator {
         }
         savesInProgress -= 1
         guard savesInProgress == 0 else { return }
-        if !success { isClosing = false }
         let mutations = pendingMutations
         pendingMutations.removeAll()
         if !success {

--- a/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
+++ b/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+@MainActor
+final class ProjectPackageCoordinator {
+    private var savesInProgress = 0
+    private var activeMutations = 0
+    private var nextMutationID = 0
+    private var pendingMutations: [(id: Int, run: () -> Void, cancel: () -> Void)] = []
+    private var idleWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isClosing = false
+
+    func saveStarted() { savesInProgress += 1 }
+
+    func saveFinished() {
+        guard savesInProgress > 0 else {
+            assertionFailure("Unbalanced project save completion")
+            return
+        }
+        savesInProgress -= 1
+        guard savesInProgress == 0 else { return }
+        let mutations = pendingMutations
+        pendingMutations.removeAll()
+        mutations.forEach { $0.run() }
+        resumeIdleWaitersIfNeeded()
+    }
+
+    func beginMutation() throws {
+        try Task.checkCancellation()
+        guard !isClosing else { throw CancellationError() }
+        activeMutations += 1
+    }
+
+    func endMutation() {
+        guard activeMutations > 0 else {
+            assertionFailure("Unbalanced project package mutation")
+            return
+        }
+        activeMutations -= 1
+        resumeIdleWaitersIfNeeded()
+    }
+
+    func performMutation<T: Sendable>(_ operation: @escaping () throws -> T) async throws -> T {
+        try Task.checkCancellation()
+        guard savesInProgress > 0 else { return try operation() }
+
+        let id = nextMutationID
+        nextMutationID += 1
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingMutations.append((
+                    id: id,
+                    run: { continuation.resume(with: Result { try operation() }) },
+                    cancel: { continuation.resume(throwing: CancellationError()) }
+                ))
+            }
+        } onCancel: { Task { @MainActor [weak self] in self?.cancelMutation(id: id) } }
+    }
+
+    func beginClosing() async {
+        isClosing = true
+        await waitUntilIdle()
+    }
+
+    func cancelClosing() { isClosing = false }
+
+    func waitUntilIdle() async {
+        guard savesInProgress > 0 || activeMutations > 0 else { return }
+        await withCheckedContinuation { idleWaiters.append($0) }
+    }
+
+    private func cancelMutation(id: Int) {
+        guard let index = pendingMutations.firstIndex(where: { $0.id == id }) else { return }
+        let mutation = pendingMutations.remove(at: index)
+        mutation.cancel()
+    }
+
+    private func resumeIdleWaitersIfNeeded() {
+        guard savesInProgress == 0, activeMutations == 0 else { return }
+        let waiting = idleWaiters
+        idleWaiters.removeAll()
+        waiting.forEach { $0.resume() }
+    }
+}

--- a/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
+++ b/Sources/PalmierPro/Project/ProjectPackageCoordinator.swift
@@ -28,9 +28,9 @@ final class ProjectPackageCoordinator {
         resumeIdleWaitersIfNeeded()
     }
 
-    func beginMutation(allowDuringClosing: Bool = false) throws {
+    func beginMutation() throws {
         try Task.checkCancellation()
-        guard allowDuringClosing || !isClosing else { throw CancellationError() }
+        guard !isClosing else { throw CancellationError() }
         activeMutations += 1
     }
 

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -28,29 +28,6 @@ private typealias DocumentCloseCallback = @convention(c) (
     AnyObject, Selector, NSDocument, Bool, UnsafeMutableRawPointer?
 ) -> Void
 
-@MainActor
-private final class DocumentCloseRelay: NSObject {
-    private let target: AnyObject
-    private let action: Selector
-    private let originalContextInfo: UnsafeMutableRawPointer?
-    private let onResult: (Bool) -> Void
-
-    init(target: Any, action: Selector, contextInfo: UnsafeMutableRawPointer?, onResult: @escaping (Bool) -> Void) {
-        self.target = target as AnyObject
-        self.action = action
-        self.originalContextInfo = contextInfo
-        self.onResult = onResult
-    }
-
-    @objc func document(_ document: NSDocument, shouldClose: Bool, contextInfo: UnsafeMutableRawPointer?) {
-        onResult(shouldClose)
-        let implementation = target.method(for: action)
-        unsafeBitCast(implementation, to: DocumentCloseCallback.self)(
-            target, action, document, shouldClose, originalContextInfo
-        )
-    }
-}
-
 final class VideoProject: NSDocument {
 
     static let typeIdentifier = Project.typeIdentifier
@@ -75,7 +52,6 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var snapshotPreparedForWrite = false
     private var projectCheckpointAutosaveScheduled = false
     private var isSavingBeforeClose = false
-    private var closeRelays: [UUID: DocumentCloseRelay] = [:]
 
     // MARK: - Persistence
 
@@ -178,40 +154,19 @@ final class VideoProject: NSDocument {
         contextInfo: UnsafeMutableRawPointer?
     ) {
         Task { @MainActor in
-            let relay: DocumentCloseRelay?
-            if let shouldCloseSelector {
-                let id = UUID()
-                relay = DocumentCloseRelay(
-                    target: delegate,
-                    action: shouldCloseSelector,
-                    contextInfo: contextInfo
-                ) { [weak self] shouldClose in
-                    self?.closeRelays[id] = nil
-                    if !shouldClose { self?.editorViewModel.projectPackageCoordinator.cancelClosing() }
-                }
-                closeRelays[id] = relay
-            } else {
-                relay = nil
-            }
-
             do {
                 try await saveBeforeClosing()
-                if let relay {
-                    super.canClose(
-                        withDelegate: relay,
-                        shouldClose: #selector(DocumentCloseRelay.document(_:shouldClose:contextInfo:)),
-                        contextInfo: nil
-                    )
-                } else {
-                    super.canClose(
-                        withDelegate: delegate,
-                        shouldClose: shouldCloseSelector,
-                        contextInfo: contextInfo
-                    )
-                }
+                super.canClose(
+                    withDelegate: delegate,
+                    shouldClose: shouldCloseSelector,
+                    contextInfo: contextInfo
+                )
             } catch {
                 presentError(error)
-                relay?.document(self, shouldClose: false, contextInfo: nil)
+                guard let shouldCloseSelector else { return }
+                let target = delegate as AnyObject
+                let callback = unsafeBitCast(target.method(for: shouldCloseSelector), to: DocumentCloseCallback.self)
+                callback(target, shouldCloseSelector, self, false, contextInfo)
             }
         }
     }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -143,7 +143,7 @@ final class VideoProject: NSDocument {
         captureSaveSnapshot()
         snapshotSourceProjectURL = fileURL
         super.save(to: url, ofType: typeName, for: saveOperation) { error in
-            coordinator.saveFinished()
+            coordinator.saveFinished(success: error == nil)
             completionHandler(error)
         }
     }

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -47,8 +47,6 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var snapshotSourceProjectURL: URL?
     private nonisolated(unsafe) var snapshotPreparedForWrite = false
     private var projectCheckpointAutosaveScheduled = false
-    private var savesInProgress = 0
-    private var saveWaiters: [CheckedContinuation<Void, Never>] = []
     private var isSavingBeforeClose = false
 
     // MARK: - Persistence
@@ -136,17 +134,13 @@ final class VideoProject: NSDocument {
             fileModificationDate = date
         }
 
-        savesInProgress += 1
+        let coordinator = editorViewModel.projectPackageCoordinator
+        coordinator.saveStarted()
         captureSaveSnapshot()
         snapshotSourceProjectURL = fileURL
-        super.save(to: url, ofType: typeName, for: saveOperation) { [weak self] error in
+        super.save(to: url, ofType: typeName, for: saveOperation) { error in
+            coordinator.saveFinished()
             completionHandler(error)
-            guard let self else { return }
-            self.savesInProgress -= 1
-            if self.savesInProgress == 0 {
-                self.saveWaiters.forEach { $0.resume() }
-                self.saveWaiters.removeAll()
-            }
         }
     }
 
@@ -154,24 +148,26 @@ final class VideoProject: NSDocument {
     func saveBeforeClosing() async throws {
         isSavingBeforeClose = true
         defer { isSavingBeforeClose = false }
-        repeat {
-            await waitForSaves()
-            guard let url = fileURL else { throw CocoaError(.fileNoSuchFile) }
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                save(to: url, ofType: Self.typeIdentifier, for: .saveOperation) { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
+        let coordinator = editorViewModel.projectPackageCoordinator
+        await coordinator.beginClosing()
+        do {
+            repeat {
+                guard let url = fileURL else { throw CocoaError(.fileNoSuchFile) }
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    save(to: url, ofType: Self.typeIdentifier, for: .saveOperation) { error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume()
+                        }
                     }
                 }
-            }
-        } while hasUnautosavedChanges
-    }
-
-    private func waitForSaves() async {
-        guard savesInProgress > 0 else { return }
-        await withCheckedContinuation { saveWaiters.append($0) }
+            } while hasUnautosavedChanges
+            await coordinator.waitUntilIdle()
+        } catch {
+            coordinator.cancelClosing()
+            throw error
+        }
     }
 
     override func write(to url: URL, ofType typeName: String) throws {
@@ -357,6 +353,7 @@ final class VideoProject: NSDocument {
                oldURL.standardizedFileURL != newURL.standardizedFileURL {
                 MainActor.assumeIsolated {
                     ProjectRegistry.shared.updateURL(from: oldURL, to: newURL)
+                    editorViewModel.rebaseProjectURL(from: oldURL, to: newURL)
                 }
             }
         }
@@ -515,19 +512,7 @@ final class VideoProject: NSDocument {
 
         guard let data else { return }
         cachedThumbnail = data
-        guard let packageURL = fileURL else { return }
-        let thumbURL = packageURL.appendingPathComponent(Project.thumbnailFilename, isDirectory: false)
-
-        // Pick up package mod date from our write so autosave won't hit "changed by another application".
-        let newDate: Date? = try? await Task.detached(priority: .utility) {
-            try data.write(to: thumbURL, options: .atomic)
-            var resolved = packageURL
-            resolved.removeCachedResourceValue(forKey: .contentModificationDateKey)
-            return try resolved.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
-        }.value
-        if let newDate {
-            fileModificationDate = newDate
-        }
+        editorViewModel.onProjectCheckpointRequired?()
     }
 
     // MARK: - Media restore

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -293,6 +293,10 @@ final class VideoProject: NSDocument {
         }
         try writeChatDirectory(snapshot.chatSessionFiles, to: packageURL, fm: fm)
         try copyMediaDirectoryIfNeeded(from: sourceURL, to: packageURL, fm: fm)
+        try fm.createDirectory(
+            at: packageURL.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true),
+            withIntermediateDirectories: true
+        )
     }
 
     private nonisolated static func createPackageDirectory(at url: URL, fm: FileManager) throws {

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -24,6 +24,33 @@ private struct RestoredMediaCandidate: Sendable {
     let url: URL
 }
 
+private typealias DocumentCloseCallback = @convention(c) (
+    AnyObject, Selector, NSDocument, Bool, UnsafeMutableRawPointer?
+) -> Void
+
+@MainActor
+private final class DocumentCloseRelay: NSObject {
+    private let target: AnyObject
+    private let action: Selector
+    private let originalContextInfo: UnsafeMutableRawPointer?
+    private let onResult: (Bool) -> Void
+
+    init(target: Any, action: Selector, contextInfo: UnsafeMutableRawPointer?, onResult: @escaping (Bool) -> Void) {
+        self.target = target as AnyObject
+        self.action = action
+        self.originalContextInfo = contextInfo
+        self.onResult = onResult
+    }
+
+    @objc func document(_ document: NSDocument, shouldClose: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        onResult(shouldClose)
+        let implementation = target.method(for: action)
+        unsafeBitCast(implementation, to: DocumentCloseCallback.self)(
+            target, action, document, shouldClose, originalContextInfo
+        )
+    }
+}
+
 final class VideoProject: NSDocument {
 
     static let typeIdentifier = Project.typeIdentifier
@@ -48,6 +75,7 @@ final class VideoProject: NSDocument {
     private nonisolated(unsafe) var snapshotPreparedForWrite = false
     private var projectCheckpointAutosaveScheduled = false
     private var isSavingBeforeClose = false
+    private var closeRelays: [UUID: DocumentCloseRelay] = [:]
 
     // MARK: - Persistence
 
@@ -141,6 +169,50 @@ final class VideoProject: NSDocument {
         super.save(to: url, ofType: typeName, for: saveOperation) { error in
             coordinator.saveFinished()
             completionHandler(error)
+        }
+    }
+
+    override func canClose(
+        withDelegate delegate: Any,
+        shouldClose shouldCloseSelector: Selector?,
+        contextInfo: UnsafeMutableRawPointer?
+    ) {
+        Task { @MainActor in
+            let relay: DocumentCloseRelay?
+            if let shouldCloseSelector {
+                let id = UUID()
+                relay = DocumentCloseRelay(
+                    target: delegate,
+                    action: shouldCloseSelector,
+                    contextInfo: contextInfo
+                ) { [weak self] shouldClose in
+                    self?.closeRelays[id] = nil
+                    if !shouldClose { self?.editorViewModel.projectPackageCoordinator.cancelClosing() }
+                }
+                closeRelays[id] = relay
+            } else {
+                relay = nil
+            }
+
+            do {
+                try await saveBeforeClosing()
+                if let relay {
+                    super.canClose(
+                        withDelegate: relay,
+                        shouldClose: #selector(DocumentCloseRelay.document(_:shouldClose:contextInfo:)),
+                        contextInfo: nil
+                    )
+                } else {
+                    super.canClose(
+                        withDelegate: delegate,
+                        shouldClose: shouldCloseSelector,
+                        contextInfo: contextInfo
+                    )
+                }
+            } catch {
+                presentError(error)
+                relay?.document(self, shouldClose: false, contextInfo: nil)
+            }
         }
     }
 

--- a/Sources/PalmierPro/Utilities/FileIO.swift
+++ b/Sources/PalmierPro/Utilities/FileIO.swift
@@ -12,6 +12,42 @@ enum FileIOError: LocalizedError {
 }
 
 enum FileIO {
+    nonisolated static func temporaryFileURL(pathExtension: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-stage-\(UUID().uuidString)")
+            .appendingPathExtension(pathExtension)
+    }
+
+    nonisolated static func stageData(_ data: Data, pathExtension: String) throws -> URL {
+        let url = temporaryFileURL(pathExtension: pathExtension)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    nonisolated static func prepareStagedFile(from stagedURL: URL, nextTo packageURL: URL, maxBytes: Int64? = nil) throws -> URL {
+        let fm = FileManager.default
+        let directory = packageURL.deletingLastPathComponent()
+        let preparedURL = directory.appendingPathComponent(".palmier-stage-\(UUID().uuidString)")
+        do {
+            try copyReplacingDestination(from: stagedURL, to: preparedURL, maxBytes: maxBytes)
+            return preparedURL
+        } catch {
+            try? fm.removeItem(at: preparedURL)
+            throw error
+        }
+    }
+
+    nonisolated static func installPreparedFile(from preparedURL: URL, to destinationURL: URL) throws {
+        let fm = FileManager.default
+        defer { try? fm.removeItem(at: preparedURL) }
+        try fm.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fm.fileExists(atPath: destinationURL.path) {
+            _ = try fm.replaceItemAt(destinationURL, withItemAt: preparedURL)
+        } else {
+            try fm.moveItem(at: preparedURL, to: destinationURL)
+        }
+    }
+
     nonisolated static func writeData(_ data: Data, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try data.write(to: url)

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -143,6 +143,25 @@ struct ToolExecutorImportMediaTests {
         #expect(h.editor.mediaManifest.entries.first?.name == "Imported Still")
     }
 
+    @Test func importBytesRejectsInvalidLottieBeforePackageCommit() async {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pp-import-lottie-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let h = ToolHarness()
+        let package = root.appendingPathComponent("Import.palmier", isDirectory: true)
+        h.editor.projectURL = package
+        let bytes = Data("not-lottie".utf8).base64EncodedString()
+
+        let result = await h.runRaw("import_media", args: [
+            "source": ["bytes": bytes, "mimeType": "application/json"],
+        ])
+
+        #expect(result.isError)
+        #expect(h.editor.mediaAssets.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: package.path))
+    }
+
     @Test func importPathReferencesSourceFile() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("pp-import-path-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Project package coordination", .serialized)
+@MainActor
+struct ProjectPackageCoordinatorTests {
+    @Test func queuedMutationRunsBeforeSaveCompletionReturns() async throws {
+        let coordinator = ProjectPackageCoordinator()
+        coordinator.saveStarted()
+        var enteredCoordinator = false
+        var mutationRan = false
+        let mutation = Task {
+            enteredCoordinator = true
+            try await coordinator.performMutation { mutationRan = true }
+        }
+        while !enteredCoordinator { await Task.yield() }
+        #expect(!mutationRan)
+
+        coordinator.saveFinished()
+        #expect(mutationRan)
+        coordinator.saveStarted()
+        coordinator.saveFinished()
+        try await mutation.value
+    }
+
+    @Test func queuedMediaCommitUsesRebasedProjectURL() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("coordinator-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let oldURL = root.appendingPathComponent("Old.palmier", isDirectory: true)
+        let newURL = root.appendingPathComponent("New.palmier", isDirectory: true)
+
+        let document = VideoProject()
+        document.fileURL = oldURL
+        let editor = document.editorViewModel
+        editor.projectURL = oldURL
+        let asset = MediaAsset(url: oldURL.appendingPathComponent("media/existing.mp4"), type: .video, name: "Existing")
+        editor.mediaAssets.append(asset)
+
+        editor.projectPackageCoordinator.saveStarted()
+        let stagedURL = try FileIO.stageData(Data("video".utf8), pathExtension: "mp4")
+        let commit = Task { try await editor.commitStagedProjectMedia(stagedURL, filename: "new.mp4") }
+        await Task.yield()
+        document.fileURL = newURL
+        editor.projectPackageCoordinator.saveFinished()
+
+        let destination = try await commit.value
+        #expect(destination == newURL.appendingPathComponent("media/new.mp4"))
+        #expect(asset.url == newURL.appendingPathComponent("media/existing.mp4"))
+    }
+
+    @Test func closeWaitsForAcceptedMutationAndRejectsLateWork() async throws {
+        let coordinator = ProjectPackageCoordinator()
+        try coordinator.beginMutation()
+        var didClose = false
+        let closing = Task {
+            await coordinator.beginClosing()
+            didClose = true
+        }
+        await Task.yield()
+        #expect(!didClose)
+
+        coordinator.endMutation()
+        await closing.value
+        #expect(didClose)
+        #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
+    }
+
+}

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -17,6 +17,7 @@ struct ProjectPackageCoordinatorTests {
     @Test func queuedMutationRunsBeforeSaveCompletionReturns() async throws {
         let coordinator = ProjectPackageCoordinator()
         coordinator.saveStarted()
+        coordinator.saveStarted()
         var enteredCoordinator = false
         var mutationRan = false
         let mutation = Task {
@@ -26,13 +27,16 @@ struct ProjectPackageCoordinatorTests {
         while !enteredCoordinator { await Task.yield() }
         #expect(!mutationRan)
 
+        coordinator.saveFinished(success: false)
+        #expect(!mutationRan)
         coordinator.saveFinished(success: true)
         #expect(mutationRan)
         try await mutation.value
     }
 
-    @Test func failedSaveCancelsQueuedMutation() async {
+    @Test func failedSaveCancelsQueuedMutation() async throws {
         let coordinator = ProjectPackageCoordinator()
+        await coordinator.beginClosing()
         coordinator.saveStarted()
         var entered = false
         let mutation = Task {
@@ -43,6 +47,8 @@ struct ProjectPackageCoordinatorTests {
 
         coordinator.saveFinished(success: false)
         await #expect(throws: CancellationError.self) { try await mutation.value }
+        try coordinator.beginMutation()
+        coordinator.endMutation()
     }
 
     @Test func queuedMediaCommitUsesRebasedProjectURL() async throws {

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -1,6 +1,23 @@
-import Foundation
+import AppKit
 import Testing
 @testable import PalmierPro
+
+@MainActor
+private final class DocumentCloseProbe: NSObject {
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private(set) var result: Bool?
+
+    @objc func document(_ document: NSDocument, shouldClose: Bool, contextInfo: UnsafeMutableRawPointer?) {
+        result = shouldClose
+        continuation?.resume(returning: shouldClose)
+        continuation = nil
+    }
+
+    func waitForResult() async -> Bool {
+        if let result { return result }
+        return await withCheckedContinuation { continuation = $0 }
+    }
+}
 
 @Suite("Project package coordination", .serialized)
 @MainActor
@@ -44,19 +61,35 @@ struct ProjectPackageCoordinatorTests {
         #expect(destination == newURL.appendingPathComponent("media/new.mp4"))
     }
 
-    @Test func closeWaitsForAcceptedMutationAndRejectsLateWork() async throws {
-        let coordinator = ProjectPackageCoordinator()
+    @Test func nativeCloseWaitsForAcceptedMutationAndRejectsLateWork() async throws {
+        let package = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-close-\(UUID().uuidString).palmier", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: package) }
+        let document = VideoProject()
+        document.fileURL = package
+        document.fileType = VideoProject.typeIdentifier
+        let coordinator = document.editorViewModel.projectPackageCoordinator
         try coordinator.beginMutation()
-        var didClose = false
-        let closing = Task {
-            await coordinator.beginClosing()
-            didClose = true
+
+        let probe = DocumentCloseProbe()
+        document.canClose(
+            withDelegate: probe,
+            shouldClose: #selector(DocumentCloseProbe.document(_:shouldClose:contextInfo:)),
+            contextInfo: nil
+        )
+        while true {
+            do {
+                try coordinator.beginMutation()
+                coordinator.endMutation()
+                await Task.yield()
+            } catch is CancellationError {
+                break
+            }
         }
-        await Task.yield()
-        #expect(!didClose)
+        #expect(probe.result == nil)
 
         coordinator.endMutation()
-        await closing.value
+        #expect(await probe.waitForResult())
         #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
     }
 }

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -19,8 +19,6 @@ struct ProjectPackageCoordinatorTests {
 
         coordinator.saveFinished()
         #expect(mutationRan)
-        coordinator.saveStarted()
-        coordinator.saveFinished()
         try await mutation.value
     }
 
@@ -34,8 +32,6 @@ struct ProjectPackageCoordinatorTests {
         document.fileURL = oldURL
         let editor = document.editorViewModel
         editor.projectURL = oldURL
-        let asset = MediaAsset(url: oldURL.appendingPathComponent("media/existing.mp4"), type: .video, name: "Existing")
-        editor.mediaAssets.append(asset)
 
         editor.projectPackageCoordinator.saveStarted()
         let stagedURL = try FileIO.stageData(Data("video".utf8), pathExtension: "mp4")
@@ -46,7 +42,6 @@ struct ProjectPackageCoordinatorTests {
 
         let destination = try await commit.value
         #expect(destination == newURL.appendingPathComponent("media/new.mp4"))
-        #expect(asset.url == newURL.appendingPathComponent("media/existing.mp4"))
     }
 
     @Test func closeWaitsForAcceptedMutationAndRejectsLateWork() async throws {
@@ -62,8 +57,6 @@ struct ProjectPackageCoordinatorTests {
 
         coordinator.endMutation()
         await closing.value
-        #expect(didClose)
         #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
     }
-
 }

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -102,7 +102,40 @@ struct ProjectPackageCoordinatorTests {
         while probe.result == nil { await Task.yield() }
         #expect(probe.result == true)
         #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
-        try coordinator.beginMutation(allowDuringClosing: true)
-        coordinator.endMutation()
+    }
+
+    @Test func admittedMediaWorkCommitsBeforeCloseSave() async throws {
+        let package = FileManager.default.temporaryDirectory
+            .appendingPathComponent("admitted-work-\(UUID().uuidString).palmier", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: package) }
+        let document = VideoProject()
+        document.fileURL = package
+        document.fileType = VideoProject.typeIdentifier
+        let editor = document.editorViewModel
+        editor.projectURL = package
+        let coordinator = editor.projectPackageCoordinator
+        let closing: Task<Void, any Error>
+        do {
+            try coordinator.beginMutation()
+            defer { coordinator.endMutation() }
+
+            var closingStarted = false
+            closing = Task {
+                closingStarted = true
+                try await document.saveBeforeClosing()
+            }
+            while !closingStarted { await Task.yield() }
+            await Task.yield()
+
+            let stagedURL = try FileIO.stageData(Data("video".utf8), pathExtension: "mp4")
+            let destination = try await editor.commitStagedProjectMedia(
+                stagedURL, filename: "rendered.mp4", workAlreadyAdmitted: true
+            )
+            editor.importMediaAsset(MediaAsset(url: destination, type: .video, name: "Rendered"))
+        }
+        try await closing.value
+
+        let saved = try VideoProject.readProjectPackage(at: package)
+        #expect(saved.manifest?.entries.first?.source == .project(relativePath: "media/rendered.mp4"))
     }
 }

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -34,10 +34,16 @@ struct ProjectPackageCoordinatorTests {
         try await mutation.value
     }
 
-    @Test func failedSaveCancelsQueuedMutation() async throws {
+    @Test func failedPreexistingSaveCancelsQueueWithoutReopening() async {
         let coordinator = ProjectPackageCoordinator()
-        await coordinator.beginClosing()
         coordinator.saveStarted()
+        var closingStarted = false
+        let closing = Task {
+            closingStarted = true
+            await coordinator.beginClosing()
+        }
+        while !closingStarted { await Task.yield() }
+
         var entered = false
         let mutation = Task {
             entered = true
@@ -46,9 +52,9 @@ struct ProjectPackageCoordinatorTests {
         while !entered { await Task.yield() }
 
         coordinator.saveFinished(success: false)
+        await closing.value
         await #expect(throws: CancellationError.self) { try await mutation.value }
-        try coordinator.beginMutation()
-        coordinator.endMutation()
+        #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
     }
 
     @Test func queuedMediaCommitUsesRebasedProjectURL() async throws {

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -4,18 +4,10 @@ import Testing
 
 @MainActor
 private final class DocumentCloseProbe: NSObject {
-    private var continuation: CheckedContinuation<Bool, Never>?
     private(set) var result: Bool?
 
     @objc func document(_ document: NSDocument, shouldClose: Bool, contextInfo: UnsafeMutableRawPointer?) {
         result = shouldClose
-        continuation?.resume(returning: shouldClose)
-        continuation = nil
-    }
-
-    func waitForResult() async -> Bool {
-        if let result { return result }
-        return await withCheckedContinuation { continuation = $0 }
     }
 }
 
@@ -77,19 +69,12 @@ struct ProjectPackageCoordinatorTests {
             shouldClose: #selector(DocumentCloseProbe.document(_:shouldClose:contextInfo:)),
             contextInfo: nil
         )
-        while true {
-            do {
-                try coordinator.beginMutation()
-                coordinator.endMutation()
-                await Task.yield()
-            } catch is CancellationError {
-                break
-            }
-        }
+        await Task.yield()
         #expect(probe.result == nil)
 
         coordinator.endMutation()
-        #expect(await probe.waitForResult())
+        while probe.result == nil { await Task.yield() }
+        #expect(probe.result == true)
         #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
     }
 }

--- a/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
+++ b/Tests/PalmierProTests/Project/ProjectPackageCoordinatorTests.swift
@@ -26,9 +26,23 @@ struct ProjectPackageCoordinatorTests {
         while !enteredCoordinator { await Task.yield() }
         #expect(!mutationRan)
 
-        coordinator.saveFinished()
+        coordinator.saveFinished(success: true)
         #expect(mutationRan)
         try await mutation.value
+    }
+
+    @Test func failedSaveCancelsQueuedMutation() async {
+        let coordinator = ProjectPackageCoordinator()
+        coordinator.saveStarted()
+        var entered = false
+        let mutation = Task {
+            entered = true
+            try await coordinator.performMutation {}
+        }
+        while !entered { await Task.yield() }
+
+        coordinator.saveFinished(success: false)
+        await #expect(throws: CancellationError.self) { try await mutation.value }
     }
 
     @Test func queuedMediaCommitUsesRebasedProjectURL() async throws {
@@ -47,7 +61,7 @@ struct ProjectPackageCoordinatorTests {
         let commit = Task { try await editor.commitStagedProjectMedia(stagedURL, filename: "new.mp4") }
         await Task.yield()
         document.fileURL = newURL
-        editor.projectPackageCoordinator.saveFinished()
+        editor.projectPackageCoordinator.saveFinished(success: true)
 
         let destination = try await commit.value
         #expect(destination == newURL.appendingPathComponent("media/new.mp4"))
@@ -76,5 +90,7 @@ struct ProjectPackageCoordinatorTests {
         while probe.result == nil { await Task.yield() }
         #expect(probe.result == true)
         #expect(throws: CancellationError.self) { try coordinator.beginMutation() }
+        try coordinator.beginMutation(allowDuringClosing: true)
+        coordinator.endMutation()
     }
 }

--- a/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectLoadTests.swift
@@ -261,6 +261,25 @@ struct VideoProjectLoadTests {
         #expect(VideoProject.manifestSnapshot(manifest: MediaManifest(), loadFailed: false) != nil)
     }
 
+    @Test func packageWriteCreatesMediaDirectory() throws {
+        let bundle = try makeBundle()
+        defer { try? fm.removeItem(at: bundle) }
+        let snapshot = ProjectPackageSnapshot(
+            timeline: try JSONEncoder().encode(Fixtures.timeline()),
+            manifest: nil,
+            generationLog: nil,
+            thumbnail: nil,
+            chatSessionFiles: []
+        )
+
+        try VideoProject.writeProjectPackage(snapshot, to: bundle, sourceURL: bundle)
+
+        var isDirectory = ObjCBool(false)
+        let mediaURL = bundle.appendingPathComponent(Project.mediaDirectoryName, isDirectory: true)
+        #expect(fm.fileExists(atPath: mediaURL.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+    }
+
     @Test func saveAsPreservesUnreadableManifestFile() throws {
         let source = try makeBundle()
         defer { try? fm.removeItem(at: source) }


### PR DESCRIPTION
## Issue

Fixes [PAL-111](https://linear.app/palmier/issue/PAL-111/media-catalog-entry-survives-while-backing-video-file-silently-goes) (`jn7f2pk8tnqmw6kaw4d59xvgmd8ahza5`).

A project could retain a valid media catalog entry after its backing file disappeared or became unreadable. A successful export did not guarantee persistence: another media write could overlap a later `NSDocument` package save, and the completed save could replace the live package with a snapshot that did not contain the completed file.

## Before

Media producers wrote directly into the live package. `NSDocument` independently built and installed a replacement package.

```mermaid
sequenceDiagram
    participant W as Media writer
    participant P as Live .palmier package
    participant S as NSDocument save
    participant T as Temporary package snapshot

    W->>P: Copy media into media/
    S->>P: Read package state
    S->>T: Build replacement snapshot
    W-->>P: Finish media copy
    S->>P: Atomically replace package with snapshot
    Note over P: Catalog may reference a file absent<br/>from the installed snapshot
```

## Solution

- Stage complete media outside the project package.
- Prepare a hidden sibling file on the package volume.
- Route all seven project media-producing call sites, plus removals, through one per-project `ProjectPackageCoordinator`.
- Queue final atomic mutations while a save is active, then drain them synchronously in the save-completion handoff before another save can begin.
- Make agent close, native window close, and app termination wait for accepted package mutations and reject late commits.
- Rebase media URLs across Save As and bound retries when the destination changes.

## After

```mermaid
flowchart LR
    A[Agent imports: bytes and URL] --> S[Stage complete file outside package]
    B[Generation download] --> S
    C[Paste and matte] --> S
    E[Save clip and timeline range as media] --> S
    S --> V[Prepare sibling file on package volume]
    V --> Q[ProjectPackageCoordinator]
    D[Media removal] --> Q
    N[NSDocument save lifecycle] --> Q
    Q -->|save idle| I[Atomic install or removal]
    Q -->|save active| P[Queue until save completion]
    P --> I
    I --> M[Live .palmier/media]
```

```mermaid
sequenceDiagram
    participant W as Media producer
    participant F as Prepared sibling file
    participant C as Package coordinator
    participant S as NSDocument save
    participant P as Live .palmier package

    W->>F: Finish complete file
    W->>C: Request final package mutation
    alt Save active
        C-->>W: Suspend mutation
        S-->>C: saveFinished
        C->>P: Atomic rename before next save
        C-->>W: Resume
    else Save idle
        C->>P: Atomic rename immediately
    end
```

## Save-hang regression caught during implementation

The first coordinator attempt deferred `super.save` into a `MainActor` task. AppKit's synchronous document serialization path then waited on work queued back to the main actor, producing a save hang in `_NSDocumentSerializationSemaphore.wait`.

The final design keeps `super.save` synchronous, as AppKit expects, and coordinates only package mutations around the save lifecycle.

## Validation

- `swift test`: 1,066 tests across 164 suites passed.
- Coordinator coverage verifies save-completion handoff, Save As rebasing, native close waiting, and late-work rejection.
- MCP end-to-end: imported one 74 MB file, then three concurrent 74 MB files; immediately closed and reopened the project; decoded first and final frames; completed a 1080p H.264 export; found no zero-byte files or orphan staging files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core project persistence and coordinates all media installs with `NSDocument` saves and shutdown; bugs could lose media, block close/quit, or regress Save As paths.
> 
> **Overview**
> Fixes a race where **media could finish writing into the live `.palmier` package while `NSDocument` was installing a save snapshot**, leaving manifest entries pointing at files missing from the package on disk.
> 
> **Staging and install:** New `FileIO` helpers write complete files outside the package (temp or a hidden sibling next to the bundle), then `EditorViewModel.commitStagedProjectMedia` atomically installs into `media/` via `prepareStagedFile` + `installPreparedFile`.
> 
> **Coordination:** Per-project `ProjectPackageCoordinator` ties into the save lifecycle (`saveStarted` / `saveFinished`), **queues final installs while a save is in flight**, drains them on successful save completion, and tracks active mutations plus a closing state so late work is rejected.
> 
> **Call sites:** Agent byte/URL import, generation downloads, mattes, pasted images, and save-clip/timeline-range-as-media now commit through this path instead of writing directly into `media/`. Byte import also validates Lottie **before** package commit.
> 
> **Close / quit:** `VideoProject` overrides `canClose` to await `saveBeforeClosing` (coordinator idle + unsaved flush); app termination saves all open projects first and cancels closing on failure. **Save As** rebases in-memory asset URLs via `rebaseProjectURL`. Package writes always ensure `media/` exists; thumbnail side-writes defer to checkpoint autosave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0898ee751083a0daa15948b52aaded5c7c32c180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->