### PR TITLE
[fix/telemetry] Reduce expected VAD failure telemetry

### DIFF
--- a/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
@@ -27,8 +27,16 @@ final class SpeechMaskStore {
                 let analysis = try await VoiceActivity.analysis(for: url, mediaRef: key)
                 mask = analysis.mask
                 Log.preview.notice("vad ok mediaRef=\(key) segments=\(analysis.segments.count) chunks=\(analysis.chunkCount)")
+            } catch is CancellationError {
             } catch {
-                Log.preview.error("vad failed mediaRef=\(key): \(Log.detail(error))")
+                if VoiceActivity.isDamagedMedia(error) {
+                    Log.preview.error(
+                        "vad failed mediaRef=\(key): \(Log.detail(error))",
+                        telemetry: "VAD media decode failed"
+                    )
+                } else {
+                    Log.preview.info("vad unavailable mediaRef=\(key): \(Log.detail(error))")
+                }
             }
             guard let self else { return }
             await MainActor.run { [self] in

--- a/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
@@ -39,13 +39,14 @@ enum VoiceActivity {
         #if BUNDLED_SPEECH
         try await pipelineGate.wait()
         defer { Task { await pipelineGate.signal() } }
-        let samples = try await AudioTrackReader.readMonoFloats(from: sourceURL, sampleRate: Double(sampleRate))
-        let analysis = try await modelBox.analyze(samples: samples)
-        let outputURL = analysisURL(for: sourceURL, mediaRef: mediaRef)
-        removeStaleCaches(for: mediaRef, keeping: outputURL)
-        if let data = try? JSONEncoder().encode(analysis) {
-            try? data.write(to: outputURL)
+        let samples: [Float]
+        do {
+            samples = try await AudioTrackReader.readMonoFloats(from: sourceURL, sampleRate: Double(sampleRate))
+        } catch AudioTrackReader.ReadError.noAudioTrack(_) {
+            return cacheNoAudioAnalysis(for: sourceURL, mediaRef: mediaRef)
         }
+        let analysis = try await modelBox.analyze(samples: samples)
+        cache(analysis, for: sourceURL, mediaRef: mediaRef)
         return analysis
         #else
         throw MLXRuntime.Unavailable()
@@ -58,6 +59,7 @@ enum VoiceActivity {
     /// Silero is not thread-safe; the actor serializes model use.
     private actor ModelBox {
         private var model: SileroVADModel?
+        private var modelLoadFailure: (any Error)?
 
         func analyze(samples: [Float]) async throws -> Analysis {
             guard !samples.isEmpty else { return Analysis(chunkCount: 0, segments: []) }
@@ -69,7 +71,15 @@ enum VoiceActivity {
             if let model {
                 vad = model
             } else {
-                vad = try await SileroVADModel.fromPretrained(engine: .mlx)
+                if let modelLoadFailure { throw modelLoadFailure }
+                do {
+                    vad = try await SileroVADModel.fromPretrained(engine: .mlx)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    modelLoadFailure = error
+                    throw error
+                }
                 model = vad
             }
             let chunkCount = (samples.count + SileroVADModel.chunkSize - 1) / SileroVADModel.chunkSize
@@ -111,6 +121,25 @@ enum VoiceActivity {
     static func cachedAnalysis(for sourceURL: URL, mediaRef: String) -> Analysis? {
         guard let data = try? Data(contentsOf: analysisURL(for: sourceURL, mediaRef: mediaRef)) else { return nil }
         return try? JSONDecoder().decode(Analysis.self, from: data)
+    }
+
+    static func isDamagedMedia(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == AVFoundationErrorDomain && nsError.code == -11829
+    }
+
+    private static func cache(_ analysis: Analysis, for sourceURL: URL, mediaRef: String) {
+        let outputURL = analysisURL(for: sourceURL, mediaRef: mediaRef)
+        removeStaleCaches(for: mediaRef, keeping: outputURL)
+        if let data = try? JSONEncoder().encode(analysis) {
+            try? data.write(to: outputURL)
+        }
+    }
+
+    static func cacheNoAudioAnalysis(for sourceURL: URL, mediaRef: String) -> Analysis {
+        let analysis = Analysis(chunkCount: 0, segments: [])
+        cache(analysis, for: sourceURL, mediaRef: mediaRef)
+        return analysis
     }
 
     private static func analysisURL(for sourceURL: URL, mediaRef: String) -> URL {

--- a/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
+++ b/Sources/PalmierPro/Audio/Analysis/VoiceActivity.swift
@@ -124,7 +124,14 @@ enum VoiceActivity {
     }
 
     static func isDamagedMedia(_ error: Error) -> Bool {
-        let nsError = error as NSError
+        let nsError: NSError
+        if let readError = error as? AudioTrackReader.ReadError,
+           case .readFailed(_, let underlying) = readError,
+           let underlying {
+            nsError = underlying
+        } else {
+            nsError = error as NSError
+        }
         return nsError.domain == AVFoundationErrorDomain && nsError.code == -11829
     }
 

--- a/Sources/PalmierPro/Audio/AudioEnvelope.swift
+++ b/Sources/PalmierPro/Audio/AudioEnvelope.swift
@@ -62,7 +62,7 @@ enum AudioEnvelopeExtractor {
         } catch let error as AudioTrackReader.ReadError {
             switch error {
             case .noAudioTrack(let name): throw AudioEnvelopeError.noAudioTrack(name)
-            case .readFailed(let reason): throw AudioEnvelopeError.readFailed(reason)
+            case .readFailed(let reason, _): throw AudioEnvelopeError.readFailed(reason)
             }
         }
 

--- a/Sources/PalmierPro/Audio/AudioTrackReader.swift
+++ b/Sources/PalmierPro/Audio/AudioTrackReader.swift
@@ -5,12 +5,12 @@ import Foundation
 enum AudioTrackReader {
     enum ReadError: Error {
         case noAudioTrack(String)
-        case readFailed(String)
+        case readFailed(String, underlying: NSError? = nil)
 
         var message: String {
             switch self {
             case .noAudioTrack(let name): "No audio track in \(name)"
-            case .readFailed(let reason): reason
+            case .readFailed(let reason, _): reason
             }
         }
     }
@@ -48,7 +48,7 @@ enum AudioTrackReader {
 
         let reader: AVAssetReader
         do { reader = try AVAssetReader(asset: asset) } catch {
-            throw ReadError.readFailed(error.localizedDescription)
+            throw ReadError.readFailed(error.localizedDescription, underlying: error as NSError)
         }
 
         let output = AVAssetReaderTrackOutput(track: track, outputSettings: outputSettings)
@@ -64,7 +64,11 @@ enum AudioTrackReader {
         }
 
         guard reader.startReading() else {
-            throw ReadError.readFailed(reader.error?.localizedDescription ?? "Reader could not start")
+            let error = reader.error
+            throw ReadError.readFailed(
+                error?.localizedDescription ?? "Reader could not start",
+                underlying: error as NSError?
+            )
         }
 
         while let sample = output.copyNextSampleBuffer() {
@@ -81,7 +85,8 @@ enum AudioTrackReader {
         }
 
         if reader.status == .failed {
-            throw ReadError.readFailed(reader.error?.localizedDescription ?? "Read failed")
+            let error = reader.error
+            throw ReadError.readFailed(error?.localizedDescription ?? "Read failed", underlying: error as NSError?)
         }
     }
 }

--- a/Tests/PalmierProTests/Audio/VoiceActivityTests.swift
+++ b/Tests/PalmierProTests/Audio/VoiceActivityTests.swift
@@ -1,0 +1,40 @@
+import AVFoundation
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("VoiceActivity")
+struct VoiceActivityTests {
+    @Test func reportsOnlyDamagedMedia() {
+        #expect(VoiceActivity.isDamagedMedia(NSError(domain: AVFoundationErrorDomain, code: -11829)))
+        #expect(!VoiceActivity.isDamagedMedia(NSError(domain: AVFoundationErrorDomain, code: -11800)))
+        #expect(!VoiceActivity.isDamagedMedia(CancellationError()))
+    }
+
+    @Test func cachesNoAudioAsEmptyAnalysis() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vad-no-audio-\(UUID().uuidString).mov")
+        try Data().write(to: url)
+        let mediaRef = "vad-no-audio-\(UUID().uuidString)"
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            removeCacheEntries(for: mediaRef)
+        }
+
+        let analysis = VoiceActivity.cacheNoAudioAnalysis(for: url, mediaRef: mediaRef)
+
+        #expect(analysis.chunkCount == 0)
+        #expect(analysis.segments.isEmpty)
+        #expect(VoiceActivity.cachedAnalysis(for: url, mediaRef: mediaRef)?.chunkCount == 0)
+    }
+
+    private func removeCacheEntries(for mediaRef: String) {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: VoiceActivity.cache.directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for entry in entries where entry.lastPathComponent.hasPrefix("\(mediaRef)_") {
+            try? FileManager.default.removeItem(at: entry)
+        }
+    }
+}

--- a/Tests/PalmierProTests/Audio/VoiceActivityTests.swift
+++ b/Tests/PalmierProTests/Audio/VoiceActivityTests.swift
@@ -6,7 +6,14 @@ import Testing
 @Suite("VoiceActivity")
 struct VoiceActivityTests {
     @Test func reportsOnlyDamagedMedia() {
-        #expect(VoiceActivity.isDamagedMedia(NSError(domain: AVFoundationErrorDomain, code: -11829)))
+        let damagedMedia = NSError(domain: AVFoundationErrorDomain, code: -11829)
+        let wrappedDamage = AudioTrackReader.ReadError.readFailed(
+            damagedMedia.localizedDescription,
+            underlying: damagedMedia
+        )
+
+        #expect(VoiceActivity.isDamagedMedia(damagedMedia))
+        #expect(VoiceActivity.isDamagedMedia(wrappedDamage))
         #expect(!VoiceActivity.isDamagedMedia(NSError(domain: AVFoundationErrorDomain, code: -11800)))
         #expect(!VoiceActivity.isDamagedMedia(CancellationError()))
     }


### PR DESCRIPTION
## Summary

- Cache media without an audio track as an empty VAD analysis so it is not retried on every launch.
- Latch model download failures for the current app session instead of repeating the full retry sequence for each asset.
- Keep cancellations and expected VAD failures local while continuing to report damaged media (`AVFoundation -11829`) to Sentry.

## Root cause

`SpeechMaskStore` reported every VAD failure as a Sentry error, while its failed state lasted only for the current session. Media without audio therefore failed again after every launch, and offline model downloads repeated their retry sequence across assets.

## Impact

Expected VAD conditions no longer flood Sentry or repeat unnecessary work. Genuinely damaged media remains actionable telemetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to audio/VAD logging, caching, and error classification with no security or data-model impact; misclassification could hide or over-report telemetry but scope is narrow.
> 
> **Overview**
> **VAD failures are logged and reported to Sentry only when they represent genuinely damaged media**, while cancellations stay silent and other expected failures downgrade to info logs.
> 
> `SpeechMaskStore` now uses `VoiceActivity.isDamagedMedia` (AVFoundation **-11829**, including when wrapped in `AudioTrackReader.ReadError`) for Sentry telemetry; everything else logs as “vad unavailable” without error telemetry.
> 
> **Voice activity analysis avoids redundant work:** assets with **no audio track** persist an empty cached analysis instead of failing every session, and **Silero model load failures** are latched for the app session so later assets do not repeat the full download/retry path. `AudioTrackReader.readFailed` now preserves an optional **underlying `NSError`** so damage can be classified; `AudioEnvelope` only updates its `switch` for the new associated value.
> 
> Tests cover damaged-media detection and no-audio caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ddb105286ecc2bc9b17f79e115d84f6d9a1e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->