### PR TITLE
[fix/ui] Keep text layout and resize interactions consistent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ Rule: **any drop target that spans an area containing other drop targets must us
   2. **Approach:** important design decisions, technical details, invariants, tradeoffs, and alternatives rejected.
   3. **Design:** for large architectural changes, Mermaid diagrams showing the relevant before and after data flow, ownership, or lifecycle.
   4. **Testing:** exact automated commands and results, plus end-to-end UI or MCP scenarios, expected outcomes, and any verification not completed.
+  5. **Change statistics:** additions and deletions for every changed file, plus separate aggregate additions and deletions for code logic and tests.
 - Describe the full resulting change, not the sequence of edits made while developing it. Remove stale investigation notes and unsupported claims.
 - Open substantial changes as draft PRs until automated checks pass and required manual UI verification is identified or completed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ Rule: **any drop target that spans an area containing other drop targets must us
   2. **Approach:** important design decisions, technical details, invariants, tradeoffs, and alternatives rejected.
   3. **Design:** for large architectural changes, Mermaid diagrams showing the relevant before and after data flow, ownership, or lifecycle.
   4. **Testing:** exact automated commands and results, plus end-to-end UI or MCP scenarios, expected outcomes, and any verification not completed.
-  5. **Change statistics:** additions and deletions for every changed file, plus separate aggregate additions and deletions for code logic and tests.
+  5. **Change statistics:** aggregate additions and deletions by category, including code logic and tests.
 - Describe the full resulting change, not the sequence of edits made while developing it. Remove stale investigation notes and unsupported claims.
 - Open substantial changes as draft PRs until automated checks pass and required manual UI verification is identified or completed.
 

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -91,15 +91,16 @@ enum TextFrameRenderer {
     }
 
     private static func drawOverlines(_ ctx: CGContext, frame: CTFrame, style: TextStyle,
-                                      box: CGRect, fontSize: CGFloat) {
+                                      fontSize: CGFloat) {
         guard style.isOverlined else { return }
         let lines = CTFrameGetLines(frame) as? [CTLine] ?? []
         var origins = [CGPoint](repeating: .zero, count: lines.count)
         CTFrameGetLineOrigins(frame, CFRange(location: 0, length: 0), &origins)
+        let frameBounds = CTFrameGetPath(frame).boundingBox
         let font = style.resolvedFont(size: fontSize)
         for (index, line) in lines.enumerated() {
             let width = CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil) - CTLineGetTrailingWhitespaceWidth(line))
-            drawOverline(ctx, x: box.minX + origins[index].x, y: origins[index].y,
+            drawOverline(ctx, x: frameBounds.minX + origins[index].x, y: frameBounds.minY + origins[index].y,
                          width: width, font: font, color: style.color)
         }
     }
@@ -128,7 +129,7 @@ enum TextFrameRenderer {
             in: boxes.text
         )
         CTFrameDraw(frame, ctx)
-        drawOverlines(ctx, frame: frame, style: style, box: boxes.text, fontSize: fontSize)
+        drawOverlines(ctx, frame: frame, style: style, fontSize: fontSize)
         guard let image = finish(ctx) else { return nil }
         cache.setObject(image, forKey: key)
         return image
