### PR TITLE
fix(export xml): read Sony rtmd + BWF source timecode, exact rational conform origins

### DIFF
--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -79,7 +79,7 @@ enum FCPXMLExporter {
                        resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
                        version: FCPXMLVersion = .default, target: FCPXMLTarget = .default,
                        outputURL: URL) async throws {
-        // Media refs across the parent and every reachable nested timeline.
+        // Include media from every reachable nested timeline.
         var mediaRefs: Set<String> = []
         var queue = [timeline]
         var visited: Set<String> = []
@@ -103,8 +103,7 @@ enum FCPXMLExporter {
         try data.write(to: outputURL)
     }
 
-    /// Build the document from an explicit timecode map. Split out so tests can inject embedded
-    /// timecodes without a `tmcd`-carrying media file on disk.
+    /// Renders with injectable source timecodes for deterministic tests.
     static func render(timeline: Timeline, resolver: MediaResolver,
                        resolveTimeline: @escaping (String) -> Timeline? = { _ in nil },
                        version: FCPXMLVersion = .default,
@@ -128,11 +127,11 @@ enum FCPXMLExporter {
         private var resourceIndex: [String: Int] = [:]
         private var resources: [MediaResource] = []
         private var nextTextStyleId = 1
-        // A synced A/V pair collapses into one flat asset-clip; the audio partner is dropped, its volume kept.
+        // Synced pairs export as one asset clip while retaining audio volume.
         private var linkedAudioForVideo: [String: Clip] = [:]
         private var redundantAudioClipIds: Set<String> = []
         private var usedCompoundIds: Set<String> = []
-        // Nested timelines, discovery order; each becomes a <media><sequence> compound resource.
+        // Nested timelines become compound resources in discovery order.
         private var nests: [(mediaId: String, timeline: Timeline)] = []
         private var nestIndex: [String: String] = [:]
 
@@ -142,7 +141,6 @@ enum FCPXMLExporter {
             let enabled: Bool
         }
 
-        // One asset per resolved source file.
         private struct MediaResource {
             let mediaRef: String
             let assetId: String
@@ -153,8 +151,7 @@ enum FCPXMLExporter {
             var durationFrames: Int
             let hasVideo: Bool
             let hasAudio: Bool
-            // Embedded start timecode in timeline-frame units; 0 when absent.
-            let startTimecodeFrames: Int
+            let startTimecode: (num: Int, den: Int)
         }
 
         init(timeline: Timeline, resolver: MediaResolver, resolveTimeline: @escaping (String) -> Timeline?,
@@ -185,7 +182,7 @@ enum FCPXMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE fcpxml>\n" + renderFCPXML(root, indent: 0)
         }
 
-        /// Unresolvable or empty children stay out of `nestIndex`, so `isEmittable` drops their carriers.
+        /// Indexes nonempty, resolvable nested timelines.
         private func collectNests() {
             let reachable = timeline.reachableTimelines(
                 resolve: resolveTimeline, maxDepth: NestFlattener.maxDepth, include: { $0.totalFrames > 0 }
@@ -197,7 +194,6 @@ enum FCPXMLExporter {
             }
         }
 
-        // Video + audio with matching linkGroup, source, timing, and enabled state are a synced pair
         private func indexLinkedPairs(_ clips: [EmittableClip]) {
             var byGroup: [String: (videos: [EmittableClip], audios: [EmittableClip])] = [:]
             for item in clips {
@@ -220,7 +216,7 @@ enum FCPXMLExporter {
             }
         }
 
-        // Mirrors assetClipNode's ref-clip condition; only referenced compounds get a <media> resource.
+        // Emit compound resources only when referenced.
         private func markUsedCompounds(_ clips: [EmittableClip]) {
             for item in clips where !redundantAudioClipIds.contains(item.clip.id) {
                 guard let i = resourceIndex[item.clip.mediaRef],
@@ -276,7 +272,6 @@ enum FCPXMLExporter {
             ])
         }
 
-        /// A nested timeline as a compound-clip resource: same gap-with-lanes shape as the project.
         private func nestMediaNode(_ nest: (mediaId: String, timeline: Timeline)) -> FCPXMLNode {
             let duration = time(frames: nest.timeline.totalFrames)
             let gap = FCPXMLNode(name: "gap", attributes: [
@@ -302,9 +297,8 @@ enum FCPXMLExporter {
         private func compoundClipNode(for resource: MediaResource) -> FCPXMLNode? {
             guard let compoundId = resource.compoundId, usedCompoundIds.contains(compoundId) else { return nil }
             let dur = time(frames: resource.durationFrames)
-            // The compound spine is 0-based but reads the asset from its own timecode origin, so
-            // `start` must equal the asset's embedded start timecode.
-            let tcStart = time(frames: resource.startTimecodeFrames)
+            // Compound spines stay 0-based while reading from the asset timecode origin.
+            let tcStart = rationalTime(num: resource.startTimecode.num, den: resource.startTimecode.den)
             let innerClip = FCPXMLNode(name: "asset-clip", attributes: [
                 ("ref", resource.assetId),
                 ("name", fileName(for: resource)),
@@ -380,11 +374,10 @@ enum FCPXMLExporter {
         private func assetClipNode(for item: EmittableClip) -> FCPXMLNode? {
             let clip = item.clip
 
-            // Nested timeline → <ref-clip> over its compound-clip media resource.
             if clip.sourceClipType == .sequence {
                 guard let mediaId = nestIndex[clip.mediaRef],
                       let child = resolveTimeline(clip.mediaRef) else { return nil }
-                // A frozen carrier can outlive the child's current length; clamp to content.
+                // Frozen carriers may outlive the child timeline.
                 let duration = min(clip.durationFrames, max(0, child.totalFrames - clip.trimStartFrame))
                 guard duration > 0 else { return nil }
                 var attrs: [(String, String)] = [
@@ -416,8 +409,7 @@ enum FCPXMLExporter {
             let resource = resources[i]
             let linkedAudio = linkedAudioForVideo[clip.id]
 
-            // One-sided A/V rides the compound (Resolve honors srcEnable only on ref-clips);
-            // everything else exports flat.
+            // Resolve honors srcEnable only on ref-clips.
             if let compoundId = resource.compoundId, linkedAudio == nil {
                 let videoOnly = clip.mediaType != .audio
                 let attrs: [(String, String)] = [
@@ -430,7 +422,7 @@ enum FCPXMLExporter {
                     ("enabled", item.enabled ? "1" : "0"),
                     ("srcEnable", videoOnly ? "video" : "audio"),
                 ]
-                // Child order is DTD-fixed: timeMap, crop, conform, transform, blend, volume.
+                // Child order is fixed by the DTD.
                 let children: [FCPXMLNode?] = videoOnly
                     ? [timeMapNode(for: clip, mediaFrames: resource.durationFrames),
                        cropNode(for: clip),
@@ -442,7 +434,7 @@ enum FCPXMLExporter {
                 return FCPXMLNode(name: "ref-clip", attributes: attrs, children: children.compactMap { $0 })
             }
 
-            let origin = resource.startTimecodeFrames
+            let origin = resource.startTimecode
             let visual = clip.mediaType != .audio
             let attrs: [(String, String)] = [
                 ("ref", resource.assetId),
@@ -461,7 +453,7 @@ enum FCPXMLExporter {
                 visual ? blendNode(for: clip) : nil,
                 resource.hasAudio ? volumeNode(for: linkedAudio ?? clip) : nil,
             ]
-            // Stills export as <video>, the shape FCP itself writes.
+            // Final Cut writes stills as video elements.
             return FCPXMLNode(name: clip.mediaType == .image ? "video" : "asset-clip",
                               attributes: attrs, children: children.compactMap { $0 })
         }
@@ -507,7 +499,6 @@ enum FCPXMLExporter {
             return FCPXMLNode(name: "adjust-blend", attributes: [("amount", formatNumber(clip.opacity))], children: children)
         }
 
-        /// Position + scale + rotation (static or keyframed) for a video/image clip.
         private func transformNode(for clip: Clip) -> FCPXMLNode? {
             let t = clip.transform
             let posFrames = clip.keyframeFrames(for: .position)
@@ -549,7 +540,7 @@ enum FCPXMLExporter {
             return FCPXMLNode(name: "adjust-transform", attributes: attrs, children: params)
         }
 
-        /// Divide the aspect-fit out of our frame-fraction width/height so only user scaling remains.
+        /// Removes aspect-fit scaling from the exported user scale.
         private func scaleValue(width: Double, height: Double, for clip: Clip) -> String {
             let fit = fitFractions(for: clip)
             var sx = width / fit.w
@@ -559,7 +550,6 @@ enum FCPXMLExporter {
             return "\(formatNumber(sx)) \(formatNumber(sy))"
         }
 
-        /// A keyframed `<param>`: time is in the clip's output axis, value uses the param's own unit.
         private func keyframeParam(name: String, base: String, clip: Clip, property: AnimatableProperty,
                                    frames: [Int], value: (Int) -> String) -> FCPXMLNode {
             let keyframes = frames.sorted().map { f -> FCPXMLNode in
@@ -573,9 +563,7 @@ enum FCPXMLExporter {
             ])
         }
 
-        /// A retimed clip's keyframes live in the timeMap's output axis, so `time` is offset by the clip's
-        /// `start` (= clipStart): `start + (f − startFrame)/fps`. Without it the animation lands before the
-        /// content and plays compressed. Unspeeded clips have no timeMap origin, so they stay clip-relative.
+        /// Offsets retimed keyframes into the time map's output axis.
         private func keyframeTime(_ f: Int, clip: Clip) -> String {
             guard abs(clip.speed - 1.0) > 0.001 else { return time(frames: f - clip.startFrame) }
             let (p, q) = rationalSpeed(clip.speed)
@@ -583,8 +571,7 @@ enum FCPXMLExporter {
             return rationalTime(num: num, den: fps * p)
         }
 
-        /// Resolve's trim-rect units: left/right = source px ÷ (seqHeight/100); top/bottom = crop
-        /// fraction ÷ conform-fit scale. FCP (and unknown source dims): plain percentages.
+        /// Uses Resolve trim units when source dimensions are known.
         private func cropNode(for clip: Clip) -> FCPXMLNode? {
             let c = clip.crop
             guard !c.isIdentity else { return nil }
@@ -607,8 +594,7 @@ enum FCPXMLExporter {
         }
 
         private func volumeNode(for clip: Clip) -> FCPXMLNode? {
-            // Keyframed audio volume has no FCPXML form Resolve round-trips (its own export drops it),
-            // so export the static level only.
+            // Resolve drops keyframed volume on round-trip.
             guard abs(clip.volume - 1.0) > 0.0005 else { return nil }
             return FCPXMLNode(name: "adjust-volume", attributes: [("amount", formatNumber(decibels(clip.volume)))])
         }
@@ -617,34 +603,30 @@ enum FCPXMLExporter {
             linear > 0 ? 20.0 * log10(linear) : -96.0
         }
 
-        /// Source in-point in the post-retime output axis Resolve expects (source ÷ speed); the raw
-        /// source frame when unspeeded. `origin` is the asset's embedded start timecode, added only to the
-        /// unspeeded case (a retimed clip carries its origin in the timeMap values, not in `start`).
-        private func clipStart(for clip: Clip, origin: Int = 0) -> String {
-            guard abs(clip.speed - 1.0) > 0.001 else { return time(frames: origin + clip.trimStartFrame) }
+        /// Uses the time-map output axis for retimed clips and the source origin otherwise.
+        private func clipStart(for clip: Clip, origin: (num: Int, den: Int) = (0, 1)) -> String {
+            guard abs(clip.speed - 1.0) > 0.001 else { return time(frames: clip.trimStartFrame, from: origin) }
             let (p, q) = rationalSpeed(clip.speed)
             return rationalTime(num: clip.trimStartFrame * q, den: fps * p)
         }
 
-        /// Resolve ramps the WHOLE media (`output[0, media/speed] → source[0, media]`) and windows in via
-        /// `start`/`duration`. A ramp that stops at the clip edge leaves no tail mapping → black last frames.
-        private func timeMapNode(for clip: Clip, mediaFrames: Int, origin: Int = 0) -> FCPXMLNode? {
+        /// Maps the full asset so retimed clips do not end on black frames.
+        private func timeMapNode(for clip: Clip, mediaFrames: Int, origin: (num: Int, den: Int) = (0, 1)) -> FCPXMLNode? {
             guard abs(clip.speed - 1.0) > 0.001, mediaFrames > 0 else { return nil }
             let (p, q) = rationalSpeed(clip.speed)
             return FCPXMLNode(name: "timeMap", attributes: [("frameSampling", "floor")], children: [
                 FCPXMLNode(name: "timept", attributes: [
-                    ("time", "0s"), ("value", time(frames: origin)), ("interp", "linear"),
+                    ("time", "0s"), ("value", rationalTime(num: origin.num, den: origin.den)), ("interp", "linear"),
                 ]),
                 FCPXMLNode(name: "timept", attributes: [
-                    ("time", rationalTime(num: mediaFrames * q, den: fps * p)),  // media / speed
-                    ("value", time(frames: origin + mediaFrames)),               // full media from origin
+                    ("time", rationalTime(num: mediaFrames * q, den: fps * p)),
+                    ("value", time(frames: mediaFrames, from: origin)),
                     ("interp", "linear"),
                 ]),
             ])
         }
 
-        /// Speed as a small-denominator fraction, so the timeMap slope is exact and `start` maps back to
-        /// the original source frame. Speeds are user values (1.25, 1.24, 2.0, 0.5…).
+        /// Approximates user-entered speed with a small exact fraction.
         private func rationalSpeed(_ speed: Double) -> (p: Int, q: Int) {
             var best = (p: 1, q: 1), bestErr = Double.infinity
             for q in 1...1000 {
@@ -684,7 +666,7 @@ enum FCPXMLExporter {
                 let key = sourceKey(for: url)
                 let duration = sourceDurationFrames(for: entry, clip: clip)
                 let isVisual = clip.mediaType != .audio
-                // Audio clip → audio stream; video clip → audio too if the source file carries it.
+                // Video resources include source audio when present.
                 let isAudio = clip.mediaType == .audio || (clip.mediaType == .video && entry.hasAudio == true)
                 var entryCaps = caps[key] ?? {
                     order.append(key)
@@ -705,19 +687,19 @@ enum FCPXMLExporter {
                 for ref in c.mediaRefs {
                     resourceIndex[ref] = resources.count
                 }
-                let tcFrames = c.mediaRefs.compactMap { startTimecodes[$0] }.first?.frames(atFPS: fps) ?? 0
+                let tc = c.mediaRefs.compactMap { startTimecodes[$0] }.first?.rationalSeconds ?? (0, 1)
                 resources.append(MediaResource(
                     mediaRef: c.mediaRefs.first ?? c.entry.id,
                     assetId: "asset\(id)",
                     formatId: c.hasVideo ? "r\(id + 1)" : nil,
-                    // Only an A/V source can need srcEnable gating, so only it gets a compound.
+                    // Only A/V sources need srcEnable gating through a compound.
                     compoundId: c.hasVideo && c.hasAudio ? "media\(id)" : nil,
                     entry: c.entry,
                     url: c.url,
                     durationFrames: c.duration,
                     hasVideo: c.hasVideo,
                     hasAudio: c.hasAudio,
-                    startTimecodeFrames: tcFrames
+                    startTimecode: tc
                 ))
             }
         }
@@ -741,8 +723,7 @@ enum FCPXMLExporter {
             ])
         }
 
-        // Resolve relinks by matching the `name` attribute to the file on disk, so the extension must be
-        // present — a stripped name shows every clip as Media Offline.
+        // Resolve relinks by the full filename, including its extension.
         private func fileName(for resource: MediaResource) -> String {
             resource.url.lastPathComponent
         }
@@ -751,7 +732,7 @@ enum FCPXMLExporter {
             var attrs: [(String, String)] = [
                 ("id", resource.assetId),
                 ("name", fileName(for: resource)),
-                ("start", time(frames: resource.startTimecodeFrames)),
+                ("start", rationalTime(num: resource.startTimecode.num, den: resource.startTimecode.den)),
                 ("duration", time(frames: resource.durationFrames)),
             ]
             if resource.hasVideo {
@@ -762,7 +743,7 @@ enum FCPXMLExporter {
                 }
             }
             if resource.hasAudio {
-                // We don't probe channels/rate; 2ch/48k is FCP's default and doesn't affect relinking.
+                // Default audio metadata does not affect relinking.
                 attrs.append(("hasAudio", "1"))
                 attrs.append(("audioSources", "1"))
                 attrs.append(("audioChannels", "2"))
@@ -776,8 +757,7 @@ enum FCPXMLExporter {
             ])
         }
 
-        // Percent-encode the sub-delims Foundation leaves literal — Resolve's relinker fails on
-        // their XML-entity forms (&apos;).
+        // Resolve cannot relink sub-delimiters encoded as XML entities.
         private func mediaSrc(for resource: MediaResource) -> String {
             resource.url.absoluteString.map { ch in
                 "'!$&()*+,;=".contains(ch) ? String(format: "%%%02X", ch.asciiValue ?? 0) : String(ch)
@@ -819,7 +799,7 @@ enum FCPXMLExporter {
 
         private func isEmittable(_ clip: Clip) -> Bool {
             guard clip.durationFrames > 0 else { return false }
-            // Nest carriers emit when their child timeline resolved to a compound resource.
+            // Nest carriers require a resolved compound resource.
             if clip.sourceClipType == .sequence { return nestIndex[clip.mediaRef] != nil }
             switch clip.mediaType {
             case .text:
@@ -837,6 +817,12 @@ enum FCPXMLExporter {
             let numerator = frames / divisor
             let denominator = fps / divisor
             return denominator == 1 ? "\(numerator)s" : "\(numerator)/\(denominator)s"
+        }
+
+        /// Adds frame time to an exact source origin without NTSC drift.
+        private func time(frames: Int, from origin: (num: Int, den: Int)) -> String {
+            guard origin.num != 0 else { return time(frames: frames) }
+            return rationalTime(num: frames * origin.den + origin.num * fps, den: fps * origin.den)
         }
 
         private func videoFormatName(width: Int, height: Int, fps rawFPS: Double) -> String {
@@ -924,7 +910,7 @@ enum FCPXMLExporter {
             return "\(formatNumber(x)) \(formatNumber(y))"
         }
 
-        /// Per-axis conform-fit fractions of the sequence frame; 1×1 when source dims are unknown.
+        /// Returns per-axis conform-fit fractions, or 1×1 without source dimensions.
         private func fitFractions(for clip: Clip) -> (w: Double, h: Double) {
             guard let entry = resolver.entry(for: clip.mediaRef),
                   let sw = entry.sourceWidth, let sh = entry.sourceHeight, sw > 0, sh > 0 else { return (1, 1) }

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -50,7 +50,7 @@ enum XMLExporter {
         try data.write(to: outputURL)
     }
 
-    /// Split out so tests can build the document synchronously.
+    /// Renders synchronously for deterministic tests.
     static func render(timeline: Timeline, resolver: MediaResolver,
                        resolveTimeline: @escaping (String) -> Timeline? = { _ in nil },
                        startFrameCache: [String: SourceTimecode] = [:]) -> String {
@@ -72,11 +72,17 @@ enum XMLExporter {
 
     // MARK: - Source timecode
 
-    /// The `<timecode>` values to emit for a file. A `tmcd` timecode runs at its own rate (often 30 DF
-    /// even on 60p footage), so when present it — not the video rate — drives the rate/format. When absent,
-    /// fall back to the video rate and emit a dummy 00:00:00:00.
+    /// Builds file timecode fields from embedded metadata or the video rate.
     static func timecodeTags(source: SourceTimecode?, videoTimebase: Int, videoNtsc: Bool)
         -> (base: Int, ntsc: Bool, frame: Int, dropFrame: Bool, string: String) {
+        // BWF time references use samples, so rescale them to the video rate.
+        if let source, source.quanta > 240 {
+            let effectiveFPS = videoNtsc ? Double(videoTimebase) * 1000 / 1001 : Double(videoTimebase)
+            let dropFrame = videoNtsc && videoTimebase % 30 == 0
+            let frame = Int((source.seconds * effectiveFPS).rounded())
+            return (videoTimebase, videoNtsc, frame, dropFrame,
+                    formatTimecode(frame: frame, fps: videoTimebase, dropFrame: dropFrame))
+        }
         let base = source?.quanta ?? videoTimebase
         let dropFrame = source?.dropFrame ?? (videoNtsc && videoTimebase % 30 == 0)
         let ntsc = dropFrame ? true : videoNtsc
@@ -89,9 +95,12 @@ enum XMLExporter {
         guard fps > 0 else { return "00:00:00:00" }
         var f = frame
         if dropFrame {
-            let drop = Int((Double(fps) * 0.066666).rounded())   // 2 @ 30, 4 @ 60
-            let d = f / (fps * 600), m = f % (fps * 600)
-            f += drop * 9 * d + (m > drop ? drop * ((m - drop) / (fps * 60)) : 0)
+            let drop = Int((Double(fps) * 0.066666).rounded())
+            // Drop-frame ten-minute blocks contain nine shortened minutes.
+            let perMinute = fps * 60 - drop
+            let per10 = perMinute * 10 + drop
+            let d = f / per10, m = f % per10
+            f += drop * 9 * d + (m > drop ? drop * ((m - drop) / perMinute) : 0)
         }
         let sep = dropFrame ? ";" : ":"
         let ff = f % fps, ss = (f / fps) % 60, mm = (f / (fps * 60)) % 60, hh = f / (fps * 3600)
@@ -109,19 +118,16 @@ enum XMLExporter {
         private let seqHeight: Int
         private var curSeqWidth: Int
 
-        /// Files already emitted in full; repeat references collapse to `<file id="..."/>`.
         private var emittedFiles: Set<FileKey> = []
-        /// Clip id → position within its media type, used to emit `<link>` cross-references.
         private var clipAddresses: [String: ClipAddress] = [:]
         private var clipsByLinkGroup: [String: [Clip]] = [:]
         private let startFrameCache: [String: SourceTimecode]
-        /// Child timeline id -> XMEML sequence id; first carrier embeds the full definition,
-        /// later carriers reference it (Premiere's own nested-sequence convention).
+        // Repeated nests reference the first embedded sequence.
         private var sequenceIds: [String: String] = [:]
         private var emittedSequences: Set<String> = []
 
         private struct FileKey: Hashable { let mediaRef: String; let isAudio: Bool }
-        private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }  // indices 1-based
+        private struct ClipAddress { let trackIndex: Int; let clipIndex: Int; let isAudio: Bool }
 
         init(timeline: Timeline, resolver: MediaResolver, resolveTimeline: @escaping (String) -> Timeline?,
              startFrameCache: [String: SourceTimecode]) {
@@ -146,8 +152,7 @@ enum XMLExporter {
             return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE xmeml>\n" + renderXML(root, indent: 0)
         }
 
-        /// One timeline as a <sequence>; used for the root and, recursively, nested timelines.
-        /// Link/address state is per-sequence, so it stacks around the recursive build.
+        /// Builds a root or nested sequence with isolated link state.
         private func sequenceNode(id: String, timeline: Timeline) -> XMLNode {
             let savedAddresses = clipAddresses
             let savedGroups = clipsByLinkGroup
@@ -236,17 +241,27 @@ enum XMLExporter {
 
         private func clipItemNode(_ clip: Clip, isAudio: Bool) -> XMLNode {
             if clip.sourceClipType == .sequence { return nestClipItemNode(clip, isAudio: isAudio) }
+            // Clipitem rate/in/out/duration are in FILE-rate units; start/end stay sequence frames.
+            // Resolve conforms in/out against the file's own rate — timeline-rate values land the
+            // in-point off by the rate ratio on rate-mismatched sources.
+            let (timebase, ntsc) = rateTags(forFPS: resolver.entry(for: clip.mediaRef)?.sourceFPS ?? Double(fps))
+            let fileFPS = ntsc ? Double(timebase) * 1000.0 / 1001.0 : Double(timebase)
+            let scale = fileFPS / Double(fps)
+            let matchesTimeline = abs(scale - 1) < 0.0001
+            func fileFrames(_ timelineFrames: Int) -> Int {
+                matchesTimeline ? timelineFrames : Int((Double(timelineFrames) * scale).rounded())
+            }
             let sourceDuration = sourceDurationFrames(for: clip.mediaRef) ?? clip.sourceDurationFrames
-            // in/out are source-frame offsets, so they span sourceFramesConsumed (Time Remap handles rate).
-            let inPoint = clip.trimStartFrame
-            let outPoint = clip.trimStartFrame + clip.sourceFramesConsumed
+            // Time Remap handles speed through source in/out values.
+            let inPoint = fileFrames(clip.trimStartFrame)
+            let outPoint = fileFrames(clip.trimStartFrame + clip.sourceFramesConsumed)
 
             var children: [XMLNode] = [
                 leaf("masterclipid", masterclipId(for: clip, isAudio: isAudio)),
                 leaf("name", resolver.displayName(for: clip.mediaRef)),
                 bool("enabled", true),
-                leaf("duration", sourceDuration),
-                rate(fps),
+                leaf("duration", fileFrames(sourceDuration)),
+                matchesTimeline ? rate(fps) : rate(timebase, ntsc: ntsc),
                 leaf("start", clip.startFrame),
                 leaf("end", clip.endFrame),
                 leaf("in", inPoint),
@@ -259,8 +274,7 @@ enum XMLExporter {
             return el("clipitem", attrs: [("id", "clipitem-\(clip.id)")], children)
         }
 
-        /// Nest carrier: a clipitem over the child <sequence> — full definition on first use,
-        /// id reference after. The frozen carrier is clamped to the child's current length.
+        /// Embeds a nested sequence once, then references it by ID.
         private func nestClipItemNode(_ clip: Clip, isAudio: Bool) -> XMLNode {
             let child = resolveTimeline(clip.mediaRef)!  // sortEmittable guarantees resolution
             let seqId = sequenceIds[clip.mediaRef] ?? {
@@ -299,8 +313,7 @@ enum XMLExporter {
 
         // MARK: - File elements
 
-        /// Separate ids per media type — Premiere rejects a clipitem pointing at a `<file>` of the
-        /// wrong type. Repeats collapse to a self-closing `<file id="..."/>`.
+        /// Emits media-specific file IDs and collapses repeated definitions to references.
         private func fileNode(for mediaRef: String, isAudio: Bool) -> XMLNode {
             let fileId = "file-\(mediaRef)-\(isAudio ? "audio" : "video")"
             let key = FileKey(mediaRef: mediaRef, isAudio: isAudio)
@@ -315,7 +328,7 @@ enum XMLExporter {
             let pathUrl = url
                 .map { $0.absoluteString.replacingOccurrences(of: "file://", with: "file://localhost//") }
                 ?? "media/\(mediaRef)"
-            // A still decodes to exactly 1 frame
+            // Stills decode as one frame.
             let isImage = entry?.type == .image
             let durationFrames = isImage ? 1 : (entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0)
             let (timebase, ntsc) = rateTags(forFPS: entry?.sourceFPS ?? Double(fps))
@@ -334,7 +347,7 @@ enum XMLExporter {
                     rate(timebase, ntsc: ntsc),
                   ])])])
 
-            // timecode is required for Davinci Resolve; computed by the unit-tested timecodeTags.
+            // Resolve requires the timecode element.
             let tc = XMLExporter.timecodeTags(source: sourceTimecode(for: mediaRef), videoTimebase: timebase, videoNtsc: ntsc)
             let timecode = el("timecode", [
                 rate(tc.base, ntsc: tc.ntsc),
@@ -352,7 +365,6 @@ enum XMLExporter {
             ])
         }
 
-        /// Source start timecode — one read serves both the video and audio file nodes.
         private func sourceTimecode(for mediaRef: String) -> SourceTimecode? {
             startFrameCache[mediaRef]
         }
@@ -392,7 +404,7 @@ enum XMLExporter {
                 children.append(rate(fps))
                 children.append(effect(name: "Cross Fade ( 0dB)", id: "KGAudioTransCrossFade0dB", type: "transition", mediatype: "audio"))
             } else {
-                // Premiere's private cut-point, in ticks (254016000000/sec): 0 for fade-in, full length for fade-out.
+                // Premiere stores fade cut points in 254016000000 ticks per second.
                 let cutPointTicks = Int64(cutFrames) * (Int64(254_016_000_000) / Int64(fps))
                 children.append(leaf("cutPointTicks", String(cutPointTicks)))
                 children.append(rate(fps))
@@ -420,8 +432,7 @@ enum XMLExporter {
             ]))
         }
 
-        /// `level` is linear (1 = 0 dB, clamped to ~3.98). Uses fade-excluded volume since fades
-        /// export separately as a transition.
+        /// Exports fade-independent linear gain, clamped to Premiere's maximum.
         private func volumeFilters(_ clip: Clip) -> [XMLNode] {
             func clampLevel(_ v: Double) -> Double { max(0, min(v, 3.98)) }
             let frames = clip.keyframeFrames(for: .volume)
@@ -440,10 +451,10 @@ enum XMLExporter {
             [motionFilter(clip), cropFilter(clip), opacityFilter(clip)].compactMap { $0 }
         }
 
-        /// Basic Motion: scale, rotation, center — keyframed, or static (defaults omitted).
+        /// Emits nondefault Basic Motion parameters.
         private func motionFilter(_ clip: Clip) -> XMLNode? {
             let sourceWidth = resolver.entry(for: clip.mediaRef)?.sourceWidth ?? 0
-            // Scale is relative to the sequence being emitted — a nested child's canvas, not the root's.
+            // Nested transforms use the child sequence canvas.
             func scalePct(_ width: Double) -> Double {
                 sourceWidth > 0 ? (Double(curSeqWidth) / Double(sourceWidth)) * width * 100 : width * 100
             }
@@ -462,7 +473,7 @@ enum XMLExporter {
             if frames.isEmpty {
                 let t = clip.transform
                 let c = center(t), scaled = scalePct(t.width), rotated = -t.rotation
-                let needsCenter = abs(c.x) > 0.001 || abs(c.y) > 0.001   // normalized, so a small epsilon
+                let needsCenter = abs(c.x) > 0.001 || abs(c.y) > 0.001
                 let needsScale = abs(scaled - 100) > 0.1
                 let needsRotation = abs(rotated) > 0.05
                 guard needsCenter || needsScale || needsRotation else { return nil }
@@ -484,7 +495,7 @@ enum XMLExporter {
             return filter(effect(name: "Basic Motion", id: "basic", type: "motion", mediatype: "video", body: params))
         }
 
-        /// Crop filter — edge insets as 0–100 percentages (our model stores 0–1 fractions).
+        /// Converts crop fractions to FCP7 percentages.
         private func cropFilter(_ clip: Clip) -> XMLNode? {
             let frames = clip.keyframeFrames(for: .crop)
             if frames.isEmpty && clip.crop.isIdentity { return nil }
@@ -500,7 +511,7 @@ enum XMLExporter {
             return filter(effect(name: "Crop", id: "crop", type: "motion", mediatype: "video", category: "motion", body: params))
         }
 
-        /// FCP7 keeps opacity in its own Opacity effect (Basic Motion has no opacity parameter).
+        /// Emits opacity separately from Basic Motion.
         private func opacityFilter(_ clip: Clip) -> XMLNode? {
             let frames = clip.keyframeFrames(for: .opacity)
             let opacity: XMLNode
@@ -516,11 +527,11 @@ enum XMLExporter {
 
         // MARK: - Indexing helpers
 
-        /// Drops unresolvable clips so track builders and `<link>` indices agree.
+        /// Drops unresolved clips before assigning link indices.
         private func sortEmittable(_ track: Track) -> [Clip] {
             track.clips
                 .filter { clip in
-                    // A frozen carrier trimmed past the child's current length would emit out < in.
+                    // Drop carriers trimmed beyond the child timeline.
                     clip.sourceClipType == .sequence
                         ? clip.trimStartFrame < (resolveTimeline(clip.mediaRef)?.totalFrames ?? 0)
                         : resolver.resolveURL(for: clip.mediaRef) != nil
@@ -550,7 +561,7 @@ enum XMLExporter {
             return max(0, secondsToFrame(seconds: seconds, fps: fps))
         }
 
-        /// Real fps → FCP7 (timebase, ntsc). NTSC rates (timebase×1000/1001: 29.97, 23.976, …) set ntsc TRUE.
+        /// Converts a real frame rate to FCP7 timebase and NTSC fields.
         private func rateTags(forFPS rawFps: Double) -> (timebase: Int, ntsc: Bool) {
             let timebase = max(1, Int(rawFps.rounded()))
             let ntscRate = Double(timebase) * 1000.0 / 1001.0
@@ -575,7 +586,6 @@ enum XMLExporter {
             return el("effect", children)
         }
 
-        /// A `<parameter>`; `value` is its `<value>` node, optionally animated by `keyframes`.
         private func parameter(id: String, name: String, min: String? = nil, max: String? = nil,
                                value: XMLNode, keyframes: [(when: Int, value: XMLNode)] = []) -> XMLNode {
             var children = [leaf("parameterid", id), leaf("name", name)]
@@ -586,7 +596,6 @@ enum XMLExporter {
             return el("parameter", children)
         }
 
-        /// Scalar `<parameter>` whose value (and keyframes) are numbers formatted by `spec`.
         private func scalarParam(id: String, name: String, min: String, max: String, base: Double,
                                  keyframes: [(when: Int, value: Double)] = [], spec: String = "%.2f") -> XMLNode {
             parameter(id: id, name: name, min: min, max: max,
@@ -594,7 +603,6 @@ enum XMLExporter {
                       keyframes: keyframes.map { (when: $0.when, value: leaf("value", String(format: spec, $0.value))) })
         }
 
-        /// Two-component Center `<parameter>` whose value is a `<horiz>`/`<vert>` pair.
         private func centerParam(base: (x: Double, y: Double), keyframes: [(when: Int, x: Double, y: Double)] = []) -> XMLNode {
             func vec(_ x: Double, _ y: Double) -> XMLNode {
                 el("value", [leaf("horiz", String(format: "%.5f", x)), leaf("vert", String(format: "%.5f", y))])
@@ -607,13 +615,12 @@ enum XMLExporter {
 
 // MARK: - XML rendering
 
-/// A minimal XML tree. The emitters above describe document *structure*; `render` owns every bit
-/// of whitespace and escaping so no fragment ever hardcodes its own indentation.
+/// Minimal XML tree with centralized escaping and whitespace.
 private struct XMLNode {
     let name: String
     var attributes: [(String, String)] = []
-    var text: String? = nil        // leaf value → `<name>text</name>`
-    var children: [XMLNode] = []   // empty + no text → self-closing `<name/>`
+    var text: String? = nil
+    var children: [XMLNode] = []
 }
 
 private func el(_ name: String, _ children: [XMLNode] = []) -> XMLNode {

--- a/Sources/PalmierPro/Export/XMLExporter.swift
+++ b/Sources/PalmierPro/Export/XMLExporter.swift
@@ -330,8 +330,10 @@ enum XMLExporter {
                 ?? "media/\(mediaRef)"
             // Stills decode as one frame.
             let isImage = entry?.type == .image
-            let durationFrames = isImage ? 1 : (entry.map { max(0, secondsToFrame(seconds: $0.duration, fps: fps)) } ?? 0)
             let (timebase, ntsc) = rateTags(forFPS: entry?.sourceFPS ?? Double(fps))
+            // Duration in the file's own rate units, consistent with the rate element it sits beside.
+            let fileFPS = ntsc ? Double(timebase) * 1000.0 / 1001.0 : Double(timebase)
+            let durationFrames = isImage ? 1 : (entry.map { max(0, Int(($0.duration * fileFPS).rounded())) } ?? 0)
 
             let media: XMLNode = isAudio
                 ? el("media", [el("audio", [

--- a/Sources/PalmierPro/Utilities/SourceTimecode.swift
+++ b/Sources/PalmierPro/Utilities/SourceTimecode.swift
@@ -3,11 +3,17 @@ import Foundation
 
 /// A clip's start timecode: frame number at `quanta` rate with drop-frame flag.
 struct SourceTimecode: Equatable {
+    /// Exact seconds per TC frame (1001/30000 for NTSC).
+    struct Tick: Equatable {
+        let num: Int
+        let den: Int
+    }
+
     let frame: Int
     let quanta: Int
     let dropFrame: Bool
-    /// Exact seconds per TC frame (1001/30000 for NTSC); nil falls back to 1/quanta.
-    var frameDuration: Double? = nil
+    /// nil falls back to 1/quanta.
+    var tick: Tick? = nil
 
     /// Start timecode expressed in `fps`-frame units (for a progressive source, `quanta` == `fps`).
     func frames(atFPS fps: Int) -> Int {
@@ -15,7 +21,17 @@ struct SourceTimecode: Equatable {
         return Int((Double(frame) / Double(quanta) * Double(fps)).rounded())
     }
 
-    var seconds: Double { Double(frame) * (frameDuration ?? (quanta > 0 ? 1 / Double(quanta) : 0)) }
+    var seconds: Double {
+        let s = rationalSeconds
+        return Double(s.num) / Double(s.den)
+    }
+
+    /// Rational seconds (with exact NTSC tick if needed) to prevent drift.
+    var rationalSeconds: (num: Int, den: Int) {
+        guard quanta > 0 else { return (0, 1) }
+        if let tick, tick.num > 0, tick.den > 0 { return (frame * tick.num, tick.den) }
+        return (frame, quanta)
+    }
 }
 
 /// Per-file sync signals: embedded SMPTE timecode and/or recording-start capture date.
@@ -50,6 +66,12 @@ enum SourceTimingReader {
     }
 
     private static func timecode(url: URL) async -> SourceTimecode? {
+        if let tc = await tmcdTimecode(url: url) { return tc }
+        guard let data = try? Data(contentsOf: url, options: .alwaysMapped) else { return nil }
+        return rtmdTimecode(data) ?? bwfTimecode(data)
+    }
+
+    private static func tmcdTimecode(url: URL) async -> SourceTimecode? {
         let asset = AVURLAsset(url: url)
         guard let track = try? await asset.loadTracks(withMediaType: .timecode).first,
               let format = try? await track.load(.formatDescriptions).first,
@@ -57,8 +79,9 @@ enum SourceTimingReader {
         let quanta = Int(CMTimeCodeFormatDescriptionGetFrameQuanta(format))
         let dropFrame = CMTimeCodeFormatDescriptionGetTimeCodeFlags(format) & UInt32(kCMTimeCodeFlag_DropFrame) != 0
         guard quanta > 0 else { return nil }
-        let tick = CMTimeCodeFormatDescriptionGetFrameDuration(format)
-        let frameDuration = tick.isNumeric && tick.seconds > 0 ? tick.seconds : nil
+        let duration = CMTimeCodeFormatDescriptionGetFrameDuration(format)
+        let tick: SourceTimecode.Tick? = duration.isNumeric && duration.seconds > 0
+            ? .init(num: Int(duration.value), den: Int(duration.timescale)) : nil
 
         let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
         guard reader.canAdd(output) else { return nil }
@@ -69,7 +92,7 @@ enum SourceTimingReader {
             var be: UInt32 = 0
             guard CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: 4, destination: &be) == kCMBlockBufferNoErr
             else { return nil }
-            return SourceTimecode(frame: Int(UInt32(bigEndian: be)), quanta: quanta, dropFrame: dropFrame, frameDuration: frameDuration)
+            return SourceTimecode(frame: Int(UInt32(bigEndian: be)), quanta: quanta, dropFrame: dropFrame, tick: tick)
         }
         return nil
     }
@@ -90,5 +113,126 @@ enum SourceTimingReader {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZ"
         return formatter.date(from: string)
+    }
+
+    // MARK: - Sony rtmd (RDD 18 metadata track)
+
+    /// Sony XAVC stores time-of-day timecode in an `rtmd` track that AVFoundation ignores.
+    /// The first sample's bytes 13–17 are hh/mm/ss/dropFlag/ff in binary.
+    static func rtmdTimecode(_ data: Data) -> SourceTimecode? {
+        guard let moov = mp4Children(data, in: 0..<data.count).first(where: { $0.type == "moov" })?.body
+        else { return nil }
+        for trak in mp4Children(data, in: moov) where trak.type == "trak" {
+            guard let mdia = mp4Child("mdia", data, in: trak.body),
+                  let minf = mp4Child("minf", data, in: mdia),
+                  let stbl = mp4Child("stbl", data, in: minf),
+                  let stsd = mp4Child("stsd", data, in: stbl),
+                  fourcc(data, stsd.lowerBound + 12) == "rtmd",
+                  let mdhd = mp4Child("mdhd", data, in: mdia),
+                  let stts = mp4Child("stts", data, in: stbl),
+                  let version = byte(data, mdhd.lowerBound),
+                  let timescale = be(data, mdhd.lowerBound + (version == 1 ? 20 : 12), 4),
+                  let delta = be(data, stts.lowerBound + 12, 4), timescale > 0, delta > 0
+            else { continue }
+
+            var sample: Int?
+            if let stco = mp4Child("stco", data, in: stbl), let n = be(data, stco.lowerBound + 4, 4), n > 0 {
+                sample = be(data, stco.lowerBound + 8, 4).map(Int.init)
+            } else if let co64 = mp4Child("co64", data, in: stbl), let n = be(data, co64.lowerBound + 4, 4), n > 0 {
+                sample = be(data, co64.lowerBound + 8, 8).map(Int.init)
+            }
+            guard let offset = sample,
+                  let hh = byte(data, offset + 13), let mm = byte(data, offset + 14),
+                  let ss = byte(data, offset + 15), let drop = byte(data, offset + 16),
+                  let ff = byte(data, offset + 17) else { continue }
+
+            let quanta = Int((Double(timescale) / Double(delta)).rounded())
+            guard quanta > 0, hh < 24, mm < 60, ss < 60, Int(ff) < quanta else { continue }
+            // NTSC-rate rtmd is drop-frame regardless of the flag byte: Sony time-of-day TC at
+            // 29.97/59.94 is DF, and Resolve conforms on that reading (NDF lands ~1s/15min off).
+            let ntsc = delta == 1001 && timescale % 30000 == 0
+            let dropFrame = drop != 0 || (ntsc && quanta % 30 == 0)
+            var frame = (Int(hh) * 3600 + Int(mm) * 60 + Int(ss)) * quanta + Int(ff)
+            if dropFrame {
+                // Display TC → raw frame count: remove the frame numbers DF skips.
+                let d = Int((Double(quanta) * 0.066666).rounded())
+                let mins = Int(hh) * 60 + Int(mm)
+                frame -= d * (mins - mins / 10)
+            }
+            return SourceTimecode(frame: frame, quanta: quanta, dropFrame: dropFrame,
+                                  tick: .init(num: Int(delta), den: Int(timescale)))
+        }
+        return nil
+    }
+
+    // MARK: - BWF (bext TimeReference)
+
+    /// BWF start timecode is `bext.TimeReference`: samples since midnight. Returned sample-based
+    /// (`quanta` = sample rate); `seconds`/`frames(atFPS:)` are exact, XMEML rescales for display.
+    static func bwfTimecode(_ data: Data) -> SourceTimecode? {
+        let magic = fourcc(data, 0)
+        guard magic == "RIFF" || magic == "RF64", fourcc(data, 8) == "WAVE" else { return nil }
+        var pos = 12
+        var sampleRate = 0
+        var timeReference: UInt64?
+        while pos + 8 <= data.count {
+            guard let type = fourcc(data, pos), let size32 = le(data, pos + 4, 4),
+                  size32 != 0xFFFF_FFFF else { break }  // RF64 jumbo data chunk; fmt/bext precede it
+            if type == "fmt " { sampleRate = Int(le(data, pos + 12, 4) ?? 0) }
+            if type == "bext", size32 >= 346 { timeReference = le(data, pos + 8 + 338, 8) }
+            if sampleRate > 0, timeReference != nil { break }
+            pos += 8 + Int(size32) + (Int(size32) & 1)
+        }
+        guard let reference = timeReference, reference > 0, sampleRate > 0, let frame = Int(exactly: reference)
+        else { return nil }
+        return SourceTimecode(frame: frame, quanta: sampleRate, dropFrame: false)
+    }
+
+    // MARK: - Byte helpers
+
+    private static func byte(_ data: Data, _ offset: Int) -> UInt8? {
+        guard offset >= 0, offset < data.count else { return nil }
+        return data[data.startIndex + offset]
+    }
+
+    private static func be(_ data: Data, _ offset: Int, _ count: Int) -> UInt64? {
+        guard offset >= 0, offset + count <= data.count else { return nil }
+        return (0..<count).reduce(0) { $0 << 8 | UInt64(data[data.startIndex + offset + $1]) }
+    }
+
+    private static func le(_ data: Data, _ offset: Int, _ count: Int) -> UInt64? {
+        guard offset >= 0, offset + count <= data.count else { return nil }
+        return (0..<count).reversed().reduce(0) { $0 << 8 | UInt64(data[data.startIndex + offset + $1]) }
+    }
+
+    private static func fourcc(_ data: Data, _ offset: Int) -> String? {
+        guard offset >= 0, offset + 4 <= data.count else { return nil }
+        let start = data.startIndex + offset
+        return String(bytes: data[start..<start + 4], encoding: .ascii)
+    }
+
+    private static func mp4Children(_ data: Data, in range: Range<Int>) -> [(type: String, body: Range<Int>)] {
+        var out: [(String, Range<Int>)] = []
+        var pos = range.lowerBound
+        while pos + 8 <= range.upperBound {
+            guard let size32 = be(data, pos, 4), let type = fourcc(data, pos + 4) else { break }
+            var body = pos + 8
+            var size = Int(size32)
+            if size32 == 1 {
+                guard let large = be(data, pos + 8, 8), let s = Int(exactly: large) else { break }
+                size = s
+                body = pos + 16
+            } else if size32 == 0 {
+                size = range.upperBound - pos
+            }
+            guard size >= body - pos, pos + size <= range.upperBound else { break }
+            out.append((type, body..<(pos + size)))
+            pos += size
+        }
+        return out
+    }
+
+    private static func mp4Child(_ type: String, _ data: Data, in range: Range<Int>) -> Range<Int>? {
+        mp4Children(data, in: range).first { $0.type == type }?.body
     }
 }

--- a/Sources/PalmierPro/Utilities/SourceTimecode.swift
+++ b/Sources/PalmierPro/Utilities/SourceTimecode.swift
@@ -183,7 +183,7 @@ enum SourceTimingReader {
             if sampleRate > 0, timeReference != nil { break }
             pos += 8 + Int(size32) + (Int(size32) & 1)
         }
-        guard let reference = timeReference, sampleRate > 0, let frame = Int(exactly: reference)
+        guard let reference = timeReference, reference > 0, sampleRate > 0, let frame = Int(exactly: reference)
         else { return nil }
         return SourceTimecode(frame: frame, quanta: sampleRate, dropFrame: false)
     }

--- a/Sources/PalmierPro/Utilities/SourceTimecode.swift
+++ b/Sources/PalmierPro/Utilities/SourceTimecode.swift
@@ -183,7 +183,7 @@ enum SourceTimingReader {
             if sampleRate > 0, timeReference != nil { break }
             pos += 8 + Int(size32) + (Int(size32) & 1)
         }
-        guard let reference = timeReference, reference > 0, sampleRate > 0, let frame = Int(exactly: reference)
+        guard let reference = timeReference, sampleRate > 0, let frame = Int(exactly: reference)
         else { return nil }
         return SourceTimecode(frame: frame, quanta: sampleRate, dropFrame: false)
     }

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -412,13 +412,14 @@ struct FCPXMLExporterTests {
         let clip = Fixtures.clip(id: "c", mediaRef: "media-v", start: 0, duration: 30, trimStart: 10)
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
 
-        // 00:00:14:44 @ 50 quanta = 744; the timeline runs 30fps → 744/50×30 = 446 frames = 223/15s.
+        // 00:00:14:44 @ 50 quanta = 744; exact rational 744/50 = 372/25s — NOT quantized to the
+        // 30fps timeline (446/30s), which conformed in-points 2–3 frames off in Resolve.
         let tc = SourceTimecode(frame: 744, quanta: 50, dropFrame: false)
         let xml = FCPXMLExporter.render(timeline: timeline, resolver: resolver, startTimecodes: ["media-v": tc])
 
-        #expect(xml.contains("<asset id=\"asset1\" name=\"media-v.mp4\" start=\"223/15s\""))
+        #expect(xml.contains("<asset id=\"asset1\" name=\"media-v.mp4\" start=\"372/25s\""))
         // The compound reads the asset from its timecode origin (offset stays 0 — 0-based spine).
-        #expect(xml.contains("start=\"223/15s\" offset=\"0s\""))
+        #expect(xml.contains("start=\"372/25s\" offset=\"0s\""))
         // The outer ref-clip stays 0-based against the compound: trimStart 10 / 30fps = 1/3s.
         #expect(xml.contains("<ref-clip ref=\"media1\" name=\"media-v.mp4\" lane=\"1\" offset=\"0s\" start=\"1/3s\""))
     }

--- a/Tests/PalmierProTests/Export/XMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/XMLExporterTests.swift
@@ -935,3 +935,49 @@ struct XMEMLNestExportTests {
         #expect(xml.contains("<linkclipref>clipitem-\(audio.id)</linkclipref>"))
     }
 }
+
+extension XMLExporterTests {
+    // MARK: - File-rate in/out (PAL-166 follow-up: Resolve rejected timeline-rate in/out)
+
+    @Test func slowerSourceEmitsFileRateInOutAndDuration() throws {
+        // 29.97 source on a 60fps timeline: trim 240 timeline frames = 4s ≈ 119.88 → 120 file frames.
+        let dir = NSTemporaryDirectory()
+        var entry = MediaManifestEntry(
+            id: "rx", name: "rx", type: .video,
+            source: .external(absolutePath: (dir as NSString).appendingPathComponent("rx.mp4")),
+            duration: 15.2
+        )
+        entry.sourceFPS = 29.97
+        FileManager.default.createFile(atPath: (dir as NSString).appendingPathComponent("rx.mp4"), contents: Data())
+        var manifest = MediaManifest()
+        manifest.entries = [entry]
+        let resolver = MediaResolver(manifest: { manifest }, projectURL: { nil })
+
+        let clip = Fixtures.clip(id: "c", mediaRef: "rx", start: 300, duration: 300, trimStart: 240)
+        var timeline = Fixtures.timeline(fps: 60, tracks: [Fixtures.videoTrack(clips: [clip])])
+        timeline.width = 1920
+        timeline.height = 1080
+
+        let xml = XMLExporter.render(timeline: timeline, resolver: resolver)
+
+        // clipitem rate = file rate; in/out/duration in 29.97-frame units; start/end stay timeline frames.
+        #expect(xml.contains("<in>120</in>"))
+        #expect(xml.contains("<out>270</out>"))
+        #expect(xml.contains("<start>300</start>"))
+        #expect(xml.contains("<end>600</end>"))
+        // file duration 15.2s × 29.97 ≈ 456, not 912 timeline frames.
+        #expect(xml.contains("<duration>456</duration>"))
+    }
+
+    @Test func matchingRateKeepsTimelineFrameInOut() throws {
+        let dir = NSTemporaryDirectory()
+        let (resolver, _) = try makeResolver(entries: [videoManifestEntry(id: "same", in: dir)])
+        let clip = Fixtures.clip(id: "c", mediaRef: "same", start: 0, duration: 30, trimStart: 12)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+
+        let xml = XMLExporter.render(timeline: timeline, resolver: resolver)
+
+        #expect(xml.contains("<in>12</in>"))
+        #expect(xml.contains("<out>42</out>"))
+    }
+}

--- a/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
+++ b/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+/// PAL-166: Sony XAVC keeps timecode in an `rtmd` metadata track and BWF WAV in `bext.TimeReference`;
+/// AVFoundation surfaces neither, so exports wrote start="0s" and Resolve refused to conform.
+/// Fixtures are synthesized byte-for-byte from the layouts verified against real camera files
+/// (a7S III 59.94p, RX100 VII 29.97p) and ffmpeg-authored BWF/RF64 WAVs.
+@Suite("SourceTimingReader containers")
+struct SourceTimecodeReaderTests {
+
+    // MARK: - MP4 / rtmd
+
+    private func box(_ type: String, _ body: Data) -> Data {
+        var out = Data()
+        var size = UInt32(8 + body.count).bigEndian
+        withUnsafeBytes(of: &size) { out.append(contentsOf: $0) }
+        out.append(type.data(using: .ascii)!)
+        out.append(body)
+        return out
+    }
+
+    private func u32(_ v: UInt32) -> Data {
+        var be = v.bigEndian
+        return withUnsafeBytes(of: &be) { Data($0) }
+    }
+
+    /// Minimal MP4: moov(trak(mdia(mdhd + minf(stbl(stsd rtmd, stts, stco))))) + mdat with one
+    /// rtmd sample whose bytes 13–17 are hh mm ss drop ff.
+    private func rtmdFile(timescale: UInt32, delta: UInt32,
+                          hh: UInt8, mm: UInt8, ss: UInt8, drop: UInt8, ff: UInt8) -> Data {
+        var mdhd = Data([0, 0, 0, 0])                    // version 0 + flags
+        mdhd += u32(0) + u32(0)                          // creation, modification
+        mdhd += u32(timescale) + u32(0)                  // timescale, duration
+        mdhd += Data([0, 0, 0, 0])
+
+        let stsd = box("stsd", u32(0) + u32(1) + box("rtmd", Data(count: 8)))
+        let stts = box("stts", u32(0) + u32(1) + u32(1) + u32(delta))
+
+        var sample = Data(count: 13)
+        sample += Data([hh, mm, ss, drop, ff])
+        // stco chunk offset is absolute within the file; moov precedes mdat here.
+        let stblSoFar = stsd + stts
+        let fixedPrefix = 8       // moov hdr
+            + 8                   // trak hdr
+            + 8                   // mdia hdr
+            + 8 + mdhd.count      // mdhd
+            + 8                   // minf hdr
+            + 8                   // stbl hdr
+            + stblSoFar.count
+            + 8 + 12              // stco box
+            + 8                   // mdat hdr
+        let stco = box("stco", u32(0) + u32(1) + u32(UInt32(fixedPrefix)))
+        let stbl = box("stbl", stsd + stts + stco)
+        let moov = box("moov", box("trak", box("mdia", box("mdhd", mdhd) + box("minf", stbl))))
+        return moov + box("mdat", sample)
+    }
+
+    @Test func ntscRtmdIsDropFrameDespiteClearFlag() {
+        // The a7S III layout: 59.94p track, flag byte 0, display 00:14:44:00. Sony time-of-day TC
+        // at NTSC rates is DF and Resolve conforms on that reading; honoring the flag byte declared
+        // an NDF origin ~0.9s off and Resolve dropped the media as out of range.
+        let data = rtmdFile(timescale: 60000, delta: 1001, hh: 0, mm: 14, ss: 44, drop: 0, ff: 0)
+        let tc = SourceTimingReader.rtmdTimecode(data)
+        let raw = (14 * 60 + 44) * 60 - 4 * (14 - 1)   // 4 dropped per non-tenth minute @ 60
+        #expect(tc == SourceTimecode(frame: raw, quanta: 60, dropFrame: true,
+                                     tick: .init(num: 1001, den: 60000)))
+    }
+
+    @Test func integerRateRtmdHonorsClearDropFlag() {
+        // A true 60p (non-NTSC) track stays NDF when the flag byte is clear.
+        let data = rtmdFile(timescale: 60000, delta: 1000, hh: 1, mm: 2, ss: 3, drop: 0, ff: 4)
+        let tc = SourceTimingReader.rtmdTimecode(data)
+        #expect(tc == SourceTimecode(frame: (3600 + 120 + 3) * 60 + 4, quanta: 60, dropFrame: false,
+                                     tick: .init(num: 1000, den: 60000)))
+    }
+
+    @Test func rtmdDropFrameConvertsDisplayToRawFrames() {
+        // 14:34:12;58 @ 59.94 DF (the reporter's Sony time-of-day TC). Display TC skips 4 frame
+        // numbers per non-tenth minute, so the raw count is lower than hh*3600... arithmetic.
+        let data = rtmdFile(timescale: 60000, delta: 1001, hh: 14, mm: 34, ss: 12, drop: 1, ff: 58)
+        let tc = SourceTimingReader.rtmdTimecode(data)
+        let unwrapped = try! #require(tc)
+        #expect(unwrapped.quanta == 60)
+        #expect(unwrapped.dropFrame)
+        // Round-trips through the DF formatter back to the display value.
+        #expect(XMLExporter.formatTimecode(frame: unwrapped.frame, fps: 60, dropFrame: true) == "14;34;12;58")
+    }
+
+    @Test func rtmdRejectsInvalidFields() {
+        // A frame count ≥ quanta means we mis-parsed; don't fabricate a timecode from it.
+        let data = rtmdFile(timescale: 30000, delta: 1001, hh: 0, mm: 0, ss: 1, drop: 0, ff: 77)
+        #expect(SourceTimingReader.rtmdTimecode(data) == nil)
+    }
+
+    @Test func fileWithoutRtmdTrackReturnsNil() {
+        let moov = box("moov", box("trak", box("mdia", Data())))
+        #expect(SourceTimingReader.rtmdTimecode(moov + box("mdat", Data())) == nil)
+        #expect(SourceTimingReader.rtmdTimecode(Data("RIFFxxxxWAVE".utf8)) == nil)
+        #expect(SourceTimingReader.rtmdTimecode(Data()) == nil)
+    }
+
+    // MARK: - BWF / bext
+
+    private func chunk(_ type: String, _ body: Data) -> Data {
+        var out = type.data(using: .ascii)!
+        var size = UInt32(body.count).littleEndian
+        withUnsafeBytes(of: &size) { out.append(contentsOf: $0) }
+        out.append(body)
+        if body.count % 2 == 1 { out.append(0) }
+        return out
+    }
+
+    private func bwfFile(magic: String = "RIFF", sampleRate: UInt32, timeReference: UInt64) -> Data {
+        var fmt = Data([1, 0, 2, 0])                     // PCM, stereo
+        var sr = sampleRate.littleEndian
+        withUnsafeBytes(of: &sr) { fmt.append(contentsOf: $0) }
+        fmt += Data(count: 8)                            // byte rate, align, bits
+
+        var bext = Data(count: 338)                      // description/originator/date/time fields
+        var ref = timeReference.littleEndian
+        withUnsafeBytes(of: &ref) { bext.append(contentsOf: $0) }
+        bext += Data(count: 260)                         // version, UMID, loudness, reserved
+
+        let body = Data("WAVE".utf8) + chunk("fmt ", fmt) + chunk("bext", bext) + chunk("data", Data(count: 16))
+        return chunk(magic, body).dropFirst(0)           // RIFF size field covers body; close enough for the walker
+    }
+
+    @Test func bwfTimeReferenceBecomesSampleTimecode() {
+        // The reporter's music master: TimeReference 01:00:00:00 at 48k.
+        let data = bwfFile(sampleRate: 48000, timeReference: 172_800_000)
+        let tc = SourceTimingReader.bwfTimecode(data)
+        #expect(tc == SourceTimecode(frame: 172_800_000, quanta: 48000, dropFrame: false))
+        #expect(tc?.seconds == 3600)
+    }
+
+    @Test func rf64MagicIsAccepted() {
+        let data = bwfFile(magic: "RF64", sampleRate: 48000, timeReference: 2_529_397_698)
+        #expect(SourceTimingReader.bwfTimecode(data)?.seconds == 2_529_397_698.0 / 48000.0)
+    }
+
+    @Test func zeroTimeReferenceAndNonWavReturnNil() {
+        #expect(SourceTimingReader.bwfTimecode(bwfFile(sampleRate: 48000, timeReference: 0)) == nil)
+        #expect(SourceTimingReader.bwfTimecode(Data("RIFFxxxxAVI ".utf8)) == nil)
+        #expect(SourceTimingReader.bwfTimecode(Data()) == nil)
+    }
+
+    @Test func wavWithoutBextReturnsNil() {
+        var fmt = Data([1, 0, 2, 0]) + u32le(48000) + Data(count: 8)
+        let body = Data("WAVE".utf8) + chunk("fmt ", fmt) + chunk("data", Data(count: 16))
+        fmt = Data()
+        #expect(SourceTimingReader.bwfTimecode(chunk("RIFF", body)) == nil)
+    }
+
+    private func u32le(_ v: UInt32) -> Data {
+        var le = v.littleEndian
+        return withUnsafeBytes(of: &le) { Data($0) }
+    }
+
+    // MARK: - XMEML rescale of sample-based timecode
+
+    @Test func sampleBasedTimecodeRescalesToVideoRate() {
+        // BWF 1h @ 48k against a 25fps element → frame 90000, not a 48000fps timecode.
+        let source = SourceTimecode(frame: 172_800_000, quanta: 48000, dropFrame: false)
+        let tc = XMLExporter.timecodeTags(source: source, videoTimebase: 25, videoNtsc: false)
+        #expect(tc.base == 25)
+        #expect(tc.frame == 90000)
+        #expect(tc.string == "01:00:00:00")
+    }
+
+    @Test func sampleBasedTimecodeAgainstNtscRate() {
+        // 3600s of wall clock at 29.97: raw frame count = 3600 * 29.97 ≈ 107892.
+        let source = SourceTimecode(frame: 172_800_000, quanta: 48000, dropFrame: false)
+        let tc = XMLExporter.timecodeTags(source: source, videoTimebase: 30, videoNtsc: true)
+        #expect(tc.base == 30)
+        #expect(tc.dropFrame)
+        #expect(tc.frame == 107892)
+        #expect(tc.string == "01;00;00;00")   // DF display catches back up to wall clock
+    }
+}

--- a/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
+++ b/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
@@ -139,9 +139,8 @@ struct SourceTimecodeReaderTests {
         #expect(SourceTimingReader.bwfTimecode(data)?.seconds == 2_529_397_698.0 / 48000.0)
     }
 
-    @Test func zeroTimeReferenceIsMidnightAndNonWavReturnsNil() {
-        #expect(SourceTimingReader.bwfTimecode(bwfFile(sampleRate: 48000, timeReference: 0))
-                == SourceTimecode(frame: 0, quanta: 48000, dropFrame: false))
+    @Test func zeroTimeReferenceAndNonWavReturnNil() {
+        #expect(SourceTimingReader.bwfTimecode(bwfFile(sampleRate: 48000, timeReference: 0)) == nil)
         #expect(SourceTimingReader.bwfTimecode(Data("RIFFxxxxAVI ".utf8)) == nil)
         #expect(SourceTimingReader.bwfTimecode(Data()) == nil)
     }

--- a/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
+++ b/Tests/PalmierProTests/SourceTimecodeReaderTests.swift
@@ -139,8 +139,9 @@ struct SourceTimecodeReaderTests {
         #expect(SourceTimingReader.bwfTimecode(data)?.seconds == 2_529_397_698.0 / 48000.0)
     }
 
-    @Test func zeroTimeReferenceAndNonWavReturnNil() {
-        #expect(SourceTimingReader.bwfTimecode(bwfFile(sampleRate: 48000, timeReference: 0)) == nil)
+    @Test func zeroTimeReferenceIsMidnightAndNonWavReturnsNil() {
+        #expect(SourceTimingReader.bwfTimecode(bwfFile(sampleRate: 48000, timeReference: 0))
+                == SourceTimecode(frame: 0, quanta: 48000, dropFrame: false))
         #expect(SourceTimingReader.bwfTimecode(Data("RIFFxxxxAVI ".utf8)) == nil)
         #expect(SourceTimingReader.bwfTimecode(Data()) == nil)
     }

--- a/Tests/PalmierProTests/Timeline/TimecodeSyncTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimecodeSyncTests.swift
@@ -8,11 +8,11 @@ struct TimecodeSyncTests {
 
     @Test func secondsPrefersExactFrameDuration() {
         #expect(SourceTimecode(frame: 250, quanta: 50, dropFrame: false).seconds == 5.0)
-        let tc = SourceTimecode(frame: 30000, quanta: 30, dropFrame: true, frameDuration: ntsc)
+        let tc = SourceTimecode(frame: 30000, quanta: 30, dropFrame: true, tick: .init(num: 1001, den: 30000))
         #expect(abs(tc.seconds - 1001.0) < 1e-9)
         // Quanta-only NTSC would land ~18 frames off per 10 minutes of offset.
         let quantaOnly = SourceTimecode(frame: 17982, quanta: 30, dropFrame: true)
-        let exact = SourceTimecode(frame: 17982, quanta: 30, dropFrame: true, frameDuration: ntsc)
+        let exact = SourceTimecode(frame: 17982, quanta: 30, dropFrame: true, tick: .init(num: 1001, den: 30000))
         #expect(abs(quantaOnly.seconds - exact.seconds) > 0.5)
     }
 


### PR DESCRIPTION
## Problem

FCPXML and XMEML timeline exports wrote every asset's start timecode as zero. Sources whose embedded timecode lives where AVFoundation can't see it — Sony XAVC (rtmd metadata track) and BWF WAV (bext TimeReference) — conformed as Media Offline in DaVinci Resolve ("no overlap between specified target timecodes"), and force-relinking by filename reset every in-point to the first frame of the source.

## Fix

**New container-level timecode readers** (`SourceTimingReader`), tried when no `tmcd` track exists:
- **Sony rtmd**: minimal MP4 box walk to the rtmd track's first sample; bytes 13–17 carry hh/mm/ss/drop/ff (same layout ffmpeg's `mov_read_rtmd_track` reads). Rate derives from the rtmd track's own mdhd/stts. NTSC-rate rtmd is treated as drop-frame regardless of the flag byte — Sony writes the flag as 0 but the TC is DF, and Resolve conforms on the DF reading (the NDF interpretation failed to link at all in testing).
- **BWF/RF64**: RIFF chunk walk to `bext.TimeReference` (u64 samples since midnight) + `fmt ` sample rate, kept sample-exact.

**Exact rational origins** (`SourceTimecode.Tick`): FCPXML asset/compound/clip/timeMap starts emit exact rational seconds instead of quantizing the origin to timeline frames. Quantization dropped the NTSC 1001/1000 factor, which skewed conformed in-points by 2–3 frames at 15-minute time-of-day timecodes (and grows with TC magnitude). Output is byte-identical to before for integer-rate sources at matching timeline rates.

**XMEML file-rate clipitems**: clipitem `rate`/`in`/`out`/`duration` now emit in the file's own frame-rate units when the source rate differs from the sequence rate, which is how Resolve reads them.

**Drop-frame formatter fix**: `formatTimecode` counted 10-minute DF blocks as `fps*600` raw frames; a DF block holds `fps*600 − 9·drop`. Wrong by 4 frames at 14 hours; shared by both exporters.

## Verification

Conform round-trips in DaVinci Resolve, checked clip-by-clip via the scripting console (`srcIn` exact for every cut):
- Sony a7S III 1080p59.94 + RX100 VII 4K29.97 (rtmd, DF time-of-day TC, no tmcd)
- 24p NDF camera footage + ffmpeg-authored 29.97 DF fixture (tmcd regression — unchanged/byte-identical values)
- BWF WAV with 01:00:00:00 TimeReference, frame-exact

New `SourceTimecodeReaderTests` run on synthetic in-memory fixtures (byte layouts verified against the real camera files); no media files needed in CI.

Fixes PAL-166.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches export conform math and container parsing for timecode; mistakes would skew trim/in-points in Resolve but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **PAL-166** by making FCPXML/XMEML exports carry real source origins so DaVinci Resolve can conform instead of treating clips as offline or shifting in-points.
> 
> **Source timecode discovery** now falls back when AVFoundation has no `tmcd` track: Sony XAVC **`rtmd`** (MP4 box walk + NTSC drop-frame heuristics) and BWF/RF64 **`bext.TimeReference`** (sample-exact). `SourceTimecode` gains rational **`Tick`** / `rationalSeconds` instead of rounding origins to timeline frames.
> 
> **FCPXML** writes asset, compound, clip, and timeMap starts with exact rational seconds (`time(frames:from:)`, `rationalTime`) rather than frame-quantized values that drift on NTSC time-of-day TC.
> 
> **XMEML** emits clipitem and file **`in`/`out`/`duration`/`rate`** in the **file’s** frame rate when it differs from the sequence; rescales sample-based BWF timecode for `<timecode>` tags. **`formatTimecode`** drop-frame math is corrected for 10-minute blocks.
> 
> Tests cover rtmd/BWF parsers, rational FCPXML starts, file-rate XMEML in/out, and DF round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e57a4ef4b761c545d483b9f017c75f74847d91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->