### PR TITLE
[fix/text animation] Hold complete typewriter text before clip end

### DIFF
--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -254,7 +254,10 @@ enum TextFrameRenderer {
             if i == tokens.count - 1, t.endFrame > t.startFrame {
                 let desiredHold = min(holdFrames, max(1, clip.durationFrames / 3))
                 let existingHold = max(1, clip.durationFrames - t.endFrame + 1)
-                let extraHold = max(0, desiredHold - existingHold)
+                let timingSpan = t.endFrame - t.startFrame
+                let minimumRevealFrames = min(timingSpan - 1, tok.range.length) + 1
+                let availableHoldFrames = timingSpan - minimumRevealFrames
+                let extraHold = min(max(0, desiredHold - existingHold), availableHoldFrames)
                 revealEnd = max(t.startFrame + 1, t.endFrame - extraHold)
             } else {
                 revealEnd = t.endFrame

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -240,6 +240,7 @@ enum TextFrameRenderer {
 
     private static func renderTypewriter(clip: Clip, content: String, style: TextStyle, boxes: LayoutBoxes,
                                          fontSize: CGFloat, frame: Int, renderSize: CGSize) -> CIImage? {
+        let holdFrames = 18
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
         let rel = frame - clip.startFrame
         let ns = content as NSString
@@ -249,10 +250,23 @@ enum TextFrameRenderer {
         var visLen = 0
         for (i, tok) in tokens.enumerated() {
             let t = timings[i]
-            if rel >= t.endFrame {
+            let revealEnd: Int
+            if i == tokens.count - 1, t.endFrame > t.startFrame {
+                let desiredHold = min(holdFrames, max(1, clip.durationFrames / 3))
+                let existingHold = max(1, clip.durationFrames - t.endFrame + 1)
+                let extraHold = max(0, desiredHold - existingHold)
+                revealEnd = max(t.startFrame + 1, t.endFrame - extraHold)
+            } else {
+                revealEnd = t.endFrame
+            }
+
+            if rel >= revealEnd {
                 visLen = tok.range.location + tok.range.length
             } else if rel >= t.startFrame {
-                let p = Double(rel - t.startFrame) / Double(max(1, t.endFrame - t.startFrame))
+                let span = revealEnd - t.startFrame
+                let p = span == 1
+                    ? 1
+                    : Double(rel - t.startFrame) / Double(span - 1)
                 visLen = tok.range.location + Int((Double(tok.range.length) * p).rounded(.down))
                 break
             } else {
@@ -262,7 +276,7 @@ enum TextFrameRenderer {
         var visible = ns.substring(to: min(visLen, ns.length))
         // Caret blinks (~0.5s) until shortly after the last word finishes.
         let doneAt = timings.last?.endFrame ?? clip.durationFrames
-        if rel <= doneAt + 18, (rel / 15) % 2 == 0 { visible += "|" }
+        if rel <= doneAt + holdFrames, (rel / 15) % 2 == 0 { visible += "|" }
         guard !visible.isEmpty else { return finish(ctx) }
         // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
         var attrs = style.attributes(size: fontSize)

--- a/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
@@ -84,6 +84,21 @@ struct TextAnimationRenderTests {
         #expect(actualPixels == expectedPixels)
     }
 
+    @Test func typewriterPreviewTypesFinalTokenBeforeHold() {
+        var animated = clip(TextAnimation(preset: .typewriter))
+        animated.durationFrames = 54
+        animated.textContent = "Aa Bb Cc"
+        animated.textStyle?.alignment = .left
+        animated.wordTimings = nil
+        var expected = animated
+        expected.textAnimation = nil
+        expected.textContent = "Aa Bb |"
+
+        let actualPixels = pixels(animated, frame: 36)
+        let expectedPixels = pixels(expected, frame: 36)
+        #expect(actualPixels == expectedPixels)
+    }
+
     @Test func tokenTimingsSplitAlignedTranscriptSpan() {
         let tokens = [
             (range: NSRange(location: 0, length: 3), text: "New"),

--- a/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
@@ -62,6 +62,28 @@ struct TextAnimationRenderTests {
         #expect(yellow > 20, "active word should be highlighted yellow (\(yellow))")
     }
 
+    @Test func typewriterShowsCompleteTextOnFinalFrame() {
+        var animated = clip(TextAnimation(preset: .typewriter))
+        animated.textStyle?.alignment = .left
+        var expected = animated
+        expected.textAnimation = nil
+
+        let actualPixels = pixels(animated, frame: animated.endFrame - 1)
+        let expectedPixels = pixels(expected, frame: expected.endFrame - 1)
+        #expect(actualPixels == expectedPixels)
+    }
+
+    @Test func typewriterHoldsCompleteTextBeforeClipEnds() {
+        var animated = clip(TextAnimation(preset: .typewriter))
+        animated.textStyle?.alignment = .left
+        var expected = animated
+        expected.textAnimation = nil
+
+        let actualPixels = pixels(animated, frame: animated.endFrame - 15)
+        let expectedPixels = pixels(expected, frame: expected.endFrame - 15)
+        #expect(actualPixels == expectedPixels)
+    }
+
     @Test func tokenTimingsSplitAlignedTranscriptSpan() {
         let tokens = [
             (range: NSRange(location: 0, length: 3), text: "New"),


### PR DESCRIPTION
## Summary

- Fix the typewriter animation dropping its final character at the clip boundary.
- Hold the completed text for up to 18 frames so the final result remains readable before the clip ends.
- Add rendering regressions for both final-frame completeness and the completed-text hold.

The reveal previously reached 100% only at the exclusive word end frame, which the clip never rendered. Mapping the final sample to completion exposed the last character for only one frame, so the completed state was still effectively unreadable.

## Approach

- Treat the final renderable sample in a token timing as 100% progress.
- Adjust only the final token's reveal end, leaving earlier transcript and word timings unchanged.
- Preserve an existing tail hold when one is already present.
- Cap the requested hold at 18 frames and one third of the clip duration so short clips retain reveal time.

## Testing

- `swift test --filter TextAnimationRenderTests` — passed, 6 tests.
- `swift build` — passed.

Manual playback and export verification were not completed. Apply Typewriter to a text clip, play through its end, and confirm the final character appears and the completed text remains visible during the tail. Repeat with a short clip and a caption with transcript timings; earlier word timing should remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized compositing change to the typewriter animation path with new render tests; no security or data-handling impact.
> 
> **Overview**
> Fixes the **typewriter** preset so the full string (and a readable completed state) shows before the clip ends, instead of losing the last character at the boundary.
> 
> For the **last word token only**, reveal now finishes earlier when needed: up to **18 frames** (or one-third of clip length) of completed text can be held while earlier tokens and transcript timings stay the same. In-progress reveal maps the last sample in that window to **100%** progress (`span == 1` → full token), and the blinking caret uses the same **18-frame** tail.
> 
> Adds **pixel-level** regression tests for final-frame parity with static text, hold ~15 frames before end, and mid-clip behavior for the final token with even timings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f3122a61fc54c8630baf23ece82bacb87de2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->