### PR TITLE
Improve Audio Synchronization

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -563,7 +563,7 @@ enum ToolDefinitions {
                     "targetClipId": ["type": "string", "description": "Single clip to align. Use targetClipIds for several."],
                     "targetClipIds": ["type": "array", "items": ["type": "string"], "description": "Clips to align with the reference."],
                     "mode": ["type": "string", "enum": ["auto", "audio", "timecode"], "description": "auto (default): timecode when available, else audio. audio/timecode force that method."],
-                    "searchWindowSeconds": ["type": "number", "description": "Max ± offset to search in seconds, audio mode only (default 30)."],
+                    "searchWindowSeconds": ["type": "number", "description": "Optional max ± offset to search in seconds. Omit to search the full feasible overlap."],
                     "minConfidence": ["type": "number", "description": "Minimum audio correlation confidence 0–1 (default 0.5)."],
                 ],
                 required: ["referenceClipId"]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Multicam.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Multicam.swift
@@ -36,7 +36,7 @@ extension ToolExecutor {
         }
 
         let masterRef = try resolveMasterRef(args.string("master"), specs: specs, editor: editor)
-        let sync = await editor.syncMulticamMembers(
+        let sync = try await editor.syncMulticamMembers(
             specs: specs, masterRef: masterRef,
             searchWindowSeconds: args.double("searchWindowSeconds") ?? EditorViewModel.SyncDefaults.memberSearchWindowSeconds
         )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
@@ -56,6 +56,9 @@ extension ToolExecutor {
                 ["clipId": $0.clipId, "driftPpm": ($0.driftPpm * 10).rounded() / 10]
             }
         }
+        if !report.retimeSkipped.isEmpty {
+            extra["driftCorrectionSkipped"] = report.retimeSkipped.map { ["clipId": $0.clipId, "reason": $0.message] }
+        }
         if !report.failures.isEmpty {
             extra["failed"] = report.failures.map { ["clipId": $0.clipId, "reason": $0.message] }
         }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Sync.swift
@@ -23,8 +23,10 @@ extension ToolExecutor {
             }
             mode = parsed
         }
-        let searchWindow = args.double("searchWindowSeconds") ?? EditorViewModel.SyncDefaults.searchWindowSeconds
-        guard searchWindow > 0 else { throw ToolError("sync_clips: searchWindowSeconds must be > 0.") }
+        let searchWindow = args.double("searchWindowSeconds")
+        if let searchWindow, !searchWindow.isFinite || searchWindow <= 0 {
+            throw ToolError("sync_clips: searchWindowSeconds must be finite and > 0.")
+        }
 
         let snapshot = timelineSnapshot(editor)
         let report = try await editor.syncClips(
@@ -49,6 +51,11 @@ extension ToolExecutor {
             },
         ]
         if report.shiftedFrames > 0 { extra["shiftedFrames"] = report.shiftedFrames }
+        if !report.retimed.isEmpty {
+            extra["driftCorrected"] = report.retimed.map {
+                ["clipId": $0.clipId, "driftPpm": ($0.driftPpm * 10).rounded() / 10]
+            }
+        }
         if !report.failures.isEmpty {
             extra["failed"] = report.failures.map { ["clipId": $0.clipId, "reason": $0.message] }
         }

