### PR TITLE
[ui] Remove the Claude Desktop manual-setup fallback

### DIFF
--- a/Sources/PalmierPro/Help/MCPInstructionsPane.swift
+++ b/Sources/PalmierPro/Help/MCPInstructionsPane.swift
@@ -67,7 +67,7 @@ struct MCPInstructionsPane: View {
         ) {
             Button("Dismiss") { claudeInstallError = nil }
         } message: {
-            Text(claudeInstallError ?? "Use manual setup instead.")
+            Text(claudeInstallError ?? "Try again.")
         }
     }
 
@@ -199,7 +199,7 @@ struct MCPInstructionsPane: View {
 
     private func openClaudeDesktopBundle() {
         guard let bundleURL = claudeDesktopBundleURL else {
-            claudeInstallError = "The Palmier Pro connector could not be found. Use manual setup instead."
+            claudeInstallError = "The Palmier Pro connector could not be found. Reinstall Palmier Pro, then try again."
             return
         }
         guard let claudeURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.anthropic.claudefordesktop") else {
@@ -214,7 +214,7 @@ struct MCPInstructionsPane: View {
         ) { _, error in
             guard error != nil else { return }
             Task { @MainActor in
-                claudeInstallError = "Claude Desktop could not open the Palmier Pro connector. Use manual setup instead."
+                claudeInstallError = "Claude Desktop could not open the Palmier Pro connector. Update Claude Desktop, then try again."
             }
         }
     }

--- a/Sources/PalmierPro/Help/MCPInstructionsPane.swift
+++ b/Sources/PalmierPro/Help/MCPInstructionsPane.swift
@@ -113,10 +113,7 @@ struct MCPInstructionsPane: View {
             description: "Install the bundled Palmier Pro connector.",
             action: ("Install in Claude Desktop", openClaudeDesktopBundle)
         ) {
-            ManualFallback(
-                intro: "In Claude Desktop, choose Settings › Extensions › Advanced settings › Install extension…, then select the connector at this path.",
-                code: claudeDesktopBundleURL?.path ?? "palmier-pro.mcpb"
-            )
+            EmptyView()
         }
     }
 

--- a/Sources/PalmierPro/Help/MCPInstructionsPane.swift
+++ b/Sources/PalmierPro/Help/MCPInstructionsPane.swift
@@ -27,26 +27,6 @@ struct MCPInstructionsPane: View {
         """
     }
 
-    private var claudeDesktopJSONConfig: String {
-        """
-        {
-          "mcpServers": {
-            "palmier-pro": {
-              "command": "npx",
-              "args": [
-                "-y",
-                "mcp-remote",
-                "\(mcpEndpoint)",
-                "--allow-http",
-                "--transport",
-                "http-only"
-              ]
-            }
-          }
-        }
-        """
-    }
-
     private var cursorDeepLink: URL? {
         let config: [String: String] = ["type": "http", "url": mcpEndpoint]
         guard
@@ -134,8 +114,8 @@ struct MCPInstructionsPane: View {
             action: ("Install in Claude Desktop", openClaudeDesktopBundle)
         ) {
             ManualFallback(
-                intro: "In Claude Desktop, open Settings › Developer › Edit Config, then add this configuration to mcpServers.",
-                code: claudeDesktopJSONConfig
+                intro: "In Claude Desktop, choose Settings › Extensions › Advanced settings › Install extension…, then select the connector at this path.",
+                code: claudeDesktopBundleURL?.path ?? "palmier-pro.mcpb"
             )
         }
     }


### PR DESCRIPTION
## Summary

The Claude Desktop manual-setup fallback in Help › MCP prescribed an `npx mcp-remote` config snippet. Post-#356 that path is a trap:

- It spawns the old mcp-remote shim with the give-up-after-2-retries behavior #356 replaced, so it zombies on every Palmier restart.
- Users who used both the snippet and the one-click connector end up with two servers offering identical tools; Claude Desktop routes calls to either, so tools intermittently hang into the 60s timeout depending on which duplicate receives them. (Observed live: `manage_project list` answered in 17ms over HTTP while Desktop timed out through the stale duplicate. A user report with matching symptoms is in triage.)

## Approach

Remove the Claude Desktop manual-setup section entirely rather than repointing it: the one-click `.mcpb` install is the single supported path, it already alerts when Claude Desktop is missing, and any manual instructions reintroduce config drift. Claude Code, Codex, and Cursor sections are unchanged (their commands/deep link remain the supported path for those clients). `claudeDesktopJSONConfig` is deleted.

## Testing

- `swift build` clean.
- UI verification pending (draft): Help › MCP › Claude Desktop should show only the install action with no manual-setup disclosure; Cursor's manual fallback still expands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help UI and copy only; no MCP server or connector install logic changes.
> 
> **Overview**
> **Help › MCP** no longer shows a **Manual setup** disclosure for Claude Desktop or the `npx mcp-remote` JSON snippet. The one-click **Install in Claude Desktop** (`.mcpb`) path is the only documented option there; Cursor’s manual fallback is unchanged.
> 
> `claudeDesktopJSONConfig` is removed. Claude Desktop install failure copy no longer points users at manual setup—it asks them to reinstall Palmier Pro, install/update Claude Desktop, or try again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120806da52a2f2aefd6f078304e41485f47e8324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->