### PR TITLE
[feat] Add text clip rotation

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -468,7 +468,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .setClipProperties,
-            description: "Apply the same generic clip property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volumeDb, opacity, transform, or blendMode (video/image clips only). For text content, typography, captions, and text animation, use update_text.\n\nNOT for preview layout — split screen, picture-in-picture, grid, sidebar, and any multi-clip canvas arrangement belong to apply_layout, which sets transform and crop together. Do not use transform here (or set_keyframes position/scale/crop) to build those layouts.\n\nAll values apply to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volumeDb is −60 through +15 dB; 0 dB keeps source level and −60 dB is mute. opacity is 0.0–1.0. transform is for rare single-clip tweaks only — 0–1 normalized canvas coords, partial merge; flipHorizontal/flipVertical mirror across the axis.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volumeDb or opacity here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volumeDb, opacity, transform, blendMode) don't propagate. trim and speed are skipped for text partners.\n\nTiming fields (trims, durationFrames, speed) are refused on multicam clips — they would slip the clip out of sync; property fields stay editable, and angle changes go through change_cam.",
+            description: "Apply the same generic clip property values to one or more clips in a single undoable action. Pass any combination of durationFrames, trimStartFrame, trimEndFrame, speed, volumeDb, opacity, transform, or blendMode (video/image clips only). For text content, typography, captions, and text animation, use update_text.\n\nNOT for preview layout — split screen, picture-in-picture, grid, sidebar, and any multi-clip canvas arrangement belong to apply_layout, which sets transform and crop together. Do not use transform here (or set_keyframes position/scale/crop) to build those layouts.\n\nAll values apply to every clip in clipIds; for per-clip differences, make separate calls. trimStartFrame/trimEndFrame are offsets from the source media, not the timeline. speed 1.0 is normal, <1.0 slows (clip gets longer on the timeline), >1.0 speeds up. volumeDb is −60 through +15 dB; 0 dB keeps source level and −60 dB is mute. opacity is 0.0–1.0. transform is for rare single-clip tweaks only — 0–1 normalized canvas coords, partial merge; rotation is clockwise degrees; flipHorizontal/flipVertical mirror across the axis.\n\nFor moves and start-frame changes, use move_clips. For animated values (keyframes), use set_keyframes — setting volumeDb, opacity, or transform.rotation here clears any existing keyframe track on that property.\n\nTiming changes (durationFrames, trimStartFrame, trimEndFrame, speed) on a linked clip carry over to its linked partner so audio/video stay in sync — same as the timeline UI. Per-clip fields (volumeDb, opacity, transform, blendMode) don't propagate. trim and speed are skipped for text partners.\n\nTiming fields (trims, durationFrames, speed) are refused on multicam clips — they would slip the clip out of sync; property fields stay editable, and angle changes go through change_cam.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": [
@@ -489,12 +489,13 @@ enum ToolDefinitions {
                     "opacity": ["type": "number", "description": "Opacity 0.0-1.0. Clears any existing opacity keyframes."],
                     "transform": [
                         "type": "object",
-                        "description": "Single-clip only — not for split screen, PIP, or grid (use apply_layout). Partial transform: centerX, centerY, width, height, flipHorizontal, flipVertical; omitted fields keep current value.",
+                        "description": "Single-clip only — not for split screen, PIP, or grid (use apply_layout). Partial transform; omitted fields keep current values. Static rotation uses clockwise degrees and clears rotation keyframes.",
                         "properties": [
                             "centerX": ["type": "number"],
                             "centerY": ["type": "number"],
                             "width": ["type": "number"],
                             "height": ["type": "number"],
+                            "rotation": ["type": "number", "description": "Clockwise degrees."],
                             "flipHorizontal": ["type": "boolean", "description": "Mirror across the vertical axis."],
                             "flipVertical": ["type": "boolean", "description": "Mirror across the horizontal axis."],
                         ],
@@ -736,7 +737,7 @@ enum ToolDefinitions {
                                 "content": ["type": "string", "description": "Text. Supports \\n."],
                                 "transform": [
                                     "type": "object",
-                                    "description": "Text box. Omit for centered auto-fit; center only auto-fits size; all four override.",
+                                    "description": "Text box. Omit for centered auto-fit; rotation alone rotates an auto-fit box; center only auto-fits size; all four override.",
                                     "properties": textBoxTransformProperties(),
                                 ],
                             ], textStyleProperties(detailed: false), [
@@ -753,7 +754,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .updateText,
-            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box unless transform is passed. Unknown fields are rejected.",
+            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box unless transform includes box geometry; rotation alone keeps auto-fit. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "clipIds": [
@@ -1083,6 +1084,7 @@ enum ToolDefinitions {
             "centerY": ["type": "number", "description": "0-1 vertical center."],
             "width": ["type": "number", "description": "0-1 width."],
             "height": ["type": "number", "description": "0-1 height."],
+            "rotation": ["type": "number", "description": "Clockwise degrees."],
         ]
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -77,7 +77,7 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     var hasAnyProperty: Bool {
         durationFrames != nil || trimStartFrame != nil || trimEndFrame != nil
             || speed != nil || volumeDb != nil || opacity != nil
-            || transform != nil
+            || transform?.hasAnyField == true
             || blendMode != nil
     }
 }
@@ -97,18 +97,37 @@ fileprivate struct SetKeyframesInput: DecodableToolArgs {
     static let allowedKeys: Set<String> = ["clipId", "property", "keyframes"]
 }
 
-/// Partial transform shared between set_clip_properties and add_texts.
+/// Partial transform shared by clip and text property tools.
 struct ParsedTransform: Decodable {
     var centerX: Double?
     var centerY: Double?
     var width: Double?
     var height: Double?
+    var rotation: Double?
     var flipHorizontal: Bool?
     var flipVertical: Bool?
 
-    var hasAnyField: Bool {
+    static let allowedKeys: Set<String> = [
+        "centerX", "centerY", "width", "height", "rotation", "flipHorizontal", "flipVertical",
+    ]
+
+    var hasLayoutField: Bool {
         centerX != nil || centerY != nil || width != nil || height != nil
+    }
+
+    var hasAnyField: Bool {
+        hasLayoutField || rotation != nil
             || flipHorizontal != nil || flipVertical != nil
+    }
+
+    func apply(to clip: inout Clip) {
+        if let centerX { clip.transform.centerX = centerX }
+        if let centerY { clip.transform.centerY = centerY }
+        if let width { clip.transform.width = width }
+        if let height { clip.transform.height = height }
+        if let rotation { clip.transform.rotation = rotation; clip.rotationTrack = nil }
+        if let flipHorizontal { clip.transform.flipHorizontal = flipHorizontal }
+        if let flipVertical { clip.transform.flipVertical = flipVertical }
     }
 }
 
@@ -445,6 +464,16 @@ extension ToolExecutor {
     // MARK: set_clip_properties
 
     func setClipProperties(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        if let rawTransform = args["transform"] {
+            guard let transform = rawTransform as? [String: Any] else {
+                throw ToolError("set_clip_properties.transform: expected object")
+            }
+            try validateUnknownKeys(
+                transform,
+                allowed: ParsedTransform.allowedKeys,
+                path: "set_clip_properties.transform"
+            )
+        }
         let input: SetClipPropertiesInput = try decodeToolArgs(args, path: "set_clip_properties")
         let clipIds = input.clipIds ?? []
         guard !clipIds.isEmpty else { throw ToolError("Provide a non-empty 'clipIds' array") }
@@ -512,9 +541,15 @@ extension ToolExecutor {
             let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
             return (input.volumeDb != nil && clip.volumeTrack != nil)
                 || (input.opacity != nil && clip.opacityTrack != nil)
+                || (input.transform?.rotation != nil && clip.rotationTrack != nil)
         }
         if !clearedKeyframes.isEmpty {
-            notes.append("Setting a scalar cleared existing keyframes on: \(clearedKeyframes.joined(separator: ", ")).")
+            notes.append("Setting a static value cleared existing keyframes on: \(clearedKeyframes.joined(separator: ", ")).")
+        }
+
+        var beforeClips: [String: Clip] = [:]
+        for id in clipIds + Array(partners) {
+            beforeClips[id] = editor.clipFor(id: id)
         }
 
         let snapshot = timelineSnapshot(editor)
@@ -551,7 +586,14 @@ extension ToolExecutor {
                 )
             }
         }
-        return mutationResult(editor, since: snapshot, touched: clipIds + Array(partners), notes: notes)
+        let changed = beforeClips.contains { id, clip in editor.clipFor(id: id) != clip }
+        return mutationResult(
+            editor,
+            since: snapshot,
+            touched: clipIds + Array(partners),
+            extra: ["changed": changed],
+            notes: notes
+        )
     }
 
     fileprivate static func applyPropertyChanges(
@@ -597,16 +639,7 @@ extension ToolExecutor {
             if let v = opacity        { clip.opacity = v; clip.opacityTrack = nil; changed.append("opacity") }
             if setBlendMode           { clip.blendMode = blendMode; changed.append("blendMode") }
             if let t = transform {
-                let cur = clip.transform
-                var next = Transform(
-                    center: (t.centerX ?? cur.center.x, t.centerY ?? cur.center.y),
-                    width: t.width ?? cur.width,
-                    height: t.height ?? cur.height
-                )
-                next.rotation = cur.rotation
-                next.flipHorizontal = t.flipHorizontal ?? cur.flipHorizontal
-                next.flipVertical = t.flipVertical ?? cur.flipVertical
-                clip.transform = next
+                t.apply(to: &clip)
                 changed.append("transform")
             }
         }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -230,7 +230,20 @@ extension ToolExecutor {
         range: ClosedRange<Double>? = nil
     ) throws -> Double? {
         guard args.keys.contains(key) else { return nil }
-        guard let value = args.double(key), value.isFinite else {
+        guard let raw = args[key], !isJSONBoolean(raw) else {
+            throw ToolError("\(path).\(key): expected finite number")
+        }
+        let value: Double
+        if let raw = raw as? Double {
+            value = raw
+        } else if let raw = raw as? Int {
+            value = Double(raw)
+        } else if let raw = raw as? NSNumber {
+            value = raw.doubleValue
+        } else {
+            throw ToolError("\(path).\(key): expected finite number")
+        }
+        guard value.isFinite else {
             throw ToolError("\(path).\(key): expected finite number")
         }
         if let range, !range.contains(value) {
@@ -344,31 +357,49 @@ extension ToolExecutor {
         path: String
     ) throws -> Transform? {
         guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height"], path: "\(path).transform")
-        let cX = tDict.double("centerX"), cY = tDict.double("centerY")
-        let w = tDict.double("width"), h = tDict.double("height")
-        if cX == nil && cY == nil && w == nil && h == nil { return nil }
+        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height", "rotation"], path: "\(path).transform")
+        let cX = try optionalNumber(tDict, key: "centerX", path: "\(path).transform")
+        let cY = try optionalNumber(tDict, key: "centerY", path: "\(path).transform")
+        let w = try optionalNumber(tDict, key: "width", path: "\(path).transform")
+        let h = try optionalNumber(tDict, key: "height", path: "\(path).transform")
+        let rotation = try optionalNumber(tDict, key: "rotation", path: "\(path).transform")
+
+        func autoFit(centerX: Double, centerY: Double) -> Transform {
+            let natural = TextLayout.naturalSize(content: content, style: style, maxWidth: CGFloat(canvas.w) * 0.9, canvasHeight: CGFloat(canvas.h))
+            return Transform(
+                centerX: centerX,
+                centerY: centerY,
+                width: Double(natural.width) / canvas.w,
+                height: Double(natural.height) / canvas.h,
+                rotation: rotation ?? 0
+            )
+        }
+
+        if cX == nil && cY == nil && w == nil && h == nil {
+            guard rotation != nil else { return nil }
+            return autoFit(centerX: 0.5, centerY: 0.5)
+        }
         guard let cx = cX, let cy = cY else {
             throw ToolError("\(path): transform must be either {centerX, centerY} for auto-fit, or all four of {centerX, centerY, width, height}")
         }
         if let ww = w, let hh = h {
-            return Transform(center: (cx, cy), width: ww, height: hh)
+            return Transform(centerX: cx, centerY: cy, width: ww, height: hh, rotation: rotation ?? 0)
         }
         guard w == nil && h == nil else {
             throw ToolError("\(path): transform must be either {centerX, centerY} for auto-fit, or all four of {centerX, centerY, width, height}")
         }
-        let natural = TextLayout.naturalSize(content: content, style: style, maxWidth: CGFloat(canvas.w) * 0.9, canvasHeight: CGFloat(canvas.h))
-        return Transform(center: (cx, cy), width: Double(natural.width) / canvas.w, height: Double(natural.height) / canvas.h)
+        return autoFit(centerX: cx, centerY: cy)
     }
 
     private func parseUpdateTextTransform(_ tDict: [String: Any]?, path: String) throws -> ParsedTransform? {
         guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height"], path: "\(path).transform")
+        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height", "rotation"], path: "\(path).transform")
         let transform = ParsedTransform(
-            centerX: tDict.double("centerX"),
-            centerY: tDict.double("centerY"),
-            width: tDict.double("width"),
-            height: tDict.double("height"),
+            centerX: try optionalNumber(tDict, key: "centerX", path: "\(path).transform"),
+            centerY: try optionalNumber(tDict, key: "centerY", path: "\(path).transform"),
+            width: try optionalNumber(tDict, key: "width", path: "\(path).transform"),
+            height: try optionalNumber(tDict, key: "height", path: "\(path).transform"),
+            rotation: try optionalNumber(tDict, key: "rotation", path: "\(path).transform"),
             flipHorizontal: nil,
             flipVertical: nil
         )
@@ -419,7 +450,7 @@ extension ToolExecutor {
             }
 
             let transform = try parseAddTextTransform(
-                entry["transform"] as? [String: Any],
+                optionalObject(entry, key: "transform", path: path),
                 content: content, style: style,
                 canvas: (Double(editor.timeline.width), Double(editor.timeline.height)),
                 path: path
@@ -511,7 +542,10 @@ extension ToolExecutor {
         guard !clipIds.isEmpty else { throw ToolError("Provide a non-empty 'clipIds' array or a 'captionGroupId'") }
 
         let textStylePatch = try parseTextStylePatch(args, path: "update_text")
-        let transform = try parseUpdateTextTransform(args["transform"] as? [String: Any], path: "update_text")
+        let transform = try parseUpdateTextTransform(
+            optionalObject(args, key: "transform", path: "update_text"),
+            path: "update_text"
+        )
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "update_text")
         let shouldSetAnimation = args.string("animation") != nil
         let highlightOnly = shouldSetAnimation ? nil : try parseColorHex(args.string("highlightColor"), path: "update_text")
@@ -540,10 +574,20 @@ extension ToolExecutor {
                 notes.append("Content change cleared word timings on \(timingCleared.count) clip\(timingCleared.count == 1 ? "" : "s") — karaoke highlighting falls back to plain text there.")
             }
         }
+        if transform?.rotation != nil {
+            let cleared = clipIds.filter { editor.clipFor(id: $0)?.rotationTrack != nil }
+            if !cleared.isEmpty {
+                notes.append("Static rotation cleared existing rotation keyframes on: \(cleared.joined(separator: ", ")).")
+            }
+        }
 
+        var beforeClips: [String: Clip] = [:]
+        for id in clipIds {
+            beforeClips[id] = editor.clipFor(id: id)
+        }
         let snapshot = timelineSnapshot(editor)
         let actionName = clipIds.count == 1 ? "Update Text (Agent)" : "Update Texts (Agent)"
-        let shouldFitToContent = transform == nil && (hasContent || textStylePatch?.affectsLayout == true)
+        let shouldFitToContent = transform?.hasLayoutField != true && (hasContent || textStylePatch?.affectsLayout == true)
         let canvasW = Double(editor.timeline.width)
         let canvasH = Double(editor.timeline.height)
         editor.undo.perform(actionName) {
@@ -560,16 +604,7 @@ extension ToolExecutor {
                     clip.textStyle = style
                 }
                 if let t = transform {
-                    let cur = clip.transform
-                    var next = Transform(
-                        center: (t.centerX ?? cur.center.x, t.centerY ?? cur.center.y),
-                        width: t.width ?? cur.width,
-                        height: t.height ?? cur.height
-                    )
-                    next.rotation = cur.rotation
-                    next.flipHorizontal = cur.flipHorizontal
-                    next.flipVertical = cur.flipVertical
-                    clip.transform = next
+                    t.apply(to: &clip)
                 }
                 if shouldSetAnimation {
                     if let animation {
@@ -597,6 +632,13 @@ extension ToolExecutor {
             }
         }
 
-        return mutationResult(editor, since: snapshot, touched: clipIds, notes: notes)
+        let changed = beforeClips.contains { id, clip in editor.clipFor(id: id) != clip }
+        return mutationResult(
+            editor,
+            since: snapshot,
+            touched: clipIds,
+            extra: ["changed": changed],
+            notes: notes
+        )
     }
 }

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -103,7 +103,10 @@ enum FrameRenderer {
         var style = clip.textStyle ?? TextStyle()
         style.color = .init(r: 1, g: 1, b: 1, a: 1)
         clip.textStyle = style
-        return TextFrameRenderer.image(clip: clip, frame: frame, renderSize: renderSize)
+        guard let image = TextFrameRenderer.image(clip: clip, frame: frame, renderSize: renderSize) else {
+            return nil
+        }
+        return rotatedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
     }
 
     /// Children composite at the child canvas; the nest clip's pipeline runs on the result.
@@ -288,8 +291,7 @@ enum FrameRenderer {
             }
         }
 
-        // transformAt drops the flip flags, so use the static transform unless animated.
-        let t = clip.hasTransformAnimation ? clip.transformAt(frame: frame) : clip.transform
+        let t = clip.transformAt(frame: frame)
         let av = layer.preferredTransform.concatenating(
             CompositionBuilder.affineTransform(for: t, natSize: layer.natSize, renderSize: renderSize)
         )
@@ -307,7 +309,7 @@ enum FrameRenderer {
         return image
     }
 
-    /// Text renders flat in place; opacity fades apply after. Per-word animation bakes in at raster. Preset only, no keyframed transform.
+    /// Text renders in place; effects run before rotation and opacity, matching visual clips.
     private static func composedTextLayer(
         _ layer: LayerPlan,
         frame: Int,
@@ -327,6 +329,7 @@ enum FrameRenderer {
                 image = descriptor.render(image, effect: effect, atOffset: offset)
             }
         }
+        image = rotatedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
         image = image.premultiplyingAlpha()
 
         if bakeOpacity, alpha < 1 {
@@ -335,6 +338,23 @@ enum FrameRenderer {
             ])
         }
         return image
+    }
+
+    private static func rotatedTextImage(
+        _ image: CIImage,
+        clip: Clip,
+        frame: Int,
+        renderSize: CGSize
+    ) -> CIImage {
+        let rotation = CompositionBuilder.canvasRotationTransform(
+            for: clip.transformAt(frame: frame),
+            renderSize: renderSize
+        )
+        guard !rotation.isIdentity else { return image }
+        let ciTransform = flipY(renderSize.height)
+            .concatenating(rotation)
+            .concatenating(flipY(renderSize.height))
+        return image.transformed(by: ciTransform)
     }
 
     private static func flipY(_ height: CGFloat) -> CGAffineTransform {

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -12,7 +12,8 @@ enum TextFrameRenderer {
         let style = (clip.textStyle ?? TextStyle()).scaledVisualStyle
         let content = style.displayText(clip.textContent ?? "")
         guard !content.isEmpty else { return nil }
-        let box = boxRect(clip.transform, renderSize)
+        let transform = clip.transformAt(frame: frame)
+        let box = boxRect(transform, renderSize)
         let boxes = layoutBoxes(style: style, box: box, renderSize: renderSize)
         let fontSize = CGFloat(style.fontSize) * (renderSize.height / TextLayout.referenceCanvasHeight)
         let anim = clip.textAnimation
@@ -31,7 +32,7 @@ enum TextFrameRenderer {
         }
 
         // Static base is frame-independent → cache it. Entrance reuses it under a transform.
-        guard let base = cachedStatic(content: content, style: style, transform: clip.transform,
+        guard let base = cachedStatic(content: content, style: style, transform: transform,
                                       boxes: boxes,
                                       fontSize: fontSize, renderSize: renderSize) else { return nil }
         guard let anim, anim.isActive else { return base }
@@ -499,7 +500,9 @@ enum TextFrameRenderer {
 
     private static func signature(_ content: String, _ s: TextStyle, _ t: Transform, _ size: CGSize) -> NSString {
         var h = Hasher()
-        h.combine(content); h.combine(s); h.combine(t); h.combine(size)
+        h.combine(content); h.combine(s)
+        h.combine(t.centerX); h.combine(t.centerY); h.combine(t.width); h.combine(t.height)
+        h.combine(size)
         return String(h.finalize()) as NSString
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -90,12 +90,14 @@ extension EditorViewModel {
         }
     }
 
-    func applyRotation(clipId: String, valueDeg: Double) {
-        applyClipProperty(clipId: clipId) { self.writeRotation(into: &$0, valueDeg: valueDeg) }
+    func applyRotation(clipIds: [String], valueDeg: Double) {
+        applyClipProperties(clipIds: clipIds) { self.writeRotation(into: &$0, valueDeg: valueDeg) }
     }
 
-    func commitRotation(clipId: String, valueDeg: Double) {
-        commitClipProperty(clipId: clipId, actionName: "Change Rotation") { self.writeRotation(into: &$0, valueDeg: valueDeg) }
+    func commitRotation(clipIds: [String], valueDeg: Double) {
+        commitClipProperties(clipIds: clipIds, actionName: "Change Rotation") {
+            self.writeRotation(into: &$0, valueDeg: valueDeg)
+        }
     }
 
     private func writeRotation(into clip: inout Clip, valueDeg: Double) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -469,7 +469,10 @@ extension EditorViewModel {
         case .center:
             cx = tl.x + currentW / 2
         }
-        clip.transform = Transform(center: (cx, cy), width: needW, height: needH)
+        clip.transform.centerX = cx
+        clip.transform.centerY = cy
+        clip.transform.width = needW
+        clip.transform.height = needH
         return true
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -118,6 +118,7 @@ final class EditorViewModel {
         }
     }
     var canvasOffset: CGSize = .zero
+    var rotationSnapGuidesVisible: Bool = false
     var timelineVisibleWidth: Double = 0
     var timelineRenderRevision: Int = 0
     /// Live horizontal scroll of the timeline panel, mirrored from AppKit for view-state stash.

--- a/Sources/PalmierPro/Inspector/Components/InspectorRotationField.swift
+++ b/Sources/PalmierPro/Inspector/Components/InspectorRotationField.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct InspectorRotationField: View {
+    let clips: [Clip]
+    @Environment(EditorViewModel.self) private var editor
+
+    private var clipIds: [String] { clips.map(\.id) }
+
+    var body: some View {
+        ScrubbableNumberField(
+            value: sharedClipValue(clips) { $0.rotationAt(frame: editor.activeFrame) },
+            range: -3600...3600,
+            displayMultiplier: 1,
+            format: "%.0f",
+            valueSuffix: "°",
+            fieldWidth: AppTheme.EditorPanel.numericFieldWidth,
+            dragValueAdjustment: RotationSnap.adjusted,
+            onDraggingValue: { rotation in
+                editor.rotationSnapGuidesVisible = RotationSnap.isAxisAligned(rotation)
+            },
+            onChanged: { newValue in
+                editor.applyRotation(clipIds: clipIds, valueDeg: newValue)
+            }
+        ) { newValue in
+            editor.rotationSnapGuidesVisible = false
+            editor.commitRotation(clipIds: clipIds, valueDeg: newValue)
+        }
+        .onDisappear {
+            editor.rotationSnapGuidesVisible = false
+        }
+    }
+}
+
+enum RotationSnap {
+    static let intervalDegrees = 90.0
+    static let toleranceDegrees = 4.0
+
+    static func adjusted(_ rotation: Double) -> Double {
+        guard rotation.isFinite else { return rotation }
+        let nearestAxis = (rotation / intervalDegrees).rounded() * intervalDegrees
+        guard abs(rotation - nearestAxis) <= toleranceDegrees else { return rotation }
+        return nearestAxis == 0 ? 0 : nearestAxis
+    }
+
+    static func isAxisAligned(_ rotation: Double) -> Bool {
+        guard rotation.isFinite else { return false }
+        return rotation.truncatingRemainder(dividingBy: intervalDegrees) == 0
+    }
+}

--- a/Sources/PalmierPro/Inspector/Components/ScrubbableNumberField.swift
+++ b/Sources/PalmierPro/Inspector/Components/ScrubbableNumberField.swift
@@ -10,8 +10,10 @@ struct ScrubbableNumberField: View {
     /// Display units changed per pixel of horizontal drag.
     var dragSensitivity: Double = 1
     var fieldWidth: CGFloat = AppTheme.EditorPanel.numericFieldWidth
+    var dragValueAdjustment: (Double) -> Double = { $0 }
     var trailingLabel: String? = nil
     var displayTextOverride: ((Double) -> String?)? = nil
+    var onDraggingValue: ((Double) -> Void)? = nil
     var onChanged: ((Double) -> Void)? = nil
     let onCommit: (Double) -> Void
 
@@ -102,7 +104,9 @@ struct ScrubbableNumberField: View {
                     if modifiers.contains(.shift) { sens *= 10 }
                     if modifiers.contains(.command) { sens *= 0.1 }
                     let mult = displayMultiplier == 0 ? 1 : displayMultiplier
-                    let next = (dragStartValue + Double(totalDx) * sens / mult).clamped(to: range)
+                    let candidate = (dragStartValue + Double(totalDx) * sens / mult).clamped(to: range)
+                    let next = dragValueAdjustment(candidate).clamped(to: range)
+                    onDraggingValue?(next)
                     if next != liveValue {
                         liveValue = next
                         onChanged?(next)
@@ -123,19 +127,36 @@ struct ScrubbableNumberField: View {
     }
 
     private func commitEdit() {
-        let trimmed = editText.trimmingCharacters(in: .whitespaces)
+        guard let raw = Self.committedValue(
+            from: editText,
+            suffix: valueSuffix,
+            displayMultiplier: displayMultiplier,
+            range: range
+        ) else { return }
+        liveValue = raw
+        onCommit(raw)
+    }
+
+    nonisolated static func committedValue(
+        from text: String,
+        suffix: String,
+        displayMultiplier: Double,
+        range: ClosedRange<Double>
+    ) -> Double? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
         let withoutSuffix: String = {
-            guard !valueSuffix.isEmpty, trimmed.hasSuffix(valueSuffix) else { return trimmed }
-            return String(trimmed.dropLast(valueSuffix.count))
+            guard !suffix.isEmpty, trimmed.hasSuffix(suffix) else { return trimmed }
+            return String(trimmed.dropLast(suffix.count))
         }()
         let cleaned = withoutSuffix
             .trimmingCharacters(in: .whitespaces)
             .replacingOccurrences(of: ",", with: ".")
-        guard let parsed = Double(cleaned) else { return }
+        guard let parsed = Double(cleaned), parsed.isFinite else { return nil }
         let mult = displayMultiplier == 0 ? 1 : displayMultiplier
-        let raw = (parsed / mult).clamped(to: range)
-        liveValue = raw
-        onCommit(raw)
+        guard mult.isFinite else { return nil }
+        let raw = parsed / mult
+        guard raw.isFinite else { return nil }
+        return raw.clamped(to: range)
     }
 }
 

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -505,7 +505,7 @@ struct InspectorView: View {
                     }
                 }
             ) {
-                rotationScrubField(clips: clips)
+                InspectorRotationField(clips: clips)
             }
             animatableRow(
                 label: "Opacity",
@@ -621,25 +621,6 @@ struct InspectorView: View {
         ) { newVal in
             editor.undo.perform("Change Scale") {
                 for c in clips { editor.commitScale(clipId: c.id, newScale: newVal) }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func rotationScrubField(clips: [Clip]) -> some View {
-        ScrubbableNumberField(
-            value: sharedClipValue(clips) { $0.rotationAt(frame: editor.activeFrame) },
-            range: -3600...3600,
-            displayMultiplier: 1,
-            format: "%.0f",
-            valueSuffix: "°",
-            fieldWidth: AppTheme.EditorPanel.numericFieldWidth,
-            onChanged: { newVal in
-                for c in clips { editor.applyRotation(clipId: c.id, valueDeg: newVal) }
-            }
-        ) { newVal in
-            editor.undo.perform("Change Rotation") {
-                for c in clips { editor.commitRotation(clipId: c.id, valueDeg: newVal) }
             }
         }
     }

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -27,6 +27,7 @@ struct TextTab: View {
                 actions: styleActions,
                 afterAlignment: {
                     positionSection
+                    rotationSection
                     fillModeRow
                 },
                 afterColor: { opacitySlider }
@@ -119,6 +120,20 @@ struct TextTab: View {
             }
         ) {
             InspectorPositionFields(clips: clips)
+        }
+    }
+
+    private var rotationSection: some View {
+        InspectorRow(
+            label: "Rotation",
+            onReset: {
+                editor.commitClipProperties(clipIds: clipIds, actionName: "Reset Rotation") {
+                    $0.transform.rotation = Transform().rotation
+                    $0.rotationTrack = nil
+                }
+            }
+        ) {
+            InspectorRotationField(clips: clips)
         }
     }
 

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -236,7 +236,11 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     func transformAt(frame: Int) -> Transform {
         let tl = topLeftAt(frame: frame)
         let sz = sizeAt(frame: frame)
-        var t = Transform(topLeft: (tl.x, tl.y), width: sz.width, height: sz.height)
+        var t = transform
+        t.centerX = tl.x + sz.width / 2
+        t.centerY = tl.y + sz.height / 2
+        t.width = sz.width
+        t.height = sz.height
         t.rotation = rotationAt(frame: frame)
         return t
     }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -916,11 +916,14 @@ enum CompositionBuilder {
         let ty = (t.flipVertical ? tl.y + t.height : tl.y) * renderSize.height
         let placed = CGAffineTransform(scaleX: sx, y: sy)
             .concatenating(CGAffineTransform(translationX: tx, y: ty))
-        guard t.rotation != 0 else { return placed }
+        return placed.concatenating(canvasRotationTransform(for: t, renderSize: renderSize))
+    }
+
+    static func canvasRotationTransform(for t: Transform, renderSize: CGSize) -> CGAffineTransform {
+        guard t.rotation != 0 else { return .identity }
         let cx = t.centerX * renderSize.width
         let cy = t.centerY * renderSize.height
-        return placed
-            .concatenating(CGAffineTransform(translationX: -cx, y: -cy))
+        return CGAffineTransform(translationX: -cx, y: -cy)
             .concatenating(CGAffineTransform(rotationAngle: t.rotation * .pi / 180))
             .concatenating(CGAffineTransform(translationX: cx, y: cy))
     }

--- a/Sources/PalmierPro/Preview/PreviewHitTester.swift
+++ b/Sources/PalmierPro/Preview/PreviewHitTester.swift
@@ -15,7 +15,7 @@ enum PreviewHitTester {
         for track in editor.timeline.tracks where !track.hidden {
             for clip in track.clips where clip.mediaType == .text {
                 guard clip.contains(timelineFrame: frame), clip.opacityAt(frame: frame) > 0.01 else { continue }
-                if textHit(clip, point: point, videoRect: videoRect) { topText = clip.id }
+                if textHit(clip, frame: frame, point: point, videoRect: videoRect) { topText = clip.id }
             }
         }
         if let topText { return topText }
@@ -30,12 +30,21 @@ enum PreviewHitTester {
         return nil
     }
 
-    /// Text renders as an axis-aligned `CATextLayer` from the static transform — no rotation/crop.
-    private static func textHit(_ clip: Clip, point: CGPoint, videoRect: CGRect) -> Bool {
-        clipFrame(clip.transform, videoRect: videoRect).contains(point)
+    private static func textHit(_ clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
+        transformedHit(clip, frame: frame, point: point, videoRect: videoRect, crop: nil)
     }
 
     private static func videoHit(_ clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
+        transformedHit(clip, frame: frame, point: point, videoRect: videoRect, crop: clip.cropAt(frame: frame))
+    }
+
+    private static func transformedHit(
+        _ clip: Clip,
+        frame: Int,
+        point: CGPoint,
+        videoRect: CGRect,
+        crop: Crop?
+    ) -> Bool {
         let t = clip.transformAt(frame: frame)
         let rect = clipFrame(t, videoRect: videoRect)
         guard rect.width > 0, rect.height > 0 else { return false }
@@ -48,13 +57,11 @@ enum PreviewHitTester {
         let lx = dx * c + dy * s
         let ly = -dx * s + dy * c
 
-        // Local rect spans ±half-extents; crop trims it (crop is source-space, so local too).
-        let crop = clip.cropAt(frame: frame)
         let halfW = rect.width / 2, halfH = rect.height / 2
-        let left = -halfW + crop.left * rect.width
-        let right = halfW - crop.right * rect.width
-        let top = -halfH + crop.top * rect.height
-        let bottom = halfH - crop.bottom * rect.height
+        let left = -halfW + (crop?.left ?? 0) * rect.width
+        let right = halfW - (crop?.right ?? 0) * rect.width
+        let top = -halfH + (crop?.top ?? 0) * rect.height
+        let bottom = halfH - (crop?.bottom ?? 0) * rect.height
         return lx >= left && lx <= right && ly >= top && ly <= bottom
     }
 

--- a/Sources/PalmierPro/Preview/TransformOverlayView.swift
+++ b/Sources/PalmierPro/Preview/TransformOverlayView.swift
@@ -44,14 +44,14 @@ struct TransformOverlayView: View {
                 .position(x: clipRect.midX, y: clipRect.midY)
             }
 
-            if centerGuideX {
+            if selectedClip != nil && (centerGuideX || editor.rotationSnapGuidesVisible) {
                 Rectangle()
                     .fill(centerGuideColor)
                     .frame(width: 1, height: videoRect.height)
                     .position(x: videoRect.midX, y: videoRect.midY)
                     .allowsHitTesting(false)
             }
-            if centerGuideY {
+            if selectedClip != nil && (centerGuideY || editor.rotationSnapGuidesVisible) {
                 Rectangle()
                     .fill(centerGuideColor)
                     .frame(width: videoRect.width, height: 1)
@@ -70,47 +70,26 @@ struct TransformOverlayView: View {
     @State private var centerGuideX: Bool = false
     @State private var centerGuideY: Bool = false
 
-    private let centerGuideColor = Color(red: 1.0, green: 0.2, blue: 0.6).opacity(AppTheme.Opacity.prominent)
+    private let centerGuideColor = AppTheme.Accent.timecodeColor.opacity(AppTheme.Opacity.prominent)
 
     private func moveGesture(clip: Clip, videoRect: CGRect) -> some Gesture {
         DragGesture()
             .onChanged { value in
                 if dragStart == nil { dragStart = clip.transformAt(frame: editor.activeFrame) }
                 guard let start = dragStart else { return }
-                let rotated = start.rotation != 0
-                let (moved, snap) = movedTransform(start, by: value.translation, in: videoRect, rotated: rotated)
+                let (moved, snap) = TransformOverlayMath.movedTransform(start, by: value.translation, in: videoRect)
                 if centerGuideX != snap.x { centerGuideX = snap.x }
                 if centerGuideY != snap.y { centerGuideY = snap.y }
                 editor.applyTransform(clipId: clip.id, newTransform: moved)
             }
             .onEnded { value in
                 guard let start = dragStart else { return }
-                let rotated = start.rotation != 0
-                let (moved, _) = movedTransform(start, by: value.translation, in: videoRect, rotated: rotated)
+                let (moved, _) = TransformOverlayMath.movedTransform(start, by: value.translation, in: videoRect)
                 dragStart = nil
                 if centerGuideX { centerGuideX = false }
                 if centerGuideY { centerGuideY = false }
                 editor.commitTransform(clipId: clip.id, newTransform: moved, actionName: "Change Position")
             }
-    }
-
-    /// Snaps are skipped under rotation since their thresholds target an axis-aligned bounding box
-    /// that no longer matches the visible clip edges.
-    private func movedTransform(_ start: Transform, by translation: CGSize, in videoRect: CGRect, rotated: Bool) -> (Transform, (x: Bool, y: Bool)) {
-        guard videoRect.width > 0, videoRect.height > 0 else {
-            Log.preview.warning("movedTransform: collapsed videoRect \(videoRect.debugDescription) — skipping")
-            return (start, (false, false))
-        }
-        var t = start
-        t.centerX += translation.width / videoRect.width
-        t.centerY += translation.height / videoRect.height
-        guard !rotated else { return (t, (false, false)) }
-        t.snapToCanvasEdges(threshold: Snap.thresholdPixels / Double(videoRect.width))
-        let snap = t.snapCenterToCanvasCenter(
-            thresholdH: Snap.thresholdPixels / Double(videoRect.width),
-            thresholdV: Snap.thresholdPixels / Double(videoRect.height)
-        )
-        return (t, snap)
     }
 
     private func resizeGesture(clip: Clip, corner: Corner, videoRect: CGRect) -> some Gesture {
@@ -322,5 +301,31 @@ struct TransformOverlayView: View {
             case .bottomRight: .bottomTrailing
             }
         }
+    }
+}
+
+enum TransformOverlayMath {
+    static func movedTransform(
+        _ start: Transform,
+        by translation: CGSize,
+        in videoRect: CGRect
+    ) -> (transform: Transform, guides: (x: Bool, y: Bool)) {
+        guard videoRect.width > 0, videoRect.height > 0 else {
+            Log.preview.warning("movedTransform: collapsed videoRect \(videoRect.debugDescription) — skipping")
+            return (start, (false, false))
+        }
+
+        var moved = start
+        moved.centerX += translation.width / videoRect.width
+        moved.centerY += translation.height / videoRect.height
+
+        if start.rotation == 0 {
+            moved.snapToCanvasEdges(threshold: Snap.thresholdPixels / Double(videoRect.width))
+        }
+        let guides = moved.snapCenterToCanvasCenter(
+            thresholdH: Snap.thresholdPixels / Double(videoRect.width),
+            thresholdV: Snap.thresholdPixels / Double(videoRect.height)
+        )
+        return (moved, guides)
     }
 }

--- a/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP static rotation", .serialized)
+@MainActor
+struct MCPStaticRotationTests {
+    @Test func discoveryExposesRotationInTransformSchemas() async throws {
+        let harness = ToolHarness()
+
+        try await withClient(harness: harness, name: "rotation-discovery-test") { client in
+            let (tools, _) = try await client.listTools()
+
+            let clipTool = try #require(tools.first { $0.name == "set_clip_properties" })
+            let clipProperties = try #require(clipTool.inputSchema.objectValue?["properties"]?.objectValue)
+            let clipTransform = try #require(clipProperties["transform"]?.objectValue?["properties"]?.objectValue)
+            #expect(clipTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+
+            let addTool = try #require(tools.first { $0.name == "add_texts" })
+            let addProperties = try #require(addTool.inputSchema.objectValue?["properties"]?.objectValue)
+            let entries = try #require(addProperties["entries"]?.objectValue)
+            let entryProperties = try #require(entries["items"]?.objectValue?["properties"]?.objectValue)
+            let addTransform = try #require(entryProperties["transform"]?.objectValue?["properties"]?.objectValue)
+            #expect(addTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+
+            let updateTool = try #require(tools.first { $0.name == "update_text" })
+            let updateProperties = try #require(updateTool.inputSchema.objectValue?["properties"]?.objectValue)
+            let updateTransform = try #require(updateProperties["transform"]?.objectValue?["properties"]?.objectValue)
+            #expect(updateTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+        }
+    }
+
+    @Test func textRotationCreatesUpdatesReadsBackAndUndoesThroughMCP() async throws {
+        let harness = ToolHarness()
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        try await withClient(harness: harness, name: "text-rotation-test") { client in
+            let addResult = try await client.callTool(name: "add_texts", arguments: [
+                "entries": .array([.object([
+                    "startFrame": .int(0),
+                    "endFrame": .int(60),
+                    "content": .string("Rotated title"),
+                    "transform": .object(["rotation": .double(30)]),
+                ])]),
+            ])
+            #expect(addResult.isError != true)
+            let textClip = try #require(harness.editor.timeline.tracks.flatMap(\.clips).first { $0.mediaType == .text })
+            let clipId = textClip.id
+            #expect(textClip.transform.rotation == 30)
+            #expect(textClip.transform.width < 1)
+            #expect(textClip.transform.height < 1)
+            try await expectTimelineRotation(30, clipId: clipId, client: client)
+
+            let keyframeResult = try await client.callTool(name: "set_keyframes", arguments: [
+                "clipId": .string(clipId),
+                "property": .string("rotation"),
+                "keyframes": .array([
+                    .array([.int(0), .double(15)]),
+                    .array([.int(30), .double(45)]),
+                ]),
+            ])
+            #expect(keyframeResult.isError != true)
+
+            let updateResult = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(clipId)]),
+                "transform": .object(["rotation": .double(90)]),
+            ])
+            #expect(updateResult.isError != true)
+            let updateReceipt = try json(text(updateResult.content))
+            let notes = updateReceipt["notes"] as? [String]
+            #expect(notes?.contains { $0.contains("cleared existing rotation keyframes") } == true)
+            let updated = try #require(harness.editor.clipFor(id: clipId))
+            #expect(updated.transform.rotation == 90)
+            #expect(updated.rotationTrack == nil)
+            #expect(updated.transform.width == textClip.transform.width)
+            #expect(updated.transform.height == textClip.transform.height)
+            try await expectTimelineRotation(90, clipId: clipId, client: client)
+
+            let repeatedResult = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(clipId)]),
+                "transform": .object(["rotation": .double(90)]),
+            ])
+            #expect(repeatedResult.isError != true)
+            let repeatedReceipt = try json(text(repeatedResult.content))
+            #expect(repeatedReceipt["changed"] as? Bool == false)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            let restoredTrack = try #require(harness.editor.clipFor(id: clipId)?.rotationTrack)
+            #expect(restoredTrack.keyframes.map(\.value) == [15, 45])
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotation == 30)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: clipId)?.rotationTrack == nil)
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotation == 30)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: clipId) == nil)
+            #expect((try await client.callTool(name: "undo")).isError == true)
+        }
+    }
+
+    @Test func rotationDoesNotDisableContentAutoFitThroughMCP() async throws {
+        let harness = ToolHarness()
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        try await withClient(harness: harness, name: "rotation-auto-fit-test") { client in
+            let addResult = try await client.callTool(name: "add_texts", arguments: [
+                "entries": .array([.object([
+                    "startFrame": .int(0),
+                    "endFrame": .int(60),
+                    "content": .string("I"),
+                    "transform": .object(["rotation": .double(15)]),
+                ])]),
+            ])
+            #expect(addResult.isError != true)
+            let original = try #require(harness.editor.timeline.tracks.flatMap(\.clips).first { $0.mediaType == .text })
+
+            let updateResult = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(original.id)]),
+                "content": .string("A much longer title"),
+                "transform": .object(["rotation": .double(45)]),
+            ])
+            #expect(updateResult.isError != true)
+            let updated = try #require(harness.editor.clipFor(id: original.id))
+            #expect(updated.transform.rotation == 45)
+            #expect(updated.transform.width > original.transform.width)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            let restored = try #require(harness.editor.clipFor(id: original.id))
+            #expect(restored.textContent == "I")
+            #expect(restored.transform == original.transform)
+        }
+    }
+
+    @Test func genericRotationClearsKeyframesAndUndoRestoresThemThroughMCP() async throws {
+        var clip = Fixtures.clip(id: "video", start: 0, duration: 60)
+        clip.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0),
+            Keyframe(frame: 30, value: 45),
+        ])
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        try await withClient(harness: harness, name: "clip-rotation-test") { client in
+            let result = try await client.callTool(name: "set_clip_properties", arguments: [
+                "clipIds": .array([.string("video")]),
+                "transform": .object(["rotation": .double(-90)]),
+            ])
+            #expect(result.isError != true)
+            #expect(harness.editor.clipFor(id: "video")?.transform.rotation == -90)
+            #expect(harness.editor.clipFor(id: "video")?.rotationTrack == nil)
+            try await expectTimelineRotation(-90, clipId: "video", client: client)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: "video")?.transform.rotation == 0)
+            #expect(harness.editor.clipFor(id: "video")?.rotationTrack?.keyframes.map(\.value) == [0, 45])
+        }
+    }
+
+    @Test func stringTextRotationIsRejectedWithoutMutationOrUndo() async throws {
+        var clip = Fixtures.clip(id: "title", mediaRef: "", mediaType: .text, start: 0, duration: 60)
+        clip.textContent = "Title"
+        clip.transform.rotation = 12
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        try await withClient(harness: harness, name: "invalid-rotation-test") { client in
+            let result = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string("title")]),
+                "transform": .object(["rotation": .string("90")]),
+            ])
+
+            #expect(result.isError == true)
+            #expect(harness.editor.clipFor(id: "title")?.transform.rotation == 12)
+            #expect((try await client.callTool(name: "undo")).isError == true)
+        }
+    }
+
+    private func withClient(
+        harness: ToolHarness,
+        name: String,
+        operation: (Client) async throws -> Void
+    ) async throws {
+        let server = Server(
+            name: "palmier-pro-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: name, version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            try await operation(client)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
+    private func expectTimelineRotation(_ expected: Double, clipId: String, client: Client) async throws {
+        let timelineResult = try await client.callTool(name: "get_timeline")
+        let timeline = try json(text(timelineResult.content))
+        let clip = try #require(((timeline["tracks"] as? [[String: Any]]) ?? [])
+            .flatMap { ($0["clips"] as? [[String: Any]]) ?? [] }
+            .first { ($0["id"] as? String).map { clipId.hasPrefix($0) || $0.hasPrefix(clipId) } == true })
+        let transform = try #require(clip["transform"] as? [String: Any])
+        #expect((transform["rotation"] as? NSNumber)?.doubleValue == expected)
+        #expect((clip["keyframes"] as? [String: Any])?["rotation"] == nil)
+    }
+
+    private func json(_ value: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(value.utf8)) as? [String: Any])
+    }
+
+    private func text(_ content: [Tool.Content]) throws -> String {
+        for item in content {
+            if case .text(let value, _, _) = item { return value }
+        }
+        throw CocoaError(.coderReadCorrupt)
+    }
+}

