### PR TITLE
[feat] Add AI transition and ripple delete to timeline gap menu

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
@@ -124,6 +124,7 @@ extension EditorViewModel {
         audioPlacement: PendingAudioPlacement? = nil,
         transitionPlacement: PendingTransitionPlacement? = nil
     ) {
+        if transitionPlacement == nil { cancelPendingTransitionSeed() }
         pendingEditReplacementClipId = replacementClipId
         pendingEditTrimmedSource = trimmedSource
         pendingEditAudioPlacement = audioPlacement

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
@@ -133,6 +133,15 @@ extension EditorViewModel {
         showGenerationPanel = true
     }
 
+    func clearPendingGenerationPanelState(preservingReplacement: Bool = false) {
+        cancelPendingTransitionSeed()
+        if !preservingReplacement { pendingEditReplacementClipId = nil }
+        pendingEditTrimmedSource = nil
+        pendingEditAudioPlacement = nil
+        pendingEditTransitionPlacement = nil
+        pendingPanelSeed = nil
+    }
+
     private func aiEditClipAsset(_ clipId: String) -> (clip: Clip, asset: MediaAsset)? {
         guard let clip = clipFor(id: clipId),
               let asset = mediaAssets.first(where: { $0.id == clip.mediaRef }) else { return nil }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
@@ -121,11 +121,13 @@ extension EditorViewModel {
         stored: GenerationInput,
         replacementClipId: String? = nil,
         trimmedSource: TrimmedSource? = nil,
-        audioPlacement: PendingAudioPlacement? = nil
+        audioPlacement: PendingAudioPlacement? = nil,
+        transitionPlacement: PendingTransitionPlacement? = nil
     ) {
         pendingEditReplacementClipId = replacementClipId
         pendingEditTrimmedSource = trimmedSource
         pendingEditAudioPlacement = audioPlacement
+        pendingEditTransitionPlacement = transitionPlacement
         pendingPanelSeed = PendingPanelSeed(asset: asset, stored: stored)
         showGenerationPanel = true
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+extension EditorViewModel {
+    static let maxTransitionSeconds: Double = 15
+
+    static let defaultTransitionPrompt = """
+        Create a seamless transition between the first frame and the last frame, one continuous \
+        take. No weird movements, effects, or artifacts. Natural and consistent motion that makes \
+        sense. No music, just appropriate SFX.
+        """
+
+    func transitionGapSeconds(lengthFrames: Int) -> Double {
+        Double(lengthFrames) / Double(max(1, timeline.fps))
+    }
+
+    func beginAITransition(gap: GapSelection) {
+        guard gap.range.start > 0, gap.range.length > 0,
+              transitionGapSeconds(lengthFrames: gap.range.length) <= Self.maxTransitionSeconds,
+              timeline.tracks.indices.contains(gap.trackIndex),
+              let model = VideoModelConfig.allModels.first(where: {
+                  !$0.requiresSourceVideo && $0.supportsFirstFrame && $0.supportsLastFrame
+              }) else { return }
+        let placement = PendingTransitionPlacement(
+            timelineId: timeline.id,
+            trackIndex: gap.trackIndex,
+            gapStartFrame: gap.range.start,
+            gapLengthFrames: gap.range.length
+        )
+        let gapSeconds = transitionGapSeconds(lengthFrames: placement.gapLengthFrames)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let startFrame = placement.gapStartFrame - 1
+                let endFrame = placement.gapStartFrame + placement.gapLengthFrames
+                let first = try await captureFrameToMedia(
+                    source: .timeline(frame: startFrame),
+                    name: "Transition start (frame \(startFrame))"
+                )
+                let last = try await captureFrameToMedia(
+                    source: .timeline(frame: endFrame),
+                    name: "Transition end (frame \(endFrame))"
+                )
+                var stored = GenerationInput(
+                    prompt: Self.defaultTransitionPrompt, model: model.id,
+                    duration: max(1, Int(gapSeconds.rounded())),
+                    aspectRatio: "", resolution: nil
+                )
+                stored.imageURLAssetIds = [first.asset.id, last.asset.id]
+                seedGenerationPanel(asset: first.asset, stored: stored, transitionPlacement: placement)
+            } catch {
+                mediaPanelToast = MediaPanelToast(message: error.localizedDescription)
+            }
+        }
+    }
+
+    @discardableResult
+    func placeGeneratingTransitionClip(placeholderId: String, placement: PendingTransitionPlacement) -> String? {
+        guard activeTimelineId == placement.timelineId, transitionGapIsEmpty(placement),
+              let asset = mediaAssets.first(where: { $0.id == placeholderId }) else {
+            refuseWithToast("The gap is no longer available, so the transition will land in Media instead.")
+            return nil
+        }
+        let before = timeline
+        let ids = undo.withoutRegistration {
+            placeClip(
+                asset: asset,
+                trackIndex: placement.trackIndex,
+                startFrame: placement.gapStartFrame,
+                durationFrames: placement.gapLengthFrames,
+                addLinkedAudio: false
+            )
+        }
+        guard let clipId = ids.first else {
+            timeline = before
+            return nil
+        }
+        registerTimelineSwap(undoState: before, redoState: timeline, actionName: "AI Transition")
+        notifyTimelineChanged()
+        return clipId
+    }
+
+    func finalizeTransitionClip(placeholderId: String, asset: MediaAsset) {
+        patchGeneratingClips(placeholderId: placeholderId) { clip, fps in
+            let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: fps))
+            clip.speed = Double(realFrames) / Double(max(1, clip.durationFrames))
+            clip.trimStartFrame = 0
+            clip.trimEndFrame = 0
+        }
+    }
+
+    private func transitionGapIsEmpty(_ placement: PendingTransitionPlacement) -> Bool {
+        guard timeline.tracks.indices.contains(placement.trackIndex) else { return false }
+        let end = placement.gapStartFrame + placement.gapLengthFrames
+        return !timeline.tracks[placement.trackIndex].clips.contains {
+            $0.startFrame < end && $0.endFrame > placement.gapStartFrame
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
@@ -13,6 +13,11 @@ extension EditorViewModel {
         Double(lengthFrames) / Double(max(1, timeline.fps))
     }
 
+    static func nearestSupportedDuration(seconds: Double, in durations: [Int]) -> Int {
+        durations.min { abs(Double($0) - seconds) < abs(Double($1) - seconds) }
+            ?? max(1, Int(seconds.rounded()))
+    }
+
     func beginAITransition(gap: GapSelection) {
         guard gap.range.start > 0, gap.range.length > 0,
               transitionGapSeconds(lengthFrames: gap.range.length) <= Self.maxTransitionSeconds,
@@ -26,36 +31,55 @@ extension EditorViewModel {
             gapStartFrame: gap.range.start,
             gapLengthFrames: gap.range.length
         )
-        let gapSeconds = transitionGapSeconds(lengthFrames: placement.gapLengthFrames)
-        Task { @MainActor [weak self] in
+        let duration = Self.nearestSupportedDuration(
+            seconds: transitionGapSeconds(lengthFrames: placement.gapLengthFrames),
+            in: model.durations
+        )
+        cancelPendingTransitionSeed()
+        transitionSeedTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let startFrame = placement.gapStartFrame - 1
                 let endFrame = placement.gapStartFrame + placement.gapLengthFrames
+                guard transitionSeedIsCurrent(placement) else { return }
                 let first = try await captureFrameToMedia(
                     source: .timeline(frame: startFrame),
                     name: "Transition start (frame \(startFrame))"
                 )
+                try Task.checkCancellation()
+                guard transitionSeedIsCurrent(placement) else { return }
                 let last = try await captureFrameToMedia(
                     source: .timeline(frame: endFrame),
                     name: "Transition end (frame \(endFrame))"
                 )
+                try Task.checkCancellation()
+                guard transitionSeedIsCurrent(placement) else { return }
                 var stored = GenerationInput(
                     prompt: Self.defaultTransitionPrompt, model: model.id,
-                    duration: max(1, Int(gapSeconds.rounded())),
+                    duration: duration,
                     aspectRatio: "", resolution: nil
                 )
                 stored.imageURLAssetIds = [first.asset.id, last.asset.id]
                 seedGenerationPanel(asset: first.asset, stored: stored, transitionPlacement: placement)
+            } catch is CancellationError {
             } catch {
                 mediaPanelToast = MediaPanelToast(message: error.localizedDescription)
             }
         }
     }
 
+    func transitionSeedIsCurrent(_ placement: PendingTransitionPlacement) -> Bool {
+        activeTimelineId == placement.timelineId && transitionGapIsEmpty(placement)
+    }
+
+    func cancelPendingTransitionSeed() {
+        transitionSeedTask?.cancel()
+        transitionSeedTask = nil
+    }
+
     @discardableResult
     func placeGeneratingTransitionClip(placeholderId: String, placement: PendingTransitionPlacement) -> String? {
-        guard activeTimelineId == placement.timelineId, transitionGapIsEmpty(placement),
+        guard transitionSeedIsCurrent(placement),
               let asset = mediaAssets.first(where: { $0.id == placeholderId }) else {
             refuseWithToast("The gap is no longer available, so the transition will land in Media instead.")
             return nil

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
@@ -18,13 +18,20 @@ extension EditorViewModel {
             ?? max(1, Int(seconds.rounded()))
     }
 
+    func aiTransitionAvailability(for gap: GapSelection) -> (model: VideoModelConfig?, refusal: String?) {
+        guard timeline.tracks.indices.contains(gap.trackIndex), gap.range.start > 0,
+              gap.range.length > 0, timeline.tracks[gap.trackIndex].type == .video else { return (nil, nil) }
+        let seconds = transitionGapSeconds(lengthFrames: gap.range.length)
+        guard seconds <= Self.maxTransitionSeconds else {
+            return (nil, "Transitions are limited to \(Int(Self.maxTransitionSeconds)) seconds. This gap is \(String(format: "%.1f", seconds)) seconds.")
+        }
+        guard aiEditAllowed else { return (nil, "Sign in to generate.") }
+        let model = VideoModelConfig.allModels.first { !$0.requiresSourceVideo && $0.supportsFirstFrame && $0.supportsLastFrame }
+        return (model, model == nil ? "No video model supports first and last frames." : nil)
+    }
+
     func beginAITransition(gap: GapSelection) {
-        guard gap.range.start > 0, gap.range.length > 0,
-              transitionGapSeconds(lengthFrames: gap.range.length) <= Self.maxTransitionSeconds,
-              timeline.tracks.indices.contains(gap.trackIndex),
-              let model = VideoModelConfig.allModels.first(where: {
-                  !$0.requiresSourceVideo && $0.supportsFirstFrame && $0.supportsLastFrame
-              }) else { return }
+        guard let model = aiTransitionAvailability(for: gap).model else { return }
         let placement = PendingTransitionPlacement(
             timelineId: timeline.id,
             trackIndex: gap.trackIndex,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+FrameCapture.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+FrameCapture.swift
@@ -120,6 +120,9 @@ extension EditorViewModel {
             name: requestedName ?? defaultName,
             duration: Defaults.imageDurationSeconds
         )
+        if let thumbnail = rendered.thumbnail {
+            asset.installThumbnail(thumbnail, maximumPixelSize: ImageEncoder.libraryThumbnailMaxPixelSize)
+        }
         asset.folderId = destinationFolderStillExists ? folderId : nil
         asset.sourceWidth = rendered.width
         asset.sourceHeight = rendered.height

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+GeneratedClips.swift
@@ -49,16 +49,22 @@ extension EditorViewModel {
 
     // Patch all timelines with placeholders for this asset.
     func finalizeGeneratingClip(placeholderId: String, asset: MediaAsset) {
+        patchGeneratingClips(placeholderId: placeholderId) { clip, fps in
+            clip.durationFrames = max(1, secondsToFrame(seconds: asset.duration, fps: fps))
+            clip.trimStartFrame = 0
+            clip.trimEndFrame = 0
+        }
+    }
+
+    func patchGeneratingClips(placeholderId: String, _ patch: (inout Clip, Int) -> Void) {
         var touched: Set<String> = []
         undo.withoutRegistration {
             for i in timelines.indices {
-                let realFrames = max(1, secondsToFrame(seconds: asset.duration, fps: timelines[i].fps))
+                let fps = timelines[i].fps
                 for ti in timelines[i].tracks.indices {
                     for ci in timelines[i].tracks[ti].clips.indices
                     where timelines[i].tracks[ti].clips[ci].mediaRef == placeholderId {
-                        timelines[i].tracks[ti].clips[ci].durationFrames = realFrames
-                        timelines[i].tracks[ti].clips[ci].trimStartFrame = 0
-                        timelines[i].tracks[ti].clips[ci].trimEndFrame = 0
+                        patch(&timelines[i].tracks[ti].clips[ci], fps)
                         touched.insert(timelines[i].id)
                     }
                 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -287,39 +287,46 @@ extension EditorViewModel {
     }
 
     func rippleDeleteSelectedGap() {
-        guard let gap = selectedGap,
-              timeline.tracks.indices.contains(gap.trackIndex),
-              gap.range.length > 0 else { return }
-        // An out-of-band edit may have filled the gap.
-        guard !timeline.tracks[gap.trackIndex].clips.contains(where: {
-            $0.startFrame < gap.range.end && $0.endFrame > gap.range.start
-        }) else { selectedGap = nil; return }
+        guard let gap = selectedGap else { return }
+        rippleDelete(gap: gap)
+    }
 
+    func rippleDeleteGapRefusal(_ gap: GapSelection) -> String? {
         let gapShiftingIds = Set(timeline.tracks.indices
             .filter { $0 == gap.trackIndex || timeline.tracks[$0].syncLocked }
             .map { timeline.tracks[$0].id })
         if let reason = multicamManualRippleViolation(shiftingTrackIds: gapShiftingIds, atFrame: gap.range.end) {
-            refuseRipple(reason: reason)
-            return
+            return reason
         }
-
-        var shiftsByTrack: [Int: [ClipShift]] = [:]
-        for ti in timeline.tracks.indices {
-            guard ti == gap.trackIndex || timeline.tracks[ti].syncLocked else { continue }
+        for ti in timeline.tracks.indices where ti != gap.trackIndex && timeline.tracks[ti].syncLocked {
             let shifts = RippleEngine.computeRippleShiftsForRanges(
                 clips: timeline.tracks[ti].clips,
                 removedRanges: [gap.range]
             )
-            // The gap track only ever moves clips into freed space; sync-locked followers may collide.
-            if ti != gap.trackIndex, let reason = validateShifts(trackIndex: ti, shifts: shifts) {
-                refuseRipple(reason: reason)
-                return
-            }
-            shiftsByTrack[ti] = shifts
+            if let reason = validateShifts(trackIndex: ti, shifts: shifts) { return reason }
+        }
+        return nil
+    }
+
+    func rippleDelete(gap: GapSelection) {
+        guard timeline.tracks.indices.contains(gap.trackIndex),
+              gap.range.length > 0 else { return }
+        guard !timeline.tracks[gap.trackIndex].clips.contains(where: {
+            $0.startFrame < gap.range.end && $0.endFrame > gap.range.start
+        }) else { selectedGap = nil; return }
+
+        if let reason = rippleDeleteGapRefusal(gap) {
+            refuseRipple(reason: reason)
+            return
         }
 
         withTimelineSwap(actionName: "Ripple Delete") {
-            for shifts in shiftsByTrack.values { applyShifts(shifts) }
+            for ti in timeline.tracks.indices where ti == gap.trackIndex || timeline.tracks[ti].syncLocked {
+                applyShifts(RippleEngine.computeRippleShiftsForRanges(
+                    clips: timeline.tracks[ti].clips,
+                    removedRanges: [gap.range]
+                ))
+            }
         }
         selectedGap = nil
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -127,7 +127,9 @@ final class EditorViewModel {
     var toolMode: ToolMode = .pointer
     var showExportDialog: Bool = false
     var showGenerationPanel: Bool = false {
-        didSet { if showGenerationPanel && !oldValue { showMediaPanelMediaTab() } }
+        didSet {
+            if showGenerationPanel && !oldValue { showMediaPanelMediaTab() } else if !showGenerationPanel && oldValue { clearPendingGenerationPanelState() }
+        }
     }
     /// AIEditTab input consumed by GenerationView.
     var pendingPanelSeed: PendingPanelSeed?

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -255,6 +255,7 @@ final class EditorViewModel {
     @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Error>?
     @ObservationIgnored var mediaImportSequence: Int = 0
     @ObservationIgnored var frameCaptureTask: Task<Void, Never>?
+    @ObservationIgnored var transitionSeedTask: Task<Void, Never>?
     @ObservationIgnored var pendingManifestMetadataUpdates: [String: MediaAsset] = [:]
     @ObservationIgnored var pendingManifestMetadataFlushTask: Task<Void, Never>?
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -18,6 +18,13 @@ struct PendingAudioPlacement {
     let actionName: String
 }
 
+struct PendingTransitionPlacement {
+    let timelineId: String
+    let trackIndex: Int
+    let gapStartFrame: Int
+    let gapLengthFrames: Int
+}
+
 @Observable
 @MainActor
 final class EditorViewModel {
@@ -127,6 +134,7 @@ final class EditorViewModel {
     var pendingEditReplacementClipId: String?
     var pendingEditTrimmedSource: TrimmedSource?
     var pendingEditAudioPlacement: PendingAudioPlacement?
+    var pendingEditTransitionPlacement: PendingTransitionPlacement?
     /// Clip ids currently awaiting an AI-generated replacement.
     var pendingReplacements: Set<String> = []
     var cropEditingActive: Bool = false

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -234,6 +234,8 @@ extension GenerationView {
         editor.pendingEditReplacementClipId = nil
         let pendingAudioPlacement = selectedType == .audio ? editor.pendingEditAudioPlacement : nil
         editor.pendingEditAudioPlacement = nil
+        let transitionPlacement = selectedType == .video ? editor.pendingEditTransitionPlacement : nil
+        editor.pendingEditTransitionPlacement = nil
         let editorRef = editor
         if let clipId = replacementClipId {
             editor.markPendingReplacement(clipId: clipId)
@@ -286,6 +288,14 @@ extension GenerationView {
                     ? (inputAssets.sourceVideo?.folderId ?? inputAssets.imageRefs.last?.folderId)
                     : inputAssets.textToVideoReferences.last?.folderId
             ) ?? editor.mediaPanelCurrentFolderId
+            let baseOnComplete = makeOnComplete(trimmedSource?.hasTrim == true)
+            let videoOnComplete: (@MainActor (MediaAsset) -> Void)? = {
+                guard transitionPlacement != nil else { return baseOnComplete }
+                return { [weak editorRef] asset in
+                    editorRef?.finalizeTransitionClip(placeholderId: asset.id, asset: asset)
+                    baseOnComplete?(asset)
+                }
+            }()
             let videoAssetId = VideoGenerationSubmission.make(
                 genInput: genInput,
                 model: model,
@@ -298,9 +308,12 @@ extension GenerationView {
                 service: editor.generationService,
                 projectURL: editor.projectURL,
                 editor: editor,
-                onComplete: makeOnComplete(trimmedSource?.hasTrim == true),
+                onComplete: videoOnComplete,
                 onFailure: onFailure
             )
+            if let placement = transitionPlacement {
+                editor.placeGeneratingTransitionClip(placeholderId: videoAssetId, placement: placement)
+            }
             autoOpenPreview(videoAssetId)
         case .image:
             let model = imageModel

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -231,11 +231,8 @@ extension GenerationView {
         }
 
         let replacementClipId = editor.pendingEditReplacementClipId
-        editor.pendingEditReplacementClipId = nil
         let pendingAudioPlacement = selectedType == .audio ? editor.pendingEditAudioPlacement : nil
-        editor.pendingEditAudioPlacement = nil
         let transitionPlacement = selectedType == .video ? editor.pendingEditTransitionPlacement : nil
-        editor.pendingEditTransitionPlacement = nil
         let editorRef = editor
         if let clipId = replacementClipId {
             editor.markPendingReplacement(clipId: clipId)
@@ -272,7 +269,6 @@ extension GenerationView {
                       trim.sourceURL == sv.url else { return nil }
                 return trim
             }()
-            editor.pendingEditTrimmedSource = nil
             let placeholderDuration: Double
             if model.requiresSourceVideo {
                 if let trim = trimmedSource, trim.hasTrim {
@@ -370,7 +366,7 @@ extension GenerationView {
                 )
             }
         }
-        editor.pendingEditTrimmedSource = nil
+        editor.clearPendingGenerationPanelState()
         lyrics = ""
         styleInstructions = ""
         prompt = ""

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -172,6 +172,7 @@ struct GenerationView: View {
                     editor.pendingEditReplacementClipId = nil
                     editor.pendingEditTrimmedSource = nil
                     editor.pendingEditAudioPlacement = nil
+                    editor.pendingEditTransitionPlacement = nil
                     editor.pendingPanelSeed = nil
                     editFolderId = nil
                     editor.showGenerationPanel = false
@@ -284,6 +285,7 @@ struct GenerationView: View {
             editFolderId = nil
             editor.pendingEditTrimmedSource = nil
             editor.pendingEditAudioPlacement = nil
+            editor.pendingEditTransitionPlacement = nil
         }
         .onChange(of: selectedVideoModelIndex) { _, _ in
             guard !isPopulatingPanel else { return }

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -169,6 +169,7 @@ struct GenerationView: View {
                 CreditSummaryView(style: .compact)
                 ProjectActivityButton()
                 Button {
+                    editor.cancelPendingTransitionSeed()
                     editor.pendingEditReplacementClipId = nil
                     editor.pendingEditTrimmedSource = nil
                     editor.pendingEditAudioPlacement = nil

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -169,12 +169,6 @@ struct GenerationView: View {
                 CreditSummaryView(style: .compact)
                 ProjectActivityButton()
                 Button {
-                    editor.cancelPendingTransitionSeed()
-                    editor.pendingEditReplacementClipId = nil
-                    editor.pendingEditTrimmedSource = nil
-                    editor.pendingEditAudioPlacement = nil
-                    editor.pendingEditTransitionPlacement = nil
-                    editor.pendingPanelSeed = nil
                     editFolderId = nil
                     editor.showGenerationPanel = false
                 } label: {
@@ -284,9 +278,7 @@ struct GenerationView: View {
             clearReferences()
             if newValue == .audio { resetAudioState() }
             editFolderId = nil
-            editor.pendingEditTrimmedSource = nil
-            editor.pendingEditAudioPlacement = nil
-            editor.pendingEditTransitionPlacement = nil
+            editor.clearPendingGenerationPanelState(preservingReplacement: true)
         }
         .onChange(of: selectedVideoModelIndex) { _, _ in
             guard !isPopulatingPanel else { return }

--- a/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
+++ b/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
@@ -18,6 +18,10 @@ private struct ReferenceAssetPreview: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(asset.name), \(asset.type.trackLabel)")
+        .task(id: "\(asset.id)|\(asset.url.path)|\(asset.generationStatus.serialized)") {
+            guard case .none = asset.generationStatus else { return }
+            await asset.loadLibraryThumbnail()
+        }
     }
 }
 

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -6,9 +6,6 @@ import AVFoundation
 final class MediaAsset: Identifiable {
     private nonisolated static let metadataLoadGate = AsyncSemaphore(value: 4)
     private nonisolated static let thumbnailLoadGate = AsyncSemaphore(value: 4)
-    private nonisolated static let libraryThumbnailMaxPixelSize = 320
-    private nonisolated static let previewThumbnailMaxPixelSize = ImageEncoder.maxLongestEdge
-
     let id: String
     var url: URL {
         didSet {
@@ -158,7 +155,7 @@ final class MediaAsset: Identifiable {
     func loadLibraryThumbnail() async {
         switch type {
         case .image:
-            await loadImageThumbnail(maxPixelSize: Self.libraryThumbnailMaxPixelSize)
+            await loadImageThumbnail(maxPixelSize: ImageEncoder.libraryThumbnailMaxPixelSize)
         case .video, .lottie:
             guard thumbnail == nil, await acquireThumbnailPermit() else { return }
             defer { releaseThumbnailPermit() }
@@ -171,7 +168,13 @@ final class MediaAsset: Identifiable {
 
     func loadPreviewThumbnail() async {
         guard type == .image else { return }
-        await loadImageThumbnail(maxPixelSize: Self.previewThumbnailMaxPixelSize)
+        await loadImageThumbnail(maxPixelSize: ImageEncoder.maxLongestEdge)
+    }
+
+    func installThumbnail(_ image: CGImage, maximumPixelSize: Int) {
+        guard maximumPixelSize >= thumbnailMaxPixelSize else { return }
+        thumbnail = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+        thumbnailMaxPixelSize = maximumPixelSize
     }
 
     @discardableResult

--- a/Sources/PalmierPro/Preview/FrameCaptureRenderer.swift
+++ b/Sources/PalmierPro/Preview/FrameCaptureRenderer.swift
@@ -3,6 +3,7 @@ import Foundation
 
 struct RenderedFrame: Sendable {
     let stagedURL: URL
+    let thumbnail: CGImage?
     let width: Int
     let height: Int
     let actualSourceSeconds: Double?
@@ -175,6 +176,7 @@ enum FrameCaptureRenderer {
         }
         return RenderedFrame(
             stagedURL: stagedURL,
+            thumbnail: ImageEncoder.thumbnail(data: data, maxPixelSize: ImageEncoder.libraryThumbnailMaxPixelSize),
             width: image.width,
             height: image.height,
             actualSourceSeconds: actualSourceSeconds

--- a/Sources/PalmierPro/Timeline/TimelineView+AIEditMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+AIEditMenu.swift
@@ -121,6 +121,14 @@ extension TimelineView {
         )
     }
 
+    @objc func performCreateAITransition(_ sender: Any?) {
+        guard let info = (sender as? NSMenuItem)?.representedObject as? [String: Any],
+              let trackIndex = info["trackIndex"] as? Int,
+              let start = info["start"] as? Int,
+              let end = info["end"] as? Int else { return }
+        editor.beginAITransition(gap: GapSelection(trackIndex: trackIndex, range: FrameRange(start: start, end: end)))
+    }
+
     @objc private func performAIEditCreateVideo(_ sender: Any?) {
         guard let info = (sender as? NSMenuItem)?.representedObject as? [String: Any],
               let clipId = info["clipId"] as? String,

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1047,17 +1047,11 @@ final class TimelineView: NSView {
             let gapInfo = ["trackIndex": gap.trackIndex, "start": gap.range.start, "end": gap.range.end] as [String: Any]
 
             if gap.range.start > 0, editor.timeline.tracks[gap.trackIndex].type == .video {
-                let gapSeconds = editor.transitionGapSeconds(lengthFrames: gap.range.length)
-                let tooLong = gapSeconds > EditorViewModel.maxTransitionSeconds
+                let availability = editor.aiTransitionAvailability(for: gap)
                 let item = NSMenuItem(title: "Create AI Transition", action: #selector(performCreateAITransition(_:)), keyEquivalent: "")
                 item.target = self
-                item.isEnabled = editor.aiEditAllowed && !tooLong
-                if tooLong {
-                    let limit = Int(EditorViewModel.maxTransitionSeconds)
-                    item.toolTip = "Transitions are limited to \(limit) seconds. This gap is \(String(format: "%.1f", gapSeconds)) seconds."
-                } else if !editor.aiEditAllowed {
-                    item.toolTip = "Sign in to generate."
-                }
+                item.isEnabled = availability.model != nil
+                item.toolTip = availability.refusal
                 item.representedObject = gapInfo
                 menu.addItem(item)
             }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -833,7 +833,7 @@ final class TimelineView: NSView {
         let clickFrame = max(0, geometry.frameAt(x: point.x))
         let clickedRange = editor.validSelectedTimelineRange?.contains(frame: clickFrame) ?? false
         guard let hit = inputController.hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) else {
-            return emptyAreaMenu(trackIndex: trackIndex, frame: clickFrame, clickedRange: clickedRange)
+            return emptyAreaMenu(trackIndex: trackIndex, frame: clickFrame, clickedRange: clickedRange, point: point)
         }
         let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
         let clipRect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
@@ -1033,7 +1033,7 @@ final class TimelineView: NSView {
         return menu.items.isEmpty ? nil : menu
     }
 
-    private func emptyAreaMenu(trackIndex: Int, frame: Int, clickedRange: Bool) -> NSMenu? {
+    private func emptyAreaMenu(trackIndex: Int, frame: Int, clickedRange: Bool, point: NSPoint) -> NSMenu? {
         let menu = NSMenu()
         if editor.canPasteClips,
            editor.timeline.tracks.indices.contains(trackIndex) {
@@ -1041,6 +1041,34 @@ final class TimelineView: NSView {
             item.target = self
             item.representedObject = ["trackIndex": trackIndex, "frame": frame] as [String: Any]
             menu.addItem(item)
+        }
+        if let gap = inputController.hitTestGap(at: point, trackIndex: trackIndex, geometry: geometry) {
+            menu.autoenablesItems = false
+            let gapInfo = ["trackIndex": gap.trackIndex, "start": gap.range.start, "end": gap.range.end] as [String: Any]
+
+            if gap.range.start > 0, editor.timeline.tracks[gap.trackIndex].type == .video {
+                let gapSeconds = editor.transitionGapSeconds(lengthFrames: gap.range.length)
+                let tooLong = gapSeconds > EditorViewModel.maxTransitionSeconds
+                let item = NSMenuItem(title: "Create AI Transition", action: #selector(performCreateAITransition(_:)), keyEquivalent: "")
+                item.target = self
+                item.isEnabled = editor.aiEditAllowed && !tooLong
+                if tooLong {
+                    let limit = Int(EditorViewModel.maxTransitionSeconds)
+                    item.toolTip = "Transitions are limited to \(limit) seconds. This gap is \(String(format: "%.1f", gapSeconds)) seconds."
+                } else if !editor.aiEditAllowed {
+                    item.toolTip = "Sign in to generate."
+                }
+                item.representedObject = gapInfo
+                menu.addItem(item)
+            }
+
+            let refusal = editor.rippleDeleteGapRefusal(gap)
+            let deleteItem = NSMenuItem(title: "Ripple Delete Gap", action: #selector(performRippleDeleteGap(_:)), keyEquivalent: "")
+            deleteItem.target = self
+            deleteItem.isEnabled = refusal == nil
+            deleteItem.toolTip = refusal
+            deleteItem.representedObject = gapInfo
+            menu.addItem(deleteItem)
         }
         if clickedRange {
             if !menu.items.isEmpty { menu.addItem(.separator()) }
@@ -1177,6 +1205,16 @@ final class TimelineView: NSView {
               let trackIndex = info["trackIndex"] as? Int,
               let frame = info["frame"] as? Int else { return }
         editor.pasteClips(atTrack: trackIndex, atFrame: frame)
+        needsDisplay = true
+    }
+
+    @objc private func performRippleDeleteGap(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let info = item.representedObject as? [String: Any],
+              let trackIndex = info["trackIndex"] as? Int,
+              let start = info["start"] as? Int,
+              let end = info["end"] as? Int else { return }
+        editor.rippleDelete(gap: GapSelection(trackIndex: trackIndex, range: FrameRange(start: start, end: end)))
         needsDisplay = true
     }
 

--- a/Sources/PalmierPro/Utilities/ImageEncoder.swift
+++ b/Sources/PalmierPro/Utilities/ImageEncoder.swift
@@ -9,6 +9,7 @@ enum ImageEncoder {
     static let maxBytes = 3_500_000
     /// Internal downsample target.
     static let maxLongestEdge = 1568
+    static let libraryThumbnailMaxPixelSize = 320
 
     struct Output: Sendable {
         let data: Data
@@ -63,6 +64,11 @@ enum ImageEncoder {
 
     nonisolated static func thumbnail(url: URL, maxPixelSize: Int) -> CGImage? {
         guard let source = imageSource(url: url) else { return nil }
+        return makeThumbnail(source: source, maxPixelSize: maxPixelSize)
+    }
+
+    nonisolated static func thumbnail(data: Data, maxPixelSize: Int) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
         return makeThumbnail(source: source, maxPixelSize: maxPixelSize)
     }
 

--- a/Tests/PalmierProTests/Agent/CaptureFrameToolTests.swift
+++ b/Tests/PalmierProTests/Agent/CaptureFrameToolTests.swift
@@ -38,6 +38,7 @@ struct CaptureFrameToolTests {
             let sourceReceipt = try json(text(sourceCapture.content))
             let sourceRef = try #require(sourceReceipt["mediaRef"] as? String)
             #expect(sourceReceipt["name"] as? String == "Final source frame")
+            #expect(fixture.editor.mediaAssets.first { $0.id.hasPrefix(sourceRef) }?.thumbnail != nil)
             let sourceImage = try imageData(try await client.callTool(
                 name: "inspect_media",
                 arguments: ["mediaRef": .string(sourceRef)]

--- a/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
+++ b/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
@@ -67,6 +67,32 @@ struct AITransitionPlacementTests {
         #expect(gap == GapSelection(trackIndex: 0, range: FrameRange(start: 100, end: 160)))
     }
 
+    @Test(arguments: [
+        (2.0, [4, 6, 8], 4),
+        (7.2, [4, 6, 8], 8),
+        (5.0, [4, 6, 8], 4),
+        (12.0, [4, 6, 8], 8),
+        (2.4, [Int](), 2),
+    ]) func seedDurationSnapsToNearestSupported(seconds: Double, durations: [Int], expected: Int) {
+        #expect(EditorViewModel.nearestSupportedDuration(seconds: seconds, in: durations) == expected)
+    }
+
+    @Test func seedIsStaleAfterTimelineSwitchOrFilledGap() {
+        let (e, _) = editorWithGap()
+        let placement = placement(for: e)
+        #expect(e.transitionSeedIsCurrent(placement))
+
+        e.timeline.tracks[0].clips.append(Fixtures.clip(start: 120, duration: 20))
+        #expect(!e.transitionSeedIsCurrent(placement))
+        e.timeline.tracks[0].clips.removeLast()
+
+        let other = e.createTimeline(activate: true)
+        #expect(!e.transitionSeedIsCurrent(placement))
+        e.activateTimeline(placement.timelineId)
+        e.deleteTimeline(other)
+        #expect(e.transitionSeedIsCurrent(placement))
+    }
+
     @Test func finalizeRetimesClipToFillGapExactly() {
         let (e, _) = editorWithGap()
         e.timeline.tracks[0].clips.append(Fixtures.clip(mediaRef: "gen-1", start: 100, duration: 60))

--- a/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
+++ b/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+struct AITransitionPlacementTests {
+
+    private func editorWithGap() -> (EditorViewModel, UndoManager) {
+        let e = EditorViewModel()
+        e.timeline.tracks = [Fixtures.videoTrack(clips: [
+            Fixtures.clip(start: 0, duration: 100),
+            Fixtures.clip(start: 160, duration: 100),
+        ])]
+        let undo = UndoManager()
+        e.undo.attach(undo)
+        undo.removeAllActions()
+        return (e, undo)
+    }
+
+    private func placement(for e: EditorViewModel) -> PendingTransitionPlacement {
+        PendingTransitionPlacement(
+            timelineId: e.activeTimelineId, trackIndex: 0, gapStartFrame: 100, gapLengthFrames: 60
+        )
+    }
+
+    @Test func placesPlaceholderIntoEmptyGapWithUndo() {
+        let (e, undo) = editorWithGap()
+        let asset = MediaAsset(id: "gen-1", url: URL(fileURLWithPath: "/tmp/x.mp4"), type: .video, name: "gen", duration: 2)
+        e.mediaAssets.append(asset)
+
+        let clipId = e.placeGeneratingTransitionClip(placeholderId: "gen-1", placement: placement(for: e))
+
+        let clip = e.timeline.tracks[0].clips.first { $0.id == clipId }
+        #expect(clip?.startFrame == 100)
+        #expect(clip?.durationFrames == 60)
+        #expect(undo.canUndo)
+        undo.undo()
+        #expect(e.timeline.tracks[0].clips.count == 2)
+    }
+
+    @Test func refusesWhenGapIsOccupied() {
+        let (e, undo) = editorWithGap()
+        let asset = MediaAsset(id: "gen-1", url: URL(fileURLWithPath: "/tmp/x.mp4"), type: .video, name: "gen", duration: 2)
+        e.mediaAssets.append(asset)
+        e.timeline.tracks[0].clips.append(Fixtures.clip(start: 120, duration: 20))
+
+        let clipId = e.placeGeneratingTransitionClip(placeholderId: "gen-1", placement: placement(for: e))
+
+        #expect(clipId == nil)
+        #expect(e.timeline.tracks[0].clips.count == 3)
+        #expect(!undo.canUndo)
+    }
+
+    @Test func gapHitTestFindsGapBetweenTwoClips() {
+        let (e, _) = editorWithGap()
+        let view = TimelineView(editor: e)
+        let geometry = TimelineGeometry(
+            pixelsPerFrame: 1,
+            trackHeights: e.timeline.tracks.map(\.displayHeight)
+        )
+        let point = NSPoint(x: 130, y: Double(geometry.trackY(at: 0)) + 10)
+
+        let trackIndex = geometry.trackAt(y: point.y)
+        let gap = view.inputController.hitTestGap(at: point, trackIndex: trackIndex, geometry: geometry)
+
+        #expect(trackIndex == 0)
+        #expect(gap == GapSelection(trackIndex: 0, range: FrameRange(start: 100, end: 160)))
+    }
+
+    @Test func finalizeRetimesClipToFillGapExactly() {
+        let (e, _) = editorWithGap()
+        e.timeline.tracks[0].clips.append(Fixtures.clip(mediaRef: "gen-1", start: 100, duration: 60))
+        let realSeconds = 4.0
+        let asset = MediaAsset(id: "gen-1", url: URL(fileURLWithPath: "/tmp/x.mp4"), type: .video, name: "gen", duration: realSeconds)
+
+        e.finalizeTransitionClip(placeholderId: "gen-1", asset: asset)
+
+        let clip = e.timeline.tracks[0].clips.first { $0.mediaRef == "gen-1" }
+        let realFrames = Double(realSeconds) * Double(e.timeline.fps)
+        #expect(clip?.durationFrames == 60)
+        #expect(clip?.speed == realFrames / 60)
+        #expect(clip?.sourceFramesConsumed == Int(realFrames))
+    }
+}


### PR DESCRIPTION
Right-clicking an empty gap between two clips offers Create AI Transition: captures the bounding frames via the shared capture renderer, seeds the generation panel with them plus the gap duration and a default prompt, and on submit places a generating placeholder into the gap (single undoable action), retiming the finished video to fill it exactly. Gaps over 15s and signed-out states show the item disabled with an explanatory tooltip.

Also adds Ripple Delete Gap to the same menu, extracting validation from rippleDeleteSelectedGap so menu availability and execution share one rule, and consolidates placeholder finalization behind patchGeneratingClips.

https://github.com/user-attachments/assets/2f582f03-ab45-4723-aae6-099506db9f4f



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async transition seeding and timeline mutation on generate/submit; ripple delete refactors shared validation but still shifts sync-locked tracks.
> 
> **Overview**
> Adds **Create AI Transition** on timeline gaps between clips: captures start/end frames, opens the generation panel with a default first/last-frame prompt and gap-sized duration, places an undoable generating placeholder in the gap on submit, and **retimes** the finished clip (speed) so it fills the gap exactly. Gaps over 15s, non-video tracks, or signed-out users get a disabled menu item with a tooltip.
> 
> The same gap context menu adds **Ripple Delete Gap**, with validation extracted into `rippleDeleteGapRefusal` so enablement and execution share one rule.
> 
> Supporting changes: centralized generation-panel pending state via `clearPendingGenerationPanelState`; video submit wires `PendingTransitionPlacement`; `patchGeneratingClips` shared for normal finalize vs transition retime; frame capture and reference previews get immediate library thumbnails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4352e497ab90b74608b62f3a44ea5cacc29642f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->