### PR TITLE
[fix] Prevent beat-cache hydration hangs

### DIFF
--- a/Sources/PalmierPro/Audio/Beats/BeatDetector.swift
+++ b/Sources/PalmierPro/Audio/Beats/BeatDetector.swift
@@ -10,6 +10,11 @@ struct BeatAnalysis: Codable, Sendable, Equatable {
     let downbeats: [Double]
 }
 
+struct BeatAnalysisCacheEntry: Sendable {
+    let analysis: BeatAnalysis
+    let fileTag: String
+}
+
 /// Detects beats and downbeats on-device using the bundled Beat This Core ML model.
 final class BeatDetector: @unchecked Sendable {
     enum DetectError: Error {
@@ -35,10 +40,14 @@ final class BeatDetector: @unchecked Sendable {
     static let cache = DiskCache(named: "BeatAnalysis")
     private static let shared = try? BeatDetector()
     private static let pipelineGate = AsyncSemaphore(value: 2)
+    private static let cacheLookupGate = AsyncSemaphore(value: 2)
 
     @concurrent
     static func analysis(for sourceURL: URL, mediaRef: String, force: Bool = false) async throws -> BeatAnalysis {
-        if !force, let cached = cachedAnalysis(for: sourceURL, mediaRef: mediaRef) { return cached }
+        if !force, let cached = await cachedAnalysis(for: sourceURL, mediaRef: mediaRef) {
+            return cached.analysis
+        }
+        try Task.checkCancellation()
         guard let detector = shared else { throw DetectError.modelMissing }
         try await pipelineGate.wait()
         defer { Task { await pipelineGate.signal() } }
@@ -51,13 +60,28 @@ final class BeatDetector: @unchecked Sendable {
         return analysis
     }
 
-    static func cachedAnalysis(for sourceURL: URL, mediaRef: String) -> BeatAnalysis? {
-        guard let data = try? Data(contentsOf: analysisURL(for: sourceURL, mediaRef: mediaRef)) else { return nil }
-        return try? JSONDecoder().decode(BeatAnalysis.self, from: data)
+    @concurrent
+    static func cachedAnalysis(for sourceURL: URL, mediaRef: String) async -> BeatAnalysisCacheEntry? {
+        do {
+            try await cacheLookupGate.wait()
+        } catch {
+            return nil
+        }
+        defer { Task { await cacheLookupGate.signal() } }
+        guard !Task.isCancelled else { return nil }
+        let fileTag = DiskCache.sizeMtimeTag(for: sourceURL)
+        guard let data = try? Data(contentsOf: analysisURL(mediaRef: mediaRef, fileTag: fileTag)),
+              let analysis = try? JSONDecoder().decode(BeatAnalysis.self, from: data) else { return nil }
+        guard !Task.isCancelled else { return nil }
+        return BeatAnalysisCacheEntry(analysis: analysis, fileTag: fileTag)
     }
 
     private static func analysisURL(for sourceURL: URL, mediaRef: String) -> URL {
-        cache.directory.appendingPathComponent("\(mediaRef)_\(DiskCache.sizeMtimeTag(for: sourceURL))_beats.json")
+        analysisURL(mediaRef: mediaRef, fileTag: DiskCache.sizeMtimeTag(for: sourceURL))
+    }
+
+    private static func analysisURL(mediaRef: String, fileTag: String) -> URL {
+        cache.directory.appendingPathComponent("\(mediaRef)_\(fileTag)_beats.json")
     }
 
     private static func removeStaleCaches(for mediaRef: String, keeping keep: URL) {

--- a/Sources/PalmierPro/Audio/Beats/BeatStore.swift
+++ b/Sources/PalmierPro/Audio/Beats/BeatStore.swift
@@ -3,29 +3,57 @@ import Foundation
 /// Stores beats for each mediaRef. Avoids doing the same detection twice.
 @MainActor
 final class BeatStore {
+    typealias CachedAnalysisLoader = @Sendable (URL, String) async -> BeatAnalysisCacheEntry?
+
     private var analyses: [String: BeatAnalysis] = [:]
     private var fileTags: [String: String] = [:]
     private var tasks: [String: Task<BeatAnalysis, Error>] = [:]
+    private var hydrationTasks: [String: (id: UUID, task: Task<Void, Never>)] = [:]
+    private let cachedAnalysisLoader: CachedAnalysisLoader
 
     var onBeatsReady: (() -> Void)?
+
+    init(
+        cachedAnalysisLoader: @escaping CachedAnalysisLoader = { sourceURL, mediaRef in
+            await BeatDetector.cachedAnalysis(for: sourceURL, mediaRef: mediaRef)
+        }
+    ) {
+        self.cachedAnalysisLoader = cachedAnalysisLoader
+    }
 
     nonisolated func analysis(for mediaRef: String) -> BeatAnalysis? {
         MainActor.assumeIsolated { analyses[mediaRef] }
     }
 
     /// Restores a prior session's analysis from the disk cache; never runs detection.
-    func hydrate(for asset: MediaAsset) {
+    @discardableResult
+    func hydrate(for asset: MediaAsset) -> Task<Void, Never>? {
         let key = asset.id
-        guard analyses[key] == nil, tasks[key] == nil,
-              let cached = BeatDetector.cachedAnalysis(for: asset.url, mediaRef: key) else { return }
-        analyses[key] = cached
-        fileTags[key] = DiskCache.sizeMtimeTag(for: asset.url)
-        onBeatsReady?()
+        guard analyses[key] == nil, tasks[key] == nil else { return nil }
+        if let hydration = hydrationTasks[key] { return hydration.task }
+        let id = UUID()
+        let url = asset.url
+        let loader = cachedAnalysisLoader
+        let task = Task(priority: .utility) { @MainActor [weak self] in
+            let entry = await loader(url, key)
+            guard let self, self.hydrationTasks[key]?.id == id else { return }
+            self.hydrationTasks.removeValue(forKey: key)
+            guard !Task.isCancelled,
+                  self.tasks[key] == nil,
+                  self.analyses[key] == nil,
+                  let entry else { return }
+            self.analyses[key] = entry.analysis
+            self.fileTags[key] = entry.fileTag
+            self.onBeatsReady?()
+        }
+        hydrationTasks[key] = (id, task)
+        return task
     }
 
     @discardableResult
     func detect(for asset: MediaAsset, force: Bool = false) -> Task<BeatAnalysis, Error> {
         let key = asset.id
+        hydrationTasks.removeValue(forKey: key)?.task.cancel()
         let tag = DiskCache.sizeMtimeTag(for: asset.url)
         if !force {
             if let existing = analyses[key], fileTags[key] == tag { return Task { existing } }
@@ -48,13 +76,16 @@ final class BeatStore {
 
     func reset() {
         tasks.values.forEach { $0.cancel() }
+        hydrationTasks.values.forEach { $0.task.cancel() }
         tasks.removeAll()
+        hydrationTasks.removeAll()
         analyses.removeAll()
         fileTags.removeAll()
     }
 
     func invalidate(_ mediaRef: String) {
         tasks.removeValue(forKey: mediaRef)?.cancel()
+        hydrationTasks.removeValue(forKey: mediaRef)?.task.cancel()
         analyses.removeValue(forKey: mediaRef)
         fileTags.removeValue(forKey: mediaRef)
     }

--- a/Sources/PalmierPro/Audio/Beats/BeatStore.swift
+++ b/Sources/PalmierPro/Audio/Beats/BeatStore.swift
@@ -34,12 +34,16 @@ final class BeatStore {
         let id = UUID()
         let url = asset.url
         let loader = cachedAnalysisLoader
-        let task = Task(priority: .utility) { @MainActor [weak self] in
+        let task = Task(priority: .utility) { @MainActor [weak self, weak asset] in
             let entry = await loader(url, key)
             guard let self, self.hydrationTasks[key]?.id == id else { return }
             self.hydrationTasks.removeValue(forKey: key)
-            guard !Task.isCancelled,
-                  self.tasks[key] == nil,
+            guard !Task.isCancelled, let asset else { return }
+            guard asset.url.standardizedFileURL == url.standardizedFileURL else {
+                self.hydrate(for: asset)
+                return
+            }
+            guard self.tasks[key] == nil,
                   self.analyses[key] == nil,
                   let entry else { return }
             self.analyses[key] = entry.analysis

--- a/Tests/PalmierProTests/Audio/BeatStoreTests.swift
+++ b/Tests/PalmierProTests/Audio/BeatStoreTests.swift
@@ -49,16 +49,43 @@ struct BeatStoreTests {
         #expect(store.analysis(for: asset.id) == nil)
     }
 
+    @Test func urlChangeRestartsHydrationWithCurrentURL() async throws {
+        let loader = ControlledBeatCacheLoader()
+        let store = makeStore(loader: loader)
+        let originalURL = URL(fileURLWithPath: "/tmp/original.palmier/Media/audio.wav")
+        let rebasedURL = URL(fileURLWithPath: "/tmp/rebased.palmier/Media/audio.wav")
+        let asset = makeAsset(url: originalURL)
+        let stale = BeatAnalysis(bpm: 90, beats: [0.5], downbeats: [])
+        let current = BeatAnalysis(bpm: 120, beats: [1], downbeats: [1])
+
+        let first = try #require(store.hydrate(for: asset))
+        await loader.waitUntilInvocationCount(1)
+        asset.url = rebasedURL
+        #expect(await loader.finishNext(with: BeatAnalysisCacheEntry(analysis: stale, fileTag: "old")))
+        await first.value
+
+        await loader.waitUntilInvocationCount(2)
+        let restarted = try #require(store.hydrate(for: asset))
+        #expect(await loader.requestedURLs() == [originalURL, rebasedURL])
+        #expect(store.analysis(for: asset.id) == nil)
+        #expect(await loader.finishNext(with: BeatAnalysisCacheEntry(analysis: current, fileTag: "new")))
+        await restarted.value
+
+        #expect(store.analysis(for: asset.id) == current)
+    }
+
     private func makeStore(loader: ControlledBeatCacheLoader) -> BeatStore {
         BeatStore { sourceURL, mediaRef in
             await loader.load(sourceURL: sourceURL, mediaRef: mediaRef)
         }
     }
 
-    private func makeAsset() -> MediaAsset {
+    private func makeAsset(
+        url: URL = URL(fileURLWithPath: "/tmp/beat-store-\(UUID().uuidString).wav")
+    ) -> MediaAsset {
         MediaAsset(
             id: UUID().uuidString,
-            url: URL(fileURLWithPath: "/tmp/beat-store-\(UUID().uuidString).wav"),
+            url: url,
             type: .audio,
             name: "Test Audio"
         )
@@ -67,27 +94,41 @@ struct BeatStoreTests {
 
 private actor ControlledBeatCacheLoader {
     private var loadCount = 0
-    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var sourceURLs: [URL] = []
+    private var startedWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var resultWaiters: [CheckedContinuation<BeatAnalysisCacheEntry?, Never>] = []
 
-    func load(sourceURL _: URL, mediaRef _: String) async -> BeatAnalysisCacheEntry? {
+    func load(sourceURL: URL, mediaRef _: String) async -> BeatAnalysisCacheEntry? {
         loadCount += 1
+        sourceURLs.append(sourceURL)
         let waiters = startedWaiters
         startedWaiters.removeAll()
-        for waiter in waiters { waiter.resume() }
+        for waiter in waiters {
+            if loadCount >= waiter.count {
+                waiter.continuation.resume()
+            } else {
+                startedWaiters.append(waiter)
+            }
+        }
         return await withCheckedContinuation { continuation in
             resultWaiters.append(continuation)
         }
     }
 
     func waitUntilStarted() async {
-        guard loadCount == 0 else { return }
+        await waitUntilInvocationCount(1)
+    }
+
+    func waitUntilInvocationCount(_ count: Int) async {
+        guard loadCount < count else { return }
         await withCheckedContinuation { continuation in
-            startedWaiters.append(continuation)
+            startedWaiters.append((count, continuation))
         }
     }
 
     func invocationCount() -> Int { loadCount }
+
+    func requestedURLs() -> [URL] { sourceURLs }
 
     func finishNext(with result: BeatAnalysisCacheEntry?) -> Bool {
         guard !resultWaiters.isEmpty else { return false }

--- a/Tests/PalmierProTests/Audio/BeatStoreTests.swift
+++ b/Tests/PalmierProTests/Audio/BeatStoreTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("BeatStore hydration")
+@MainActor
+struct BeatStoreTests {
+    @Test func hydrationReturnsWhileCacheLoadIsPending() async throws {
+        let loader = ControlledBeatCacheLoader()
+        let store = makeStore(loader: loader)
+        let asset = makeAsset()
+
+        let task = try #require(store.hydrate(for: asset))
+        await loader.waitUntilStarted()
+
+        #expect(store.analysis(for: asset.id) == nil)
+        #expect(await loader.invocationCount() == 1)
+        #expect(await loader.finishNext(with: nil))
+        await task.value
+    }
+
+    @Test func repeatedHydrationStartsOneCacheLoad() async throws {
+        let loader = ControlledBeatCacheLoader()
+        let store = makeStore(loader: loader)
+        let asset = makeAsset()
+
+        let first = try #require(store.hydrate(for: asset))
+        let second = try #require(store.hydrate(for: asset))
+        await loader.waitUntilStarted()
+
+        #expect(await loader.invocationCount() == 1)
+        #expect(await loader.finishNext(with: nil))
+        await first.value
+        await second.value
+    }
+
+    @Test func invalidationRejectsLateHydrationResult() async throws {
+        let loader = ControlledBeatCacheLoader()
+        let store = makeStore(loader: loader)
+        let asset = makeAsset()
+        let analysis = BeatAnalysis(bpm: 120, beats: [0.5], downbeats: [0.5])
+
+        let task = try #require(store.hydrate(for: asset))
+        await loader.waitUntilStarted()
+        store.invalidate(asset.id)
+        #expect(await loader.finishNext(with: BeatAnalysisCacheEntry(analysis: analysis, fileTag: "tag")))
+        await task.value
+
+        #expect(store.analysis(for: asset.id) == nil)
+    }
+
+    private func makeStore(loader: ControlledBeatCacheLoader) -> BeatStore {
+        BeatStore { sourceURL, mediaRef in
+            await loader.load(sourceURL: sourceURL, mediaRef: mediaRef)
+        }
+    }
+
+    private func makeAsset() -> MediaAsset {
+        MediaAsset(
+            id: UUID().uuidString,
+            url: URL(fileURLWithPath: "/tmp/beat-store-\(UUID().uuidString).wav"),
+            type: .audio,
+            name: "Test Audio"
+        )
+    }
+}
+
+private actor ControlledBeatCacheLoader {
+    private var loadCount = 0
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resultWaiters: [CheckedContinuation<BeatAnalysisCacheEntry?, Never>] = []
+
+    func load(sourceURL _: URL, mediaRef _: String) async -> BeatAnalysisCacheEntry? {
+        loadCount += 1
+        let waiters = startedWaiters
+        startedWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        return await withCheckedContinuation { continuation in
+            resultWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard loadCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append(continuation)
+        }
+    }
+
+    func invocationCount() -> Int { loadCount }
+
+    func finishNext(with result: BeatAnalysisCacheEntry?) -> Bool {
+        guard !resultWaiters.isEmpty else { return false }
+        resultWaiters.removeFirst().resume(returning: result)
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

Move beat-cache hydration file metadata lookup, cache reads, and JSON decoding off the main actor. Project restore and visual preparation no longer synchronously block the UI while hydrating beat analyses.

The hang was caused by `BeatStore.hydrate` calling the synchronous cache path while isolated to `@MainActor`. That path performed source metadata access, `Data(contentsOf:)`, and JSON decoding before returning.

## Approach

- Make cache lookup an explicit `@concurrent` asynchronous operation and cap concurrent cache reads at two.
- Keep `BeatStore` on the main actor as the authoritative state owner, but let `hydrate` schedule the cache lookup and return immediately.
- Deduplicate hydration by media ID and identify each request with a UUID so cancelled or superseded completions cannot commit stale data.
- Revalidate the asset URL after cache lookup and restart hydration when Save As rebases it.
- Cancel pending hydration when explicit detection, invalidation, or reset takes ownership of the media entry.
- Preserve cancellation before falling through from a cache miss to beat detection.

## Design

```mermaid
flowchart LR
    A[Project restore] --> B[BeatStore on main actor]
    B -->|schedule and return| C[Bounded concurrent cache lookup]
    C --> D[File tag + cache read + JSON decode]
    D -->|immutable cache entry| E{Request still current?}
    E -->|yes| F[Commit analysis on main actor]
    E -->|cancelled or stale| G[Discard result]
```

`BeatStore` remains the only mutable owner. The background operation receives only the asset URL and media ID, then returns an immutable analysis and matching file tag for a guarded main-actor commit.

## Testing

- `swift test --filter BeatStoreTests` — 4 tests passed.
- `swift build` — passed.
- `swift test` — 1,083 tests across 168 suites passed.
- Real MCP flow in a disposable project: imported generated WAV audio, added it to a timeline, detected beats, closed and reopened the project, and exercised the cached detection path without a crash or hang.
- LLDB breakpoint at the source metadata lookup confirmed cache hydration ran on a utility cooperative task rather than the main thread.

The existing `libconvexmobile` macOS 26.2-versus-26.0 linker warnings remain unchanged.

Manual UI verification remains: reopen a project containing multiple analyzed audio assets, confirm the window stays interactive while beat overlays hydrate, then invalidate or trigger detection during hydration and confirm no stale overlay appears.