--- a/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Testing
 @testable import PalmierPro
 
@@ -30,5 +31,29 @@ struct PreviewSelectionTests {
         editor.selectPreviewClip("first")
 
         #expect(editor.selectedClipIds == ["first", "second"])
+    }
+
+    @Test func rotatedTextUsesRotatedHitTarget() {
+        let editor = EditorViewModel()
+        var text = Fixtures.clip(id: "text", mediaRef: "", mediaType: .text, start: 0, duration: 20)
+        text.transform = Transform(width: 0.6, height: 0.1, rotation: 90)
+        var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [text])])
+        timeline.width = 320
+        timeline.height = 180
+        editor.timeline = timeline
+
+        let rotatedOnlyPoint = PreviewHitTester.clipID(
+            at: CGPoint(x: 160, y: 45),
+            viewSize: CGSize(width: 320, height: 180),
+            editor: editor
+        )
+        let unrotatedOnlyPoint = PreviewHitTester.clipID(
+            at: CGPoint(x: 100, y: 90),
+            viewSize: CGSize(width: 320, height: 180),
+            editor: editor
+        )
+
+        #expect(rotatedOnlyPoint == "text")
+        #expect(unrotatedOnlyPoint == nil)
     }
 }

--- a/Tests/PalmierProTests/Editor/RotationMutationTests.swift
+++ b/Tests/PalmierProTests/Editor/RotationMutationTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorViewModel — rotation mutation")
+@MainActor
+struct RotationMutationTests {
+    @Test func batchRotationCommitUndoesAllClipsTogether() {
+        let editor = EditorViewModel()
+        let undoManager = UndoManager()
+        editor.undo.attach(undoManager)
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "first", start: 0, duration: 20),
+                Fixtures.clip(id: "second", start: 20, duration: 20),
+            ]),
+        ])
+
+        editor.applyRotation(clipIds: ["first", "second"], valueDeg: 90)
+        editor.commitRotation(clipIds: ["first", "second"], valueDeg: 90)
+
+        #expect(editor.clipFor(id: "first")?.transform.rotation == 90)
+        #expect(editor.clipFor(id: "second")?.transform.rotation == 90)
+        #expect(editor.undo.undoLatest() == "Change Rotation")
+        #expect(editor.clipFor(id: "first")?.transform.rotation == 0)
+        #expect(editor.clipFor(id: "second")?.transform.rotation == 0)
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func batchRotationWritesActiveKeyframeTracks() throws {
+        let editor = EditorViewModel()
+        var staticClip = Fixtures.clip(id: "static", start: 0, duration: 20)
+        var animatedClip = Fixtures.clip(id: "animated", start: 0, duration: 20)
+        animatedClip.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0),
+        ])
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [staticClip]),
+            Fixtures.videoTrack(clips: [animatedClip]),
+        ])
+        editor.currentFrame = 10
+
+        editor.applyRotation(clipIds: ["static", "animated"], valueDeg: 45)
+        editor.commitRotation(clipIds: ["static", "animated"], valueDeg: 45)
+
+        staticClip = try #require(editor.clipFor(id: "static"))
+        animatedClip = try #require(editor.clipFor(id: "animated"))
+        #expect(staticClip.transform.rotation == 45)
+        #expect(staticClip.rotationTrack == nil)
+        #expect(animatedClip.transform.rotation == 0)
+        #expect(animatedClip.rotationAt(frame: 10) == 45)
+    }
+}

