### PR TITLE
[perf] Cache and background-fill scrub audio

### DIFF
--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -95,7 +95,7 @@ enum AudioLevelAnalyzer {
         )
     }
 
-    nonisolated static func analyze(left: [Int16], right: [Int16], range: Range<Int>) -> AudioMeterAnalysis {
+    nonisolated static func analyzeInt16(left: [Int16], right: [Int16], range: Range<Int>) -> AudioMeterAnalysis {
         let upper = min(range.upperBound, min(left.count, right.count))
         let lower = max(0, min(range.lowerBound, upper))
         guard lower < upper else { return .silence }

--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -95,6 +95,21 @@ enum AudioLevelAnalyzer {
         )
     }
 
+    nonisolated static func analyzeMono(_ samples: [Int16], range: Range<Int>) -> AudioMeterAnalysis {
+        let upper = min(range.upperBound, samples.count)
+        let lower = max(0, min(range.lowerBound, upper))
+        guard lower < upper else { return .silence }
+        let count = upper - lower
+        var floats = [Float](repeating: 0, count: count)
+        samples.withUnsafeBufferPointer { buffer in
+            vDSP_vflt16(buffer.baseAddress! + lower, 1, &floats, 1, vDSP_Length(count))
+        }
+        var peak: Float = 0
+        vDSP_maxmgv(floats, 1, &peak, vDSP_Length(count))
+        peak /= 32768.0
+        return AudioMeterAnalysis(leftPeak: peak, rightPeak: peak)
+    }
+
     nonisolated static func analyze(_ buffer: AVAudioPCMBuffer) -> AudioMeterAnalysis {
         guard buffer.format.commonFormat == .pcmFormatFloat32,
               !buffer.format.isInterleaved,

--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -113,7 +113,7 @@ enum AudioLevelAnalyzer {
         }
         var peak: Float = 0
         vDSP_maxmgv(floats, 1, &peak, vDSP_Length(count))
-        return peak / 32768.0
+        return peak / 32767.0  // matches ScrubAudioEngine quantize scale so full-scale reads as 1.0
     }
 
     nonisolated static func analyze(_ buffer: AVAudioPCMBuffer) -> AudioMeterAnalysis {

--- a/Sources/PalmierPro/Audio/AudioMeter.swift
+++ b/Sources/PalmierPro/Audio/AudioMeter.swift
@@ -95,19 +95,25 @@ enum AudioLevelAnalyzer {
         )
     }
 
-    nonisolated static func analyzeMono(_ samples: [Int16], range: Range<Int>) -> AudioMeterAnalysis {
-        let upper = min(range.upperBound, samples.count)
+    nonisolated static func analyze(left: [Int16], right: [Int16], range: Range<Int>) -> AudioMeterAnalysis {
+        let upper = min(range.upperBound, min(left.count, right.count))
         let lower = max(0, min(range.lowerBound, upper))
         guard lower < upper else { return .silence }
         let count = upper - lower
+        return AudioMeterAnalysis(
+            leftPeak: peakInt16(left, lower: lower, count: count),
+            rightPeak: peakInt16(right, lower: lower, count: count)
+        )
+    }
+
+    nonisolated private static func peakInt16(_ samples: [Int16], lower: Int, count: Int) -> Float {
         var floats = [Float](repeating: 0, count: count)
         samples.withUnsafeBufferPointer { buffer in
             vDSP_vflt16(buffer.baseAddress! + lower, 1, &floats, 1, vDSP_Length(count))
         }
         var peak: Float = 0
         vDSP_maxmgv(floats, 1, &peak, vDSP_Length(count))
-        peak /= 32768.0
-        return AudioMeterAnalysis(leftPeak: peak, rightPeak: peak)
+        return peak / 32768.0
     }
 
     nonisolated static func analyze(_ buffer: AVAudioPCMBuffer) -> AudioMeterAnalysis {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -28,6 +28,11 @@ final class ScrubAudioEngine {
         var endSample: Int64 { startSample + Int64(left.count) }
     }
 
+    private struct CachedWindow {
+        let window: PCMWindow
+        var lastUsed: UInt64
+    }
+
     nonisolated private static let sampleRate = 48_000.0
     nonisolated private static let sampleTimescale: CMTimeScale = 48_000
     nonisolated private static let channelCount: AVAudioChannelCount = 2
@@ -36,19 +41,24 @@ final class ScrubAudioEngine {
     nonisolated private static let fadeFrameCount = 144
     nonisolated private static let meterFrameCount = 960
     nonisolated private static let meterPrefetchFrameCount = 12_000
+    nonisolated private static let prefetchMarginFrameCount = 24_000
+    nonisolated private static let maxCachedWindows = 32
+    nonisolated private static let mixInvalidationDebounce = Duration.milliseconds(250)
 
     private let meter: AudioMeterHub
     private let output = ScrubAudioOutput(sampleRate: sampleRate)
 
     private var source: Source?
     private var sourceGeneration = 0
-    private var cache: PCMWindow?
+    private var windows: [CachedWindow] = []
+    private var useCounter: UInt64 = 0
     private var latestRequest: Request?
     private var latestMeterSample: Int64?
     private var lastRequestedSample: Int64?
     private var lastDirection: Direction = .forward
     private var decodeTask: Task<Void, Never>?
     private var pendingDecodeRange: Range<Int64>?
+    private var mixInvalidationTask: Task<Void, Never>?
     private var lifecycleObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     init(meter: AudioMeterHub) {
@@ -62,11 +72,28 @@ final class ScrubAudioEngine {
     }
 
     func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
+        let mixOnlyChange = asset != nil && asset === source?.asset
         stopScrubbing()
         sourceGeneration &+= 1
-        cache = nil
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
+        if mixOnlyChange {
+            scheduleMixInvalidation()
+        } else {
+            mixInvalidationTask?.cancel()
+            mixInvalidationTask = nil
+            windows.removeAll()
+        }
         if resetMeter { meter.reset() }
+    }
+
+    private func scheduleMixInvalidation() {
+        mixInvalidationTask?.cancel()
+        mixInvalidationTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.mixInvalidationDebounce)
+            guard !Task.isCancelled, let self else { return }
+            self.mixInvalidationTask = nil
+            self.windows.removeAll()
+        }
     }
 
     func scrub(to time: CMTime, movingForward: Bool? = nil) {
@@ -91,10 +118,11 @@ final class ScrubAudioEngine {
 
         let request = Request(sample: sample, direction: direction)
         latestRequest = request
-        if let cache, canServe(sample: sample, from: cache) {
-            play(request: request, from: cache)
+        if let window = serveableWindow(for: sample) {
+            play(request: request, from: window)
+            prefetchIfNeeded(sample: sample, direction: direction, from: window, source: source)
         } else {
-            requestWindow(around: sample, source: source)
+            requestWindow(around: sample, direction: direction, source: source)
         }
     }
 
@@ -105,13 +133,13 @@ final class ScrubAudioEngine {
 
         let sample = Int64((seconds * Self.sampleRate).rounded())
         latestMeterSample = sample
-        if let cache, canMeter(sample: sample, from: cache) {
-            publishMeter(sample: sample, from: cache)
-            if sample + Int64(Self.meterPrefetchFrameCount) >= cache.endSample {
-                requestWindow(around: sample, source: source)
+        if let window = meterableWindow(for: sample) {
+            publishMeter(sample: sample, from: window)
+            if sample + Int64(Self.meterPrefetchFrameCount) >= window.endSample {
+                requestWindow(around: sample, direction: .forward, source: source)
             }
         } else {
-            requestWindow(around: sample, source: source)
+            requestWindow(around: sample, direction: .forward, source: source)
         }
     }
 
@@ -132,8 +160,10 @@ final class ScrubAudioEngine {
 
     func teardown() {
         resetScrubState()
+        mixInvalidationTask?.cancel()
+        mixInvalidationTask = nil
         source = nil
-        cache = nil
+        windows.removeAll()
         output.invalidate()
         removeLifecycleObservers()
     }
@@ -145,12 +175,11 @@ final class ScrubAudioEngine {
         lifecycleObservers.removeAll()
     }
 
-    private func requestWindow(around sample: Int64, source: Source) {
+    private func requestWindow(around sample: Int64, direction: Direction, source: Source) {
         if let pendingDecodeRange, canServe(sample: sample, from: pendingDecodeRange) { return }
 
         decodeTask?.cancel()
-        let halfWindow = Int64(Self.cacheFrameCount / 2)
-        let startSample = max(0, sample - halfWindow)
+        let startSample = windowStart(around: sample, direction: direction)
         let range = startSample..<(startSample + Int64(Self.cacheFrameCount))
         pendingDecodeRange = range
 
@@ -168,13 +197,13 @@ final class ScrubAudioEngine {
                 if self.latestRequest != nil { self.lastRequestedSample = nil }
                 return
             }
-            self.cache = window
+            self.insert(window)
 
             if let request = self.latestRequest {
                 if self.canServe(sample: request.sample, from: window) {
                     self.play(request: request, from: window)
                 } else {
-                    self.requestWindow(around: request.sample, source: source)
+                    self.requestWindow(around: request.sample, direction: request.direction, source: source)
                 }
                 return
             }
@@ -182,9 +211,58 @@ final class ScrubAudioEngine {
                 if self.canMeter(sample: meterSample, from: window) {
                     self.publishMeter(sample: meterSample, from: window)
                 } else {
-                    self.requestWindow(around: meterSample, source: source)
+                    self.requestWindow(around: meterSample, direction: .forward, source: source)
                 }
             }
+        }
+    }
+
+    /// Bias the decode window in the scrub direction so most of it lands ahead of the playhead.
+    private func windowStart(around sample: Int64, direction: Direction) -> Int64 {
+        let behind = Int64(Self.cacheFrameCount / 8)
+        let offset: Int64 = direction == .forward ? behind : Int64(Self.cacheFrameCount) - behind
+        return max(0, sample - offset)
+    }
+
+    private func prefetchIfNeeded(sample: Int64, direction: Direction, from window: PCMWindow, source: Source) {
+        guard decodeTask == nil else { return }
+        let margin = Int64(Self.prefetchMarginFrameCount)
+        let nearEdge = direction == .forward
+            ? sample + margin >= window.endSample
+            : sample - margin <= window.startSample
+        guard nearEdge else { return }
+        let step = Int64(Self.cacheFrameCount - Self.prefetchMarginFrameCount)
+        let next = direction == .forward ? sample + step : sample - step
+        guard next >= 0, serveableWindow(for: next, touch: false) == nil else { return }
+        requestWindow(around: next, direction: direction, source: source)
+    }
+
+    private func serveableWindow(for sample: Int64, touch: Bool = true) -> PCMWindow? {
+        guard let index = windows.firstIndex(where: { canServe(sample: sample, from: $0.window) }) else { return nil }
+        if touch {
+            useCounter &+= 1
+            windows[index].lastUsed = useCounter
+        }
+        return windows[index].window
+    }
+
+    private func meterableWindow(for sample: Int64) -> PCMWindow? {
+        guard let index = windows.firstIndex(where: { canMeter(sample: sample, from: $0.window) }) else { return nil }
+        useCounter &+= 1
+        windows[index].lastUsed = useCounter
+        return windows[index].window
+    }
+
+    private func insert(_ window: PCMWindow) {
+        useCounter &+= 1
+        if let index = windows.firstIndex(where: { $0.window.startSample == window.startSample }) {
+            windows[index] = CachedWindow(window: window, lastUsed: useCounter)
+        } else {
+            windows.append(CachedWindow(window: window, lastUsed: useCounter))
+        }
+        if windows.count > Self.maxCachedWindows,
+           let evict = windows.indices.min(by: { windows[$0].lastUsed < windows[$1].lastUsed }) {
+            windows.remove(at: evict)
         }
     }
 

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -31,6 +31,7 @@ final class ScrubAudioEngine {
     private struct CachedWindow {
         let window: PCMWindow
         var lastUsed: UInt64
+        let inserted: UInt64
     }
 
     nonisolated private static let sampleRate = 48_000.0
@@ -62,6 +63,7 @@ final class ScrubAudioEngine {
     private var pendingDecodeRange: Range<Int64>?
     private var mixInvalidationTask: Task<Void, Never>?
     private var fillTask: Task<Void, Never>?
+    private var fillDecode: Task<PCMWindow?, Never>?
     private var lifecycleObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     init(meter: AudioMeterHub) {
@@ -76,13 +78,13 @@ final class ScrubAudioEngine {
 
     func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
         let mixOnlyChange = asset != nil && asset === source?.asset
+        let anchor = lastRequestedSample ?? 0
         stopScrubbing()
-        fillTask?.cancel()
-        fillTask = nil
+        cancelFill()
         sourceGeneration &+= 1
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
         if mixOnlyChange {
-            scheduleMixInvalidation()
+            scheduleMixInvalidation(anchor: anchor)
         } else {
             mixInvalidationTask?.cancel()
             mixInvalidationTask = nil
@@ -92,20 +94,27 @@ final class ScrubAudioEngine {
         if resetMeter { meter.reset() }
     }
 
-    private func scheduleMixInvalidation() {
+    private func scheduleMixInvalidation(anchor: Int64) {
         mixInvalidationTask?.cancel()
         mixInvalidationTask = Task { [weak self] in
             try? await Task.sleep(for: Self.mixInvalidationDebounce)
             guard !Task.isCancelled, let self else { return }
             self.mixInvalidationTask = nil
             self.windows.removeAll()
-            if let source = self.source { self.startFill(from: self.lastRequestedSample ?? 0, source: source) }
+            if let source = self.source { self.startFill(from: self.lastRequestedSample ?? anchor, source: source) }
         }
+    }
+
+    private func cancelFill() {
+        fillTask?.cancel()
+        fillTask = nil
+        fillDecode?.cancel()
+        fillDecode = nil
     }
 
     // Decode entire timeline outward from anchor, yielding so reactive misses always take priority
     private func startFill(from anchorSample: Int64, source: Source) {
-        fillTask?.cancel()
+        cancelFill()
         fillTask = Task { [weak self] in
             guard let durationSeconds = try? await source.asset.load(.duration).seconds,
                   durationSeconds.isFinite, durationSeconds > 0 else { return }
@@ -129,7 +138,11 @@ final class ScrubAudioEngine {
                         guard !Task.isCancelled, source.generation == self.source?.generation else { return }
                     }
 
-                    let window = await Self.decodeWindow(source: source, startSample: start, frameCount: Self.cacheFrameCount)
+                    // Run as a tracked child so a reactive miss can cancel it and win the reader.
+                    let decode = Task { await Self.decodeWindow(source: source, startSample: start, frameCount: Self.cacheFrameCount) }
+                    self.fillDecode = decode
+                    let window = await decode.value
+                    self.fillDecode = nil
                     guard !Task.isCancelled, source.generation == self.source?.generation else { return }
                     if let window { self.insert(window) }
                 }
@@ -207,8 +220,7 @@ final class ScrubAudioEngine {
         resetScrubState()
         mixInvalidationTask?.cancel()
         mixInvalidationTask = nil
-        fillTask?.cancel()
-        fillTask = nil
+        cancelFill()
         source = nil
         windows.removeAll()
         output.invalidate()
@@ -225,6 +237,7 @@ final class ScrubAudioEngine {
     private func requestWindow(around sample: Int64, direction: Direction, source: Source) {
         if let pendingDecodeRange, canServe(sample: sample, from: pendingDecodeRange) { return }
 
+        fillDecode?.cancel()  // reactive miss preempts an in-flight background fill decode
         decodeTask?.cancel()
         let startSample = windowStart(around: sample, direction: direction)
         let range = startSample..<(startSample + Int64(Self.cacheFrameCount))
@@ -285,7 +298,7 @@ final class ScrubAudioEngine {
     }
 
     private func serveableWindow(for sample: Int64, touch: Bool = true) -> PCMWindow? {
-        guard let index = windows.firstIndex(where: { canServe(sample: sample, from: $0.window) }) else { return nil }
+        guard let index = freshestWindowIndex(where: { canServe(sample: sample, from: $0) }) else { return nil }
         if touch {
             useCounter &+= 1
             windows[index].lastUsed = useCounter
@@ -294,18 +307,24 @@ final class ScrubAudioEngine {
     }
 
     private func meterableWindow(for sample: Int64) -> PCMWindow? {
-        guard let index = windows.firstIndex(where: { canMeter(sample: sample, from: $0.window) }) else { return nil }
+        guard let index = freshestWindowIndex(where: { canMeter(sample: sample, from: $0) }) else { return nil }
         useCounter &+= 1
         windows[index].lastUsed = useCounter
         return windows[index].window
     }
 
+    private func freshestWindowIndex(where covers: (PCMWindow) -> Bool) -> Int? {
+        windows.indices
+            .filter { covers(windows[$0].window) }
+            .max(by: { windows[$0].inserted < windows[$1].inserted })
+    }
+
     private func insert(_ window: PCMWindow) {
         useCounter &+= 1
         if let index = windows.firstIndex(where: { $0.window.startSample == window.startSample }) {
-            windows[index] = CachedWindow(window: window, lastUsed: useCounter)
+            windows[index] = CachedWindow(window: window, lastUsed: useCounter, inserted: useCounter)
         } else {
-            windows.append(CachedWindow(window: window, lastUsed: useCounter))
+            windows.append(CachedWindow(window: window, lastUsed: useCounter, inserted: useCounter))
         }
         if windows.count > Self.maxCachedWindows,
            let evict = windows.indices.min(by: { windows[$0].lastUsed < windows[$1].lastUsed }) {

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -349,7 +349,7 @@ final class ScrubAudioEngine {
         let start = Int(sample - window.startSample)
         let range = start..<(start + Self.meterFrameCount)
         let analysis = window.hasAudioTracks
-            ? AudioLevelAnalyzer.analyze(left: window.left, right: window.right, range: range)
+            ? AudioLevelAnalyzer.analyzeInt16(left: window.left, right: window.right, range: range)
             : .silence
         meter.ingest(analysis)
     }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -112,7 +112,7 @@ final class ScrubAudioEngine {
         fillDecode = nil
     }
 
-    // Decode entire timeline outward from anchor, yielding so reactive misses always take priority
+    // Fill the whole timeline outward from the anchor; reactive misses cancel and preempt each decode.
     private func startFill(from anchorSample: Int64, source: Source) {
         cancelFill()
         fillTask = Task { [weak self] in
@@ -138,7 +138,6 @@ final class ScrubAudioEngine {
                         guard !Task.isCancelled, source.generation == self.source?.generation else { return }
                     }
 
-                    // Run as a tracked child so a reactive miss can cancel it and win the reader.
                     let decode = Task { await Self.decodeWindow(source: source, startSample: start, frameCount: Self.cacheFrameCount) }
                     self.fillDecode = decode
                     let window = await decode.value

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -143,8 +143,9 @@ final class ScrubAudioEngine {
                     self.fillDecode = decode
                     let window = await decode.value
                     self.fillDecode = nil
-                    guard !Task.isCancelled, !decode.isCancelled, source.generation == self.source?.generation else { return }
-                    if let window { self.insert(window) }
+                    // Fill-task cancel or a source change stops the sweep; a preempted decode just skips this window.
+                    guard !Task.isCancelled, source.generation == self.source?.generation else { return }
+                    if let window, !decode.isCancelled { self.insert(window) }
                 }
             }
         }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -21,11 +21,10 @@ final class ScrubAudioEngine {
 
     private struct PCMWindow: Sendable {
         let startSample: Int64
-        let left: [Float]
-        let right: [Float]
+        let samples: [Int16]  // mono; ~5.6 MiB/min vs 22 MiB/min for stereo Float32
         let hasAudioTracks: Bool
 
-        var endSample: Int64 { startSample + Int64(left.count) }
+        var endSample: Int64 { startSample + Int64(samples.count) }
     }
 
     private struct CachedWindow {
@@ -302,7 +301,7 @@ final class ScrubAudioEngine {
         let start = Int(sample - window.startSample)
         let range = start..<(start + Self.meterFrameCount)
         let analysis = window.hasAudioTracks
-            ? AudioLevelAnalyzer.analyze(left: window.left, right: window.right, range: range)
+            ? AudioLevelAnalyzer.analyzeMono(window.samples, range: range)
             : .silence
         meter.ingest(analysis)
     }
@@ -322,13 +321,16 @@ final class ScrubAudioEngine {
             }
             let cacheIndex = Int(sourceSample - window.startSample)
             let gain = Self.edgeGain(at: outputIndex, frameCount: frameCount)
-            if window.left.indices.contains(cacheIndex) {
-                left[outputIndex] = window.left[cacheIndex] * gain
-                right[outputIndex] = window.right[cacheIndex] * gain
+            if window.samples.indices.contains(cacheIndex) {
+                let value = Float(window.samples[cacheIndex]) * Self.int16ToFloat * gain
+                left[outputIndex] = value
+                right[outputIndex] = value
             }
         }
         return ScrubAudioGrain(left: left, right: right)
     }
+
+    nonisolated private static let int16ToFloat: Float = 1.0 / 32768.0
 
     private func observeLifecycle() {
         let appCenter = NotificationCenter.default
@@ -375,10 +377,9 @@ final class ScrubAudioEngine {
     ) async -> PCMWindow? {
         guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio) else { return nil }
 
-        var left = [Float](repeating: 0, count: frameCount)
-        var right = [Float](repeating: 0, count: frameCount)
+        var samples = [Int16](repeating: 0, count: frameCount)
         guard !tracks.isEmpty else {
-            return PCMWindow(startSample: startSample, left: left, right: right, hasAudioTracks: false)
+            return PCMWindow(startSample: startSample, samples: samples, hasAudioTracks: false)
         }
 
         guard let reader = try? AVAssetReader(asset: source.asset) else { return nil }
@@ -438,16 +439,20 @@ final class ScrubAudioEngine {
             }
 
             let sourceChannelCount = Int(sampleFormat.channelCount)
+            let rightChannel = channels[min(1, sourceChannelCount - 1)]
             for sourceIndex in 0..<sampleCount {
                 let destinationIndex = destinationOffset + sourceIndex
-                guard left.indices.contains(destinationIndex) else { continue }
-                left[destinationIndex] = channels[0][sourceIndex]
-                right[destinationIndex] = channels[min(1, sourceChannelCount - 1)][sourceIndex]
+                guard samples.indices.contains(destinationIndex) else { continue }
+                let mono = sourceChannelCount > 1
+                    ? (channels[0][sourceIndex] + rightChannel[sourceIndex]) * 0.5
+                    : channels[0][sourceIndex]
+                let clamped = max(-1, min(1, mono))
+                samples[destinationIndex] = Int16((clamped * 32767).rounded())
             }
             runningOffset = max(runningOffset, destinationOffset + sampleCount)
         }
 
         guard reader.status != .failed else { return nil }
-        return PCMWindow(startSample: startSample, left: left, right: right, hasAudioTracks: true)
+        return PCMWindow(startSample: startSample, samples: samples, hasAudioTracks: true)
     }
 }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -63,7 +63,6 @@ final class ScrubAudioEngine {
     private var pendingDecodeRange: Range<Int64>?
     private var mixInvalidationTask: Task<Void, Never>?
     private var fillTask: Task<Void, Never>?
-    private var fillDecode: Task<PCMWindow?, Never>?
     private var lifecycleObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     init(meter: AudioMeterHub) {
@@ -108,45 +107,35 @@ final class ScrubAudioEngine {
     private func cancelFill() {
         fillTask?.cancel()
         fillTask = nil
-        fillDecode?.cancel()
-        fillDecode = nil
     }
 
-    // Fill the whole timeline outward from the anchor; reactive misses cancel and preempt each decode.
+    // Fill with two passes: anchor→end, then start→anchor for faster preview. One AVAssetReader per pass.
     private func startFill(from anchorSample: Int64, source: Source) {
         cancelFill()
         fillTask = Task { [weak self] in
             guard let durationSeconds = try? await source.asset.load(.duration).seconds,
                   durationSeconds.isFinite, durationSeconds > 0 else { return }
-            let stride = Int64(Self.fillStride)
             let totalSamples = Int64(durationSeconds * Self.sampleRate)
-            let maxIndex = Int(max(0, (totalSamples - 1) / stride))
-            let anchorIndex = max(0, min(maxIndex, Int(anchorSample / stride)))
+            let anchor = max(0, min(totalSamples, anchorSample))
 
-            // Visit anchor, then anchor-1, anchor+1, anchor-2, anchor+2, … clamped to [0, maxIndex].
-            for offset in 0...maxIndex {
-                for index in offset == 0 ? [anchorIndex] : [anchorIndex - offset, anchorIndex + offset] {
-                    guard index >= 0, index <= maxIndex else { continue }
-                    guard !Task.isCancelled, let self, source.generation == self.source?.generation else { return }
+            await self?.streamFill(from: anchor, to: totalSamples, source: source)
+            await self?.streamFill(from: 0, to: anchor, source: source)
+        }
+    }
 
-                    // Stop before the cap so the resident band stays put; reactive decode covers the rest.
-                    guard self.windows.count < Self.fillBudget else { return }
-                    let start = Int64(index) * stride
-                    if self.hasWindow(startingAt: start) { continue }
-                    while self.decodeTask != nil {
-                        try? await Task.sleep(for: .milliseconds(20))
-                        guard !Task.isCancelled, source.generation == self.source?.generation else { return }
-                    }
-
-                    let decode = Task { await Self.decodeWindow(source: source, startSample: start, frameCount: Self.cacheFrameCount) }
-                    self.fillDecode = decode
-                    let window = await decode.value
-                    self.fillDecode = nil
-                    // Fill-task cancel or a source change stops the sweep; a preempted decode just skips this window.
-                    guard !Task.isCancelled, source.generation == self.source?.generation else { return }
-                    if let window, !decode.isCancelled { self.insert(window) }
-                }
+    // Decode [start, end) with one reader; closure returns false to stop early.
+    private func streamFill(from start: Int64, to end: Int64, source: Source) async {
+        guard start < end else { return }
+        await Self.streamWindows(source: source, from: start, to: end) { [weak self] window in
+            guard let self else { return false }
+            guard !Task.isCancelled, source.generation == self.source?.generation else { return false }
+            guard self.windows.count < Self.fillBudget else { return false }
+            if !self.hasWindow(startingAt: window.startSample) { self.insert(window) }
+            while self.decodeTask != nil {
+                try? await Task.sleep(for: .milliseconds(20))
+                guard !Task.isCancelled, source.generation == self.source?.generation else { return false }
             }
+            return true
         }
     }
 
@@ -237,7 +226,6 @@ final class ScrubAudioEngine {
     private func requestWindow(around sample: Int64, direction: Direction, source: Source) {
         if let pendingDecodeRange, canServe(sample: sample, from: pendingDecodeRange) { return }
 
-        fillDecode?.cancel()  // reactive miss preempts an in-flight background fill decode
         decodeTask?.cancel()
         let startSample = windowStart(around: sample, direction: direction)
         let range = startSample..<(startSample + Int64(Self.cacheFrameCount))
@@ -440,22 +428,13 @@ final class ScrubAudioEngine {
         return min(fadeIn, fadeOut)
     }
 
-    @concurrent
-    private static func decodeWindow(
+    nonisolated private static func makeReader(
         source: Source,
+        tracks: [AVAssetTrack],
         startSample: Int64,
-        frameCount: Int
-    ) async -> PCMWindow? {
-        guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio) else { return nil }
-
-        var leftSamples = [Int16](repeating: 0, count: frameCount)
-        var rightSamples = [Int16](repeating: 0, count: frameCount)
-        guard !tracks.isEmpty else {
-            return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: false)
-        }
-
+        frameCount: Int64
+    ) -> (AVAssetReader, AVAssetReaderAudioMixOutput)? {
         guard let reader = try? AVAssetReader(asset: source.asset) else { return nil }
-
         let output = AVAssetReaderAudioMixOutput(audioTracks: tracks, audioSettings: [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: sampleRate,
@@ -471,9 +450,29 @@ final class ScrubAudioEngine {
         reader.add(output)
         reader.timeRange = CMTimeRange(
             start: CMTime(value: startSample, timescale: sampleTimescale),
-            duration: CMTime(value: CMTimeValue(frameCount), timescale: sampleTimescale)
+            duration: CMTime(value: frameCount, timescale: sampleTimescale)
         )
         guard reader.startReading() else { return nil }
+        return (reader, output)
+    }
+
+    @concurrent
+    private static func decodeWindow(
+        source: Source,
+        startSample: Int64,
+        frameCount: Int
+    ) async -> PCMWindow? {
+        guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio) else { return nil }
+
+        var leftSamples = [Int16](repeating: 0, count: frameCount)
+        var rightSamples = [Int16](repeating: 0, count: frameCount)
+        guard !tracks.isEmpty else {
+            return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: false)
+        }
+
+        guard let (reader, output) = makeReader(
+            source: source, tracks: tracks, startSample: startSample, frameCount: Int64(frameCount)
+        ) else { return nil }
 
         var runningOffset = 0
         while let sampleBuffer = output.copyNextSampleBuffer() {
@@ -523,5 +522,95 @@ final class ScrubAudioEngine {
 
         guard reader.status == .completed else { return nil }
         return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: true)
+    }
+
+    @concurrent
+    private static func streamWindows(
+        source: Source,
+        from: Int64,
+        to: Int64,
+        emit: @MainActor (PCMWindow) async -> Bool
+    ) async {
+        guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio), !tracks.isEmpty,
+              let (reader, output) = makeReader(
+                source: source, tracks: tracks, startSample: from, frameCount: to - from
+              ) else { return }
+
+        let windowLen = cacheFrameCount
+        let stride = Int64(fillStride)
+        var bufferStart = from            // absolute sample of left[0]/right[0]
+        var left = [Int16]()
+        var right = [Int16]()
+        var filledEnd = from              // absolute sample one past the last written
+
+        func drainFull() async -> Bool {
+            while filledEnd - bufferStart >= Int64(windowLen) {
+                let window = PCMWindow(
+                    startSample: bufferStart,
+                    left: Array(left[0..<windowLen]),
+                    right: Array(right[0..<windowLen]),
+                    hasAudioTracks: true
+                )
+                if !(await emit(window)) { return false }
+                left.removeFirst(Int(stride))
+                right.removeFirst(Int(stride))
+                bufferStart += stride
+            }
+            return true
+        }
+
+        while let sampleBuffer = output.copyNextSampleBuffer() {
+            if Task.isCancelled { reader.cancelReading(); return }
+            guard let description = CMSampleBufferGetFormatDescription(sampleBuffer),
+                  let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description),
+                  let sampleFormat = AVAudioFormat(streamDescription: streamDescription)
+            else { continue }
+
+            let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
+            guard sampleCount > 0,
+                  let pcm = AVAudioPCMBuffer(pcmFormat: sampleFormat, frameCapacity: AVAudioFrameCount(sampleCount))
+            else { continue }
+            pcm.frameLength = AVAudioFrameCount(sampleCount)
+            guard CMSampleBufferCopyPCMDataIntoAudioBufferList(
+                sampleBuffer, at: 0, frameCount: Int32(sampleCount), into: pcm.mutableAudioBufferList
+            ) == noErr, let channels = pcm.floatChannelData else { continue }
+
+            let presentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            let abs = presentationTime.isValid
+                ? Int64((presentationTime.seconds * sampleRate).rounded())
+                : filledEnd
+            let base = Int(abs - bufferStart)
+            guard base >= 0 else { continue }
+
+            let neededCount = base + sampleCount
+            if left.count < neededCount {
+                left.append(contentsOf: repeatElement(0, count: neededCount - left.count))
+                right.append(contentsOf: repeatElement(0, count: neededCount - right.count))
+            }
+            let sourceChannelCount = Int(sampleFormat.channelCount)
+            let rightChannel = channels[min(1, sourceChannelCount - 1)]
+            for sourceIndex in 0..<sampleCount {
+                left[base + sourceIndex] = quantize(channels[0][sourceIndex])
+                right[base + sourceIndex] = quantize(rightChannel[sourceIndex])
+            }
+            filledEnd = max(filledEnd, abs + Int64(sampleCount))
+            if !(await drainFull()) { reader.cancelReading(); return }
+        }
+
+        guard reader.status == .completed else { return }
+        // Flush the final tail as a zero-padded window so coverage reaches `to`.
+        if filledEnd > bufferStart {
+            if left.count < windowLen {
+                left.append(contentsOf: repeatElement(0, count: windowLen - left.count))
+                right.append(contentsOf: repeatElement(0, count: windowLen - right.count))
+            }
+            let window = PCMWindow(
+                startSample: bufferStart,
+                left: Array(left[0..<windowLen]),
+                right: Array(right[0..<windowLen]),
+                hasAudioTracks: true
+            )
+            _ = await emit(window)
+        }
     }
 }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -41,7 +41,9 @@ final class ScrubAudioEngine {
     nonisolated private static let meterFrameCount = 960
     nonisolated private static let meterPrefetchFrameCount = 12_000
     nonisolated private static let prefetchMarginFrameCount = 24_000
-    nonisolated private static let maxCachedWindows = 32
+    nonisolated private static let maxCachedWindows = 256
+    nonisolated private static let fillBudget = maxCachedWindows - 8
+    nonisolated private static let fillStride = cacheFrameCount - grainFrameCount
     nonisolated private static let mixInvalidationDebounce = Duration.milliseconds(250)
 
     private let meter: AudioMeterHub
@@ -58,6 +60,7 @@ final class ScrubAudioEngine {
     private var decodeTask: Task<Void, Never>?
     private var pendingDecodeRange: Range<Int64>?
     private var mixInvalidationTask: Task<Void, Never>?
+    private var fillTask: Task<Void, Never>?
     private var lifecycleObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     init(meter: AudioMeterHub) {
@@ -73,6 +76,8 @@ final class ScrubAudioEngine {
     func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
         let mixOnlyChange = asset != nil && asset === source?.asset
         stopScrubbing()
+        fillTask?.cancel()
+        fillTask = nil
         sourceGeneration &+= 1
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
         if mixOnlyChange {
@@ -81,6 +86,7 @@ final class ScrubAudioEngine {
             mixInvalidationTask?.cancel()
             mixInvalidationTask = nil
             windows.removeAll()
+            if let source { startFill(from: 0, source: source) }
         }
         if resetMeter { meter.reset() }
     }
@@ -92,7 +98,48 @@ final class ScrubAudioEngine {
             guard !Task.isCancelled, let self else { return }
             self.mixInvalidationTask = nil
             self.windows.removeAll()
+            if let source = self.source { self.startFill(from: self.lastRequestedSample ?? 0, source: source) }
         }
+    }
+
+    /// Decode the whole timeline into the window store in the background, sweeping outward from the
+    /// anchor so the region around the playhead warms first. Reuses the reactive decode path and
+    /// yields to it so an in-flight real-miss decode always wins the reader.
+    private func startFill(from anchorSample: Int64, source: Source) {
+        fillTask?.cancel()
+        fillTask = Task { [weak self] in
+            guard let durationSeconds = try? await source.asset.load(.duration).seconds,
+                  durationSeconds.isFinite, durationSeconds > 0 else { return }
+            let stride = Int64(Self.fillStride)
+            let totalSamples = Int64(durationSeconds * Self.sampleRate)
+            let maxIndex = Int(max(0, (totalSamples - 1) / stride))
+            let anchorIndex = max(0, min(maxIndex, Int(anchorSample / stride)))
+
+            // Visit anchor, then anchor-1, anchor+1, anchor-2, anchor+2, … clamped to [0, maxIndex].
+            for offset in 0...maxIndex {
+                for index in offset == 0 ? [anchorIndex] : [anchorIndex - offset, anchorIndex + offset] {
+                    guard index >= 0, index <= maxIndex else { continue }
+                    guard !Task.isCancelled, let self, source.generation == self.source?.generation else { return }
+
+                    // Stop before the cap so the resident band stays put; reactive decode covers the rest.
+                    guard self.windows.count < Self.fillBudget else { return }
+                    let start = Int64(index) * stride
+                    if self.hasWindow(startingAt: start) { continue }
+                    while self.decodeTask != nil {
+                        try? await Task.sleep(for: .milliseconds(20))
+                        guard !Task.isCancelled, source.generation == self.source?.generation else { return }
+                    }
+
+                    let window = await Self.decodeWindow(source: source, startSample: start, frameCount: Self.cacheFrameCount)
+                    guard !Task.isCancelled, source.generation == self.source?.generation else { return }
+                    if let window { self.insert(window) }
+                }
+            }
+        }
+    }
+
+    private func hasWindow(startingAt startSample: Int64) -> Bool {
+        windows.contains { $0.window.startSample == startSample }
     }
 
     func scrub(to time: CMTime, movingForward: Bool? = nil) {
@@ -161,6 +208,8 @@ final class ScrubAudioEngine {
         resetScrubState()
         mixInvalidationTask?.cancel()
         mixInvalidationTask = nil
+        fillTask?.cancel()
+        fillTask = nil
         source = nil
         windows.removeAll()
         output.invalidate()

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -143,7 +143,7 @@ final class ScrubAudioEngine {
                     self.fillDecode = decode
                     let window = await decode.value
                     self.fillDecode = nil
-                    guard !Task.isCancelled, source.generation == self.source?.generation else { return }
+                    guard !Task.isCancelled, !decode.isCancelled, source.generation == self.source?.generation else { return }
                     if let window { self.insert(window) }
                 }
             }
@@ -521,7 +521,7 @@ final class ScrubAudioEngine {
             runningOffset = max(runningOffset, destinationOffset + sampleCount)
         }
 
-        guard reader.status != .failed else { return nil }
+        guard reader.status == .completed else { return nil }
         return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: true)
     }
 }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -88,7 +88,7 @@ final class ScrubAudioEngine {
             mixInvalidationTask?.cancel()
             mixInvalidationTask = nil
             windows.removeAll()
-            if let source { startFill(from: 0, source: source) }
+            if let source { startFill(from: anchor, source: source) }
         }
         if resetMeter { meter.reset() }
     }
@@ -384,7 +384,7 @@ final class ScrubAudioEngine {
         return ScrubAudioGrain(left: left, right: right)
     }
 
-    nonisolated private static let int16ToFloat: Float = 1.0 / 32768.0
+    nonisolated private static let int16ToFloat: Float = 1.0 / 32767.0  // matches quantize scale so full-scale = 1.0
 
     nonisolated private static func quantize(_ sample: Float) -> Int16 {
         Int16((max(-1, min(1, sample)) * 32767).rounded())
@@ -580,7 +580,8 @@ final class ScrubAudioEngine {
                 ? Int64((presentationTime.seconds * sampleRate).rounded())
                 : filledEnd
             let base = Int(abs - bufferStart)
-            guard base >= 0 else { continue }
+            let sourceStart = max(0, -base)
+            guard sourceStart < sampleCount else { continue }
 
             let neededCount = base + sampleCount
             if left.count < neededCount {
@@ -589,7 +590,7 @@ final class ScrubAudioEngine {
             }
             let sourceChannelCount = Int(sampleFormat.channelCount)
             let rightChannel = channels[min(1, sourceChannelCount - 1)]
-            for sourceIndex in 0..<sampleCount {
+            for sourceIndex in sourceStart..<sampleCount {
                 left[base + sourceIndex] = quantize(channels[0][sourceIndex])
                 right[base + sourceIndex] = quantize(rightChannel[sourceIndex])
             }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -21,10 +21,11 @@ final class ScrubAudioEngine {
 
     private struct PCMWindow: Sendable {
         let startSample: Int64
-        let samples: [Int16]  // mono; ~5.6 MiB/min vs 22 MiB/min for stereo Float32
+        let left: [Int16]
+        let right: [Int16]
         let hasAudioTracks: Bool
 
-        var endSample: Int64 { startSample + Int64(samples.count) }
+        var endSample: Int64 { startSample + Int64(left.count) }
     }
 
     private struct CachedWindow {
@@ -102,9 +103,7 @@ final class ScrubAudioEngine {
         }
     }
 
-    /// Decode the whole timeline into the window store in the background, sweeping outward from the
-    /// anchor so the region around the playhead warms first. Reuses the reactive decode path and
-    /// yields to it so an in-flight real-miss decode always wins the reader.
+    // Decode entire timeline outward from anchor, yielding so reactive misses always take priority
     private func startFill(from anchorSample: Int64, source: Source) {
         fillTask?.cancel()
         fillTask = Task { [weak self] in
@@ -350,7 +349,7 @@ final class ScrubAudioEngine {
         let start = Int(sample - window.startSample)
         let range = start..<(start + Self.meterFrameCount)
         let analysis = window.hasAudioTracks
-            ? AudioLevelAnalyzer.analyzeMono(window.samples, range: range)
+            ? AudioLevelAnalyzer.analyze(left: window.left, right: window.right, range: range)
             : .silence
         meter.ingest(analysis)
     }
@@ -370,16 +369,19 @@ final class ScrubAudioEngine {
             }
             let cacheIndex = Int(sourceSample - window.startSample)
             let gain = Self.edgeGain(at: outputIndex, frameCount: frameCount)
-            if window.samples.indices.contains(cacheIndex) {
-                let value = Float(window.samples[cacheIndex]) * Self.int16ToFloat * gain
-                left[outputIndex] = value
-                right[outputIndex] = value
+            if window.left.indices.contains(cacheIndex) {
+                left[outputIndex] = Float(window.left[cacheIndex]) * Self.int16ToFloat * gain
+                right[outputIndex] = Float(window.right[cacheIndex]) * Self.int16ToFloat * gain
             }
         }
         return ScrubAudioGrain(left: left, right: right)
     }
 
     nonisolated private static let int16ToFloat: Float = 1.0 / 32768.0
+
+    nonisolated private static func quantize(_ sample: Float) -> Int16 {
+        Int16((max(-1, min(1, sample)) * 32767).rounded())
+    }
 
     private func observeLifecycle() {
         let appCenter = NotificationCenter.default
@@ -426,9 +428,10 @@ final class ScrubAudioEngine {
     ) async -> PCMWindow? {
         guard let tracks = try? await source.asset.loadTracks(withMediaType: .audio) else { return nil }
 
-        var samples = [Int16](repeating: 0, count: frameCount)
+        var leftSamples = [Int16](repeating: 0, count: frameCount)
+        var rightSamples = [Int16](repeating: 0, count: frameCount)
         guard !tracks.isEmpty else {
-            return PCMWindow(startSample: startSample, samples: samples, hasAudioTracks: false)
+            return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: false)
         }
 
         guard let reader = try? AVAssetReader(asset: source.asset) else { return nil }
@@ -491,17 +494,14 @@ final class ScrubAudioEngine {
             let rightChannel = channels[min(1, sourceChannelCount - 1)]
             for sourceIndex in 0..<sampleCount {
                 let destinationIndex = destinationOffset + sourceIndex
-                guard samples.indices.contains(destinationIndex) else { continue }
-                let mono = sourceChannelCount > 1
-                    ? (channels[0][sourceIndex] + rightChannel[sourceIndex]) * 0.5
-                    : channels[0][sourceIndex]
-                let clamped = max(-1, min(1, mono))
-                samples[destinationIndex] = Int16((clamped * 32767).rounded())
+                guard leftSamples.indices.contains(destinationIndex) else { continue }
+                leftSamples[destinationIndex] = quantize(channels[0][sourceIndex])
+                rightSamples[destinationIndex] = quantize(rightChannel[sourceIndex])
             }
             runningOffset = max(runningOffset, destinationOffset + sampleCount)
         }
 
         guard reader.status != .failed else { return nil }
-        return PCMWindow(startSample: startSample, samples: samples, hasAudioTracks: true)
+        return PCMWindow(startSample: startSample, left: leftSamples, right: rightSamples, hasAudioTracks: true)
     }
 }

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -430,6 +430,7 @@ final class ScrubAudioEngine {
 
     private func suspendOutput() {
         resetScrubState()
+        cancelFill()
         output.invalidate()
     }
 


### PR DESCRIPTION
## Summary

Improves timeline scrub audio smoothness by caching decoded PCM and filling the cache across the timeline in the background.

Previously scrub audio decoded a single ~2s PCM window on demand. Any playhead move outside that window triggered a fresh `AVAssetReader` decode, whose startup is dominated by synchronous XPC round-trips to build an audio render pipeline. Fast or wide scrubbing repeatedly paid that startup, producing intermittent gaps.

## Approach

1. **LRU window cache.** Replace the single window with a set of decoded windows (stereo Int16, ~11 MiB/min), keyed and served by sample range. Repeated and back-and-forth scrubbing over cached regions plays without re-decoding. Direction-biased decode windows and next-window prefetch smooth continuous drags. A mix-only reconfigure (volume/fade drag) keeps windows serving and wipes after a debounce instead of cold-decoding every tick; a real asset swap wipes immediately.

2. **Stereo Int16 storage.** ~11 MiB/min vs ~22 MiB/min for stereo Float32, converted to float when assembling grains. Both channels retained so scrub audio and the level meter keep left/right separation.

3. **Streaming background fill.** On configure with a fresh asset, decode the timeline into the cache using **two forward streaming passes** (anchor→end, then start→anchor) that each share a single `AVAssetReader` — one reader startup per pass instead of one per window. Fill sweeps outward from the open point so audio around the playhead warms first in both directions. A reactive scrub miss preempts the fill by suspending its emit while a reactive decode is active; no per-window task cancellation.

## Memory

Cap of 256 stereo-Int16 windows ≈ 96 MiB, ~8 min resident. Longer timelines fill a band around the anchor and fall back to reactive decode beyond it. `footprint` confirms the audio cache is a rounding error against the process total, which is video-dominated (CG raster + composition buffers).

## Performance / hangs

Decode runs off the main thread (`@concurrent`, cooperative pool) — confirmed by profile; no reader/decode frames on the main thread. The only main-thread scrub work is per-grain Int16→float assembly (~1-2% of samples during active scrubbing). No App Hang risk.

Fill behavior verified via instrumented run: the cache populates steadily as the stream sweeps the timeline, and once a region is filled scrubbing it is served entirely from cache. Scrubbing ahead of the fill front falls back to reactive decode and self-heals as the fill catches up.

## Testing

Verified by ear/eye on `scripts/dev.sh`: back-and-forth scrubbing, stereo playback, level-meter L/R separation, and fast drag across filled regions. Profiled with `sample` (thread isolation) and `footprint` (memory attribution); confirmed cache population with temporary fill/hit-miss logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time preview audio, concurrent fill vs on-demand decode, and bounded in-memory caching (~96 MiB); regressions would show as gaps, wrong levels, or stale mix after volume edits.
> 
> **Overview**
> **Scrub preview audio** no longer relies on a single on-demand decode window. `ScrubAudioEngine` keeps up to **256 overlapping PCM windows** (stereo **Int16**, ~half the memory of float), serves scrub and meter hits from cache with **LRU eviction**, and **prefetches** the next window when the playhead nears an edge with **direction-biased** reactive decode.
> 
> On a **new asset**, a **background fill** streams the timeline in two passes (playhead→end, then start→playhead) via one `AVAssetReader` per pass, emitting fixed-size windows into the cache while yielding when a reactive decode is active. **Audio-mix-only** reconfigures keep serving cached audio and **debounce** a full cache wipe before refilling.
> 
> Decoded samples are **quantized to Int16** at read time; grains still play as float via on-the-fly conversion. **`AudioLevelAnalyzer.analyzeInt16`** drives the meter from cached Int16 without building a float grain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05e6e1ab88b52e6021acae41eeb5b99bb4fa78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->