### PR TITLE
[telemetry] Capture MCP client info

### DIFF
--- a/Sources/PalmierPro/Agent/MCP/MCPClientInfo.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPClientInfo.swift
@@ -1,0 +1,44 @@
+import MCP
+
+struct MCPClientInfo: Equatable, Sendable {
+    let name: String
+    let title: String?
+    let version: String
+    let description: String?
+    let websiteUrl: String?
+
+    init(
+        name: String,
+        title: String? = nil,
+        version: String,
+        description: String? = nil,
+        websiteUrl: String? = nil
+    ) {
+        self.name = name
+        self.title = title
+        self.version = version
+        self.description = description
+        self.websiteUrl = websiteUrl
+    }
+
+    init(_ clientInfo: Client.Info) {
+        self.init(
+            name: clientInfo.name,
+            title: clientInfo.title,
+            version: clientInfo.version,
+            description: clientInfo.description,
+            websiteUrl: clientInfo.websiteUrl
+        )
+    }
+
+    var payload: Analytics.Payload {
+        var payload: Analytics.Payload = [
+            "name": name,
+            "version": version,
+        ]
+        if let title { payload["title"] = title }
+        if let description { payload["description"] = description }
+        if let websiteUrl { payload["websiteUrl"] = websiteUrl }
+        return payload
+    }
+}

--- a/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
@@ -2,11 +2,16 @@ import Foundation
 import MCP
 import Network
 