--- a/Tests/PalmierProTests/Editor/RotationSnapTests.swift
+++ b/Tests/PalmierProTests/Editor/RotationSnapTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Inspector rotation snapping")
+struct RotationSnapTests {
+    @Test(arguments: [
+        (-4.0, 0.0),
+        (4.0, 0.0),
+        (86.0, 90.0),
+        (94.0, 90.0),
+        (176.0, 180.0),
+        (184.0, 180.0),
+        (266.0, 270.0),
+        (274.0, 270.0),
+        (356.0, 360.0),
+        (-94.0, -90.0),
+    ]) func rotationsNearAxesSnap(rotation: Double, expected: Double) {
+        #expect(RotationSnap.adjusted(rotation) == expected)
+    }
+
+    @Test(arguments: [
+        4.01,
+        85.99,
+        94.01,
+        175.99,
+        184.01,
+        265.99,
+        274.01,
+    ]) func rotationsOutsideToleranceRemainExact(rotation: Double) {
+        #expect(RotationSnap.adjusted(rotation) == rotation)
+    }
+
+    @Test(arguments: [0.0, 90.0, 180.0, 270.0, 360.0, -90.0])
+    func axisAlignedRotationsShowGuides(rotation: Double) {
+        #expect(RotationSnap.isAxisAligned(rotation))
+    }
+
+    @Test(arguments: [0.01, 89.99, 179.99, 269.99, .infinity, .nan])
+    func otherRotationsHideGuides(rotation: Double) {
+        #expect(!RotationSnap.isAxisAligned(rotation))
+    }
+}