--- a/Sources/PalmierPro/Audio/AudioEnvelope.swift
+++ b/Sources/PalmierPro/Audio/AudioEnvelope.swift
@@ -23,7 +23,7 @@ enum AudioEnvelopeError: LocalizedError {
 
 enum AudioEnvelopeExtractor {
     static let sampleRate: Double = 16_000
-    static let hopSeconds: Double = 0.01
+    static let hopSeconds: Double = 0.0025
 
     static func extract(from url: URL, range: ClosedRange<Double>? = nil) async throws -> AudioEnvelope {
         let hopSize = max(1, Int((sampleRate * hopSeconds).rounded()))
@@ -53,7 +53,7 @@ enum AudioEnvelopeExtractor {
                     carry += take
                     i += take
                     if carry == hopSize {
-                        samples.append((sumSquares / Float(hopSize)).squareRoot())
+                        samples.append(logEnergy(sumSquares: sumSquares, count: hopSize))
                         sumSquares = 0
                         carry = 0
                     }
@@ -67,8 +67,12 @@ enum AudioEnvelopeExtractor {
         }
 
         if carry > 0 {
-            samples.append((sumSquares / Float(carry)).squareRoot())
+            samples.append(logEnergy(sumSquares: sumSquares, count: carry))
         }
         return AudioEnvelope(hopSeconds: hopSeconds, samples: samples)
+    }
+
+    private static func logEnergy(sumSquares: Float, count: Int) -> Float {
+        log1p((sumSquares / Float(count)).squareRoot() * 100)
     }
 }

--- a/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
+++ b/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
@@ -8,17 +8,39 @@ enum AudioSyncCorrelator {
     }
 
     static let minOverlap = 16
+    private static let coarseStride = 4
 
     static func seededCorrelate(
         reference: [Float], target: [Float], seedHops: Int?, seedWindowHops: Int,
-        maxLagHops: Int, minOverlapHops: Int, minConfidence: Double
+        maxLagHops: Int, minOverlapHops: Int, minConfidence: Double,
+        additionalSearchCenterHops: [Int] = []
     ) async -> Result? {
         let result = await Task.detached(priority: .userInitiated) { () -> Result? in
-            if let seedHops,
-               let seeded = correlate(reference: reference, target: target, maxLagHops: seedWindowHops,
-                                      centerLagHops: seedHops, minOverlapHops: minOverlapHops),
-               seeded.confidence >= minConfidence { return seeded }
-            return correlate(reference: reference, target: target, maxLagHops: maxLagHops, minOverlapHops: minOverlapHops)
+            var best = correlate(
+                reference: reference, target: target, maxLagHops: maxLagHops,
+                minOverlapHops: minOverlapHops
+            )
+            for center in Set(additionalSearchCenterHops) where center != 0 {
+                guard !Task.isCancelled else { return nil }
+                let candidate = correlate(
+                    reference: reference, target: target, maxLagHops: maxLagHops,
+                    centerLagHops: center, minOverlapHops: minOverlapHops
+                )
+                if let candidate, candidate.confidence > (best?.confidence ?? -.infinity) {
+                    best = candidate
+                }
+            }
+            if let seedHops {
+                guard !Task.isCancelled else { return nil }
+                let seeded = correlate(
+                    reference: reference, target: target, maxLagHops: seedWindowHops,
+                    centerLagHops: seedHops, minOverlapHops: minOverlapHops
+                )
+                if let seeded, seeded.confidence > (best?.confidence ?? -.infinity) {
+                    best = seeded
+                }
+            }
+            return best
         }.value
         guard let result, result.confidence >= minConfidence else { return nil }
         return result
@@ -29,16 +51,60 @@ enum AudioSyncCorrelator {
         centerLagHops: Int = 0, minOverlapHops: Int = minOverlap
     ) -> Result? {
         guard !reference.isEmpty, !target.isEmpty, maxLagHops >= 0 else { return nil }
+        let shorterCount = min(reference.count, target.count)
+        let adaptiveOverlap = max(minOverlap, shorterCount / 2)
+        let requiredOverlap = min(max(minOverlap, minOverlapHops), adaptiveOverlap)
+        guard shorterCount >= requiredOverlap else { return nil }
 
+        let validLags = (requiredOverlap - target.count)...(reference.count - requiredOverlap)
+        let requestedLower = centerLagHops.subtractingClamped(maxLagHops)
+        let requestedUpper = centerLagHops.addingClamped(maxLagHops)
+        let lower = max(validLags.lowerBound, requestedLower)
+        let upper = min(validLags.upperBound, requestedUpper)
+        guard lower <= upper else { return nil }
+
+        let lagRange = lower...upper
+        guard lagRange.count > coarseStride * 8,
+              reference.count >= coarseStride * minOverlap,
+              target.count >= coarseStride * minOverlap else {
+            return correlateExact(
+                reference: reference, target: target,
+                lagRange: lagRange, minOverlapHops: requiredOverlap
+            )
+        }
+
+        let coarseReference = downsample(reference, stride: coarseStride)
+        let coarseTarget = downsample(target, stride: coarseStride)
+        let coarseLower = Int(floor(Double(lower) / Double(coarseStride)))
+        let coarseUpper = Int(ceil(Double(upper) / Double(coarseStride)))
+        let coarseOverlap = max(minOverlap, (requiredOverlap + coarseStride - 1) / coarseStride)
+        guard let coarse = correlateExact(
+            reference: coarseReference, target: coarseTarget,
+            lagRange: coarseLower...coarseUpper, minOverlapHops: coarseOverlap
+        ) else { return nil }
+
+        let coarseLag = coarse.lagHops * coarseStride
+        let refinementRadius = coarseStride * 2
+        let refinementRange = max(lower, coarseLag - refinementRadius)...min(upper, coarseLag + refinementRadius)
+        return correlateExact(
+            reference: reference, target: target,
+            lagRange: refinementRange, minOverlapHops: requiredOverlap
+        )
+    }
+
+    private static func correlateExact(
+        reference: [Float], target: [Float],
+        lagRange: ClosedRange<Int>, minOverlapHops: Int
+    ) -> Result? {
         let ref = reference.map(Double.init)
         let tgt = target.map(Double.init)
-
         var best: Result?
         ref.withUnsafeBufferPointer { refBuf in
             tgt.withUnsafeBufferPointer { tgtBuf in
                 let refBase = refBuf.baseAddress!
                 let tgtBase = tgtBuf.baseAddress!
-                for lag in (centerLagHops - maxLagHops)...(centerLagHops + maxLagHops) {
+                for lag in lagRange {
+                    guard !Task.isCancelled else { return }
                     let iStart = max(0, -lag)
                     let iEnd = min(tgt.count, ref.count - lag)
                     let n = iEnd - iStart
@@ -71,5 +137,25 @@ enum AudioSyncCorrelator {
             }
         }
         return best
+    }
+
+    private static func downsample(_ samples: [Float], stride: Int) -> [Float] {
+        guard stride > 1 else { return samples }
+        return Swift.stride(from: 0, to: samples.count, by: stride).map { start in
+            let end = min(start + stride, samples.count)
+            return samples[start..<end].reduce(0, +) / Float(end - start)
+        }
+    }
+}
+
+private extension Int {
+    func addingClamped(_ other: Int) -> Int {
+        let (result, overflow) = addingReportingOverflow(other)
+        return overflow ? .max : result
+    }
+
+    func subtractingClamped(_ other: Int) -> Int {
+        let (result, overflow) = subtractingReportingOverflow(other)
+        return overflow ? .min : result
     }
 }

--- a/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
+++ b/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
@@ -5,45 +5,144 @@ enum AudioSyncCorrelator {
     struct Result: Sendable, Equatable {
         let lagHops: Int
         let confidence: Double
+        let driftRatio: Double
+        /// Fractional lag from the drift fit; use for placement so hop rounding
+        /// cannot flip a near-half-frame result to the wrong frame.
+        let exactLagHops: Double
+
+        init(lagHops: Int, confidence: Double, driftRatio: Double = 0, exactLagHops: Double? = nil) {
+            self.lagHops = lagHops
+            self.confidence = confidence
+            self.driftRatio = driftRatio
+            self.exactLagHops = exactLagHops ?? Double(lagHops)
+        }
     }
 
     static let minOverlap = 16
-    private static let coarseStride = 4
+    private static let pyramidStride = 2
+    /// Lag ranges up to this size are searched exactly; larger ones go through the pyramid.
+    private static let maxExactLagCount = 4_096
+    private static let maxCandidates = 16
+    // Consensus constants assume the 2.5 ms sync envelope hop.
+    /// 60-second chunks: long enough to correlate reliably, short enough that drift stays sub-hop within one.
+    private static let consensusChunkHops = 24_000
+    private static let consensusChunkCount = 5
+    /// Chunk lags within 1 s of each other count as agreeing.
+    private static let consensusToleranceHops = 400
+    /// Search radius around the previous chunk's lag before rescanning the full windows.
+    private static let reacquireRadiusHops = 800
+    /// Below this chunk spread (2.5 min) the fitted slope is dominated by hop quantization.
+    private static let driftFitMinSpanHops = 60_000
+    /// Recorder crystals disagree by tens of ppm; a larger fitted slope means mismatched content, not drift.
+    private static let maxDriftRatio = 0.0005
+    /// Slopes below ~one frame per hour are quantization noise, not drift.
+    private static let minDriftRatio = 0.00002
 
     static func seededCorrelate(
         reference: [Float], target: [Float], seedHops: Int?, seedWindowHops: Int,
-        maxLagHops: Int, minOverlapHops: Int, minConfidence: Double,
-        additionalSearchCenterHops: [Int] = []
+        maxLagHops: Int, minOverlapHops: Int, minConfidence: Double
     ) async -> Result? {
-        let result = await Task.detached(priority: .userInitiated) { () -> Result? in
-            var best = correlate(
-                reference: reference, target: target, maxLagHops: maxLagHops,
-                minOverlapHops: minOverlapHops
+        await Task.detached(priority: .userInitiated) { () -> Result? in
+            var windows = [(center: 0, radius: maxLagHops)]
+            if let seedHops { windows.append((seedHops, seedWindowHops)) }
+            return alignByConsensus(
+                reference: reference, target: target, windows: windows,
+                minOverlapHops: minOverlapHops, minConfidence: minConfidence
             )
-            for center in Set(additionalSearchCenterHops) where center != 0 {
+        }.value
+    }
+
+    private static func alignByConsensus(
+        reference: [Float], target: [Float], windows: [(center: Int, radius: Int)],
+        minOverlapHops: Int, minConfidence: Double
+    ) -> Result? {
+        func bestAcrossWindows(_ chunk: [Float], chunkStart: Int, overlap: Int) -> Result? {
+            var best: Result?
+            for window in windows {
                 guard !Task.isCancelled else { return nil }
                 let candidate = correlate(
-                    reference: reference, target: target, maxLagHops: maxLagHops,
-                    centerLagHops: center, minOverlapHops: minOverlapHops
+                    reference: reference, target: chunk, maxLagHops: window.radius,
+                    centerLagHops: window.center + chunkStart, minOverlapHops: overlap
                 )
                 if let candidate, candidate.confidence > (best?.confidence ?? -.infinity) {
                     best = candidate
                 }
             }
-            if let seedHops {
-                guard !Task.isCancelled else { return nil }
-                let seeded = correlate(
-                    reference: reference, target: target, maxLagHops: seedWindowHops,
-                    centerLagHops: seedHops, minOverlapHops: minOverlapHops
+            return best
+        }
+
+        let chunkHops = min(target.count, consensusChunkHops)
+        var starts: [Int] = [0]
+        if target.count > chunkHops {
+            let maxStart = target.count - chunkHops
+            starts = Array(Set((0..<consensusChunkCount).map {
+                maxStart * $0 / (consensusChunkCount - 1)
+            })).sorted()
+        }
+
+        var hits: [(start: Int, center: Double, clipLag: Int, confidence: Double)] = []
+        for start in starts {
+            guard !Task.isCancelled else { return nil }
+            let chunk = Array(target[start..<start + chunkHops])
+            guard chunk.min() != chunk.max() else { continue }
+            let overlap = min(max(minOverlapHops, chunk.count / 2), chunk.count)
+
+            var best: Result?
+            if let prev = hits.last {
+                best = correlate(
+                    reference: reference, target: chunk, maxLagHops: reacquireRadiusHops,
+                    centerLagHops: prev.clipLag + start, minOverlapHops: overlap
                 )
-                if let seeded, seeded.confidence > (best?.confidence ?? -.infinity) {
-                    best = seeded
+                if let found = best, found.confidence < minConfidence { best = nil }
+            }
+            if best == nil { best = bestAcrossWindows(chunk, chunkStart: start, overlap: overlap) }
+            guard let best, best.confidence >= minConfidence else { continue }
+            hits.append((start, Double(start) + Double(chunk.count) / 2, best.lagHops - start, best.confidence))
+        }
+
+        guard !hits.isEmpty else {
+            guard let best = bestAcrossWindows(target, chunkStart: 0, overlap: minOverlapHops),
+                  best.confidence >= minConfidence else { return nil }
+            return best
+        }
+
+        let sorted = hits.sorted { $0.clipLag < $1.clipLag }
+        var cluster = ArraySlice(sorted)
+        var clusterScore = -Double.infinity
+        for i in sorted.indices {
+            var j = i
+            while j + 1 < sorted.count,
+                  sorted[j + 1].clipLag - sorted[i].clipLag <= consensusToleranceHops { j += 1 }
+            let candidate = sorted[i...j]
+            let score = candidate.reduce(0) { $0 + $1.confidence }
+            if score > clusterScore {
+                clusterScore = score
+                cluster = candidate
+            }
+        }
+        let confidence = cluster.reduce(0) { $0 + $1.confidence } / Double(cluster.count)
+
+        let span = (cluster.map(\.center).max() ?? 0) - (cluster.map(\.center).min() ?? 0)
+        if cluster.count >= 3, span >= Double(driftFitMinSpanHops) {
+            let n = Double(cluster.count)
+            let meanX = cluster.reduce(0) { $0 + $1.center } / n
+            let meanY = cluster.reduce(0) { $0 + Double($1.clipLag) } / n
+            let varX = cluster.reduce(0) { $0 + ($1.center - meanX) * ($1.center - meanX) }
+            let cov = cluster.reduce(0) { $0 + ($1.center - meanX) * (Double($1.clipLag) - meanY) }
+            let slope = varX > 0 ? cov / varX : 0
+            if abs(slope) >= minDriftRatio, abs(slope) <= maxDriftRatio {
+                let maxResidual = cluster.map { abs(Double($0.clipLag) - (meanY + slope * ($0.center - meanX))) }.max() ?? 0
+                if maxResidual <= Double(consensusToleranceHops) {
+                    let lagAtHead = meanY - slope * meanX
+                    return Result(
+                        lagHops: Int(lagAtHead.rounded()), confidence: confidence,
+                        driftRatio: slope, exactLagHops: lagAtHead
+                    )
                 }
             }
-            return best
-        }.value
-        guard let result, result.confidence >= minConfidence else { return nil }
-        return result
+        }
+        guard let anchor = cluster.min(by: { $0.start < $1.start }) else { return nil }
+        return Result(lagHops: anchor.clipLag, confidence: confidence)
     }
 
     static func correlate(
@@ -57,94 +156,147 @@ enum AudioSyncCorrelator {
         guard shorterCount >= requiredOverlap else { return nil }
 
         let validLags = (requiredOverlap - target.count)...(reference.count - requiredOverlap)
-        let requestedLower = centerLagHops.subtractingClamped(maxLagHops)
-        let requestedUpper = centerLagHops.addingClamped(maxLagHops)
-        let lower = max(validLags.lowerBound, requestedLower)
-        let upper = min(validLags.upperBound, requestedUpper)
+        let lower = max(validLags.lowerBound, centerLagHops.subtractingClamped(maxLagHops))
+        let upper = min(validLags.upperBound, centerLagHops.addingClamped(maxLagHops))
         guard lower <= upper else { return nil }
 
-        let lagRange = lower...upper
-        guard lagRange.count > coarseStride * 8,
-              reference.count >= coarseStride * minOverlap,
-              target.count >= coarseStride * minOverlap else {
-            return correlateExact(
+        return correlateCandidates(
+            reference: reference, target: target,
+            lagRange: lower...upper, minOverlapHops: requiredOverlap
+        ).first
+    }
+
+    private static func correlateCandidates(
+        reference: [Float], target: [Float],
+        lagRange: ClosedRange<Int>, minOverlapHops: Int
+    ) -> [Result] {
+        guard lagRange.count > maxExactLagCount,
+              reference.count >= pyramidStride * minOverlap,
+              target.count >= pyramidStride * minOverlap else {
+            return exactCandidates(
                 reference: reference, target: target,
-                lagRange: lagRange, minOverlapHops: requiredOverlap
+                lagRanges: [lagRange], minOverlapHops: minOverlapHops
             )
         }
 
-        let coarseReference = downsample(reference, stride: coarseStride)
-        let coarseTarget = downsample(target, stride: coarseStride)
-        let coarseLower = Int(floor(Double(lower) / Double(coarseStride)))
-        let coarseUpper = Int(ceil(Double(upper) / Double(coarseStride)))
-        let coarseOverlap = max(minOverlap, (requiredOverlap + coarseStride - 1) / coarseStride)
-        guard let coarse = correlateExact(
-            reference: coarseReference, target: coarseTarget,
-            lagRange: coarseLower...coarseUpper, minOverlapHops: coarseOverlap
-        ) else { return nil }
+        let coarseTarget = downsample(target, stride: pyramidStride)
+        var mappedCandidates: [Result] = []
+        for phase in 0..<pyramidStride {
+            let coarseLower = Int(ceil(Double(lagRange.lowerBound - phase) / Double(pyramidStride)))
+            let coarseUpper = Int(floor(Double(lagRange.upperBound - phase) / Double(pyramidStride)))
+            guard coarseLower <= coarseUpper else { continue }
+            let candidates = correlateCandidates(
+                reference: downsample(reference, stride: pyramidStride, offset: phase),
+                target: coarseTarget,
+                lagRange: coarseLower...coarseUpper,
+                minOverlapHops: max(4, (minOverlapHops + pyramidStride - 1) / pyramidStride)
+            )
+            mappedCandidates.append(contentsOf: candidates.map {
+                Result(lagHops: $0.lagHops * pyramidStride + phase, confidence: $0.confidence)
+            })
+        }
+        let coarseCandidates = rankedCandidates(mappedCandidates)
+        guard !coarseCandidates.isEmpty else { return [] }
 
-        let coarseLag = coarse.lagHops * coarseStride
-        let refinementRadius = coarseStride * 2
-        let refinementRange = max(lower, coarseLag - refinementRadius)...min(upper, coarseLag + refinementRadius)
-        return correlateExact(
+        let radius = pyramidStride * 2
+        let ranges = coarseCandidates.map { candidate in
+            max(lagRange.lowerBound, candidate.lagHops - radius)...min(lagRange.upperBound, candidate.lagHops + radius)
+        }
+        return exactCandidates(
             reference: reference, target: target,
-            lagRange: refinementRange, minOverlapHops: requiredOverlap
+            lagRanges: merged(ranges), minOverlapHops: minOverlapHops
         )
     }
 
-    private static func correlateExact(
+    private static func exactCandidates(
         reference: [Float], target: [Float],
-        lagRange: ClosedRange<Int>, minOverlapHops: Int
-    ) -> Result? {
+        lagRanges: [ClosedRange<Int>], minOverlapHops: Int
+    ) -> [Result] {
         let ref = reference.map(Double.init)
         let tgt = target.map(Double.init)
-        var best: Result?
+        var results: [Result] = []
         ref.withUnsafeBufferPointer { refBuf in
             tgt.withUnsafeBufferPointer { tgtBuf in
                 let refBase = refBuf.baseAddress!
                 let tgtBase = tgtBuf.baseAddress!
-                for lag in lagRange {
-                    guard !Task.isCancelled else { return }
-                    let iStart = max(0, -lag)
-                    let iEnd = min(tgt.count, ref.count - lag)
-                    let n = iEnd - iStart
-                    guard n >= minOverlapHops else { continue }
+                for lagRange in lagRanges {
+                    for lag in lagRange {
+                        guard !Task.isCancelled else { return }
+                        let iStart = max(0, -lag)
+                        let iEnd = min(tgt.count, ref.count - lag)
+                        let n = iEnd - iStart
+                        guard n >= minOverlapHops else { continue }
 
-                    // x = tgt[iStart ..< iEnd], y = ref[iStart+lag ..< iEnd+lag]
-                    let x = tgtBase + iStart
-                    let y = refBase + iStart + lag
-                    let count = vDSP_Length(n)
+                        let x = tgtBase + iStart
+                        let y = refBase + iStart + lag
+                        let count = vDSP_Length(n)
 
-                    var sx = 0.0, sy = 0.0, sxx = 0.0, syy = 0.0, sxy = 0.0
-                    vDSP_sveD(x, 1, &sx, count)
-                    vDSP_svesqD(x, 1, &sxx, count)
-                    vDSP_sveD(y, 1, &sy, count)
-                    vDSP_svesqD(y, 1, &syy, count)
-                    vDSP_dotprD(x, 1, y, 1, &sxy, count)
+                        var sx = 0.0, sy = 0.0, sxx = 0.0, syy = 0.0, sxy = 0.0
+                        vDSP_sveD(x, 1, &sx, count)
+                        vDSP_svesqD(x, 1, &sxx, count)
+                        vDSP_sveD(y, 1, &sy, count)
+                        vDSP_svesqD(y, 1, &syy, count)
+                        vDSP_dotprD(x, 1, y, 1, &sxy, count)
 
-                    let nD = Double(n)
-                    let cov = sxy - sx * sy / nD
-                    let vx = sxx - sx * sx / nD
-                    let vy = syy - sy * sy / nD
-                    let denom = (vx * vy).squareRoot()
-                    guard denom > 0 else { continue }
-
-                    let score = max(0, cov / denom)
-                    if best == nil || score > best!.confidence {
-                        best = Result(lagHops: lag, confidence: score)
+                        let nD = Double(n)
+                        let cov = sxy - sx * sy / nD
+                        let vx = sxx - sx * sx / nD
+                        let vy = syy - sy * sy / nD
+                        let denom = (vx * vy).squareRoot()
+                        guard denom > 0 else { continue }
+                        results.append(Result(lagHops: lag, confidence: max(0, cov / denom)))
                     }
                 }
             }
         }
-        return best
+        guard !Task.isCancelled else { return [] }
+        let peaks = results.enumerated().filter { index, result in
+            result.confidence >= (index > 0 ? results[index - 1].confidence : -Double.infinity)
+                && result.confidence >= (index + 1 < results.count ? results[index + 1].confidence : -Double.infinity)
+        }.map(\.element)
+        return rankedCandidates(peaks.isEmpty ? results : peaks)
     }
 
-    private static func downsample(_ samples: [Float], stride: Int) -> [Float] {
-        guard stride > 1 else { return samples }
-        return Swift.stride(from: 0, to: samples.count, by: stride).map { start in
+    private static func rankedCandidates(_ candidates: [Result]) -> [Result] {
+        let ranked = candidates.sorted {
+            if $0.confidence != $1.confidence { return $0.confidence > $1.confidence }
+            let lhsDistance = $0.lagHops.magnitude
+            let rhsDistance = $1.lagHops.magnitude
+            return lhsDistance == rhsDistance ? $0.lagHops < $1.lagHops : lhsDistance < rhsDistance
+        }
+        var selected: [Result] = []
+        for candidate in ranked where selected.allSatisfy({
+            $0.lagHops.distance(to: candidate.lagHops).magnitude > UInt(2)
+        }) {
+            selected.append(candidate)
+            if selected.count == maxCandidates { break }
+        }
+        return selected
+    }
+
+    private static func downsample(_ samples: [Float], stride: Int, offset: Int = 0) -> [Float] {
+        guard offset < samples.count else { return [] }
+        guard stride > 1 else { return Array(samples.dropFirst(offset)) }
+        return Swift.stride(from: offset, to: samples.count, by: stride).map { start in
             let end = min(start + stride, samples.count)
             return samples[start..<end].reduce(0, +) / Float(end - start)
         }
+    }
+
+    private static func merged(_ ranges: [ClosedRange<Int>]) -> [ClosedRange<Int>] {
+        let sorted = ranges.sorted { $0.lowerBound < $1.lowerBound }
+        guard var current = sorted.first else { return [] }
+        var result: [ClosedRange<Int>] = []
+        for range in sorted.dropFirst() {
+            if range.lowerBound <= current.upperBound.addingClamped(1) {
+                current = current.lowerBound...max(current.upperBound, range.upperBound)
+            } else {
+                result.append(current)
+                current = range
+            }
+        }
+        result.append(current)
+        return result
     }
 }
 

--- a/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
+++ b/Sources/PalmierPro/Audio/AudioSyncCorrelator.swift
@@ -38,18 +38,17 @@ enum AudioSyncCorrelator {
     /// Slopes below ~one frame per hour are quantization noise, not drift.
     private static let minDriftRatio = 0.00002
 
+    @concurrent
     static func seededCorrelate(
         reference: [Float], target: [Float], seedHops: Int?, seedWindowHops: Int,
         maxLagHops: Int, minOverlapHops: Int, minConfidence: Double
     ) async -> Result? {
-        await Task.detached(priority: .userInitiated) { () -> Result? in
-            var windows = [(center: 0, radius: maxLagHops)]
-            if let seedHops { windows.append((seedHops, seedWindowHops)) }
-            return alignByConsensus(
-                reference: reference, target: target, windows: windows,
-                minOverlapHops: minOverlapHops, minConfidence: minConfidence
-            )
-        }.value
+        var windows = [(center: 0, radius: maxLagHops)]
+        if let seedHops { windows.append((seedHops, seedWindowHops)) }
+        return alignByConsensus(
+            reference: reference, target: target, windows: windows,
+            minOverlapHops: minOverlapHops, minConfidence: minConfidence
+        )
     }
 
     private static func alignByConsensus(
@@ -208,7 +207,7 @@ enum AudioSyncCorrelator {
         )
     }
 
-    private static func exactCandidates(
+    static func exactCandidates(
         reference: [Float], target: [Float],
         lagRanges: [ClosedRange<Int>], minOverlapHops: Int
     ) -> [Result] {
@@ -250,10 +249,16 @@ enum AudioSyncCorrelator {
             }
         }
         guard !Task.isCancelled else { return [] }
-        let peaks = results.enumerated().filter { index, result in
-            result.confidence >= (index > 0 ? results[index - 1].confidence : -Double.infinity)
-                && result.confidence >= (index + 1 < results.count ? results[index + 1].confidence : -Double.infinity)
-        }.map(\.element)
+        let peaks = results.indices.filter { index in
+            let result = results[index]
+            let leftIsLower = index == 0
+                || results[index - 1].lagHops != result.lagHops - 1
+                || result.confidence >= results[index - 1].confidence
+            let rightIsLower = index == results.count - 1
+                || results[index + 1].lagHops != result.lagHops + 1
+                || result.confidence >= results[index + 1].confidence
+            return leftIsLower && rightIsLower
+        }.map { results[$0] }
         return rankedCandidates(peaks.isEmpty ? results : peaks)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -229,14 +229,14 @@ extension EditorViewModel {
         setClipSpeed(at: loc, newSpeed: newSpeed)
     }
 
-    func commitClipSpeed(ids: [String], newSpeed: Double) {
+    func commitClipSpeed(ids: [String], newSpeed: Double, ripple: Bool = true) {
         guard !refusesMulticamRetime(clipIds: ids) else { return }
         let before: Timeline = preDragTimeline ?? timeline
         for id in ids {
             guard let loc = findClip(id: id) else { continue }
             guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].supportsRetiming else { continue }
             if timeline.tracks[loc.trackIndex].clips[loc.clipIndex].speed != newSpeed {
-                setClipSpeed(at: loc, newSpeed: newSpeed)
+                setClipSpeed(at: loc, newSpeed: newSpeed, ripple: ripple)
             }
         }
         let after = timeline
@@ -265,12 +265,16 @@ extension EditorViewModel {
         notifyTimelineChanged(refreshVisuals: refreshVisuals)
     }
 
-    fileprivate func setClipSpeed(at loc: ClipLocation, newSpeed: Double) {
+    nonisolated static func retimedDurationFrames(durationFrames: Int, speed: Double, newSpeed: Double) -> Int {
+        max(1, Int((Double(durationFrames) * speed / newSpeed).rounded()))
+    }
+
+    fileprivate func setClipSpeed(at loc: ClipLocation, newSpeed: Double, ripple: Bool = true) {
         let ti = loc.trackIndex
         let clip = timeline.tracks[ti].clips[loc.clipIndex]
         let basis = dragBefore[clip.id] ?? clip
-        let sourceFrames = Double(basis.durationFrames) * basis.speed
-        let newDuration = max(1, Int((sourceFrames / newSpeed).rounded()))
+        let newDuration = Self.retimedDurationFrames(
+            durationFrames: basis.durationFrames, speed: basis.speed, newSpeed: newSpeed)
         let oldDuration = clip.durationFrames
         let oldEnd = clip.endFrame
 
@@ -283,7 +287,7 @@ extension EditorViewModel {
         timeline.tracks[ti].clips[loc.clipIndex].clampFadesToDuration()
 
         let rippleDelta = (clip.startFrame + newDuration) - oldEnd
-        if rippleDelta != 0 {
+        if ripple, rippleDelta != 0 {
             let chainIds = timeline.tracks[ti].contiguousClipIds(fromEnd: oldEnd, excludeId: clip.id)
             for ci in timeline.tracks[ti].clips.indices where chainIds.contains(timeline.tracks[ti].clips[ci].id) {
                 timeline.tracks[ti].clips[ci].startFrame += rippleDelta

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -192,7 +192,7 @@ extension EditorViewModel {
                 reference: anchor.samples, target: samples, seedHops: seed, seedWindowHops: seedWindow,
                 maxLagHops: maxLag, minOverlapHops: minOverlapHops, minConfidence: SyncDefaults.minConfidence
             ) else { return nil }
-            return (anchor.offsetSeconds + Double(result.lagHops) * hop, result.confidence)
+            return (anchor.offsetSeconds + result.exactLagHops * hop, result.confidence)
         }
 
         var candidates: [(ref: String, samples: [Float], direct: (offset: Double, confidence: Double)?)] = []

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -115,7 +115,7 @@ extension EditorViewModel {
         masterRef: String,
         searchWindowSeconds: Double = SyncDefaults.memberSearchWindowSeconds,
         rebase: Bool = true
-    ) async -> MulticamSyncOutcome {
+    ) async throws -> MulticamSyncOutcome {
         var outcome = MulticamSyncOutcome()
 
         var pending: [MulticamMemberSpec] = []
@@ -145,9 +145,12 @@ extension EditorViewModel {
         }
 
         let envelopeSpan = 0...(searchWindowSeconds + 300)
-        guard let masterURL = urls[masterRef],
-              let masterEnv = try? await AudioEnvelopeExtractor.extract(from: masterURL, range: envelopeSpan),
-              !masterEnv.samples.isEmpty else {
+        var masterEnvelope: AudioEnvelope?
+        if let masterURL = urls[masterRef] {
+            masterEnvelope = try? await AudioEnvelopeExtractor.extract(from: masterURL, range: envelopeSpan)
+        }
+        try Task.checkCancellation()
+        guard let masterEnv = masterEnvelope, !masterEnv.samples.isEmpty else {
             outcome.failures.append((masterRef, "Master has no readable audio."))
             for spec in pending { resolveWithoutAudio(spec.mediaRef, reason: "No audio to sync with and no shared timecode.") }
             return rebase ? rebased(outcome) : outcome
@@ -167,6 +170,7 @@ extension EditorViewModel {
             for await (ref, samples) in group { out[ref] = samples }
             return out
         }
+        try Task.checkCancellation()
 
         let hop = AudioEnvelopeExtractor.hopSeconds
         let seedWindow = max(1, Int((SyncDefaults.dateSeedWindowSeconds / hop).rounded()))
@@ -202,6 +206,7 @@ extension EditorViewModel {
                 continue
             }
             candidates.append((spec.mediaRef, samples, await match(anchors[0], ref: spec.mediaRef, samples: samples)))
+            try Task.checkCancellation()
         }
 
         candidates.sort { ($0.direct?.confidence ?? 0) > ($1.direct?.confidence ?? 0) }
@@ -213,6 +218,7 @@ extension EditorViewModel {
                     best = hit
                 }
             }
+            try Task.checkCancellation()
             guard let best else {
                 resolveWithoutAudio(candidate.ref, reason: "No confident alignment — pin an offset or re-sync with a wider window.")
                 continue

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -9,10 +9,10 @@ extension EditorViewModel {
         var failures: [(clipId: String, message: String)] = []
         /// Frames the whole group (reference included) moved right so no target lands before frame 0.
         var shiftedFrames: Int = 0
+        var retimed: [(clipId: String, driftPpm: Double)] = []
     }
 
     enum SyncDefaults {
-        static let searchWindowSeconds: Double = 30
         static let minConfidence: Double = 0.5
         static let minSpeed: Double = 0.0001
         /// ± window around a capture-date seed; covers typical device clock skew.
@@ -38,7 +38,7 @@ extension EditorViewModel {
         referenceClipId: String,
         targetClipIds: [String],
         mode: SyncMode = .auto,
-        searchWindowSeconds: Double = SyncDefaults.searchWindowSeconds,
+        searchWindowSeconds: Double? = nil,
         minConfidence: Double = SyncDefaults.minConfidence,
         applying mutation: (@MainActor (@MainActor () -> Void) async throws -> Void)? = nil
     ) async throws -> SyncBatchReport {
@@ -75,22 +75,21 @@ extension EditorViewModel {
         let refTCCarrier = mode == .audio ? nil : tcCarrier(in: unit(of: refClip))
 
         let hop = AudioEnvelopeExtractor.hopSeconds
-        let maxLag = max(1, Int((searchWindowSeconds / hop).rounded()))
-        let seedWindow = max(1, min(maxLag, Int((SyncDefaults.dateSeedWindowSeconds / hop).rounded())))
+        let seedWindow = max(1, Int((SyncDefaults.dateSeedWindowSeconds / hop).rounded()))
         let minOverlap = max(AudioSyncCorrelator.minOverlap, Int((SyncDefaults.minOverlapSeconds / hop).rounded()))
 
         struct AudioClip {
             let clipId: String
             let samples: [Float]
             let speed: Double
-            let currentStart: Int
             let mediaRef: String
             let trimStartFrame: Int
         }
-        typealias Hit = (rawStart: Int, confidence: Double)
+        typealias Hit = (rawStart: Int, confidence: Double, driftRatio: Double, retimedSpeed: Double?)
         var anchors: [(rawStart: Int, clip: AudioClip)] = []
         var candidates: [(clip: AudioClip, direct: Hit?, tcRawStart: Int?)] = []
-        var placements: [(clipId: String, rawStart: Int, confidence: Double, method: SyncMethod)] = []
+        var placements: [(clipId: String, rawStart: Int, confidence: Double, method: SyncMethod,
+                          driftRatio: Double, retimedSpeed: Double?)] = []
         var refAudioTried = false
 
         func match(_ anchor: (rawStart: Int, clip: AudioClip), _ target: AudioClip) async -> Hit? {
@@ -101,16 +100,23 @@ extension EditorViewModel {
                     + Double(target.trimStartFrame - anchor.clip.trimStartFrame) / fps
                 seedHops = Int((lagSeconds / hop).rounded())
             }
-            let timelineLagSeconds = (Double(target.currentStart) - Double(anchor.rawStart))
-                * max(anchor.clip.speed, SyncDefaults.minSpeed) / fps
-            let timelineCenterHops = Int((timelineLagSeconds / hop).rounded())
+            let maxLag = searchWindowSeconds.map { max(1, Int(($0 / hop).rounded())) }
+                ?? max(anchor.clip.samples.count, target.samples.count)
             guard let result = await AudioSyncCorrelator.seededCorrelate(
                 reference: anchor.clip.samples, target: target.samples, seedHops: seedHops,
                 seedWindowHops: seedWindow, maxLagHops: maxLag, minOverlapHops: minOverlap,
-                minConfidence: minConfidence, additionalSearchCenterHops: [timelineCenterHops]
+                minConfidence: minConfidence
             ) else { return nil }
-            let lagFrames = Double(result.lagHops) * hop * fps / max(anchor.clip.speed, SyncDefaults.minSpeed)
-            return (Int((Double(anchor.rawStart) + lagFrames).rounded()), result.confidence)
+            let lagFrames = result.exactLagHops * hop * fps / max(anchor.clip.speed, SyncDefaults.minSpeed)
+            var retimedSpeed: Double?
+            if result.driftRatio != 0 {
+                let corrected = anchor.clip.speed / (1 + result.driftRatio)
+                if abs(corrected / max(target.speed, SyncDefaults.minSpeed) - 1) <= 0.001 {
+                    retimedSpeed = corrected
+                }
+            }
+            return (Int((Double(anchor.rawStart) + lagFrames).rounded()), result.confidence,
+                    result.driftRatio, retimedSpeed)
         }
 
         var seenUnits = Set<String>()
@@ -133,7 +139,7 @@ extension EditorViewModel {
                     refSpeed: liveRef.speed, refTimecode: refTC,
                     targetTrimStartFrame: liveCarrier.trimStartFrame, targetTimecode: targetTC, fps: fps)
                 if mode == .timecode {
-                    placements.append((carrier.id, rawStart, 1.0, .timecode))
+                    placements.append((carrier.id, rawStart, 1.0, .timecode, 0, nil))
                     continue
                 }
                 tcHint = (carrier.id, rawStart)
@@ -146,13 +152,13 @@ extension EditorViewModel {
 
             guard let bearer = unitClips.first(where: { $0.mediaType == .audio && captionCanTranscribe($0) })
                 ?? unitClips.first(where: { captionCanTranscribe($0) }) else {
-                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode)); continue }
+                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode, 0, nil)); continue }
                 report.failures.append((targetId, mode == .auto
                     ? "No source timecode, and clip has no audio." : "Clip has no audio."))
                 continue
             }
             guard let env = await envelope(of: bearer, fps: fps), !env.samples.isEmpty else {
-                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode)); continue }
+                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode, 0, nil)); continue }
                 report.failures.append((bearer.id, "Clip has no audio.")); continue
             }
             if !refAudioTried {
@@ -161,23 +167,21 @@ extension EditorViewModel {
                    let refEnv = await envelope(of: liveRef, fps: fps), !refEnv.samples.isEmpty {
                     anchors.append((liveRef.startFrame, AudioClip(
                         clipId: liveRef.id, samples: refEnv.samples, speed: liveRef.speed,
-                        currentStart: liveRef.startFrame,
                         mediaRef: liveRef.mediaRef, trimStartFrame: liveRef.trimStartFrame)))
                 }
             }
             guard let refAnchor = anchors.first else {
-                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode)); continue }
+                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode, 0, nil)); continue }
                 report.failures.append((bearer.id, mode == .auto && refTCCarrier == nil
                     ? "Reference has no source timecode or audio." : "Reference clip has no audio."))
                 continue
             }
             guard let liveBearer = liveClip(bearer.id) else {
-                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode)); continue }
+                if let tcHint { placements.append((tcHint.clipId, tcHint.rawStart, 1.0, .timecode, 0, nil)); continue }
                 report.failures.append((bearer.id, "Clip not found.")); continue
             }
             let clip = AudioClip(
                 clipId: bearer.id, samples: env.samples, speed: liveBearer.speed,
-                currentStart: liveBearer.startFrame,
                 mediaRef: liveBearer.mediaRef, trimStartFrame: liveBearer.trimStartFrame)
             candidates.append((clip, await match(refAnchor, clip), tcHint?.rawStart))
         }
@@ -191,13 +195,13 @@ extension EditorViewModel {
             }
             guard let best else {
                 if let tcRawStart {
-                    placements.append((clip.clipId, tcRawStart, 1.0, .timecode))
+                    placements.append((clip.clipId, tcRawStart, 1.0, .timecode, 0, nil))
                     anchors.append((tcRawStart, clip))
                     continue
                 }
                 report.failures.append((clip.clipId, "No confident alignment — clips may not overlap.")); continue
             }
-            placements.append((clip.clipId, best.rawStart, best.confidence, .audio))
+            placements.append((clip.clipId, best.rawStart, best.confidence, .audio, best.driftRatio, best.retimedSpeed))
             anchors.append((best.rawStart, clip))
         }
 
@@ -225,12 +229,17 @@ extension EditorViewModel {
         }
 
         var accepted: [(clipId: String, rawStart: Int, confidence: Double, method: SyncMethod, currentStart: Int)] = []
+        var retimes: [(ids: [String], speed: Double, driftPpm: Double, bearerId: String)] = []
         for p in placements {
             guard let clip = liveClip(p.clipId) else { report.failures.append((p.clipId, "Clip not found.")); continue }
             if let failure = queueMove(of: p.clipId, toFrame: p.rawStart) {
                 report.failures.append((p.clipId, failure)); continue
             }
             accepted.append((p.clipId, p.rawStart, p.confidence, p.method, clip.startFrame))
+            if let speed = p.retimedSpeed, speed != clip.speed {
+                let unitIds = [p.clipId] + linkedPartnerIds(of: p.clipId).filter { $0 != referenceClipId }
+                retimes.append((unitIds, speed, p.driftRatio * 1_000_000, p.clipId))
+            }
         }
 
         // Shift right if any accepted move (partners included) starts before frame 0.
@@ -245,16 +254,21 @@ extension EditorViewModel {
             }
         }
         report.synced = accepted.map { ($0.clipId, $0.rawStart + shift - $0.currentStart, $0.confidence, $0.method) }
+        report.retimed = retimes.map { ($0.bearerId, $0.driftPpm) }
 
         let moves = allMoves.compactMap { move -> (clipId: String, toTrack: Int, toFrame: Int)? in
             guard let clip = liveClip(move.clipId), move.toFrame + shift != clip.startFrame else { return nil }
             return (move.clipId, move.toTrack, move.toFrame + shift)
         }
-        if !moves.isEmpty {
+        if !moves.isEmpty || !retimes.isEmpty {
+            let apply: @MainActor () -> Void = { [self] in
+                for retime in retimes { commitClipSpeed(ids: retime.ids, newSpeed: retime.speed) }
+                if !moves.isEmpty { moveClips(moves) }
+            }
             if let mutation {
-                try await mutation { self.moveClips(moves) }
+                try await mutation(apply)
             } else {
-                undo.perform("Synchronize") { moveClips(moves) }
+                undo.perform("Synchronize", apply)
             }
         }
         return report

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -83,6 +83,7 @@ extension EditorViewModel {
             let clipId: String
             let samples: [Float]
             let speed: Double
+            let currentStart: Int
             let mediaRef: String
             let trimStartFrame: Int
         }
@@ -100,10 +101,13 @@ extension EditorViewModel {
                     + Double(target.trimStartFrame - anchor.clip.trimStartFrame) / fps
                 seedHops = Int((lagSeconds / hop).rounded())
             }
+            let timelineLagSeconds = (Double(target.currentStart) - Double(anchor.rawStart))
+                * max(anchor.clip.speed, SyncDefaults.minSpeed) / fps
+            let timelineCenterHops = Int((timelineLagSeconds / hop).rounded())
             guard let result = await AudioSyncCorrelator.seededCorrelate(
                 reference: anchor.clip.samples, target: target.samples, seedHops: seedHops,
                 seedWindowHops: seedWindow, maxLagHops: maxLag, minOverlapHops: minOverlap,
-                minConfidence: minConfidence
+                minConfidence: minConfidence, additionalSearchCenterHops: [timelineCenterHops]
             ) else { return nil }
             let lagFrames = Double(result.lagHops) * hop * fps / max(anchor.clip.speed, SyncDefaults.minSpeed)
             return (Int((Double(anchor.rawStart) + lagFrames).rounded()), result.confidence)
@@ -157,6 +161,7 @@ extension EditorViewModel {
                    let refEnv = await envelope(of: liveRef, fps: fps), !refEnv.samples.isEmpty {
                     anchors.append((liveRef.startFrame, AudioClip(
                         clipId: liveRef.id, samples: refEnv.samples, speed: liveRef.speed,
+                        currentStart: liveRef.startFrame,
                         mediaRef: liveRef.mediaRef, trimStartFrame: liveRef.trimStartFrame)))
                 }
             }
@@ -172,6 +177,7 @@ extension EditorViewModel {
             }
             let clip = AudioClip(
                 clipId: bearer.id, samples: env.samples, speed: liveBearer.speed,
+                currentStart: liveBearer.startFrame,
                 mediaRef: liveBearer.mediaRef, trimStartFrame: liveBearer.trimStartFrame)
             candidates.append((clip, await match(refAnchor, clip), tcHint?.rawStart))
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -10,6 +10,7 @@ extension EditorViewModel {
         /// Frames the whole group (reference included) moved right so no target lands before frame 0.
         var shiftedFrames: Int = 0
         var retimed: [(clipId: String, driftPpm: Double)] = []
+        var retimeSkipped: [(clipId: String, message: String)] = []
     }
 
     enum SyncDefaults {
@@ -121,6 +122,7 @@ extension EditorViewModel {
 
         var seenUnits = Set<String>()
         for targetId in targets {
+            try Task.checkCancellation()
             guard let targetClip = liveClip(targetId) else { report.failures.append((targetId, "Clip not found.")); continue }
             let unitKey = targetClip.linkGroupId ?? targetClip.id
             if unitKey == refUnitKey {
@@ -189,6 +191,7 @@ extension EditorViewModel {
         // Place the most confident match first; weaker clips may align better to those placed after.
         candidates.sort { ($0.direct?.confidence ?? 0) > ($1.direct?.confidence ?? 0) }
         for (clip, direct, tcRawStart) in candidates {
+            try Task.checkCancellation()
             var best = direct
             for anchor in anchors.dropFirst() {
                 if let hit = await match(anchor, clip), hit.confidence > (best?.confidence ?? 0) { best = hit }
@@ -204,10 +207,16 @@ extension EditorViewModel {
             placements.append((clip.clipId, best.rawStart, best.confidence, .audio, best.driftRatio, best.retimedSpeed))
             anchors.append((best.rawStart, clip))
         }
+        try Task.checkCancellation()
 
         // Validate moves before applying group shift; overlap results are preserved.
         var allMoves: [(clipId: String, toTrack: Int, toFrame: Int)] = []
         var movedIds = Set<String>()
+        var plannedDurations: [String: Int] = [:]
+        func plannedDuration(_ clipId: String) -> Int {
+            if let duration = plannedDurations[clipId] { return duration }
+            return liveClip(clipId)?.durationFrames ?? 0
+        }
         func queueMove(of clipId: String, toFrame rawStart: Int) -> String? {
             guard let loc = findClip(id: clipId) else { return "Clip not found." }
             let delta = rawStart - timeline.tracks[loc.trackIndex].clips[loc.clipIndex].startFrame
@@ -218,10 +227,11 @@ extension EditorViewModel {
                 let pClip = timeline.tracks[pLoc.trackIndex].clips[pLoc.clipIndex]
                 moves.append((clipId: pid, toTrack: pLoc.trackIndex, toFrame: pClip.startFrame + delta))
             }
-            if clipId != referenceClipId, moveWouldClobberReference(moves, referenceClipId: referenceClipId) {
+            if clipId != referenceClipId,
+               moveWouldClobberReference(moves, referenceClipId: referenceClipId, durationOf: plannedDuration) {
                 return "Shares the reference's track — move it to its own track first."
             }
-            if movesOverlapQueued(moves, allMoves) {
+            if movesOverlapQueued(moves, allMoves, durationOf: plannedDuration) {
                 return "Overlaps another clip being synced on the same track."
             }
             for move in moves where movedIds.insert(move.clipId).inserted { allMoves.append(move) }
@@ -232,14 +242,22 @@ extension EditorViewModel {
         var retimes: [(ids: [String], speed: Double, driftPpm: Double, bearerId: String)] = []
         for p in placements {
             guard let clip = liveClip(p.clipId) else { report.failures.append((p.clipId, "Clip not found.")); continue }
+            var retime: (ids: [String], speed: Double)?
+            if let speed = p.retimedSpeed, speed != clip.speed {
+                let unitIds = [p.clipId] + linkedPartnerIds(of: p.clipId).filter { $0 != referenceClipId }
+                retime = (unitIds, speed)
+                for id in unitIds {
+                    guard let unitClip = liveClip(id) else { continue }
+                    plannedDurations[id] = Self.retimedDurationFrames(
+                        durationFrames: unitClip.durationFrames, speed: unitClip.speed, newSpeed: speed)
+                }
+            }
             if let failure = queueMove(of: p.clipId, toFrame: p.rawStart) {
+                for id in retime?.ids ?? [] { plannedDurations.removeValue(forKey: id) }
                 report.failures.append((p.clipId, failure)); continue
             }
             accepted.append((p.clipId, p.rawStart, p.confidence, p.method, clip.startFrame))
-            if let speed = p.retimedSpeed, speed != clip.speed {
-                let unitIds = [p.clipId] + linkedPartnerIds(of: p.clipId).filter { $0 != referenceClipId }
-                retimes.append((unitIds, speed, p.driftRatio * 1_000_000, p.clipId))
-            }
+            if let retime { retimes.append((retime.ids, retime.speed, p.driftRatio * 1_000_000, p.clipId)) }
         }
 
         // Shift right if any accepted move (partners included) starts before frame 0.
@@ -254,15 +272,32 @@ extension EditorViewModel {
             }
         }
         report.synced = accepted.map { ($0.clipId, $0.rawStart + shift - $0.currentStart, $0.confidence, $0.method) }
+
+        retimes.removeAll { retime in
+            let blocked = retime.ids.contains { id in
+                guard let move = allMoves.first(where: { $0.clipId == id }),
+                      let newDuration = plannedDurations[id] else { return false }
+                return retimeGrowthWouldClobberUnmovedClip(
+                    clipId: id, finalStart: move.toFrame + shift, newDuration: newDuration, movedIds: movedIds)
+            }
+            if blocked {
+                report.retimeSkipped.append((retime.bearerId, "Drift correction skipped — it would overwrite an adjacent clip."))
+            }
+            return blocked
+        }
         report.retimed = retimes.map { ($0.bearerId, $0.driftPpm) }
 
+        let retimedIds = Set(retimes.flatMap(\.ids))
         let moves = allMoves.compactMap { move -> (clipId: String, toTrack: Int, toFrame: Int)? in
-            guard let clip = liveClip(move.clipId), move.toFrame + shift != clip.startFrame else { return nil }
+            guard let clip = liveClip(move.clipId),
+                  move.toFrame + shift != clip.startFrame || retimedIds.contains(move.clipId)
+            else { return nil }
             return (move.clipId, move.toTrack, move.toFrame + shift)
         }
         if !moves.isEmpty || !retimes.isEmpty {
+            try Task.checkCancellation()
             let apply: @MainActor () -> Void = { [self] in
-                for retime in retimes { commitClipSpeed(ids: retime.ids, newSpeed: retime.speed) }
+                for retime in retimes { commitClipSpeed(ids: retime.ids, newSpeed: retime.speed, ripple: false) }
                 if !moves.isEmpty { moveClips(moves) }
             }
             if let mutation {
@@ -300,27 +335,37 @@ extension EditorViewModel {
         return (ordered[0].clip.id, targets)
     }
 
+    func retimeGrowthWouldClobberUnmovedClip(
+        clipId: String, finalStart: Int, newDuration: Int, movedIds: Set<String>
+    ) -> Bool {
+        guard let loc = findClip(id: clipId) else { return false }
+        let clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        let grownStart = finalStart + clip.durationFrames
+        let grownEnd = finalStart + newDuration
+        guard grownEnd > grownStart else { return false }
+        return timeline.tracks[loc.trackIndex].clips.contains {
+            $0.id != clip.id && !movedIds.contains($0.id)
+                && $0.startFrame < grownEnd && $0.endFrame > grownStart
+        }
+    }
+
     private func moveWouldClobberReference(
-        _ moves: [(clipId: String, toTrack: Int, toFrame: Int)], referenceClipId: String
+        _ moves: [(clipId: String, toTrack: Int, toFrame: Int)], referenceClipId: String,
+        durationOf duration: (String) -> Int
     ) -> Bool {
         guard let refLoc = findClip(id: referenceClipId) else { return false }
         let ref = timeline.tracks[refLoc.trackIndex].clips[refLoc.clipIndex]
         for move in moves where move.toTrack == refLoc.trackIndex {
-            guard let loc = findClip(id: move.clipId) else { continue }
-            let duration = timeline.tracks[loc.trackIndex].clips[loc.clipIndex].durationFrames
-            if move.toFrame < ref.endFrame && ref.startFrame < move.toFrame + duration { return true }
+            if move.toFrame < ref.endFrame && ref.startFrame < move.toFrame + duration(move.clipId) { return true }
         }
         return false
     }
 
     private func movesOverlapQueued(
         _ moves: [(clipId: String, toTrack: Int, toFrame: Int)],
-        _ queued: [(clipId: String, toTrack: Int, toFrame: Int)]
+        _ queued: [(clipId: String, toTrack: Int, toFrame: Int)],
+        durationOf duration: (String) -> Int
     ) -> Bool {
-        func duration(_ clipId: String) -> Int {
-            guard let loc = findClip(id: clipId) else { return 0 }
-            return timeline.tracks[loc.trackIndex].clips[loc.clipIndex].durationFrames
-        }
         for move in moves {
             let end = move.toFrame + duration(move.clipId)
             for other in queued where other.toTrack == move.toTrack {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -240,50 +240,70 @@ extension EditorViewModel {
 
         var accepted: [(clipId: String, rawStart: Int, confidence: Double, method: SyncMethod, currentStart: Int)] = []
         var retimes: [(ids: [String], speed: Double, driftPpm: Double, bearerId: String)] = []
-        for p in placements {
-            guard let clip = liveClip(p.clipId) else { report.failures.append((p.clipId, "Clip not found.")); continue }
-            var retime: (ids: [String], speed: Double)?
-            if let speed = p.retimedSpeed, speed != clip.speed {
-                let unitIds = [p.clipId] + linkedPartnerIds(of: p.clipId).filter { $0 != referenceClipId }
-                retime = (unitIds, speed)
-                for id in unitIds {
-                    guard let unitClip = liveClip(id) else { continue }
-                    plannedDurations[id] = Self.retimedDurationFrames(
-                        durationFrames: unitClip.durationFrames, speed: unitClip.speed, newSpeed: speed)
+        var stagedFailures: [(clipId: String, message: String)] = []
+        var skippedRetimeBearers: [String] = []
+        var shift = 0
+
+        // A skipped retime shrinks footprints and can unblock other moves; requeue until stable.
+        while true {
+            allMoves.removeAll()
+            movedIds.removeAll()
+            plannedDurations.removeAll()
+            accepted.removeAll()
+            retimes.removeAll()
+            stagedFailures.removeAll()
+
+            for p in placements {
+                guard let clip = liveClip(p.clipId) else { stagedFailures.append((p.clipId, "Clip not found.")); continue }
+                var retime: (ids: [String], speed: Double)?
+                if let speed = p.retimedSpeed, speed != clip.speed, !skippedRetimeBearers.contains(p.clipId) {
+                    let unitIds = [p.clipId] + linkedPartnerIds(of: p.clipId).filter { $0 != referenceClipId }
+                    retime = (unitIds, speed)
+                    for id in unitIds {
+                        guard let unitClip = liveClip(id) else { continue }
+                        plannedDurations[id] = Self.retimedDurationFrames(
+                            durationFrames: unitClip.durationFrames, speed: unitClip.speed, newSpeed: speed)
+                    }
+                }
+                if let failure = queueMove(of: p.clipId, toFrame: p.rawStart) {
+                    for id in retime?.ids ?? [] { plannedDurations.removeValue(forKey: id) }
+                    stagedFailures.append((p.clipId, failure)); continue
+                }
+                accepted.append((p.clipId, p.rawStart, p.confidence, p.method, clip.startFrame))
+                if let retime { retimes.append((retime.ids, retime.speed, p.driftRatio * 1_000_000, p.clipId)) }
+            }
+
+            // Shift right if any accepted move (partners included) starts before frame 0.
+            shift = max(0, -(allMoves.map(\.toFrame).min() ?? 0))
+            if shift > 0 {
+                let failure = liveClip(referenceClipId).map { queueMove(of: referenceClipId, toFrame: $0.startFrame) }
+                    ?? "Reference clip unavailable."
+                if let failure {
+                    report.shiftedFrames = shift
+                    report.failures.append(contentsOf: stagedFailures)
+                    report.failures.append(contentsOf: accepted.map { ($0.clipId, failure) })
+                    return report
                 }
             }
-            if let failure = queueMove(of: p.clipId, toFrame: p.rawStart) {
-                for id in retime?.ids ?? [] { plannedDurations.removeValue(forKey: id) }
-                report.failures.append((p.clipId, failure)); continue
-            }
-            accepted.append((p.clipId, p.rawStart, p.confidence, p.method, clip.startFrame))
-            if let retime { retimes.append((retime.ids, retime.speed, p.driftRatio * 1_000_000, p.clipId)) }
+
+            let blockedBearers = retimes.filter { retime in
+                retime.ids.contains { id in
+                    guard let move = allMoves.first(where: { $0.clipId == id }),
+                          let newDuration = plannedDurations[id] else { return false }
+                    return retimeGrowthWouldClobberUnmovedClip(
+                        clipId: id, finalStart: move.toFrame + shift, newDuration: newDuration, movedIds: movedIds)
+                }
+            }.map(\.bearerId)
+            guard !blockedBearers.isEmpty else { break }
+            skippedRetimeBearers.append(contentsOf: blockedBearers)
         }
 
-        // Shift right if any accepted move (partners included) starts before frame 0.
-        let shift = max(0, -(allMoves.map(\.toFrame).min() ?? 0))
         report.shiftedFrames = shift
-        if shift > 0 {
-            let failure = liveClip(referenceClipId).map { queueMove(of: referenceClipId, toFrame: $0.startFrame) }
-                ?? "Reference clip unavailable."
-            if let failure {
-                report.failures.append(contentsOf: accepted.map { ($0.clipId, failure) })
-                return report
-            }
-        }
+        report.failures.append(contentsOf: stagedFailures)
         report.synced = accepted.map { ($0.clipId, $0.rawStart + shift - $0.currentStart, $0.confidence, $0.method) }
-
-        retimes.removeAll { retime in
-            let blocked = retime.ids.contains { id in
-                guard let move = allMoves.first(where: { $0.clipId == id }),
-                      let newDuration = plannedDurations[id] else { return false }
-                return retimeGrowthWouldClobberUnmovedClip(
-                    clipId: id, finalStart: move.toFrame + shift, newDuration: newDuration, movedIds: movedIds)
-            }
-            if blocked {
-                report.retimeSkipped.append((retime.bearerId, "Drift correction skipped — it would overwrite an adjacent clip."))
-            }
-            return blocked
+        let acceptedIds = Set(accepted.map(\.clipId))
+        report.retimeSkipped = skippedRetimeBearers.filter(acceptedIds.contains).map {
+            ($0, "Drift correction skipped — it would overwrite an adjacent clip.")
         }
         report.retimed = retimes.map { ($0.bearerId, $0.driftPpm) }
 

--- a/Sources/PalmierPro/MediaPanel/MediaPanelToast.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaPanelToast.swift
@@ -1,6 +1,6 @@
 /// A transient banner shown at the bottom of the media panel
 struct MediaPanelToast: Equatable, Sendable {
-    enum Kind: Equatable, Sendable { case warning, success }
+    enum Kind: Equatable, Sendable { case warning, success, progress }
     var message: String
     var kind: Kind = .warning
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -188,9 +188,19 @@ struct MediaTab: View {
 
     private func toastBanner(_ toast: MediaPanelToast) -> some View {
         HStack(spacing: AppTheme.Spacing.sm) {
-            Image(systemName: toast.kind == .success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
-                .foregroundStyle(toast.kind == .success ? AppTheme.Status.successColor : AppTheme.Accent.timecodeColor)
+            switch toast.kind {
+            case .progress:
+                ProgressView()
+                    .controlSize(.small)
+            case .success:
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
+                    .foregroundStyle(AppTheme.Status.successColor)
+            case .warning:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: AppTheme.FontSize.smMd, weight: .semibold))
+                    .foregroundStyle(AppTheme.Accent.timecodeColor)
+            }
             Text(toast.message)
                 .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
                 .foregroundStyle(AppTheme.Text.primaryColor)
@@ -210,8 +220,12 @@ struct MediaTab: View {
         .shadow(AppTheme.Shadow.lg)
         .padding(.horizontal, AppTheme.Spacing.lgXl)
         .padding(.bottom, AppTheme.Spacing.lgXl)
-        .onTapGesture { editor.dismissMediaPanelToast() }
+        .onTapGesture {
+            guard toast.kind != .progress else { return }
+            editor.dismissMediaPanelToast()
+        }
         .task(id: toast) {
+            guard toast.kind != .progress else { return }
             try? await Task.sleep(for: .seconds(4))
             guard !Task.isCancelled else { return }
             editor.dismissMediaPanelToast()

--- a/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
@@ -38,6 +38,7 @@ extension TimelineView {
         }
         if report.shiftedFrames > 0 { msg += ", group moved right to fit" }
         if !report.retimed.isEmpty { msg += ", drift-corrected" }
+        if !report.retimeSkipped.isEmpty { msg += "; drift correction skipped — it would overwrite an adjacent clip" }
         if !report.failures.isEmpty { msg += "; \(report.failures.count) couldn't align" }
         return msg + "."
     }

--- a/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+SyncMenu.swift
@@ -8,12 +8,15 @@ extension TimelineView {
         let mode = (info["mode"] as? String).flatMap(EditorViewModel.SyncMode.init) ?? .auto
         Task { @MainActor [weak self] in
             guard let self else { return }
+            editor.mediaPanelToast = MediaPanelToast(message: "Synchronizing…", kind: .progress)
             do {
                 let report = try await editor.syncClips(referenceClipId: referenceClipId, targetClipIds: targetClipIds, mode: mode)
                 editor.mediaPanelToast = MediaPanelToast(
                     message: Self.synchronizeSummary(report),
                     kind: report.synced.isEmpty ? .warning : .success
                 )
+            } catch is CancellationError {
+                editor.dismissMediaPanelToast()
             } catch {
                 editor.mediaPanelToast = MediaPanelToast(message: error.localizedDescription, kind: .warning)
             }
@@ -34,6 +37,7 @@ extension TimelineView {
         default: msg += " (\(byTimecode) by timecode, \(byAudio) by audio)"
         }
         if report.shiftedFrames > 0 { msg += ", group moved right to fit" }
+        if !report.retimed.isEmpty { msg += ", drift-corrected" }
         if !report.failures.isEmpty { msg += "; \(report.failures.count) couldn't align" }
         return msg + "."
     }

--- a/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
+++ b/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
@@ -93,6 +93,30 @@ struct AudioSyncCorrelatorTests {
         #expect((result?.confidence ?? 0) > 0.99)
     }
 
+    @Test func seededCorrelateObservesCallingTaskCancellation() async {
+        let s = signal(count: 2_000)
+        let result = await Task { () -> AudioSyncCorrelator.Result? in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await AudioSyncCorrelator.seededCorrelate(
+                reference: s, target: s, seedHops: nil, seedWindowHops: 10,
+                maxLagHops: 500, minOverlapHops: 100, minConfidence: 0.5
+            )
+        }.value
+        #expect(result == nil)
+    }
+
+    @Test func edgePeakInRefinedRangeIsNotSuppressedByNeighboringRange() {
+        let omega = 2.0 * Double.pi / 64.0
+        let reference = (0..<256).map { Float(sin(Double($0) * omega)) }
+        let target = (0..<200).map { Float(sin(Double($0 + 10) * omega)) }
+        let candidates = AudioSyncCorrelator.exactCandidates(
+            reference: reference, target: target,
+            lagRanges: [0...2, 9...11], minOverlapHops: 16
+        )
+        #expect(candidates.first?.lagHops == 10)
+        #expect(candidates.contains { $0.lagHops == 2 })
+    }
+
     @Test func requestedOverlapAdaptsForShortClips() {
         let samples = signal(count: 120)
         let result = AudioSyncCorrelator.correlate(

--- a/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
+++ b/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
@@ -93,21 +93,6 @@ struct AudioSyncCorrelatorTests {
         #expect((result?.confidence ?? 0) > 0.99)
     }
 
-    @Test func searchesAroundAdditionalTimelineCenter() async {
-        let target = signal(count: 300, seed: 11)
-        var reference = [Float](repeating: 0, count: 1_000)
-        reference.replaceSubrange(600..<900, with: target)
-
-        let result = await AudioSyncCorrelator.seededCorrelate(
-            reference: reference, target: target, seedHops: nil, seedWindowHops: 10,
-            maxLagHops: 50, minOverlapHops: 100, minConfidence: 0.5,
-            additionalSearchCenterHops: [600]
-        )
-
-        #expect(result?.lagHops == 600)
-        #expect((result?.confidence ?? 0) > 0.99)
-    }
-
     @Test func requestedOverlapAdaptsForShortClips() {
         let samples = signal(count: 120)
         let result = AudioSyncCorrelator.correlate(
@@ -127,5 +112,78 @@ struct AudioSyncCorrelatorTests {
 
         #expect(result?.lagHops == lag)
         #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func pyramidSearchFindsLargeNonalignedLag() {
+        let base = signal(count: 25_000)
+        let lag = 20_003
+        let target = Array(base[lag..<(lag + 4_000)])
+        let result = AudioSyncCorrelator.correlate(
+            reference: base, target: target, maxLagHops: 24_000, minOverlapHops: 1_000
+        )
+
+        #expect(result?.lagHops == lag)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func pyramidSearchRefinesCompetingCoarsePeaks() {
+        let target = signal(count: 512, seed: 73)
+        let coarseAlias = Swift.stride(from: 0, to: target.count, by: 2).flatMap {
+            target[$0..<min($0 + 2, target.count)].reversed()
+        }
+        var reference = [Float](repeating: 0, count: 6_000)
+        reference.replaceSubrange(800..<1_312, with: coarseAlias)
+        reference.replaceSubrange(5_000..<5_512, with: target)
+
+        let result = AudioSyncCorrelator.correlate(
+            reference: reference, target: target, maxLagHops: 5_500, minOverlapHops: 256
+        )
+
+        #expect(result?.lagHops == 5_000)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func consensusFitsClockDriftAcrossLongRecordings() async {
+        let drift = 0.0003
+        let noise = signal(count: 121_000, seed: 5)
+        var reference = [Float](repeating: 0, count: noise.count)
+        var running: Float = 0
+        for i in noise.indices {
+            running += (noise[i] - running) * 0.05
+            reference[i] = running
+        }
+        let smooth = { (x: Double) -> Float in
+            let i = Int(x)
+            guard i + 1 < reference.count else { return reference[min(i, reference.count - 1)] }
+            let frac = Float(x - Double(i))
+            return reference[i] * (1 - frac) + reference[i + 1] * frac
+        }
+        let head = 400.0
+        let target = (0..<110_000).map { smooth(head + Double($0) * (1 + drift)) }
+
+        let result = await AudioSyncCorrelator.seededCorrelate(
+            reference: reference, target: target, seedHops: nil, seedWindowHops: 10,
+            maxLagHops: 120_000, minOverlapHops: 1_200, minConfidence: 0.5
+        )
+
+        let r = try! #require(result)
+        #expect(abs(r.lagHops - Int(head)) <= 8)
+        #expect(abs(r.driftRatio - drift) < 0.00005)
+        #expect(r.confidence > 0.8)
+    }
+
+    @Test func consensusReportsZeroDriftForCleanCopies() async {
+        let reference = signal(count: 120_000, seed: 9)
+        let target = Array(reference[500..<110_500])
+
+        let result = await AudioSyncCorrelator.seededCorrelate(
+            reference: reference, target: target, seedHops: nil, seedWindowHops: 10,
+            maxLagHops: 120_000, minOverlapHops: 1_200, minConfidence: 0.5
+        )
+
+        let r = try! #require(result)
+        #expect(r.lagHops == 500)
+        #expect(r.driftRatio == 0)
+        #expect(r.confidence > 0.99)
     }
 }

--- a/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
+++ b/Tests/PalmierProTests/Audio/AudioSyncCorrelatorTests.swift
@@ -76,4 +76,56 @@ struct AudioSyncCorrelatorTests {
         #expect(AudioSyncCorrelator.correlate(reference: [], target: [1, 2, 3], maxLagHops: 5) == nil)
         #expect(AudioSyncCorrelator.correlate(reference: [1, 2, 3], target: [], maxLagHops: 5) == nil)
     }
+
+    @Test func seededCorrelationChoosesStrongerFullWindowMatch() async {
+        let target = signal(count: 300, seed: 7)
+        let interference = signal(count: 300, seed: 99)
+        var reference = [Float](repeating: 0, count: 1_000)
+        reference.replaceSubrange(100..<400, with: target)
+        reference.replaceSubrange(600..<900, with: zip(target, interference).map { $0 * 0.6 + $1 * 0.4 })
+
+        let result = await AudioSyncCorrelator.seededCorrelate(
+            reference: reference, target: target, seedHops: 600, seedWindowHops: 10,
+            maxLagHops: 200, minOverlapHops: 100, minConfidence: 0.5
+        )
+
+        #expect(result?.lagHops == 100)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func searchesAroundAdditionalTimelineCenter() async {
+        let target = signal(count: 300, seed: 11)
+        var reference = [Float](repeating: 0, count: 1_000)
+        reference.replaceSubrange(600..<900, with: target)
+
+        let result = await AudioSyncCorrelator.seededCorrelate(
+            reference: reference, target: target, seedHops: nil, seedWindowHops: 10,
+            maxLagHops: 50, minOverlapHops: 100, minConfidence: 0.5,
+            additionalSearchCenterHops: [600]
+        )
+
+        #expect(result?.lagHops == 600)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func requestedOverlapAdaptsForShortClips() {
+        let samples = signal(count: 120)
+        let result = AudioSyncCorrelator.correlate(
+            reference: samples, target: samples, maxLagHops: 20, minOverlapHops: 300
+        )
+
+        #expect(result?.lagHops == 0)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
+
+    @Test func multiresolutionSearchRefinesToExactHop() {
+        let base = signal(count: 2_000)
+        let lag = 37
+        let result = AudioSyncCorrelator.correlate(
+            reference: base, target: Array(base[lag...]), maxLagHops: 400, minOverlapHops: 300
+        )
+
+        #expect(result?.lagHops == lag)
+        #expect((result?.confidence ?? 0) > 0.99)
+    }
 }

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -53,6 +53,26 @@ struct ApplyClipSpeedTests {
         #expect(updated.startFrame == 100)
     }
 
+    @Test func commitClipSpeedWithoutRippleLeavesContiguousNeighborsInPlace() {
+        let c1 = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        let c2 = Fixtures.clip(id: "c2", start: 60, duration: 30)
+        let e = editor([Fixtures.videoTrack(clips: [c1, c2])])
+        e.commitClipSpeed(ids: ["c1"], newSpeed: 2.0, ripple: false)
+        let updated = e.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(updated[0].durationFrames == 30)
+        #expect(updated[1].startFrame == 60)
+    }
+
+    @Test func commitClipSpeedRipplesContiguousNeighborsByDefault() {
+        let c1 = Fixtures.clip(id: "c1", start: 0, duration: 60)
+        let c2 = Fixtures.clip(id: "c2", start: 60, duration: 30)
+        let e = editor([Fixtures.videoTrack(clips: [c1, c2])])
+        e.commitClipSpeed(ids: ["c1"], newSpeed: 2.0)
+        let updated = e.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
+        #expect(updated[0].durationFrames == 30)
+        #expect(updated[1].startFrame == 30)
+    }
+
     @Test func applyClipSpeedRescalesKeyframesInsteadOfDroppingThem() {
         // 2x speed halves a 60-frame clip; keyframes must rescale, not get clamped away.
         var clip = Fixtures.clip(id: "c1", start: 0, duration: 60)

--- a/Tests/PalmierProTests/Timeline/TimecodeSyncTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimecodeSyncTests.swift
@@ -39,6 +39,47 @@ struct TimecodeSyncTests {
         #expect(SourceTimingReader.parseQuickTimeDate("not a date") == nil)
     }
 
+    @Test func syncClipsThrowsInsteadOfMutatingWhenCancelled() async throws {
+        let ref = Fixtures.clip(id: "ref", start: 0, duration: 60)
+        let target = Fixtures.clip(id: "t1", start: 200, duration: 60)
+        let e = await MainActor.run { () -> EditorViewModel in
+            let e = EditorViewModel()
+            e.timeline = Fixtures.timeline(tracks: [
+                Fixtures.videoTrack(clips: [ref]),
+                Fixtures.videoTrack(clips: [target]),
+            ])
+            return e
+        }
+        let before = await MainActor.run { e.timeline }
+        await #expect(throws: CancellationError.self) {
+            try await Task { @MainActor in
+                withUnsafeCurrentTask { $0?.cancel() }
+                return try await e.syncClips(referenceClipId: "ref", targetClipIds: ["t1"])
+            }.value
+        }
+        await MainActor.run { #expect(e.timeline == before) }
+    }
+
+    @MainActor
+    @Test func retimeGrowthClobberDetectionRespectsNeighborsGapsAndBatch() {
+        let clip = Fixtures.clip(id: "c1", start: 0, duration: 100)
+        let neighbor = Fixtures.clip(id: "n1", start: 100, duration: 50)
+        let e = EditorViewModel()
+        e.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip, neighbor])])
+
+        #expect(e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 0, newDuration: 101, movedIds: ["c1"]))
+        #expect(!e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 0, newDuration: 100, movedIds: ["c1"]))
+        #expect(!e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 0, newDuration: 99, movedIds: ["c1"]))
+        #expect(!e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 0, newDuration: 101, movedIds: ["c1", "n1"]))
+        #expect(e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 25, newDuration: 101, movedIds: ["c1"]))
+        #expect(!e.retimeGrowthWouldClobberUnmovedClip(clipId: "c1", finalStart: 200, newDuration: 101, movedIds: ["c1"]))
+
+        let gapped = Fixtures.clip(id: "c2", start: 300, duration: 100)
+        e.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [gapped, Fixtures.clip(id: "n2", start: 450, duration: 50)])])
+        #expect(!e.retimeGrowthWouldClobberUnmovedClip(clipId: "c2", finalStart: 300, newDuration: 150, movedIds: ["c2"]))
+        #expect(e.retimeGrowthWouldClobberUnmovedClip(clipId: "c2", finalStart: 300, newDuration: 151, movedIds: ["c2"]))
+    }
+
     @Test func seededCorrelationFindsLagOutsideSymmetricWindow() {
         var state: UInt64 = 42
         func noise(_ n: Int) -> [Float] {


### PR DESCRIPTION
Summary
Synchronize-by-audio for clips without timecode was unreliable: alignments landed 5–6 frames off, and visibly matching waveforms could fail outright with "no matching audio." Both failures came from real dual-recorder footage (~44-minute camera MP4 + external recorder WAV) whose sample clocks drift apart by ~145 ppm — about 380 ms of slide over the take — so no single offset fits the whole recording, and the old whole-envelope correlation scored poorly everywhere.

This PR makes audio sync sample-accurate on such footage:

- Consensus matching: correlate five 60-second chunks spread across the target, cluster the offsets that agree, and reject outlier chunks (silence, repeated content).
- Drift detection and correction: fit lag-vs-position across agreeing chunks; place the clip using the exact fitted offset at its head and retime it (e.g. speed 1.000145) so alignment holds for the full duration. Move + retime commit as one undoable Synchronize action.
- Full-overlap search by default: the previous ±30 s cap silently hid large offsets and produced the "no matching audio" failures. searchWindowSeconds is now optional; when omitted, the entire feasible overlap is searched.
- Sub-frame precision: envelope hop reduced from 10 ms to 2.5 ms with log-scaled energy; placement converts the exact fractional fitted lag to frames with a single rounding (the previous hop-then-frame double rounding could flip a near-half-frame result to the wrong frame).
- UI: a persistent "Synchronizing…" progress toast shows while sync runs, replaced by the result toast.
- Multicam sync uses the same correlator and inherits all of it; its sync maps store offsets in seconds and now use the exact fractional lag with no frame quantization.
- 
<img width="714" height="520" alt="Screenshot 2026-07-18 at 8 33 40 PM" src="https://github.com/user-attachments/assets/043c8c2d-573a-4fc7-be75-99fa580fa4b5" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline mutation paths (moves + speed) and sync heuristics; behavior shifts when search window is omitted and when drift retime runs, though overlap guards and cancellation reduce accidental edits.
> 
> **Overview**
> **Audio sync** is reworked for long dual-recorder takes where clocks drift: correlation uses finer **2.5 ms** log-energy envelopes, **multi-chunk consensus** (with optional **drift fit** returning `exactLagHops` and `driftRatio`), and a **pyramid** search for very large lags. **`searchWindowSeconds`** is now optional on clip sync (and in the agent schema)—omit it to search the full feasible overlap instead of a fixed ±30 s default.
> 
> **Timeline sync** applies detected drift by **retiming** matched clips (`commitClipSpeed` with **`ripple: false`**) together with moves in one undo step, skips retime when it would hit unmoved neighbors, and surfaces **`driftCorrected` / `driftCorrectionSkipped`** in agent results. **Multicam member sync** uses the same fractional lag placement and can **throw** on cancellation.
> 
> **UI** shows a non-dismissible **“Synchronizing…”** progress toast during timeline sync; cancellation leaves the timeline unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1aa2002d6b93c92cd1d9ace2c6feafcc71ba77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->