### PR TITLE
[ui] Select preview clips with one click

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
@@ -4,6 +4,12 @@ extension EditorViewModel {
         case allTracks
     }
 
+    func selectPreviewClip(_ clipId: String) {
+        selectedGap = nil
+        guard !selectedClipIds.contains(clipId) else { return }
+        selectedClipIds = expandToLinkGroup([clipId])
+    }
+
     func selectForwardFromCurrentSelection(scope: SelectForwardScope) {
         guard let anchorId = forwardSelectionAnchorId() else { return }
         selectForward(from: anchorId, scope: scope)

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -48,14 +48,17 @@ struct PreviewContainerView: View {
                 }
                 .frame(width: scaledWidth, height: scaledHeight)
                 .simultaneousGesture(
-                    SpatialTapGesture(count: 2)
+                    SpatialTapGesture()
                         .onEnded { value in
                             guard isTimeline,
+                                  !editor.cropEditingActive,
+                                  editor.chromaKeySamplingClipId == nil,
                                   let id = PreviewHitTester.clipID(
                                     at: value.location,
                                     viewSize: CGSize(width: scaledWidth, height: scaledHeight),
                                     editor: editor
                                   ) else { return }
+                            guard !editor.selectedClipIds.contains(id) else { return }
                             editor.selectedClipIds = editor.expandToLinkGroup([id])
                         }
                 )

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -58,8 +58,7 @@ struct PreviewContainerView: View {
                                     viewSize: CGSize(width: scaledWidth, height: scaledHeight),
                                     editor: editor
                                   ) else { return }
-                            guard !editor.selectedClipIds.contains(id) else { return }
-                            editor.selectedClipIds = editor.expandToLinkGroup([id])
+                            editor.selectPreviewClip(id)
                         }
                 )
                 .overlay(

--- a/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorViewModel — preview selection")
+@MainActor
+struct PreviewSelectionTests {
+    @Test func selectingClipClearsGapSelection() {
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "clip", start: 0, duration: 20)]),
+        ])
+        editor.selectedGap = GapSelection(trackIndex: 0, range: FrameRange(start: 50, end: 100))
+
+        editor.selectPreviewClip("clip")
+
+        #expect(editor.selectedClipIds == ["clip"])
+        #expect(editor.selectedGap == nil)
+    }
+
+    @Test func selectingSelectedClipPreservesMultiSelection() {
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "first", start: 0, duration: 20),
+                Fixtures.clip(id: "second", start: 100, duration: 20),
+            ]),
+        ])
+        editor.selectedClipIds = ["first", "second"]
+
+        editor.selectPreviewClip("first")
+
+        #expect(editor.selectedClipIds == ["first", "second"])
+    }
+}


### PR DESCRIPTION
## Summary

Change timeline-preview clip selection from double-click to single-click so direct canvas selection is faster and easier to discover.

Selection remains inactive while crop editing or chroma-key sampling owns the canvas. Clicking a clip that is already selected preserves the current multi-selection, matching timeline behavior.

Preview selection also clears stale timeline-gap selection so ripple-delete commands target the newly selected clips.

## Approach

- Use the existing `PreviewHitTester` and linked-clip expansion with a single spatial tap.
- Keep empty-canvas clicks as a no-op.
- Refuse preview selection during crop editing and chroma-key sampling.
- Avoid replacing the selection when the hit clip is already selected.
- Clear timeline-gap selection through the view-model selection operation.

## Testing

Automated:

- `swift build` — passed.
- `swift test` — passed, 1,075 tests in 166 suites.

Manual UI verification pending:

1. Single-click an unselected visible clip and confirm it and its linked clips become selected.
2. Select two clips in the timeline, click either selected clip in the preview, and confirm the multi-selection remains intact.
3. Confirm crop and chroma-key sampling clicks do not change clip selection.
4. Drag and resize a selected clip and confirm the gesture does not select another clip.
5. Click empty canvas space and confirm selection remains unchanged.