--- a/Tests/PalmierProTests/Editor/ScrubbableNumberFieldTests.swift
+++ b/Tests/PalmierProTests/Editor/ScrubbableNumberFieldTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Scrubbable number field")
+struct ScrubbableNumberFieldTests {
+    @Test(arguments: ["nan", "NaN", "inf", "-inf"])
+    func rejectsNonFiniteValues(_ text: String) {
+        let value = ScrubbableNumberField.committedValue(
+            from: text,
+            suffix: "°",
+            displayMultiplier: 1,
+            range: -360...360
+        )
+
+        #expect(value == nil)
+    }
+
+    @Test func parsesSuffixDecimalCommaAndClamps() {
+        let value = ScrubbableNumberField.committedValue(
+            from: "125,5%",
+            suffix: "%",
+            displayMultiplier: 100,
+            range: 0...1
+        )
+
+        #expect(value == 1)
+    }
+}

--- a/Tests/PalmierProTests/Editor/TextClipLayoutTests.swift
+++ b/Tests/PalmierProTests/Editor/TextClipLayoutTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorViewModel — text clip layout")
+@MainActor
+struct TextClipLayoutTests {
+    @Test func fittingTextPreservesRotationAndFlips() {
+        let editor = EditorViewModel()
+        var clip = Fixtures.clip(id: "text", mediaRef: "", mediaType: .text, start: 0, duration: 20)
+        clip.textContent = "Rotated text"
+        clip.transform = Transform(
+            centerX: 0.4,
+            centerY: 0.6,
+            width: 1,
+            height: 1,
+            rotation: 37,
+            flipHorizontal: true,
+            flipVertical: true
+        )
+
+        let changed = editor.fitTextClipToContentIfNeeded(&clip, canvasW: 1920, canvasH: 1080)
+
+        #expect(changed)
+        #expect(clip.transform.rotation == 37)
+        #expect(clip.transform.flipHorizontal)
+        #expect(clip.transform.flipVertical)
+    }
+}