@@ -170,6 +171,7 @@ enum TextFrameRenderer {
         let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
         var origins = [CGPoint](repeating: .zero, count: lines.count)
         CTFrameGetLineOrigins(ctFrame, CFRange(location: 0, length: 0), &origins)
+        let frameBounds = CTFrameGetPath(ctFrame).boundingBox
 
         let tokens = words(in: content)
         let timings = tokenTimings(tokens, clip.wordTimings, duration: clip.durationFrames)
@@ -187,8 +189,8 @@ enum TextFrameRenderer {
 
                 let startOff = CTLineGetOffsetForStringIndex(line, tok.range.location, nil)
                 let endOff = CTLineGetOffsetForStringIndex(line, tok.range.location + tok.range.length, nil)
-                let penX = boxes.text.minX + origins[li].x + startOff
-                let penY = origins[li].y
+                let penX = frameBounds.minX + origins[li].x + startOff
+                let penY = frameBounds.minY + origins[li].y
                 let wWidth = endOff - startOff
 
                 var attrs = baseAttrs
@@ -262,9 +264,14 @@ enum TextFrameRenderer {
         // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
         var attrs = style.attributes(size: fontSize)
         attrs[.paragraphStyle] = style.paragraphStyle(size: fontSize, alignment: .left)
-        let textFrame = TextLayout.frame(for: NSAttributedString(string: visible, attributes: attrs), in: boxes.text)
+        let fullText = NSAttributedString(string: content, attributes: attrs)
+        let textFrame = TextLayout.frame(
+            for: NSAttributedString(string: visible, attributes: attrs),
+            in: boxes.text,
+            verticallySizedFor: fullText
+        )
         CTFrameDraw(textFrame, ctx)
-        drawOverlines(ctx, frame: textFrame, style: style, box: boxes.text, fontSize: fontSize)
+        drawOverlines(ctx, frame: textFrame, style: style, fontSize: fontSize)
         return finish(ctx)
     }
 

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -90,14 +90,6 @@ enum TextFrameRenderer {
         return CIImage(cgImage: cg, options: [.colorSpace: NSNull()])
     }
 
-    /// Tall top-anchored layout path so CoreText never drops a line overflowing the box
-    /// (CATextLayer didn't clip vertically either). Box width drives wrapping.
-    private static func layoutFrame(_ attr: NSAttributedString, box: CGRect) -> CTFrame {
-        let setter = CTFramesetterCreateWithAttributedString(attr as CFAttributedString)
-        let path = CGPath(rect: CGRect(x: box.minX, y: 0, width: box.width, height: box.maxY), transform: nil)
-        return CTFramesetterCreateFrame(setter, CFRange(location: 0, length: 0), path, nil)
-    }
-
     private static func drawOverlines(_ ctx: CGContext, frame: CTFrame, style: TextStyle,
                                       box: CGRect, fontSize: CGFloat) {
         guard style.isOverlined else { return }
@@ -131,7 +123,10 @@ enum TextFrameRenderer {
         let key = signature(content, style, transform, renderSize)
         if let cached = cache.object(forKey: key) { return cached }
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
-        let frame = layoutFrame(NSAttributedString(string: content, attributes: style.attributes(size: fontSize)), box: boxes.text)
+        let frame = TextLayout.frame(
+            for: NSAttributedString(string: content, attributes: style.attributes(size: fontSize)),
+            in: boxes.text
+        )
         CTFrameDraw(frame, ctx)
         drawOverlines(ctx, frame: frame, style: style, box: boxes.text, fontSize: fontSize)
         guard let image = finish(ctx) else { return nil }
@@ -171,7 +166,7 @@ enum TextFrameRenderer {
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
 
         let attr = NSAttributedString(string: content, attributes: style.attributes(size: fontSize))
-        let ctFrame = layoutFrame(attr, box: boxes.text)
+        let ctFrame = TextLayout.frame(for: attr, in: boxes.text)
         let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
         var origins = [CGPoint](repeating: .zero, count: lines.count)
         CTFrameGetLineOrigins(ctFrame, CFRange(location: 0, length: 0), &origins)
@@ -267,7 +262,7 @@ enum TextFrameRenderer {
         // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
         var attrs = style.attributes(size: fontSize)
         attrs[.paragraphStyle] = style.paragraphStyle(size: fontSize, alignment: .left)
-        let textFrame = layoutFrame(NSAttributedString(string: visible, attributes: attrs), box: boxes.text)
+        let textFrame = TextLayout.frame(for: NSAttributedString(string: visible, attributes: attrs), in: boxes.text)
         CTFrameDraw(textFrame, ctx)
         drawOverlines(ctx, frame: textFrame, style: style, box: boxes.text, fontSize: fontSize)
         return finish(ctx)

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -9,12 +9,12 @@ enum TextFrameRenderer {
 
     static func image(clip: Clip, frame: Int, renderSize: CGSize) -> CIImage? {
         guard renderSize.width >= 1, renderSize.height >= 1 else { return nil }
-        let style = clip.textStyle ?? TextStyle()
+        let style = (clip.textStyle ?? TextStyle()).scaledVisualStyle
         let content = style.displayText(clip.textContent ?? "")
         guard !content.isEmpty else { return nil }
         let box = boxRect(clip.transform, renderSize)
         let boxes = layoutBoxes(style: style, box: box, renderSize: renderSize)
-        let fontSize = CGFloat(style.fontSize * style.fontScale) * (renderSize.height / TextLayout.referenceCanvasHeight)
+        let fontSize = CGFloat(style.fontSize) * (renderSize.height / TextLayout.referenceCanvasHeight)
         let anim = clip.textAnimation
 
         if let anim, anim.isActive {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -418,6 +418,24 @@ extension EditorViewModel {
 
     // MARK: - Text-style mutation helpers
 
+    func applyTextContent(clipId: String, content: String) {
+        let canvasW = Double(timeline.width)
+        let canvasH = Double(timeline.height)
+        applyClipProperty(clipId: clipId, rebuild: true) { clip in
+            clip.textContent = content
+            _ = self.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
+        }
+    }
+
+    func commitTextContent(clipId: String, content: String) {
+        let canvasW = Double(timeline.width)
+        let canvasH = Double(timeline.height)
+        commitClipProperty(clipId: clipId, actionName: "Change Text") { clip in
+            clip.textContent = content
+            _ = self.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
+        }
+    }
+
     func applyTextStyle(clipId: String, fitToContent: Bool = false, _ modify: @escaping (inout TextStyle) -> Void) {
         let canvasW = Double(timeline.width)
         let canvasH = Double(timeline.height)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -444,20 +444,6 @@ extension EditorViewModel {
         }
     }
 
-    func fitTextClipToContent(clipId: String) {
-        let canvasW = Double(timeline.width)
-        let canvasH = Double(timeline.height)
-        guard let loc = findClip(id: clipId) else { return }
-        let original = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        var fitted = original
-        guard fitTextClipToContentIfNeeded(&fitted, canvasW: canvasW, canvasH: canvasH) else { return }
-        if dragBefore[clipId] == nil {
-            dragBefore[clipId] = original
-        }
-        timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = fitted
-        videoEngine?.refreshVisuals()
-    }
-
     func fitTextClipToContentIfNeeded(_ clip: inout Clip, canvasW: Double, canvasH: Double) -> Bool {
         guard clip.mediaType == .text else { return false }
         let natural = TextLayout.naturalSize(

--- a/Sources/PalmierPro/Export/FCPXMLExporter.swift
+++ b/Sources/PalmierPro/Export/FCPXMLExporter.swift
@@ -874,6 +874,7 @@ enum FCPXMLExporter {
         }
 
         private func textStyleAttributes(for style: TextStyle) -> [(String, String)] {
+            let style = style.scaledVisualStyle
             let resolvedFont = style.resolvedFont(size: CGFloat(style.fontSize))
             let family = resolvedFont.familyName ?? fontFamilyFallback(style.fontName)
             let face = fontFace(for: style, resolvedFont: resolvedFont)

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -64,14 +64,12 @@ struct TextTab: View {
                     get: { clip.textContent ?? "" },
                     set: { new in
                         guard !isBatch else { return }
-                        editor.applyClipProperty(clipId: clip.id, rebuild: true) { $0.textContent = new }
-                        editor.fitTextClipToContent(clipId: clip.id)
+                        editor.applyTextContent(clipId: clip.id, content: new)
                     }
                 ),
                 onCommit: { new in
                     guard !isBatch else { return }
-                    editor.commitClipProperty(clipId: clip.id) { $0.textContent = new }
-                    editor.fitTextClipToContent(clipId: clip.id)
+                    editor.commitTextContent(clipId: clip.id, content: new)
                 }
             )
             .disabled(isBatch)

--- a/Sources/PalmierPro/Models/TextLayout.swift
+++ b/Sources/PalmierPro/Models/TextLayout.swift
@@ -13,23 +13,27 @@ enum TextLayout {
         maxWidth: CGFloat,
         canvasHeight: CGFloat
     ) -> CGSize {
+        let visualScale = CGFloat(style.fontScale)
+        let style = style.scaledVisualStyle
         let displayText = style.displayText(content)
         let measured = displayText.isEmpty ? " " : displayText
         let canvasScale = canvasHeight / referenceCanvasHeight
-        let renderSize = CGFloat(style.fontSize * style.fontScale) * canvasScale
+        let renderSize = CGFloat(style.fontSize) * canvasScale
         let str = NSAttributedString(
             string: measured,
             attributes: style.attributes(size: renderSize, includeColor: false)
         )
-        let bounding = suggestedSize(for: str, maxWidth: maxWidth)
-        // +4px slack absorbs canvas→preview scale rounding.
-        let slack: CGFloat = 4
+        let proposedMaxWidth = maxWidth * visualScale
+        let scaledMaxWidth = proposedMaxWidth.isFinite ? proposedMaxWidth : .greatestFiniteMagnitude
+        let bounding = suggestedSize(for: str, maxWidth: scaledMaxWidth)
+        // Four reference pixels absorb canvas→preview scale rounding.
+        let slack = max(0, visualScale) * 4
         let shadowBlur = max(0, CGFloat(style.shadow.blur))
         let shadowX = style.shadow.enabled
-            ? max(shadowPadding, shadowBlur + abs(CGFloat(style.shadow.offsetX))) * canvasScale * 2
+            ? max(shadowPadding * visualScale, shadowBlur + abs(CGFloat(style.shadow.offsetX))) * canvasScale * 2
             : 0
         let shadowY = style.shadow.enabled
-            ? max(shadowPadding, shadowBlur + abs(CGFloat(style.shadow.offsetY))) * canvasScale * 2
+            ? max(shadowPadding * visualScale, shadowBlur + abs(CGFloat(style.shadow.offsetY))) * canvasScale * 2
             : 0
         let borderPad = style.border.enabled ? style.glyphBorderPadding(fontSize: renderSize) * 2 : 0
         let backgroundPadX = style.background.enabled ? CGFloat(max(0, style.background.paddingX)) * canvasScale * 2 : 0

--- a/Sources/PalmierPro/Models/TextLayout.swift
+++ b/Sources/PalmierPro/Models/TextLayout.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreText
 
 /// Natural bounding size of a rendered text clip, shared between the layer
 /// controller and clip placement.
@@ -20,10 +21,7 @@ enum TextLayout {
             string: measured,
             attributes: style.attributes(size: renderSize, includeColor: false)
         )
-        let bounding = str.boundingRect(
-            with: CGSize(width: maxWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading]
-        )
+        let bounding = suggestedSize(for: str, maxWidth: maxWidth)
         // +4px slack absorbs canvas→preview scale rounding.
         let slack: CGFloat = 4
         let shadowBlur = max(0, CGFloat(style.shadow.blur))
@@ -40,5 +38,36 @@ enum TextLayout {
             width: max(1, ceil(bounding.width) + shadowX + borderPad + backgroundPadX + slack),
             height: max(1, ceil(bounding.height) + shadowY + borderPad + backgroundPadY + slack)
         )
+    }
+
+    static func frame(for attributedString: NSAttributedString, in box: CGRect) -> CTFrame {
+        let framesetter = framesetter(for: attributedString)
+        let path = CGPath(rect: box, transform: nil)
+        return CTFramesetterCreateFrame(framesetter, CFRange(location: 0, length: 0), path, nil)
+    }
+
+    private static func suggestedSize(for attributedString: NSAttributedString, maxWidth: CGFloat) -> CGSize {
+        let measured: NSAttributedString
+        if attributedString.string.last?.isNewline == true {
+            // CoreText omits a final empty line unless measurement includes a zero-width glyph.
+            let mutable = NSMutableAttributedString(attributedString: attributedString)
+            var attributes = attributedString.attributes(at: attributedString.length - 1, effectiveRange: nil)
+            attributes[.kern] = 0
+            mutable.append(NSAttributedString(string: "\u{200B}", attributes: attributes))
+            measured = mutable
+        } else {
+            measured = attributedString
+        }
+        return CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter(for: measured),
+            CFRange(location: 0, length: 0),
+            nil,
+            CGSize(width: maxWidth, height: .greatestFiniteMagnitude),
+            nil
+        )
+    }
+
+    private static func framesetter(for attributedString: NSAttributedString) -> CTFramesetter {
+        CTFramesetterCreateWithAttributedString(attributedString as CFAttributedString)
     }
 }

--- a/Sources/PalmierPro/Models/TextLayout.swift
+++ b/Sources/PalmierPro/Models/TextLayout.swift
@@ -44,26 +44,47 @@ enum TextLayout {
         )
     }
 
-    static func frame(for attributedString: NSAttributedString, in box: CGRect) -> CTFrame {
-        let framesetter = framesetter(for: attributedString)
-        let path = CGPath(rect: box, transform: nil)
-        return CTFramesetterCreateFrame(framesetter, CFRange(location: 0, length: 0), path, nil)
+    static func frame(
+        for attributedString: NSAttributedString,
+        in box: CGRect,
+        verticallySizedFor sizingString: NSAttributedString? = nil
+    ) -> CTFrame {
+        let textFramesetter = framesetter(for: attributedString)
+        let measurementString = measurementString(for: sizingString ?? attributedString)
+        let measurementFramesetter = measurementString === attributedString
+            ? textFramesetter
+            : framesetter(for: measurementString)
+        let contentHeight = suggestedSize(using: measurementFramesetter, maxWidth: box.width).height
+        let frameHeight = min(box.height, ceil(contentHeight))
+        let centeredBox = CGRect(
+            x: box.minX,
+            y: box.midY - frameHeight / 2,
+            width: box.width,
+            height: frameHeight
+        )
+        let path = CGPath(rect: centeredBox, transform: nil)
+        return CTFramesetterCreateFrame(textFramesetter, CFRange(location: 0, length: 0), path, nil)
     }
 
     private static func suggestedSize(for attributedString: NSAttributedString, maxWidth: CGFloat) -> CGSize {
-        let measured: NSAttributedString
+        suggestedSize(using: framesetter(for: measurementString(for: attributedString)), maxWidth: maxWidth)
+    }
+
+    private static func measurementString(for attributedString: NSAttributedString) -> NSAttributedString {
         if attributedString.string.last?.isNewline == true {
             // CoreText omits a final empty line unless measurement includes a zero-width glyph.
             let mutable = NSMutableAttributedString(attributedString: attributedString)
             var attributes = attributedString.attributes(at: attributedString.length - 1, effectiveRange: nil)
             attributes[.kern] = 0
             mutable.append(NSAttributedString(string: "\u{200B}", attributes: attributes))
-            measured = mutable
-        } else {
-            measured = attributedString
+            return mutable
         }
+        return attributedString
+    }
+
+    private static func suggestedSize(using framesetter: CTFramesetter, maxWidth: CGFloat) -> CGSize {
         return CTFramesetterSuggestFrameSizeWithConstraints(
-            framesetter(for: measured),
+            framesetter,
             CFRange(location: 0, length: 0),
             nil,
             CGSize(width: maxWidth, height: .greatestFiniteMagnitude),

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -238,6 +238,26 @@ extension TextStyle.RGBA {
 }
 
 extension TextStyle {
+    var scaledVisualStyle: TextStyle {
+        guard fontScale != 1 else { return self }
+        var style = self
+        style.fontSize *= fontScale
+        style.tracking *= fontScale
+        style.lineSpacing *= fontScale
+        style.shadow.offsetX *= fontScale
+        style.shadow.offsetY *= fontScale
+        style.shadow.blur *= fontScale
+        style.border.width *= fontScale
+        style.background.paddingX *= fontScale
+        style.background.paddingY *= fontScale
+        style.background.cornerRadius *= fontScale
+        style.background.offsetX *= fontScale
+        style.background.offsetY *= fontScale
+        style.background.outlineWidth *= fontScale
+        style.fontScale = 1
+        return style
+    }
+
     func resolvedFont(size: CGFloat) -> NSFont {
         let base = NSFont(name: fontName, size: size) ?? NSFont.systemFont(ofSize: size)
         return Self.font(base, size: size, bold: isBold, italic: isItalic)

--- a/Sources/PalmierPro/Preview/TransformOverlayView.swift
+++ b/Sources/PalmierPro/Preview/TransformOverlayView.swift
@@ -35,6 +35,7 @@ struct TransformOverlayView: View {
                             .fill(borderColor)
                             .frame(width: handleSize, height: handleSize)
                             .offset(x: off.x, y: off.y)
+                            .pointerStyle(.frameResize(position: corner.resizePosition))
                             .gesture(resizeGesture(clip: clip, corner: corner, videoRect: videoRect))
                     }
                 }
@@ -312,5 +313,14 @@ struct TransformOverlayView: View {
 
     private enum Corner: CaseIterable {
         case topLeft, topRight, bottomLeft, bottomRight
+
+        var resizePosition: FrameResizePosition {
+            switch self {
+            case .topLeft: .topLeading
+            case .topRight: .topTrailing
+            case .bottomLeft: .bottomLeading
+            case .bottomRight: .bottomTrailing
+            }
+        }
     }
 }

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -815,7 +815,7 @@ struct FCPXMLExporterTests {
         let xml = try await export(timeline, resolver: resolver, tmpDir: tmpDir)
 
         #expect(xml.contains("strokeColor=\"0 0 0 1\""))
-        #expect(xml.contains("strokeWidth=\"7\""))
+        #expect(xml.contains("strokeWidth=\"14\""))
     }
 
     @Test func disabledBorderOmitsStroke() async throws {

--- a/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
@@ -20,7 +20,7 @@ struct CompositorTextLayerTests {
         c.textStyle = style
         // A band over the left-center, where the pattern is red (top) / blue (bottom) —
         // never white — so any white pixel there is unambiguously text.
-        c.transform = Transform(topLeft: (0.1, 0.4), width: 0.8, height: 0.2)
+        c.transform = Transform(topLeft: (0.1, 0.4), width: 0.8, height: 0.25)
         return c
     }
 

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -204,6 +204,35 @@ struct TextFrameRendererTests {
         #expect(spacedSize.width > compactSize.width + 50)
     }
 
+    @Test func fontScalePreservesCompleteTextLayoutProportions() {
+        let content = "fasfasfasf\nsfsaf\nsfasfsaf"
+        var style = TextStyle()
+        style.tracking = 18
+        style.lineSpacing = 24
+        style.shadow.offsetX = 15
+        style.shadow.offsetY = -9
+        style.shadow.blur = 10
+        style.border = .init(enabled: true, width: 6)
+        style.background = .init(enabled: true, paddingX: 40, paddingY: 28)
+        let fullSize = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: 1_728,
+            canvasHeight: 1_080
+        )
+
+        style.fontScale = 0.25
+        let scaledSize = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: 1_728,
+            canvasHeight: 1_080
+        )
+
+        #expect(abs(scaledSize.width - fullSize.width * 0.25) <= 2)
+        #expect(abs(scaledSize.height - fullSize.height * 0.25) <= 2)
+    }
+
     @Test func verticalShadowOffsetExpandsMeasuredHeight() {
         var centered = TextStyle()
         centered.shadow.offsetX = 0

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -1,4 +1,5 @@
 import CoreImage
+import CoreText
 import Foundation
 import Testing
 @testable import PalmierPro
@@ -225,5 +226,59 @@ struct TextFrameRendererTests {
 
         #expect(shiftedSize.height > centeredSize.height + 80)
         #expect(shiftedSize.width == centeredSize.width)
+    }
+
+    @Test func multilineNaturalSizeFitsTheSharedCoreTextFrame() {
+        let content = "Text\nfasfasf\nfsafasff\nfasfsafsa\nfasfasfas\nfasfasffs"
+        var style = TextStyle()
+        style.shadow.enabled = false
+        let size = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: 1_728,
+            canvasHeight: 1_080
+        )
+        let attributedString = NSAttributedString(
+            string: content,
+            attributes: style.attributes(size: CGFloat(style.fontSize))
+        )
+        let frame = TextLayout.frame(for: attributedString, in: CGRect(origin: .zero, size: size))
+        let visibleRange = CTFrameGetVisibleStringRange(frame)
+        let lines = CTFrameGetLines(frame) as? [CTLine] ?? []
+
+        #expect(visibleRange.length == (content as NSString).length)
+        #expect(lines.count == 6)
+    }
+
+    @Test func trailingNewlineReservesTheNextLine() {
+        var style = TextStyle()
+        style.shadow.enabled = false
+
+        func size(_ content: String) -> CGSize {
+            TextLayout.naturalSize(
+                content: content,
+                style: style,
+                maxWidth: 1_728,
+                canvasHeight: 1_080
+            )
+        }
+
+        #expect(size("Line\n").height == size("Line\nNext").height)
+        #expect(size("Line\n").height > size("Line").height)
+    }
+
+    @Test func sharedCoreTextFrameHonorsAnUndersizedBox() {
+        let content = "First line\nSecond line"
+        let style = TextStyle()
+        let attributedString = NSAttributedString(
+            string: content,
+            attributes: style.attributes(size: CGFloat(style.fontSize))
+        )
+        let frame = TextLayout.frame(
+            for: attributedString,
+            in: CGRect(x: 0, y: 100, width: 800, height: 1)
+        )
+
+        #expect(CTFrameGetVisibleStringRange(frame).length < (content as NSString).length)
     }
 }

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -296,6 +296,41 @@ struct TextFrameRendererTests {
         #expect(size("Line\n").height > size("Line").height)
     }
 
+    @Test func sharedCoreTextFrameCentersTextVerticallyInExtraSpace() throws {
+        let style = TextStyle(fontSize: 80)
+        let attributedString = NSAttributedString(
+            string: "Text",
+            attributes: style.attributes(size: CGFloat(style.fontSize))
+        )
+        let box = CGRect(x: 100, y: 40, width: 600, height: 300)
+        let frame = TextLayout.frame(for: attributedString, in: box)
+        let line = try #require((CTFrameGetLines(frame) as? [CTLine])?.first)
+        var origin = CGPoint.zero
+        CTFrameGetLineOrigins(frame, CFRange(location: 0, length: 1), &origin)
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        CTLineGetTypographicBounds(line, &ascent, &descent, nil)
+        let pathBounds = CTFrameGetPath(frame).boundingBox
+        let textMidY = pathBounds.minY + origin.y + (ascent - descent) / 2
+
+        #expect(
+            abs(textMidY - box.midY) < 10,
+            "textMidY=\(textMidY), origin=\(origin), path=\(pathBounds)"
+        )
+
+        let fullText = NSAttributedString(
+            string: "First\nSecond",
+            attributes: style.attributes(size: CGFloat(style.fontSize))
+        )
+        let fullFrame = TextLayout.frame(for: fullText, in: box)
+        let revealFrame = TextLayout.frame(
+            for: attributedString,
+            in: box,
+            verticallySizedFor: fullText
+        )
+        #expect(CTFrameGetPath(revealFrame).boundingBox == CTFrameGetPath(fullFrame).boundingBox)
+    }
+
     @Test func sharedCoreTextFrameHonorsAnUndersizedBox() {
         let content = "First line\nSecond line"
         let style = TextStyle()

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -432,6 +432,44 @@ struct WritePositionTests {
 @MainActor
 struct ClipPropertyCommitTests {
 
+    @Test func editingMultilineTextResizesAndUndoesTheTextBoxAtomically() throws {
+        let originalContent = "Text"
+        var style = TextStyle()
+        style.shadow.enabled = false
+        let natural = TextLayout.naturalSize(
+            content: originalContent,
+            style: style,
+            maxWidth: 1_728,
+            canvasHeight: 1_080
+        )
+        var clip = Fixtures.clip(id: "text", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        clip.textContent = originalContent
+        clip.textStyle = style
+        clip.transform = Transform(
+            center: (0.5, 0.5),
+            width: Double(natural.width) / 1_920,
+            height: Double(natural.height) / 1_080
+        )
+        let originalTransform = clip.transform
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+        let multiline = "Text\nfasfasf\nfsafasff\nfasfsafsa\nfasfasfas\nfasfasffs"
+
+        e.applyTextContent(clipId: clip.id, content: multiline)
+        let resized = try #require(e.clipFor(id: clip.id))
+        #expect(resized.textContent == multiline)
+        #expect(resized.transform.height > originalTransform.height)
+        #expect(resized.transform.centerY == originalTransform.centerY)
+
+        e.commitTextContent(clipId: clip.id, content: multiline)
+        undoManager.undo()
+        let restored = try #require(e.clipFor(id: clip.id))
+        #expect(restored.textContent == originalContent)
+        #expect(restored.transform == originalTransform)
+        #expect(undoManager.canUndo == false)
+    }
+
     @Test func sampledChromaKeyUndoes() throws {
         let clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
         let e = editor([Fixtures.videoTrack(clips: [clip])])

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -470,6 +470,47 @@ struct ClipPropertyCommitTests {
         #expect(undoManager.canUndo == false)
     }
 
+    @Test func scalingTextPreservesAuthoredStyleAndUndoesTheBoxAtomically() throws {
+        let content = "fasfasfasf\nsfsaf\nsfasfsaf"
+        var style = TextStyle()
+        style.tracking = 18
+        style.lineSpacing = 24
+        style.background = .init(enabled: true, paddingX: 40, paddingY: 28, cornerRadius: 20)
+        let natural = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: 1_728,
+            canvasHeight: 1_080
+        )
+        var clip = Fixtures.clip(id: "text", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        clip.textContent = content
+        clip.textStyle = style
+        clip.transform = Transform(
+            center: (0.5, 0.5),
+            width: Double(natural.width) / 1_920,
+            height: Double(natural.height) / 1_080
+        )
+        let original = clip
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        e.applyTextStyle(clipId: clip.id, fitToContent: true) { $0.fontScale = 0.25 }
+        let scaled = try #require(e.clipFor(id: clip.id))
+        let scaledStyle = try #require(scaled.textStyle)
+        #expect(scaledStyle.fontScale == 0.25)
+        #expect(scaledStyle.tracking == style.tracking)
+        #expect(scaledStyle.lineSpacing == style.lineSpacing)
+        #expect(scaledStyle.background == style.background)
+        #expect(abs(scaled.transform.width - original.transform.width * 0.25) < 0.002)
+        #expect(abs(scaled.transform.height - original.transform.height * 0.25) < 0.002)
+
+        e.commitTextStyle(clipId: clip.id, fitToContent: true) { $0.fontScale = 0.25 }
+        undoManager.undo()
+        #expect(e.clipFor(id: clip.id) == original)
+        #expect(undoManager.canUndo == false)
+    }
+
     @Test func sampledChromaKeyUndoes() throws {
         let clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
         let e = editor([Fixtures.videoTrack(clips: [clip])])


### PR DESCRIPTION
1. fix text box
2. add drag handle hover state
3. center text in the text box

## Summary

Text clip sizing and rendering used different layout calculations, so multiline edits could escape the selection box, terminal newlines were under-measured, and canvas resizing changed font size without scaling the rest of the visual style. CoreText also top-aligned short text inside taller clip bounds, making background padding look uneven.

This change gives text measurement and rendering one CoreText layout source of truth, updates text content and fitted clip bounds atomically, scales the complete visual style from one authored `fontScale`, vertically centers the measured text block, and shows native diagonal resize cursors on canvas handles. It also requires future PR bodies to report per-file, code-logic, and test line statistics.

## Approach

- Use `TextLayout` for both natural-size measurement and static or animated CoreText frames.
- Preserve terminal empty lines with a measurement-only zero-width glyph.
- Apply text content and its fitted transform in one editor mutation so preview, commit, persistence, and undo retain the same clip state.
- Derive a fully scaled visual style for font metrics, tracking, line spacing, shadows, borders, and background geometry while keeping the authored style unchanged.
- Reuse the scaled style in rendering and FCPXML export.
- Center the measured CoreText path vertically while retaining the supplied box when content is too tall; size typewriter frames from the final text to prevent vertical movement during reveal.
- Resolve CoreText line positions relative to the centered frame path for per-word animation and overlines.
- Use native `frameResize` pointer styles for each canvas corner.

## Design

```mermaid
flowchart LR
    A[Text edit or canvas resize] --> B[Editor text mutation]
    B --> C[Authored TextStyle and fontScale]
    C --> D[scaledVisualStyle]
    D --> E[Shared CoreText TextLayout]
    E --> F[Clip bounds]
    E --> G[Static and animated rendering]
    D --> H[FCPXML export]
```

## Testing

- `swift test -q` — passed 1,148 tests in 173 suites.
- `swift test --filter "TextFrameRendererTests|TextAnimationRenderTests"` — passed 16 tests in 2 suites.
- `swift build` — passed after the final Swift source change; existing dependency and concurrency warnings remain.
- Manual verification confirmed multiline text auto-sizing, terminal-newline sizing, proportional canvas text resizing, and native corner resize cursors.
- Remaining manual coverage: compare vertical centering across several fonts, multiline/typewriter animations, and rotated clips.

## Change statistics

| Category | + | − |
| --- | ---: | ---: |
| Code logic | 135 | 46 |
| Tests | 200 | 2 |
| Documentation | 1 | 0 |
| Total | 336 | 48 |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core text layout, compositing, editor undo, and FCPXML export with broad test coverage; regressions would show as mis-sized clips, wrong export typography, or broken multiline/animated text—not data loss.
> 
> **Overview**
> Fixes text clips where **measurement, rendering, and selection bounds diverged**—multiline edits could overflow the box, trailing newlines were under-sized, canvas resize only changed font size, and short text looked top-aligned inside taller bounds.
> 
> **Shared layout:** `TextLayout` now drives both `naturalSize` (CoreText `CTFramesetterSuggestFrameSizeWithConstraints` instead of `boundingRect`) and compositor frames via `TextLayout.frame`, with vertical centering in the clip box, terminal-newline handling via a measurement-only zero-width glyph, and typewriter reveal sized against the full final text so it doesn’t jump.
> 
> **Scaling:** `TextStyle.scaledVisualStyle` folds authored `fontScale` into font metrics, tracking, line spacing, shadow, border, and background geometry for layout/render/export while keeping stored style unchanged; `TextFrameRenderer` and FCPXML export use it (e.g. stroke width scales with scale).
> 
> **Editor:** `applyTextContent` / `commitTextContent` update content and auto-fit transform in one mutation (replacing separate `fitTextClipToContent`); `TextTab` routes through these for correct undo.
> 
> **UI:** Canvas transform handles use native `frameResize` pointer styles per corner.
> 
> **Docs:** PR template adds a change-statistics section in `AGENTS.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5b93432dc09b4edb9a330f888f1ed53954e025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->