### PR TITLE
[test] Pin agent transactions against automatic event-group corruption

### DIFF
--- a/Tests/PalmierProTests/Editor/EditorUndoTests.swift
+++ b/Tests/PalmierProTests/Editor/EditorUndoTests.swift
@@ -82,6 +82,39 @@ struct EditorUndoTests {
         #expect(manager.undoActionName == "Outer")
     }
 
+    @Test func transactionDoesNotCloseArmedEventGroup() {
+        let (undo, manager, counter) = harness()
+        let textStorage = UndoCounter()
+
+        // A direct registration (AppKit-style, outside EditorUndo) lazily
+        // opens the automatic event group. Foundation only disarms its
+        // "event group open" bookkeeping in the deferred group ending that
+        // NSDocument's save completion also invokes — nothing else clears it.
+        manager.registerUndo(withTarget: textStorage) { _ in }
+        let armedLevel = manager.groupingLevel
+        #expect(armedLevel > 0)
+
+        // An agent transaction must therefore never close the automatic
+        // event group itself. 0.6.6's ToolExecutor did
+        // (`if groupingLevel == 1 { endUndoGrouping() }`), which left the
+        // bookkeeping armed with no open group; the next save completion
+        // then raised "endUndoGrouping called with no matching begin" —
+        // fatal under NSApplicationCrashOnExceptions, and far from the
+        // cause. The transaction has to nest inside the armed group and
+        // leave it open for its scheduled ending.
+        undo.perform("Agent Edit") {
+            setCounter(1, actionName: "Agent Edit", counter: counter, undo: undo)
+        }
+        #expect(manager.groupingLevel == armedLevel)
+        #expect(manager.groupsByEvent)
+
+        // removeAllActions is the public API that both drains the history
+        // and cancels the scheduled automatic ending, so no armed state
+        // leaks into other tests.
+        manager.removeAllActions()
+        #expect(manager.groupingLevel == 0)
+    }
+
     @Test func throwingScopesRestoreUndoState() {
         let (undo, manager, counter) = harness()
 


### PR DESCRIPTION
## Context

Root-cause analysis of the crash class that shipped in 0.6.6–0.6.8 and shows up in crash reports as `EXC_BREAKPOINT` at **save completion**:

```
Application Specific Backtrace:
2   Foundation   -[NSUndoManager _postCheckpointNotification] + 0
3   AppKit       __85-[NSDocument(NSDocumentSaving) _saveToURL:ofType:forSaveOperation:completionHandler:]_block_invoke_3.372 + 160
4   AppKit       __85-[NSDocument(NSDocumentSaving) _saveToURL:...]_block_invoke_2.467 + 244
5   AppKit       -[NSDocument(NSDocumentSerializationAPIs) continueFileAccessUsingBlock:] + 220
```

Exception: `NSUndoManager ... is in invalid state, endUndoGrouping called with no matching begin` (the `_postCheckpointNotification + 0` frame is a symbolication artifact; the raise is in `_endUndoGroupRemovingIfEmpty:`). Under Sentry's `NSApplicationCrashOnExceptions` this is fatal, and unsaved edits roll back. Reproduced deterministically on 0.6.6 with an MCP session doing `import_media` → timeline edits → `manage_project close` (3× today on one machine).

## Root cause

`NSUndoManager` tracks the automatic event group with an internal "event group open" flag that is cleared **only** by `_processEndOfEventNotification:` — the deferred ending scheduled on the run loop, which `NSDocument`'s async-save completion also invokes directly. (Foundation's own `-undo` knows this: when it closes the top-level group manually it also calls `_cancelAutomaticTopLevelGroupEnding` to disarm the flag.)

0.6.6's `ToolExecutor` wrapped agent mutations like this:

```swift
let restoresEventGrouping = undoManager.groupsByEvent && undoManager.groupingLevel <= 1
if restoresEventGrouping {
    undoManager.groupsByEvent = false
    if undoManager.groupingLevel == 1 { undoManager.endUndoGrouping() }  // ← closes the AUTOMATIC event group
}
```

Manually ending the automatic event group closes it but leaves the internal flag armed. The next save completion then calls `endUndoGrouping` at grouping level 0 → raise → crash. The crash fires **far from the cause** (at the next autosave/close), which is why the reports look like a save bug.

Minimal standalone repro of the 0.6.6 algorithm (raises the exact exception + backtrace above):

```swift
let manager = UndoManager()
manager.registerUndo(withTarget: target) { _ in }        // auto event group opens (level 1, flag armed)
manager.groupsByEvent = false
if manager.groupingLevel == 1 { manager.endUndoGrouping() }  // 0.6.6 agent wrapper
manager.beginUndoGrouping()
manager.registerUndo(withTarget: target) { _ in }
manager.endUndoGrouping()
manager.groupsByEvent = true
RunLoop.main.run(mode: .default, before: .distantFuture) // deferred ending fires → NSInternalInconsistencyException
```

## This PR

#326/#331 already removed the manual event-group ending — current `EditorUndo` passes this sequence. This PR adds a regression test pinning the invariant so the pattern can't quietly come back: a direct (AppKit-style) registration arms the automatic event group, then an agent transaction runs — and the group must still be open (same level, `groupsByEvent` intact) afterwards, left for its scheduled ending. Run against the 0.6.6 algorithm, the same sequence drops the level to 0 and the test fails; in the real app that state detonates at the next save completion.

Verified: `swift test --filter EditorUndo` — 5/5 pass on `main`.

(Unrelated: `swift test` on Swift 6.2.3 currently fails to build `LottieVideoGeneratorTests.swift` — `sending 'unsafeGen' risks causing data races` promoted to an error. Marking the local `sample` helper `nonisolated` fixes it; happy to PR that separately if useful.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified.
> 
> **Overview**
> Adds **`transactionDoesNotCloseArmedEventGroup`** to **`EditorUndoTests`**, locking in undo behavior that already shipped with the fix in #326/#331.
> 
> The test simulates AppKit-style **`registerUndo`** (automatic event group armed), runs an agent **`EditorUndo.perform`**, and asserts **`groupingLevel`** and **`groupsByEvent`** are unchanged so Foundation’s deferred group ending can still run. It would fail on the old 0.6.6 pattern that called **`endUndoGrouping()`** at level 1 and led to save-completion crashes. Teardown uses **`removeAllActions()`** so armed undo state does not leak across tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c20e771a7f9b9d5e40d56d8e84c63e7d6d0643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->