--- a/Tests/PalmierProTests/Editor/TransformOverlayMathTests.swift
+++ b/Tests/PalmierProTests/Editor/TransformOverlayMathTests.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+import Testing
+@testable import PalmierPro
+
+@Suite("Preview transform overlay")
+struct TransformOverlayMathTests {
+    @Test func rotatedMoveSnapsToBothCanvasAxes() {
+        let start = Transform(
+            centerX: 0.496,
+            centerY: 0.51,
+            width: 0.4,
+            height: 0.2,
+            rotation: 37
+        )
+
+        let result = TransformOverlayMath.movedTransform(
+            start,
+            by: .zero,
+            in: CGRect(x: 0, y: 0, width: 1_000, height: 500)
+        )
+
+        #expect(result.transform.centerX == 0.5)
+        #expect(result.transform.centerY == 0.5)
+        #expect(result.guides.x)
+        #expect(result.guides.y)
+        #expect(result.transform.rotation == 37)
+    }
+
+    @Test func rotatedMoveReportsOnlyTheAlignedAxis() {
+        let start = Transform(centerX: 0.496, centerY: 0.7, rotation: 90)
+
+        let result = TransformOverlayMath.movedTransform(
+            start,
+            by: .zero,
+            in: CGRect(x: 0, y: 0, width: 1_000, height: 500)
+        )
+
+        #expect(result.transform.centerX == 0.5)
+        #expect(result.transform.centerY == 0.7)
+        #expect(result.guides.x)
+        #expect(!result.guides.y)
+    }
+}