+struct MCPServerInstance: Sendable {
+    let server: Server
+    let onInitialize: @Sendable (Client.Info) async -> Void
+}
+
 /// HTTP server for MCP. Each client session gets its own `Server` + stateful transport
 actor MCPHTTPServer {
 
     private let port: UInt16
-    private let makeServer: @Sendable () async -> Server
+    private let makeServer: @Sendable () async -> MCPServerInstance
     private nonisolated(unsafe) var listener: NWListener?
 
     private struct Session {
@@ -22,7 +27,7 @@ actor MCPHTTPServer {
 
     init(
         port: UInt16,
-        makeServer: @escaping @Sendable () async -> Server
+        makeServer: @escaping @Sendable () async -> MCPServerInstance
     ) {
         self.port = port
         self.makeServer = makeServer
@@ -145,12 +150,14 @@ actor MCPHTTPServer {
             let transport = StatefulHTTPServerTransport(
                 validationPipeline: StandardValidationPipeline(validators: baseValidators() + [SessionValidator()])
             )
-            let server = await makeServer()
-            try? await server.start(transport: transport)
+            let instance = await makeServer()
+            try? await instance.server.start(transport: transport) { clientInfo, _ in
+                await instance.onInitialize(clientInfo)
+            }
             response = await transport.handleRequest(request)
             if let assigned = response.headers[HTTPHeaderName.sessionID] {
                 pruneIdleSessions()
-                sessions[assigned] = Session(server: server, transport: transport, lastUsed: .now)
+                sessions[assigned] = Session(server: instance.server, transport: transport, lastUsed: .now)
                 Log.mcp.notice("session started id=\(assigned) total=\(self.sessions.count)")
             } else {
                 await transport.disconnect()
@@ -175,8 +182,11 @@ actor MCPHTTPServer {
     private func fallbackPair() async -> (server: Server, transport: StatelessHTTPServerTransport) {
         if let fallback { return fallback }
         let pipeline = StandardValidationPipeline(validators: baseValidators())
-        let pair = (server: await makeServer(), transport: StatelessHTTPServerTransport(validationPipeline: pipeline))
-        try? await pair.server.start(transport: pair.transport)
+        let instance = await makeServer()
+        let pair = (server: instance.server, transport: StatelessHTTPServerTransport(validationPipeline: pipeline))
+        try? await pair.server.start(transport: pair.transport) { clientInfo, _ in
+            await instance.onInitialize(clientInfo)
+        }
         fallback = pair
         return pair
     }

--- a/Sources/PalmierPro/Agent/MCP/MCPService.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPService.swift
@@ -46,7 +46,9 @@ final class MCPService {
             )
             await Self.registerTools(on: server, executor: toolExecutor)
             await Self.registerResources(on: server)
-            return server
+            return MCPServerInstance(server: server) { clientInfo in
+                await toolExecutor.setMCPClientInfo(MCPClientInfo(clientInfo))
+            }
         }
         self.httpServer = httpServer
         Task { @MainActor [weak self] in

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -13,6 +13,7 @@ final class ToolExecutor {
     private let frontmostProjectProvider: (() -> VideoProject?)?
     // External MCP stays on this project until manage_project rebinds it.
     private weak var boundProject: VideoProject?
+    private var mcpClientInfo: MCPClientInfo?
     private(set) var mcpSessionActivation = Analytics.SessionActivation()
     let exportQueue: ExportQueue
 
@@ -46,6 +47,10 @@ final class ToolExecutor {
     func bindProject(_ project: VideoProject?) {
         guard frontmostProjectProvider != nil else { return }
         boundProject = project
+    }
+
+    func setMCPClientInfo(_ clientInfo: MCPClientInfo) {
+        mcpClientInfo = clientInfo
     }
 
     var feedbackState = FeedbackState()
@@ -148,10 +153,18 @@ final class ToolExecutor {
 
     private func activateMCPSessionIfNeeded(source: String, toolName: String) {
         guard source == "mcp", mcpSessionActivation.activate() else { return }
-        Analytics.capture(.mcpSessionActivated, properties: [
+        Analytics.capture(.mcpSessionActivated, properties: mcpSessionActivationProperties(toolName: toolName))
+    }
+
+    func mcpSessionActivationProperties(toolName: String) -> Analytics.Payload {
+        var properties: Analytics.Payload = [
             "source": "mcp",
             "tool_name": toolName,
-        ])
+        ]
+        if let mcpClientInfo {
+            properties["client_info"] = mcpClientInfo.payload
+        }
+        return properties
     }
 
     private func projectFocusError() -> String? {

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -200,6 +200,7 @@ enum Analytics {
     private static var allowedCapturePropertyKeys: Set<String> {
         Set([
             "active_day",
+            "client_info",
             "export_duration_seconds",
             "failure_reason",
             "format",

--- a/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
+++ b/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
@@ -21,4 +21,39 @@ struct AnalyticsSessionActivationTests {
 
         #expect(!repeatedActivation)
     }
+
+    @Test func mcpClientInfoPreservesReportedJSONFields() {
+        let info = MCPClientInfo(
+            name: "claude-code",
+            title: "Claude Code",
+            version: "2.1.212",
+            description: "Anthropic's agentic coding tool",
+            websiteUrl: "https://claude.com/claude-code"
+        )
+
+        #expect(info.payload["name"] as? String == "claude-code")
+        #expect(info.payload["title"] as? String == "Claude Code")
+        #expect(info.payload["version"] as? String == "2.1.212")
+        #expect(info.payload["description"] as? String == "Anthropic's agentic coding tool")
+        #expect(info.payload["websiteUrl"] as? String == "https://claude.com/claude-code")
+    }
+
+    @Test func mcpClientInfoOmitsUnreportedOptionalFields() {
+        let info = MCPClientInfo(name: "codex-mcp-client", version: "0.144.5")
+
+        #expect(Set(info.payload.keys) == ["name", "version"])
+    }
+
+    @Test @MainActor func mcpSessionActivationIncludesClientInfo() throws {
+        let executor = ToolExecutor(projectProvider: { nil })
+        executor.setMCPClientInfo(MCPClientInfo(name: "Cursor", version: "1.0.0"))
+
+        let properties = executor.mcpSessionActivationProperties(toolName: "get_timeline")
+        let clientInfo = try #require(properties["client_info"] as? Analytics.Payload)
+
+        #expect(properties["source"] as? String == "mcp")
+        #expect(properties["tool_name"] as? String == "get_timeline")
+        #expect(clientInfo["name"] as? String == "Cursor")
+        #expect(clientInfo["version"] as? String == "1.0.0")
+    }
 }


### PR DESCRIPTION
## Summary

Include the connecting MCP client's reported implementation metadata in the `mcp session activated` telemetry event. This distinguishes sessions from clients such as Claude Code, Codex, and Cursor without inferring client identity from tool behavior.

## Approach

- Capture `Client.Info` through the MCP SDK initialization hook for both stateful and fallback HTTP transports.
- Store the client metadata on the session-owned `ToolExecutor` so each MCP session keeps its own client identity.
- Emit the known MCP implementation fields as a nested `client_info` property on the first session activation event.
- Preserve optional `title`, `description`, and `websiteUrl` fields while omitting unreported fields and icons.
- Allow `client_info` through the telemetry property filter.

## Testing

- `swift test --filter AnalyticsSessionActivationTests` — 5 tests passed.
- `swift test --filter ManageProjectToolTests` — 5 tests passed.
- `swift build` — passed.
- `git diff --check` — passed.
- End-to-end MCP and telemetry verification:
  - Called `get_timeline` through Codex 0.144.5 and Claude Code 2.1.214 against a release build.
  - Queried the resulting PostHog `mcp session activated` events.
  - Verified Codex reported `codex-mcp-client` with title and version.
  - Verified Claude Code reported `claude-code` with title, version, description, and website URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only plumbing with no auth or project-edit behavior changes; main risk is missing client_info if initialize runs after the first tool call.
> 
> **Overview**
> MCP HTTP sessions now record each client's reported **implementation metadata** (name, version, and optional title/description/website) and attach it to the first **`mcp session activated`** analytics event as nested **`client_info`**.
> 
> The MCP SDK **initialize** hook is wired for both stateful sessions and the stateless fallback transport; metadata is stored on the per-session **`ToolExecutor`** via a new **`MCPClientInfo`** type. Analytics filtering is updated to allow **`client_info`** through to PostHog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1296deb3b5a037b9ab29c85e33add6f87bceb973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->