### PR TITLE
[fix] Serialize MLX inference behind a process-wide gate

### DIFF
--- a/Sources/PalmierPro/Audio/Analysis/SpeakerIdentity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeakerIdentity.swift
@@ -40,8 +40,8 @@ enum SpeakerIdentity {
     private actor ModelBox {
         private var model: WeSpeakerModel?
         func embed(_ samples: [Float]) async throws -> [Float] {
-            try MLXRuntime.beginOperation()
-            defer { MLXRuntime.endOperation() }
+            try await MLXRuntime.beginInference()
+            defer { MLXRuntime.endInference() }
             if model == nil {
                 model = try await WeSpeakerModel.fromPretrained()
             }

--- a/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
@@ -61,8 +61,8 @@ enum VoiceActivity {
 
         func analyze(samples: [Float]) async throws -> Analysis {
             guard !samples.isEmpty else { return Analysis(chunkCount: 0, segments: []) }
-            try MLXRuntime.beginOperation()
-            defer { MLXRuntime.endOperation() }
+            try await MLXRuntime.beginInference()
+            defer { MLXRuntime.endInference() }
 
             // .mlx pinned: the CoreML engine soft-fails per chunk on ANE errors, caching empty segments as truth.
             let vad: SileroVADModel

--- a/Sources/PalmierPro/Audio/AudioEnhancer.swift
+++ b/Sources/PalmierPro/Audio/AudioEnhancer.swift
@@ -22,6 +22,7 @@ enum AudioEnhancer {
         let outputURL = denoisedURL(for: sourceURL, mediaRef: mediaRef)
         if FileManager.default.fileExists(atPath: outputURL.path) { return outputURL }
         #if BUNDLED_SPEECH
+        let start = ContinuousClock.now
         var dry = try await readChannels(from: sourceURL)
         guard dry.contains(where: { !$0.isEmpty }) else { throw EnhanceError.noAudioTrack }
         var wet: [[Float]] = []
@@ -31,6 +32,8 @@ enum AudioEnhancer {
         }
         removeStaleCaches(for: mediaRef, keeping: outputURL)
         try write(channels: wet, to: outputURL)
+        let elapsed = Double(start.duration(to: .now).components.seconds)
+        Log.preview.notice("denoise ok mediaRef=\(mediaRef) seconds=\(String(format: "%.0f", elapsed))")
         return outputURL
         #else
         throw MLXRuntime.Unavailable()
@@ -53,6 +56,8 @@ enum AudioEnhancer {
         private var enhancer: SpeechEnhancer?
 
         func enhance(audio: [Float], sampleRate: Int) async throws -> [Float] {
+            try await MLXRuntime.beginInference()
+            defer { MLXRuntime.endInference() }
             if enhancer == nil { enhancer = try await SpeechEnhancer.fromPretrained() }
             return try enhancer!.enhanceChunked(audio: audio, sampleRate: sampleRate)
         }

--- a/Sources/PalmierPro/Utilities/MLXRuntime.swift
+++ b/Sources/PalmierPro/Utilities/MLXRuntime.swift
@@ -21,6 +21,20 @@ enum MLXRuntime {
         guard gate.begin() else { throw CancellationError() }
     }
     static func endOperation() { gate.end() }
+
+    private static let inferenceGate = AsyncSemaphore(value: 1)
+
+    static func beginInference() async throws {
+        try beginOperation()
+        do { try await inferenceGate.wait() } catch {
+            endOperation()
+            throw error
+        }
+    }
+    static func endInference() {
+        Task { await inferenceGate.signal() }
+        endOperation()
+    }
     static var shouldStop: Bool { gate.shouldStop }
     static func beginTermination() -> Bool { gate.stop() }
     static func waitUntilIdle() async { await gate.waitUntilIdle() }


### PR DESCRIPTION
## Problem

Crash reports show `EXC_BAD_ACCESS` (null deref) inside `mlx::core::detail::CompilerCache::find` → `std::unordered_map::operator[]` during audio analysis.

MLX's frontend compiler cache is a single process-global `static CompilerCache` with no locking (`compile.cpp`). Each of our model boxes (Silero VAD, WeSpeaker, DeepFilterNet) serializes its own model behind an actor, but the three actors can run inference concurrently with each other — two threads compiling MLX graphs at once corrupt the cache's bucket list.

Upstream mlx fixed this with thread-local caches (ml-explore/mlx@70a0da6f, 2026-03-19), but every mlx-swift release through 0.31.6 — and `main` — pins mlx at a commit from before that fix, so upgrading the package doesn't help.

## Fix

- `MLXRuntime.beginInference()/endInference()`: an `AsyncSemaphore(value: 1)` layered on the existing termination gate, so at most one MLX inference runs process-wide.
- Adopted in the VAD, speaker-embedding, and speech-enhancement model boxes. `AudioEnhancer` previously had **no** gate at all (it also wasn't participating in the termination drain).
- Log successful denoise bakes (`denoise ok mediaRef=… seconds=…`) — previously only failures were logged, so a clean bake was invisible in log streams.

## Notes

- The wait is an async suspension off the main thread; it cannot beachball. `AsyncSemaphore` is cancellation-aware, and `beginInference` releases the termination gate if the wait throws.
- No deadlock: nothing calls `beginInference` while holding it (`SpeakerIdentity` calls `VoiceActivity.analysis` outside its ModelBox).
- Perf impact is minimal: these are GPU-bound inferences on the same device, and per-file decode still overlaps inference via `VoiceActivity`'s pipeline gate. Trade-off: a long denoise bake briefly delays background VAD/speaker analysis (and vice versa).
- If mlx-swift ever ships the upstream thread-local fix, this gate can relax.

## Verified

`swift build --traits BundledSpeech` passes. Live-run via `scripts/dev.sh`: import batch + VAD + transcription + denoise bake + export in one session — all completed, queued inference drained (`vad ok` after the bake), export unimpeded, clean quit.