--- a/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
@@ -24,6 +24,16 @@ struct CompositorTextLayerTests {
         return c
     }
 
+    private func backgroundTextClip(rotation: Double = 0) -> Clip {
+        var clip = textClip(" ")
+        var style = clip.textStyle ?? TextStyle()
+        style.color.a = 0
+        style.background = .init(enabled: true, color: .init(r: 1, g: 1, b: 1, a: 1))
+        clip.textStyle = style
+        clip.transform = Transform(width: 0.6, height: 0.2, rotation: rotation)
+        return clip
+    }
+
     /// White pixels in the discriminating band (x 40–150, y 72–108).
     private func whiteInBand(_ f: CompositorRenderTests.Frame) -> Int {
         var n = 0
@@ -53,6 +63,66 @@ struct CompositorTextLayerTests {
         )
         let f = try await CompositorRenderTests.render(behind, frame: 15, renderSize: Self.size)
         #expect(whiteInBand(f) == 0, "text behind an opaque video must be hidden: \(whiteInBand(f))")
+    }
+
+    @Test func textUsesVideoCanvasRotation() async throws {
+        let timeline = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [backgroundTextClip(rotation: 90)])
+        )
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(frame.at(160, 30)))
+        #expect(CompositorFixtures.isBlack(frame.at(80, 90)))
+    }
+
+    @Test func textRotationSamplesKeyframes() async throws {
+        var text = backgroundTextClip()
+        text.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0, interpolationOut: .linear),
+            Keyframe(frame: 30, value: 90, interpolationOut: .linear),
+        ])
+        let timeline = CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [text]))
+
+        let horizontal = try await CompositorRenderTests.render(timeline, frame: 0, renderSize: Self.size)
+        let vertical = try await CompositorRenderTests.render(timeline, frame: 30, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(horizontal.at(80, 90)))
+        #expect(CompositorFixtures.isBlack(horizontal.at(160, 30)))
+        #expect(CompositorFixtures.isWhite(vertical.at(160, 30)))
+        #expect(CompositorFixtures.isBlack(vertical.at(80, 90)))
+    }
+
+    @Test func textRenderingUsesFrameResolvedTransform() async throws {
+        var text = backgroundTextClip()
+        text.transform = Transform(centerX: 0.2, centerY: 0.2, width: 0.2, height: 0.1)
+        text.positionTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 30, value: AnimPair(a: 0.65, b: 0.2)),
+        ])
+        text.scaleTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 30, value: AnimPair(a: 0.2, b: 0.4)),
+        ])
+        text.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 30, value: 90),
+        ])
+        let timeline = CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [text]))
+
+        let frame = try await CompositorRenderTests.render(timeline, frame: 30, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(frame.at(240, 72)))
+        #expect(CompositorFixtures.isBlack(frame.at(64, 36)))
+    }
+
+    @Test func footageFillUsesTextRotation() async throws {
+        var text = backgroundTextClip(rotation: 90)
+        text.textFillMode = .footage
+        let timeline = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [text]),
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "bg")])
+        )
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(!CompositorFixtures.isBlack(frame.at(160, 30)))
+        #expect(CompositorFixtures.isBlack(frame.at(80, 90)))
     }
 
     @Test func footageFillStencilsVideoThroughGlyphs() async throws {

--- a/Tests/PalmierProTests/Timeline/KeyframeTests.swift
+++ b/Tests/PalmierProTests/Timeline/KeyframeTests.swift
@@ -161,6 +161,41 @@ struct KeyframeTrackSampleTests {
     }
 }
 
