### PR TITLE
[feat] Drop Finder files directly onto the timeline

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -350,6 +350,36 @@ extension EditorViewModel {
         return DropPlan(placements: placements, visualTarget: visualTarget, audioTarget: audioTarget)
     }
 
+    /// Shared placement for media dropped on the timeline (panel assets and Finder files).
+    func placeDroppedAssets(
+        _ assets: [MediaAsset],
+        cursor: TrackDropTarget,
+        atFrame: Int,
+        segments: [String: ClosedRange<Double>] = [:],
+        ripple: Bool
+    ) {
+        undo.perform("Add Clips") {
+            let plan = resolveDropPlan(cursor: cursor, assets: assets, atFrame: atFrame, segments: segments)
+            let (visualIdx, audioIdx) = materialize(plan: plan)
+
+            @MainActor func insert(_ assets: [MediaAsset], trackIndex: Int, linkedAudio: Int?) {
+                if ripple {
+                    rippleInsertClips(assets: assets, trackIndex: trackIndex, atFrame: atFrame, segments: segments)
+                } else {
+                    addClips(assets: assets, trackIndex: trackIndex, startFrame: atFrame, linkedAudioTrackIndex: linkedAudio, segments: segments)
+                }
+            }
+            let visualAssets = plan.visualAssets
+            if !visualAssets.isEmpty, let vIdx = visualIdx {
+                insert(visualAssets, trackIndex: vIdx, linkedAudio: audioIdx)
+            }
+            let audioOnlyAssets = plan.audioOnlyAssets
+            if !audioOnlyAssets.isEmpty, let aIdx = audioIdx {
+                insert(audioOnlyAssets, trackIndex: aIdx, linkedAudio: nil)
+            }
+        }
+    }
+
     func materialize(plan: DropPlan) -> (visual: Int?, audio: Int?) {
         let visualIdx = plan.visualTarget.map { materializeTrackIndex(target: $0, type: .video) }
         let audioIdx = audioTargetAfterVisualInsertion(plan: plan).map { materializeTrackIndex(target: $0, type: .audio) }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -262,6 +262,7 @@ extension EditorViewModel {
     struct MediaImportSummary: Sendable {
         var assetCount: Int
         var folderCount: Int
+        var assets: [MediaAsset] = []
     }
 
     /// Import files and folders from the open panel or a Finder drop as one undo step
@@ -269,6 +270,7 @@ extension EditorViewModel {
     func importFinderItems(
         _ urls: [URL],
         into folderId: String?,
+        finalize: Bool = true,
         applying mutation: (@MainActor (@MainActor () -> MediaImportSummary) async throws -> MediaImportSummary)? = nil
     ) async throws -> MediaImportSummary {
         let previous = mediaImportTail
@@ -276,7 +278,7 @@ extension EditorViewModel {
         let sequence = mediaImportSequence
         let task = Task { @MainActor in
             _ = try? await previous?.value
-            return try await performFinderImport(urls, into: folderId, applying: mutation)
+            return try await performFinderImport(urls, into: folderId, finalize: finalize, applying: mutation)
         }
         mediaImportTail = task
 
@@ -290,6 +292,7 @@ extension EditorViewModel {
     private func performFinderImport(
         _ urls: [URL],
         into folderId: String?,
+        finalize: Bool,
         applying mutation: (@MainActor (@MainActor () -> MediaImportSummary) async throws -> MediaImportSummary)?
     ) async throws -> MediaImportSummary {
         let before = mediaLibraryUndoSnapshot()
@@ -299,13 +302,17 @@ extension EditorViewModel {
             MediaImportScanner.scan(roots: roots)
         }.value
         if let mutation {
-            return try await mutation { self.applyMediaImportPlan(plan, restoringFrom: before) }
+            return try await mutation { self.applyMediaImportPlan(plan, restoringFrom: before, finalize: finalize) }
         }
-        return applyMediaImportPlan(plan, restoringFrom: before)
+        return applyMediaImportPlan(plan, restoringFrom: before, finalize: finalize)
     }
 
     @discardableResult
-    private func applyMediaImportPlan(_ plan: MediaImportPlan, restoringFrom before: MediaLibraryUndoSnapshot) -> MediaImportSummary {
+    private func applyMediaImportPlan(
+        _ plan: MediaImportPlan,
+        restoringFrom before: MediaLibraryUndoSnapshot,
+        finalize: Bool = true
+    ) -> MediaImportSummary {
         let importedAssets = undo.withoutRegistration {
             var folderIds = Array(repeating: "", count: plan.folders.count)
             for (index, folder) in plan.folders.enumerated() {
@@ -344,14 +351,17 @@ extension EditorViewModel {
 
         let summary = MediaImportSummary(
             assetCount: mediaAssets.count - before.mediaAssets.count,
-            folderCount: mediaManifest.folders.count - before.mediaManifest.folders.count
+            folderCount: mediaManifest.folders.count - before.mediaManifest.folders.count,
+            assets: importedAssets
         )
         guard summary.assetCount != 0 || summary.folderCount != 0 else { return summary }
         undo.register("Import Media", withTarget: self) { vm in
             vm.restoreMediaLibraryUndoSnapshot(before, actionName: "Import Media")
         }
-        for asset in importedAssets {
-            Task { await finalizeImportedAsset(asset, batchManifestUpdate: true) }
+        if finalize {
+            for asset in importedAssets {
+                Task { await finalizeImportedAsset(asset, batchManifestUpdate: true) }
+            }
         }
         return summary
     }
@@ -362,6 +372,62 @@ extension EditorViewModel {
             id
         case .plannedFolder(let index):
             plannedFolderIds[index]
+        }
+    }
+
+    func dropPlaceholderAssets(for urls: [URL]) -> [MediaAsset] {
+        urls.compactMap { url in
+            // hasDirectoryPath avoids disk access on the drag-hover path.
+            guard !url.hasDirectoryPath,
+                  let type = ClipType(fileExtension: url.pathExtension.lowercased()) else { return nil }
+            let asset = MediaAsset(
+                url: url, type: type,
+                name: url.deletingPathExtension().lastPathComponent,
+                duration: Defaults.imageDurationSeconds
+            )
+            asset.hasAudio = type == .video
+            return asset
+        }
+    }
+
+    func importFinderItemsToTimeline(
+        _ urls: [URL],
+        cursor: TrackDropTarget,
+        atFrame: Int,
+        ripple: Bool
+    ) async {
+        var before: MediaLibraryUndoSnapshot?
+        let summary = try? await importFinderItems(urls, into: mediaPanelCurrentFolderId, finalize: false) { apply in
+            before = self.mediaLibraryUndoSnapshot()
+            return self.undo.withoutRegistration { apply() }
+        }
+        guard let summary, let before,
+              summary.assetCount != 0 || summary.folderCount != 0 else { return }
+
+        var placeable: [MediaAsset] = []
+        for asset in summary.assets {
+            if await finalizeImportedAsset(asset, batchManifestUpdate: true) {
+                placeable.append(asset)
+            }
+        }
+        // Revalidate after the awaits: bail if the project changed while metadata loaded.
+        guard summary.assets.allSatisfy({ mediaAssetsById[$0.id] === $0 }) else { return }
+
+        let operation: @MainActor () -> Void = { [weak self] in
+            guard let self else { return }
+            undo.perform("Add Media") {
+                undo.register("Add Media", withTarget: self) { vm in
+                    vm.restoreMediaLibraryUndoSnapshot(before, actionName: "Add Media")
+                }
+                if !placeable.isEmpty {
+                    placeDroppedAssets(placeable, cursor: cursor, atFrame: atFrame, ripple: ripple)
+                }
+            }
+        }
+        if placeable.isEmpty {
+            operation()
+        } else {
+            addClipsWithSettingsCheck(assets: placeable, operation: operation)
         }
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1307,8 +1307,12 @@ final class TimelineView: NSView {
         let point = convert(sender.draggingLocation, from: nil)
         let geo = geometry
         if externalDragAssets == nil, let urlString = sender.draggingPasteboard.string(forType: .string) {
-            externalDragAssets = editor.assetsFromDragPayload(urlString)
-            externalDragSegments = editor.segmentsFromDragPayload(urlString)
+            let assets = editor.assetsFromDragPayload(urlString)
+            // Non-sentinel strings (e.g. alongside file URLs) fall through to the Finder path.
+            if !assets.isEmpty || !editor.timelineIdsFromDragPayload(urlString).isEmpty {
+                externalDragAssets = assets
+                externalDragSegments = editor.segmentsFromDragPayload(urlString)
+            }
         }
         if externalDragAssets == nil {
             let urls = Self.finderFileURLs(sender.draggingPasteboard)
@@ -1386,39 +1390,39 @@ final class TimelineView: NSView {
         externalDragIsRippleInsert = false
 
         let editor = self.editor
+        let urlString = sender.draggingPasteboard.string(forType: .string)
 
-        guard let urlString = sender.draggingPasteboard.string(forType: .string) else {
-            let urls = Self.finderFileURLs(sender.draggingPasteboard)
-            guard !urls.isEmpty else { return false }
-            let ripple = NSEvent.modifierFlags.contains(.command)
-            Task { @MainActor in
-                await editor.importFinderItemsToTimeline(urls, cursor: cursorTarget, atFrame: targetFrame, ripple: ripple)
-                self.needsDisplay = true
+        if let urlString {
+            let timelineIds = editor.timelineIdsFromDragPayload(urlString)
+            if !timelineIds.isEmpty {
+                var frame = targetFrame
+                for id in timelineIds {
+                    guard editor.nestTimeline(id, cursor: cursorTarget, atFrame: frame) else { continue }
+                    frame += editor.timeline(for: id)?.totalFrames ?? 0
+                }
+                needsDisplay = true
+                return true
             }
-            return true
+
+            let assets = editor.assetsFromDragPayload(urlString)
+            if !assets.isEmpty {
+                let segments = editor.segmentsFromDragPayload(urlString)
+                let ripple = NSEvent.modifierFlags.contains(.command)
+                editor.addClipsWithSettingsCheck(assets: assets) {
+                    editor.placeDroppedAssets(assets, cursor: cursorTarget, atFrame: targetFrame, segments: segments, ripple: ripple)
+                }
+                needsDisplay = true
+                return true
+            }
         }
 
-        let timelineIds = editor.timelineIdsFromDragPayload(urlString)
-        if !timelineIds.isEmpty {
-            var frame = targetFrame
-            for id in timelineIds {
-                guard editor.nestTimeline(id, cursor: cursorTarget, atFrame: frame) else { continue }
-                frame += editor.timeline(for: id)?.totalFrames ?? 0
-            }
-            needsDisplay = true
-            return true
-        }
-
-        let assets = editor.assetsFromDragPayload(urlString)
-        let segments = editor.segmentsFromDragPayload(urlString)
-        guard !assets.isEmpty else { return false }
-
+        let urls = Self.finderFileURLs(sender.draggingPasteboard)
+        guard !urls.isEmpty else { return false }
         let ripple = NSEvent.modifierFlags.contains(.command)
-        editor.addClipsWithSettingsCheck(assets: assets) {
-            editor.placeDroppedAssets(assets, cursor: cursorTarget, atFrame: targetFrame, segments: segments, ripple: ripple)
+        Task { @MainActor in
+            await editor.importFinderItemsToTimeline(urls, cursor: cursorTarget, atFrame: targetFrame, ripple: ripple)
+            self.needsDisplay = true
         }
-
-        needsDisplay = true
         return true
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1310,6 +1310,13 @@ final class TimelineView: NSView {
             externalDragAssets = editor.assetsFromDragPayload(urlString)
             externalDragSegments = editor.segmentsFromDragPayload(urlString)
         }
+        if externalDragAssets == nil {
+            let urls = Self.finderFileURLs(sender.draggingPasteboard)
+            let placeholders = editor.dropPlaceholderAssets(for: urls)
+            // Folders carry no placeholder ghost but still import recursively on drop.
+            guard !placeholders.isEmpty || urls.contains(where: \.hasDirectoryPath) else { return [] }
+            externalDragAssets = placeholders
+        }
         externalDropTarget = geo.dropTargetAt(y: point.y)
         externalSnapState = SnapEngine.SnapState()
         externalDragFrame = applyExternalSnap(at: point, geo: geo)
@@ -1319,6 +1326,7 @@ final class TimelineView: NSView {
     }
 
     override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard externalDragAssets != nil else { return [] }
         let point = convert(sender.draggingLocation, from: nil)
         let geo = geometry
         externalDropTarget = geo.dropTargetAt(y: point.y)
@@ -1377,9 +1385,18 @@ final class TimelineView: NSView {
         externalSnapState = SnapEngine.SnapState()
         externalDragIsRippleInsert = false
 
-        guard let urlString = sender.draggingPasteboard.string(forType: .string) else { return false }
-
         let editor = self.editor
+
+        guard let urlString = sender.draggingPasteboard.string(forType: .string) else {
+            let urls = Self.finderFileURLs(sender.draggingPasteboard)
+            guard !urls.isEmpty else { return false }
+            let ripple = NSEvent.modifierFlags.contains(.command)
+            Task { @MainActor in
+                await editor.importFinderItemsToTimeline(urls, cursor: cursorTarget, atFrame: targetFrame, ripple: ripple)
+                self.needsDisplay = true
+            }
+            return true
+        }
 
         let timelineIds = editor.timelineIdsFromDragPayload(urlString)
         if !timelineIds.isEmpty {
@@ -1396,37 +1413,20 @@ final class TimelineView: NSView {
         let segments = editor.segmentsFromDragPayload(urlString)
         guard !assets.isEmpty else { return false }
 
-        let mods = NSEvent.modifierFlags
-
-        let operation: @MainActor () -> Void = {
-            editor.undo.perform("Add Clips") {
-                let plan = editor.resolveDropPlan(cursor: cursorTarget, assets: assets, atFrame: targetFrame, segments: segments)
-                let (visualIdx, audioIdx) = editor.materialize(plan: plan)
-                let ripple = mods.contains(.command)
-
-                let insert: ([MediaAsset], Int, Int?) -> Void = { assets, trackIdx, linkedAudio in
-                    if ripple {
-                        editor.rippleInsertClips(assets: assets, trackIndex: trackIdx, atFrame: targetFrame, segments: segments)
-                    } else {
-                        editor.addClips(assets: assets, trackIndex: trackIdx, startFrame: targetFrame, linkedAudioTrackIndex: linkedAudio, segments: segments)
-                    }
-                }
-
-                let visualAssets = plan.visualAssets
-                if !visualAssets.isEmpty, let vIdx = visualIdx {
-                    insert(visualAssets, vIdx, audioIdx)
-                }
-                let audioOnlyAssets = plan.audioOnlyAssets
-                if !audioOnlyAssets.isEmpty, let aIdx = audioIdx {
-                    insert(audioOnlyAssets, aIdx, nil)
-                }
-            }
+        let ripple = NSEvent.modifierFlags.contains(.command)
+        editor.addClipsWithSettingsCheck(assets: assets) {
+            editor.placeDroppedAssets(assets, cursor: cursorTarget, atFrame: targetFrame, segments: segments, ripple: ripple)
         }
-
-        editor.addClipsWithSettingsCheck(assets: assets, operation: operation)
 
         needsDisplay = true
         return true
+    }
+
+    private static func finderFileURLs(_ pasteboard: NSPasteboard) -> [URL] {
+        (pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL]) ?? []
     }
 }
 

--- a/Tests/PalmierProTests/Media/FinderTimelineDropTests.swift
+++ b/Tests/PalmierProTests/Media/FinderTimelineDropTests.swift
@@ -1,0 +1,89 @@
+import AppKit
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Finder → timeline drop")
+@MainActor
+struct FinderTimelineDropTests {
+
+    private func editor() -> EditorViewModel {
+        let e = EditorViewModel()
+        e.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+        return e
+    }
+
+    private func writePNG(to url: URL) throws {
+        let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 4, pixelsHigh: 4, bitsPerSample: 8,
+            samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        )!
+        try #require(rep.representation(using: .png, properties: [:])).write(to: url)
+    }
+
+    @Test func dropImportsAndPlacesClipAtFrame() async throws {
+        let e = editor()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finder-drop-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("still.png")
+        try writePNG(to: file)
+
+        await e.importFinderItemsToTimeline([file], cursor: .existingTrack(0), atFrame: 42, ripple: false)
+
+        let asset = try #require(e.mediaAssets.first { $0.name == "still" })
+        let clip = try #require(e.timeline.tracks[0].clips.first)
+        #expect(clip.mediaRef == asset.id)
+        #expect(clip.startFrame == 42)
+    }
+
+    @Test func singleUndoRevertsImportAndPlacement() async throws {
+        let e = editor()
+        let um = UndoManager()
+        e.undo.attach(um)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finder-drop-undo-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("still.png")
+        try writePNG(to: file)
+
+        await e.importFinderItemsToTimeline([file], cursor: .existingTrack(0), atFrame: 0, ripple: false)
+        #expect(e.mediaAssets.count == 1)
+        #expect(!e.timeline.tracks[0].clips.isEmpty)
+
+        #expect(e.undo.undoLatest() == "Add Media")
+        #expect(e.mediaAssets.isEmpty)
+        #expect(e.timeline.tracks.allSatisfy { $0.clips.isEmpty })
+        #expect(!um.canUndo)
+    }
+
+    @Test func unreadableFileImportsWithoutPlacingClip() async throws {
+        let e = editor()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finder-drop-bad-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("broken.mp4")
+        try Data().write(to: file)
+
+        await e.importFinderItemsToTimeline([file], cursor: .existingTrack(0), atFrame: 0, ripple: false)
+
+        #expect(e.mediaAssets.count == 1)
+        #expect(e.timeline.tracks.allSatisfy { $0.clips.isEmpty })
+    }
+
+    @Test func placeholderAssetsSkipFoldersAndUnsupportedTypes() {
+        let e = editor()
+        let urls = [
+            URL(fileURLWithPath: "/tmp/a.mp4"),
+            URL(fileURLWithPath: "/tmp/b.txt"),
+            URL(fileURLWithPath: "/tmp/folder", isDirectory: true),
+        ]
+        let placeholders = e.dropPlaceholderAssets(for: urls)
+        #expect(placeholders.map(\.name) == ["a"])
+        #expect(placeholders[0].type == .video)
+    }
+}


### PR DESCRIPTION
## Summary

Dragging media from Finder previously required two steps: drop into the media panel, then drag from the panel to the timeline. Worse, the timeline already registered for `.fileURL` drags, so a Finder drag showed a copy cursor but dropped as a silent no-op. Finder files can now be dropped directly onto the timeline: they import into the media library and place as clips at the drop point, as one undoable action.

## Approach

- **Placement reuses the internal-drag path.** The placement closure previously inlined in `TimelineView.performDragOperation` is extracted into `EditorViewModel.placeDroppedAssets(_:cursor:atFrame:segments:ripple:)` (resolve drop plan → materialize tracks → `addClips`/`rippleInsertClips`), now shared by panel-asset drags and Finder drops. Cmd-drop ripple-inserts in both.
- **Import reuses the shared Finder pipeline.** `importFinderItems` (already used by panel drops, File > Import, and the `import_media` MCP tool) gains a `finalize:` flag and returns the created assets in `MediaImportSummary`. The new `importFinderItemsToTimeline` imports without auto-finalize, awaits metadata per asset to get real durations, then places. Files are referenced in place, matching panel-drop semantics.
- **One undo entry.** Import applies without registration; a single "Add Media" entry restores the pre-import media-library snapshot and the placement undoes with it. A staleness check (`mediaAssetsById[$0.id] === $0`) after the metadata awaits prevents a mid-import undo from resurrecting assets.
- **Drag-over feedback.** `draggingEntered` builds preview placeholder assets from the pasteboard URLs so the existing ghost clips, snap line, new-track insertion line, and ripple badge all render during hover. Placeholders use a nominal 5 s duration until import loads real metadata; folders show no ghost but import recursively on drop. Unsupported-only drags are rejected (`[]`).
- Unreadable files import to the panel (offline-badged) without placing a clip. Video/resolution mismatch on an empty configured timeline goes through the existing `addClipsWithSettingsCheck` prompt before placement.

Known limitations, consistent with the media panel: file promises (drags from Photos/Mail/browsers) are not supported, and dropped files are referenced in place rather than copied into the project package. If the timeline layout is edited during a slow import (e.g. network volume), the clip places at the captured track index against the new layout; a track-identity guard was prototyped and dropped as over-engineering for the realistic local-file case.

## Testing

- `swift build` clean.
- `swift test`: 1077 tests, 166 suites, all pass.
- New `FinderTimelineDropTests` (4): drop imports + places at the drop frame, single undo reverts import and placement together, unreadable media imports without placing, placeholders skip folders/unsupported types.
- Manual UI verification (done): Finder video drop shows ghost + snap and places with linked audio; ⌘Z removes clip and asset; Cmd-drop ripple-inserts; drop below tracks creates a new track; folder drop imports recursively and places supported files sequentially; `.txt` drag rejected; panel-asset drags unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches timeline drag/drop, media import, and undo composition with async finalize; behavior is covered by new tests but spans core editing paths.
> 
> **Overview**
> **Finder files can be dropped directly on the timeline** instead of only via the media panel. On drop, items go through the existing Finder import pipeline, load metadata, then place at the snapped frame (Cmd for ripple insert), registered as a single **“Add Media”** undo.
> 
> **`TimelineView`** now reads file URLs from the pasteboard when the string payload isn’t a panel/timeline drag. Hover builds **placeholder assets** for ghost clips, snap, and new-track lines; unsupported-only drags return no operation. Panel-asset drops call the new shared **`placeDroppedAssets`** instead of inlined placement code.
> 
> **`importFinderItems`** gains a **`finalize:`** flag and returns created assets in **`MediaImportSummary`**. **`importFinderItemsToTimeline`** imports without auto-finalize, finalizes per asset, then places with a staleness guard after async work. Unreadable files can still land in the library without a clip.
> 
> **Tests:** `FinderTimelineDropTests` covers placement, unified undo, failed finalize, and placeholder filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b1278e4a64993be19f2143e94736a04172709a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->