### PR TITLE
[fix] Prevent beat detection main-actor hang

### DIFF
--- a/Sources/PalmierPro/Audio/Beats/BeatStore.swift
+++ b/Sources/PalmierPro/Audio/Beats/BeatStore.swift
@@ -64,42 +64,43 @@ final class BeatStore {
     func detect(for asset: MediaAsset, force: Bool = false) -> Task<BeatAnalysis, Error> {
         let key = asset.id
         hydrationTasks.removeValue(forKey: key)?.task.cancel()
-        if !force {
-            if let running = tasks[key] { return running.task }
-        }
+        if !force, let running = tasks[key] { return running.task }
         tasks[key]?.task.cancel()
         let id = UUID()
-        let url = asset.url
-        let existing = analyses[key]
-        let existingTag = fileTags[key]
-        let tagLoader = fileTagLoader
         let task = Task(priority: .utility) { @MainActor [weak self, weak asset] in
-            guard let self else { throw CancellationError() }
-            defer {
-                if self.tasks[key]?.id == id {
-                    self.tasks[key] = nil
-                }
-            }
-            let tag = await tagLoader(url)
-            try Task.checkCancellation()
-            guard let asset, asset.url.standardizedFileURL == url.standardizedFileURL else {
-                throw CancellationError()
-            }
-            if !force, let existing, existingTag == tag {
-                return existing
-            }
-            let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
-            try Task.checkCancellation()
-            guard asset.url.standardizedFileURL == url.standardizedFileURL else {
-                throw CancellationError()
-            }
-            self.analyses[key] = analysis
-            self.fileTags[key] = tag
-            self.onBeatsReady?()
-            return analysis
+            guard let self, let asset else { throw CancellationError() }
+            defer { self.finishDetection(for: key, id: id) }
+            return try await self.analysisForCurrentSource(of: asset, force: force)
         }
         tasks[key] = (id, task)
         return task
+    }
+
+    private func analysisForCurrentSource(of asset: MediaAsset, force: Bool) async throws -> BeatAnalysis {
+        let key = asset.id
+        while true {
+            let url = asset.url.standardizedFileURL
+            let tag = await fileTagLoader(url)
+            try Task.checkCancellation()
+            guard asset.url.standardizedFileURL == url else { continue }
+            if !force, let existing = analyses[key], fileTags[key] == tag {
+                return existing
+            }
+
+            let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
+            try Task.checkCancellation()
+            guard asset.url.standardizedFileURL == url else { continue }
+            analyses[key] = analysis
+            fileTags[key] = tag
+            onBeatsReady?()
+            return analysis
+        }
+    }
+
+    private func finishDetection(for key: String, id: UUID) {
+        if tasks[key]?.id == id {
+            tasks[key] = nil
+        }
     }
 
     func reset() {

--- a/Sources/PalmierPro/Audio/Beats/BeatStore.swift
+++ b/Sources/PalmierPro/Audio/Beats/BeatStore.swift
@@ -4,21 +4,27 @@ import Foundation
 @MainActor
 final class BeatStore {
     typealias CachedAnalysisLoader = @Sendable (URL, String) async -> BeatAnalysisCacheEntry?
+    typealias FileTagLoader = @Sendable (URL) async -> String
 
     private var analyses: [String: BeatAnalysis] = [:]
     private var fileTags: [String: String] = [:]
-    private var tasks: [String: Task<BeatAnalysis, Error>] = [:]
+    private var tasks: [String: (id: UUID, task: Task<BeatAnalysis, Error>)] = [:]
     private var hydrationTasks: [String: (id: UUID, task: Task<Void, Never>)] = [:]
     private let cachedAnalysisLoader: CachedAnalysisLoader
+    private let fileTagLoader: FileTagLoader
 
     var onBeatsReady: (() -> Void)?
 
     init(
         cachedAnalysisLoader: @escaping CachedAnalysisLoader = { sourceURL, mediaRef in
             await BeatDetector.cachedAnalysis(for: sourceURL, mediaRef: mediaRef)
+        },
+        fileTagLoader: @escaping FileTagLoader = { sourceURL in
+            await DiskCache.loadSizeMtimeTag(for: sourceURL)
         }
     ) {
         self.cachedAnalysisLoader = cachedAnalysisLoader
+        self.fileTagLoader = fileTagLoader
     }
 
     nonisolated func analysis(for mediaRef: String) -> BeatAnalysis? {
@@ -58,28 +64,46 @@ final class BeatStore {
     func detect(for asset: MediaAsset, force: Bool = false) -> Task<BeatAnalysis, Error> {
         let key = asset.id
         hydrationTasks.removeValue(forKey: key)?.task.cancel()
-        let tag = DiskCache.sizeMtimeTag(for: asset.url)
         if !force {
-            if let existing = analyses[key], fileTags[key] == tag { return Task { existing } }
-            if let running = tasks[key] { return running }
+            if let running = tasks[key] { return running.task }
         }
-        tasks[key]?.cancel()
+        tasks[key]?.task.cancel()
+        let id = UUID()
         let url = asset.url
-        let task = Task(priority: .utility) { @MainActor in
-            defer { if !Task.isCancelled { tasks[key] = nil } }
+        let existing = analyses[key]
+        let existingTag = fileTags[key]
+        let tagLoader = fileTagLoader
+        let task = Task(priority: .utility) { @MainActor [weak self, weak asset] in
+            guard let self else { throw CancellationError() }
+            defer {
+                if self.tasks[key]?.id == id {
+                    self.tasks[key] = nil
+                }
+            }
+            let tag = await tagLoader(url)
+            try Task.checkCancellation()
+            guard let asset, asset.url.standardizedFileURL == url.standardizedFileURL else {
+                throw CancellationError()
+            }
+            if !force, let existing, existingTag == tag {
+                return existing
+            }
             let analysis = try await BeatDetector.analysis(for: url, mediaRef: key, force: force)
             try Task.checkCancellation()
-            analyses[key] = analysis
-            fileTags[key] = tag
-            onBeatsReady?()
+            guard asset.url.standardizedFileURL == url.standardizedFileURL else {
+                throw CancellationError()
+            }
+            self.analyses[key] = analysis
+            self.fileTags[key] = tag
+            self.onBeatsReady?()
             return analysis
         }
-        tasks[key] = task
+        tasks[key] = (id, task)
         return task
     }
 
     func reset() {
-        tasks.values.forEach { $0.cancel() }
+        tasks.values.forEach { $0.task.cancel() }
         hydrationTasks.values.forEach { $0.task.cancel() }
         tasks.removeAll()
         hydrationTasks.removeAll()
@@ -88,7 +112,7 @@ final class BeatStore {
     }
 
     func invalidate(_ mediaRef: String) {
-        tasks.removeValue(forKey: mediaRef)?.cancel()
+        tasks.removeValue(forKey: mediaRef)?.task.cancel()
         hydrationTasks.removeValue(forKey: mediaRef)?.task.cancel()
         analyses.removeValue(forKey: mediaRef)
         fileTags.removeValue(forKey: mediaRef)

--- a/Sources/PalmierPro/Utilities/DiskCache.swift
+++ b/Sources/PalmierPro/Utilities/DiskCache.swift
@@ -38,6 +38,11 @@ struct DiskCache: Sendable {
         return "\(size)_\(Int(modified))"
     }
 
+    @concurrent
+    static func loadSizeMtimeTag(for url: URL) async -> String {
+        sizeMtimeTag(for: url)
+    }
+
     func clear() {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else { return }

--- a/Tests/PalmierProTests/Audio/BeatStoreTests.swift
+++ b/Tests/PalmierProTests/Audio/BeatStoreTests.swift
@@ -102,6 +102,39 @@ struct BeatStoreTests {
         #expect(try await detection.value == analysis)
     }
 
+    @Test func urlChangeDuringDetectionRestartsWithCurrentURL() async throws {
+        let cacheLoader = ControlledBeatCacheLoader()
+        let tagLoader = ControlledFileTagLoader()
+        let store = BeatStore(
+            cachedAnalysisLoader: { sourceURL, mediaRef in
+                await cacheLoader.load(sourceURL: sourceURL, mediaRef: mediaRef)
+            },
+            fileTagLoader: { sourceURL in
+                await tagLoader.load(sourceURL: sourceURL)
+            }
+        )
+        let originalURL = URL(fileURLWithPath: "/tmp/original.palmier/Media/audio.wav")
+        let rebasedURL = URL(fileURLWithPath: "/tmp/rebased.palmier/Media/audio.wav")
+        let asset = makeAsset(url: originalURL)
+        let analysis = BeatAnalysis(bpm: 120, beats: [0.5], downbeats: [0.5])
+
+        let hydration = try #require(store.hydrate(for: asset))
+        await cacheLoader.waitUntilStarted()
+        #expect(await cacheLoader.finishNext(with: BeatAnalysisCacheEntry(analysis: analysis, fileTag: "tag")))
+        await hydration.value
+
+        let detection = store.detect(for: asset)
+        await tagLoader.waitUntilInvocationCount(1)
+        asset.url = rebasedURL
+        #expect(await tagLoader.finishNext(with: "tag"))
+
+        await tagLoader.waitUntilInvocationCount(2)
+        #expect(await tagLoader.requestedURLs() == [originalURL, rebasedURL])
+        #expect(await tagLoader.finishNext(with: "tag"))
+        #expect(try await detection.value == analysis)
+        #expect(store.analysis(for: asset.id) == analysis)
+    }
+
     private func makeStore(loader: ControlledBeatCacheLoader) -> BeatStore {
         BeatStore(cachedAnalysisLoader: { sourceURL, mediaRef in
             await loader.load(sourceURL: sourceURL, mediaRef: mediaRef)
@@ -122,27 +155,41 @@ struct BeatStoreTests {
 
 private actor ControlledFileTagLoader {
     private var loadCount = 0
-    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var sourceURLs: [URL] = []
+    private var startedWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var resultWaiters: [CheckedContinuation<String, Never>] = []
 
-    func load(sourceURL _: URL) async -> String {
+    func load(sourceURL: URL) async -> String {
         loadCount += 1
+        sourceURLs.append(sourceURL)
         let waiters = startedWaiters
         startedWaiters.removeAll()
-        waiters.forEach { $0.resume() }
+        for waiter in waiters {
+            if loadCount >= waiter.count {
+                waiter.continuation.resume()
+            } else {
+                startedWaiters.append(waiter)
+            }
+        }
         return await withCheckedContinuation { continuation in
             resultWaiters.append(continuation)
         }
     }
 
     func waitUntilStarted() async {
-        guard loadCount == 0 else { return }
+        await waitUntilInvocationCount(1)
+    }
+
+    func waitUntilInvocationCount(_ count: Int) async {
+        guard loadCount < count else { return }
         await withCheckedContinuation { continuation in
-            startedWaiters.append(continuation)
+            startedWaiters.append((count, continuation))
         }
     }
 
     func invocationCount() -> Int { loadCount }
+
+    func requestedURLs() -> [URL] { sourceURLs }
 
     func finishNext(with tag: String) -> Bool {
         guard !resultWaiters.isEmpty else { return false }

--- a/Tests/PalmierProTests/Audio/BeatStoreTests.swift
+++ b/Tests/PalmierProTests/Audio/BeatStoreTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import PalmierPro
 
-@Suite("BeatStore hydration")
+@Suite("BeatStore")
 @MainActor
 struct BeatStoreTests {
     @Test func hydrationReturnsWhileCacheLoadIsPending() async throws {
@@ -74,10 +74,38 @@ struct BeatStoreTests {
         #expect(store.analysis(for: asset.id) == current)
     }
 
+    @Test func detectionReturnsWhileFileTagLoadIsPending() async throws {
+        let cacheLoader = ControlledBeatCacheLoader()
+        let tagLoader = ControlledFileTagLoader()
+        let store = BeatStore(
+            cachedAnalysisLoader: { sourceURL, mediaRef in
+                await cacheLoader.load(sourceURL: sourceURL, mediaRef: mediaRef)
+            },
+            fileTagLoader: { sourceURL in
+                await tagLoader.load(sourceURL: sourceURL)
+            }
+        )
+        let asset = makeAsset()
+        let analysis = BeatAnalysis(bpm: 120, beats: [0.5], downbeats: [0.5])
+
+        let hydration = try #require(store.hydrate(for: asset))
+        await cacheLoader.waitUntilStarted()
+        #expect(await cacheLoader.finishNext(with: BeatAnalysisCacheEntry(analysis: analysis, fileTag: "tag")))
+        await hydration.value
+
+        let detection = store.detect(for: asset)
+        await tagLoader.waitUntilStarted()
+
+        #expect(store.analysis(for: asset.id) == analysis)
+        #expect(await tagLoader.invocationCount() == 1)
+        #expect(await tagLoader.finishNext(with: "tag"))
+        #expect(try await detection.value == analysis)
+    }
+
     private func makeStore(loader: ControlledBeatCacheLoader) -> BeatStore {
-        BeatStore { sourceURL, mediaRef in
+        BeatStore(cachedAnalysisLoader: { sourceURL, mediaRef in
             await loader.load(sourceURL: sourceURL, mediaRef: mediaRef)
-        }
+        })
     }
 
     private func makeAsset(
@@ -89,6 +117,37 @@ struct BeatStoreTests {
             type: .audio,
             name: "Test Audio"
         )
+    }
+}
+
+private actor ControlledFileTagLoader {
+    private var loadCount = 0
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resultWaiters: [CheckedContinuation<String, Never>] = []
+
+    func load(sourceURL _: URL) async -> String {
+        loadCount += 1
+        let waiters = startedWaiters
+        startedWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        return await withCheckedContinuation { continuation in
+            resultWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard loadCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append(continuation)
+        }
+    }
+
+    func invocationCount() -> Int { loadCount }
+
+    func finishNext(with tag: String) -> Bool {
+        guard !resultWaiters.isEmpty else { return false }
+        resultWaiters.removeFirst().resume(returning: tag)
+        return true
     }
 }
 


### PR DESCRIPTION
## Summary

- Move beat-cache file metadata lookup off the main actor, preventing `detect_beats` from freezing the app on slow project volumes.
- Address the separate production hang observed in v0.6.12 build 73 after the earlier cache-hydration fix ([Sentry PALMIER-PRO-164](https://palmier.sentry.io/issues/7620681686/)).
- Keep active detection running when Save As rebases project media URLs.
- Preserve in-flight request deduplication, cancellation, and stale-result rejection.

## Approach

- Add an asynchronous `DiskCache` file-tag loader with an explicit concurrent executor hop.
- Keep `detect(for:)` focused on task ownership and deduplication; a separate helper follows the asset's current source URL across awaits.
- Revalidate the asset URL before cache reuse and commit, retrying against the current URL instead of returning a misleading cancellation.
- Identify in-flight tasks so cleanup from a cancelled stale task cannot remove its replacement.
- Add deterministic regression tests for suspended metadata loading and Save As URL rebasing.

## Testing

- `swift build` — passed.
- `swift test --filter BeatStoreTests` — 6 tests passed.
- `swift test` — 1,096 tests in 170 suites passed.
- `./scripts/dev.sh` — debug app bundle built and codesigned successfully.
- Fresh bundle launched directly from `.build/PalmierPro.app/Contents/MacOS/PalmierPro`; verified that process owned MCP port 19789.
- MCP E2E — created an isolated project, imported a generated 12-second 120 BPM WAV, and called `detect_beats`. It returned 20 beats, downbeats, and `bpm: 120` in 1.10 seconds.
- MCP cached E2E — repeated `detect_beats`; it returned the identical analysis in 0.01 seconds (0.00046-second tool duration in app logs).
- MCP readback — `get_media` independently confirmed the imported asset was ready audio with a 12-second duration.