+@Suite("Clip transform sampling")
+struct ClipTransformSamplingTests {
+    @Test func sampledTransformPreservesStaticOrientation() {
+        var clip = Fixtures.clip(start: 10, duration: 60)
+        clip.transform = Transform(
+            centerX: 0.5,
+            centerY: 0.5,
+            width: 0.4,
+            height: 0.3,
+            rotation: 15,
+            flipHorizontal: true,
+            flipVertical: true
+        )
+        clip.positionTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 5, value: AnimPair(a: 0.2, b: 0.25)),
+        ])
+        clip.scaleTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 5, value: AnimPair(a: 0.5, b: 0.4)),
+        ])
+        clip.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 5, value: 90),
+        ])
+
+        let transform = clip.transformAt(frame: 15)
+
+        #expect(transform.centerX == 0.45)
+        #expect(transform.centerY == 0.45)
+        #expect(transform.width == 0.5)
+        #expect(transform.height == 0.4)
+        #expect(transform.rotation == 90)
+        #expect(transform.flipHorizontal)
+        #expect(transform.flipVertical)
+    }
+}
+
 @Suite("Interpolation primitives")
 struct InterpolationPrimitiveTests {
 


### PR DESCRIPTION
logic +317 - 126
tests +556 - 0

## Summary

- Add rotation controls to the text inspector and render text with the same canvas-pivot rotation used by visual clips.
- Snap rotation within 4° of 90° intervals and show the canvas X/Y axes while snapped.
- Keep rendering, keyframes, hit-testing, movement guides, auto-fit, batch undo, and footage-filled text consistent with the resolved text transform.
- Let the Agent create and update static clockwise rotation through `add_texts`, `update_text`, and `set_clip_properties`.
- Reject invalid numeric inspector and Agent input before it reaches editor state.

## Approach

- Extract the canvas rotation transform from the visual-clip composition path and reuse it after text rasterization, effects, and stencil generation.
- Resolve text position, size, and rotation at the current frame. Preserve static flip flags when constructing a frame-resolved transform.
- Reuse one `InspectorRotationField` in the visual and text inspectors. It owns snapping, guide lifecycle, and one atomic batch rotation commit for multi-selection.
- Extend the generic scrubbable number field with opt-in drag adjustment and observation hooks, while keeping rotation-specific behavior outside the generic component.
- Preserve rotation and flips when text auto-fit updates its position and dimensions.
- Continue center snapping for rotated clips while moving them. Edge snapping remains limited to unrotated clips because the existing edge calculation is axis-aligned.
- Reuse one partial-transform application path for Agent clip and text updates. Rotation-only text edits preserve auto-fit; setting a static rotation clears the rotation keyframe track so the requested value is visible and undo restores the exact prior state.
- Return an explicit `changed` receipt for property updates and reject empty, unknown, non-number, or non-finite transform input before mutation.

## Testing

Automated verification completed:

- `git diff --check` — passed.
- `swift test --filter 'ClipTransformSamplingTests|ScrubbableNumberFieldTests|CompositorTextLayerTests|TextFrameRendererTests|PreviewSelectionTests|RotationMutationTests|RotationSnapTests|TransformOverlayMathTests|TextClipLayoutTests|CompositionBuilderTests'` — 62 tests across 18 suites passed.
- `swift test --filter 'MCPStaticRotationTests|ToolExecutorTests'` — 131 tests across 7 suites passed.
- `swift test --filter MCPStaticRotationTests` — 5 end-to-end MCP tests in 1 suite passed, covering discovery, creation, update, readback, auto-fit, keyframe clearing, no-op receipts, validation, and undo.
- `swift build` — passed.
- `swift test` — 1,177 tests across 181 suites passed.

SwiftPM continues to emit the existing linker warning that some dependency objects were built for macOS 26.2 while the package links for macOS 26.0; it did not cause build or test failures.

Manual UI verification is not completed. Verify in the app:

1. Select a text clip and scrub rotation near 0°, 90°, 180°, and 270°. It should snap within 4° and show both canvas axes only while snapped.
2. Release rotation and move the clip. Rotation axes should disappear; center guides should appear only when movement aligns with the canvas center.
3. Resize or auto-fit rotated text. Position and dimensions should update without losing rotation.
4. Rotate multiple selected clips, then undo. All selected clips should return to their previous rotations in one undo action.
5. Confirm ordinary and footage-filled text render, select, and animate at the same rotated location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compositing, transform sampling, and agent mutation paths across preview and export; behavior is heavily tested but regressions in rotation/keyframe interaction are possible.
> 
> **Overview**
> **Text clips can be rotated** like visual clips: inspector controls (shared `InspectorRotationField` on video and text tabs), canvas-pivot rendering after rasterization, rotated preview hit-testing, and footage-fill stencils that respect rotation.
> 
> **Compositor and sampling changes** apply canvas rotation via shared `CompositionBuilder.canvasRotationTransform`, resolve text layout from `transformAt(frame:)` (including keyframed position/scale/rotation), and fix `Clip.transformAt` so animated transforms keep static flips/orientation.
> 
> **Inspector UX** adds 90° rotation snapping (4° tolerance) with canvas axis guides while scrubbing, batch `applyRotation`/`commitRotation` for multi-select, and stricter numeric parsing in `ScrubbableNumberField` (rejects non-finite values). Rotated clips still get center snap guides when moving; edge snap stays unrotated-only.
> 
> **Agent/MCP** exposes `transform.rotation` on `set_clip_properties`, `add_texts`, and `update_text`; static rotation clears rotation keyframes; rotation-only text transforms keep auto-fit; tool results include a `changed` flag.
> 
> **Tests** cover MCP rotation, compositor text rotation/keyframes, preview selection, snap math, and related editor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111210dc635a0679256d27e6aa243e3e0104c098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
