### PR TITLE
[feat] Add preview playback speed controls

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -102,6 +102,7 @@ final class EditorViewModel {
     }
     var activeFrame: Int { playheadState.timelineFrame }
     var isPlaying: Bool = false
+    private(set) var playbackRate: PreviewPlaybackRate = .normal
     var selectedClipIds: Set<String> = []
     var isMarqueeSelecting: Bool = false
     var selectedGap: GapSelection?
@@ -363,6 +364,12 @@ final class EditorViewModel {
     var pendingSettingsContinuation: (@MainActor () -> Void)?
 
     // MARK: - Playback
+
+    func setPlaybackRate(_ rate: PreviewPlaybackRate) {
+        guard playbackRate != rate else { return }
+        playbackRate = rate
+        videoEngine?.setPlaybackRate(rate)
+    }
 
     func togglePlayback() {
         if let videoEngine {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -120,7 +120,20 @@ struct PreviewContainerView: View {
             if isTimeline || editor.activePreviewTab.clipType == .video {
                 captureFrameButton
             }
-            settingsMenuButton(label: zoomBadgeLabel, help: "Canvas Zoom") { zoomMenuItems }
+            settingsMenuButton(
+                systemImage: "speedometer",
+                label: editor.playbackRate.label,
+                help: "Playback Speed"
+            ) {
+                playbackRateMenuItems
+            }
+            settingsMenuButton(
+                systemImage: "magnifyingglass",
+                label: zoomBadgeLabel,
+                help: "Canvas Zoom"
+            ) {
+                zoomMenuItems
+            }
         }
         .padding(.horizontal, AppTheme.Spacing.lg)
         .frame(height: 36)
@@ -131,7 +144,13 @@ struct PreviewContainerView: View {
     private var imageSettingsBar: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
             Spacer()
-            settingsMenuButton(label: zoomBadgeLabel, help: "Canvas Zoom") { zoomMenuItems }
+            settingsMenuButton(
+                systemImage: "magnifyingglass",
+                label: zoomBadgeLabel,
+                help: "Canvas Zoom"
+            ) {
+                zoomMenuItems
+            }
         }
         .padding(.horizontal, AppTheme.Spacing.lg)
         .frame(height: 36)
@@ -152,7 +171,24 @@ struct PreviewContainerView: View {
         .tourAnchor(.screenshotButton)
     }
 
-    // MARK: - Project settings
+    // MARK: - Preview settings
+
+    @ViewBuilder
+    private var playbackRateMenuItems: some View {
+        ForEach(PreviewPlaybackRate.allCases, id: \.self) { rate in
+            Button {
+                editor.setPlaybackRate(rate)
+            } label: {
+                HStack {
+                    Text(rate.label)
+                    Spacer()
+                    if editor.playbackRate == rate {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
+    }
 
     @ViewBuilder
     private var zoomMenuItems: some View {
@@ -185,6 +221,7 @@ struct PreviewContainerView: View {
     }
 
     private func settingsMenuButton<MenuContent: View>(
+        systemImage: String,
         label: String,
         help: String,
         @ViewBuilder menu: @escaping () -> MenuContent
@@ -192,21 +229,31 @@ struct PreviewContainerView: View {
         Menu {
             menu()
         } label: {
-            badgeLabel(label)
+            badgeLabel(systemImage: systemImage, text: label)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
         .hoverHighlight()
         .help(help)
+        .accessibilityLabel(help)
+        .accessibilityValue(label)
     }
 
-    private func badgeLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: AppTheme.FontSize.xxs, weight: .bold, design: .rounded))
-            .foregroundStyle(AppTheme.Text.secondaryColor)
-            .padding(.horizontal, AppTheme.Spacing.sm)
-            .frame(height: AppTheme.IconSize.mdLg)
+    private func badgeLabel(systemImage: String, text: String) -> some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            Image(systemName: systemImage)
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold))
+            Text(text)
+                .font(.system(
+                    size: AppTheme.FontSize.xxs,
+                    weight: AppTheme.FontWeight.bold,
+                    design: .rounded
+                ))
+        }
+        .foregroundStyle(AppTheme.Text.secondaryColor)
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .frame(height: AppTheme.IconSize.mdLg)
     }
 
     // MARK: - Image preview

--- a/Sources/PalmierPro/Preview/PreviewPlaybackRate.swift
+++ b/Sources/PalmierPro/Preview/PreviewPlaybackRate.swift
@@ -1,0 +1,28 @@
+enum PreviewPlaybackRate: Float, CaseIterable, Sendable {
+    case half = 0.5
+    case threeQuarters = 0.75
+    case normal = 1
+    case oneAndHalf = 1.5
+    case double = 2
+    case quadruple = 4
+    case tenfold = 10
+
+    var label: String {
+        switch self {
+        case .half: "0.5×"
+        case .threeQuarters: "0.75×"
+        case .normal: "1×"
+        case .oneAndHalf: "1.5×"
+        case .double: "2×"
+        case .quadruple: "4×"
+        case .tenfold: "10×"
+        }
+    }
+
+    var allowsAudioMetering: Bool {
+        switch self {
+        case .half, .threeQuarters, .normal, .oneAndHalf, .double: true
+        case .quadruple, .tenfold: false
+        }
+    }
+}

--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -190,6 +190,16 @@ final class ScrubAudioEngine {
         }
     }
 
+    func stopPlaybackMetering() {
+        latestMeterSample = nil
+        if latestRequest == nil {
+            decodeTask?.cancel()
+            decodeTask = nil
+            pendingDecodeRange = nil
+        }
+        meter.reset()
+    }
+
     func stopScrubbing() {
         resetScrubState()
         output.stop()

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -49,7 +49,8 @@ final class VideoEngine {
     init(editor: EditorViewModel) {
         self.editor = editor
         scrubAudioEngine = ScrubAudioEngine(meter: editor.audioMeter)
-        setupTimeObserver()
+        player.defaultRate = editor.playbackRate.rawValue
+        installTimeObserver(for: editor.playbackRate)
     }
 
     func teardown() {
@@ -64,6 +65,17 @@ final class VideoEngine {
     }
 
     // MARK: - Playback
+
+    func setPlaybackRate(_ rate: PreviewPlaybackRate) {
+        player.defaultRate = rate.rawValue
+        installTimeObserver(for: rate)
+        if !rate.allowsAudioMetering {
+            scrubAudioEngine.stopPlaybackMetering()
+        }
+        if editor?.isPlaying == true {
+            player.rate = rate.rawValue
+        }
+    }
 
     func play() {
         guard let editor else { return }
@@ -367,7 +379,7 @@ final class VideoEngine {
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
         scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix, resetMeter: false)
-        if editor.isPlaying {
+        if editor.isPlaying, editor.playbackRate.allowsAudioMetering {
             scrubAudioEngine.meterPlayback(at: player.currentTime())
         } else if let time = playerTime(forPreviewFrame: editor.activeFrame) {
             cancelInteractiveSeek()
@@ -585,32 +597,48 @@ final class VideoEngine {
 
     // MARK: - Time Observer
 
-    private func setupTimeObserver() {
-        guard let editor else { return }
-        let interval = CMTime(value: 1, timescale: CMTimeScale(editor.timeline.fps))
+    private func installTimeObserver(for playbackRate: PreviewPlaybackRate) {
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+            self.timeObserver = nil
+        }
+        let interval = Self.playheadObserverInterval(for: playbackRate)
         timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
             MainActor.assumeIsolated {
-                guard let self, let editor = self.editor else { return }
-                guard editor.isPlaying, !editor.isScrubbing else { return }
-                self.scrubAudioEngine.meterPlayback(at: time)
-
-                let frame = SourceMediaTimebase.relativeFrame(
-                    absoluteTime: time,
-                    fps: editor.timeline.fps,
-                    trackStart: self.sourceTrackStart
-                )
-                let duration = editor.activePreviewDurationFrames
-                let clamped = duration > 0 ? min(frame, duration) : frame
-                if editor.activePreviewTab == .timeline {
-                    editor.currentFrame = clamped
-                } else {
-                    editor.sourcePlayheadFrame = clamped
-                }
-                if duration > 0, frame >= duration {
-                    self.pause()
-                }
+                self?.updatePlaybackTime(time)
             }
         }
+    }
+
+    private func updatePlaybackTime(_ time: CMTime) {
+        guard let editor, editor.isPlaying, !editor.isScrubbing else { return }
+        if editor.playbackRate.allowsAudioMetering {
+            scrubAudioEngine.meterPlayback(at: time)
+        }
+
+        let frame = SourceMediaTimebase.relativeFrame(
+            absoluteTime: time,
+            fps: editor.timeline.fps,
+            trackStart: sourceTrackStart
+        )
+        let duration = editor.activePreviewDurationFrames
+        let clamped = duration > 0 ? min(frame, duration) : frame
+        if editor.activePreviewTab == .timeline {
+            editor.currentFrame = clamped
+        } else {
+            editor.sourcePlayheadFrame = clamped
+        }
+        if duration > 0, frame >= duration {
+            pause()
+        }
+    }
+
+    nonisolated static func playheadObserverInterval(for playbackRate: PreviewPlaybackRate) -> CMTime {
+        let updatesPerSecond = 30.0
+        return CMTime(
+            seconds: Double(playbackRate.rawValue) / updatesPerSecond,
+            preferredTimescale: 600
+        )
     }
 
     private func playbackStartFrame(for editor: EditorViewModel) -> Int {

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -11,6 +11,12 @@ enum PreviewSeekMode: String {
 
 @MainActor
 final class VideoEngine {
+    enum VisualRefreshAction: Equatable {
+        case meterPlayback
+        case seekToActiveFrame
+        case none
+    }
+
     private(set) var player = AVPlayer()
     private let scrubAudioEngine: ScrubAudioEngine
 
@@ -19,6 +25,7 @@ final class VideoEngine {
     weak var editor: EditorViewModel?
 
     private var timeObserver: Any?
+    private var playbackEndObserver: NSObjectProtocol?
     private var rebuildTask: Task<Void, Never>?
     private(set) var sourcePreviewTask: Task<Void, Never>?
     private var sourcePreviewGeneration = 0
@@ -51,6 +58,7 @@ final class VideoEngine {
         scrubAudioEngine = ScrubAudioEngine(meter: editor.audioMeter)
         player.defaultRate = editor.playbackRate.rawValue
         installTimeObserver(for: editor.playbackRate)
+        installPlaybackEndObserver()
     }
 
     func teardown() {
@@ -62,6 +70,8 @@ final class VideoEngine {
         scrubAudioEngine.teardown()
         if let timeObserver { player.removeTimeObserver(timeObserver) }
         timeObserver = nil
+        if let playbackEndObserver { NotificationCenter.default.removeObserver(playbackEndObserver) }
+        playbackEndObserver = nil
     }
 
     // MARK: - Playback
@@ -72,7 +82,7 @@ final class VideoEngine {
         if !rate.allowsAudioMetering {
             scrubAudioEngine.stopPlaybackMetering()
         }
-        if editor?.isPlaying == true {
+        if editor?.isPlaying == true, player.timeControlStatus != .paused {
             player.rate = rate.rawValue
         }
     }
@@ -379,11 +389,15 @@ final class VideoEngine {
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
         scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix, resetMeter: false)
-        if editor.isPlaying, editor.playbackRate.allowsAudioMetering {
+        switch Self.visualRefreshAction(isPlaying: editor.isPlaying, playbackRate: editor.playbackRate) {
+        case .meterPlayback:
             scrubAudioEngine.meterPlayback(at: player.currentTime())
-        } else if let time = playerTime(forPreviewFrame: editor.activeFrame) {
+        case .seekToActiveFrame:
+            guard let time = playerTime(forPreviewFrame: editor.activeFrame) else { return }
             cancelInteractiveSeek()
             performSeek(time: time, tolerance: .zero)
+        case .none:
+            break
         }
     }
 
@@ -596,6 +610,41 @@ final class VideoEngine {
     }
 
     // MARK: - Time Observer
+
+    nonisolated static func visualRefreshAction(
+        isPlaying: Bool,
+        playbackRate: PreviewPlaybackRate
+    ) -> VisualRefreshAction {
+        guard isPlaying else { return .seekToActiveFrame }
+        return playbackRate.allowsAudioMetering ? .meterPlayback : .none
+    }
+
+    private func installPlaybackEndObserver() {
+        playbackEndObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.didPlayToEndTimeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let object = notification.object else { return }
+            let itemIdentifier = ObjectIdentifier(object as AnyObject)
+            MainActor.assumeIsolated {
+                self?.handlePlaybackEnd(for: itemIdentifier)
+            }
+        }
+    }
+
+    private func handlePlaybackEnd(for itemIdentifier: ObjectIdentifier) {
+        guard let item = player.currentItem,
+              ObjectIdentifier(item) == itemIdentifier,
+              let editor else { return }
+        pause()
+        let duration = editor.activePreviewDurationFrames
+        if editor.activePreviewTab == .timeline {
+            editor.currentFrame = duration
+        } else {
+            editor.sourcePlayheadFrame = duration
+        }
+    }
 
     private func installTimeObserver(for playbackRate: PreviewPlaybackRate) {
         if let timeObserver {

--- a/Tests/PalmierProTests/Editor/PreviewPlaybackRateTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewPlaybackRateTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Testing
 @testable import PalmierPro
 
@@ -48,6 +49,84 @@ struct PreviewPlaybackRateTests {
         #expect(editor.playbackRate == .quadruple)
         #expect(engine.player.defaultRate == 4)
         #expect(engine.player.rate == 0)
+    }
+
+    @Test func visualRefreshNeverSeeksDuringPlayback() {
+        #expect(VideoEngine.visualRefreshAction(isPlaying: true, playbackRate: .normal) == .meterPlayback)
+        #expect(VideoEngine.visualRefreshAction(isPlaying: true, playbackRate: .quadruple) == .none)
+        #expect(VideoEngine.visualRefreshAction(isPlaying: false, playbackRate: .quadruple) == .seekToActiveFrame)
+    }
+
+    @Test func rateChangeDoesNotStartDeferredPlayback() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        engine.player.replaceCurrentItem(with: AVPlayerItem(asset: AVMutableComposition()))
+        editor.isPlaying = true
+
+        editor.setPlaybackRate(.quadruple)
+
+        #expect(engine.player.defaultRate == 4)
+        #expect(engine.player.rate == 0)
+    }
+
+    @Test func rateChangeUpdatesActivePlayback() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.pause()
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        engine.player.replaceCurrentItem(with: AVPlayerItem(asset: AVMutableComposition()))
+        editor.isPlaying = true
+        engine.player.play()
+
+        editor.setPlaybackRate(.quadruple)
+
+        #expect(engine.player.rate == 4)
+    }
+
+    @Test func currentItemEndStopsPlayback() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        let item = AVPlayerItem(asset: AVMutableComposition())
+        engine.player.replaceCurrentItem(with: item)
+        editor.isPlaying = true
+        editor.currentFrame = 1
+
+        NotificationCenter.default.post(name: AVPlayerItem.didPlayToEndTimeNotification, object: item)
+
+        #expect(!editor.isPlaying)
+        #expect(editor.currentFrame == editor.activePreviewDurationFrames)
+    }
+
+    @Test func anotherPlayerItemEndingDoesNotStopPlayback() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        let currentItem = AVPlayerItem(asset: AVMutableComposition())
+        engine.player.replaceCurrentItem(with: currentItem)
+        editor.isPlaying = true
+
+        let otherItem = AVPlayerItem(asset: AVMutableComposition())
+        NotificationCenter.default.post(name: AVPlayerItem.didPlayToEndTimeNotification, object: otherItem)
+
+        #expect(editor.isPlaying)
     }
 
     @Test func fastPlaybackRateResetsTheAudioMeter() {

--- a/Tests/PalmierProTests/Editor/PreviewPlaybackRateTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewPlaybackRateTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Preview playback rate")
+@MainActor
+struct PreviewPlaybackRateTests {
+    @Test func presetsMatchReviewSpeeds() {
+        #expect(PreviewPlaybackRate.allCases.map(\.rawValue) == [0.5, 0.75, 1, 1.5, 2, 4, 10])
+        #expect(PreviewPlaybackRate.allCases.map(\.label) == [
+            "0.5×",
+            "0.75×",
+            "1×",
+            "1.5×",
+            "2×",
+            "4×",
+            "10×",
+        ])
+    }
+
+    @Test(arguments: PreviewPlaybackRate.allCases)
+    func observerCadenceStaysAtThirtyUpdatesPerSecond(rate: PreviewPlaybackRate) {
+        let interval = VideoEngine.playheadObserverInterval(for: rate)
+        let updatesPerSecond = Double(rate.rawValue) / interval.seconds
+        #expect(abs(updatesPerSecond - 30) < 0.0001)
+    }
+
+    @Test func audioMeteringStopsAboveDoubleSpeed() {
+        #expect(PreviewPlaybackRate.allCases.filter(\.allowsAudioMetering) == [
+            .half,
+            .threeQuarters,
+            .normal,
+            .oneAndHalf,
+            .double,
+        ])
+    }
+
+    @Test func selectionUpdatesThePlayerDefaultRate() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+
+        editor.setPlaybackRate(.quadruple)
+
+        #expect(editor.playbackRate == .quadruple)
+        #expect(engine.player.defaultRate == 4)
+        #expect(engine.player.rate == 0)
+    }
+
+    @Test func fastPlaybackRateResetsTheAudioMeter() {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        editor.audioMeter.ingest(AudioMeterAnalysis(leftPeak: 1, rightPeak: 0.5), at: 100)
+
+        editor.setPlaybackRate(.quadruple)
+
+        let display = editor.audioMeter.display(at: 100)
+        #expect(display.left.levelDb == AudioMeterChannelState.floorDb)
+        #expect(display.right.levelDb == AudioMeterChannelState.floorDb)
+    }
+}


### PR DESCRIPTION
## Summary

- Add preview playback speeds from 0.5× through 10× for reviewing long timelines and source clips without exporting first.
- Show the current speed beside a speedometer icon and make canvas zoom easier to identify with a magnifying-glass icon.
- Keep fast playback responsive by bounding playhead updates and disabling visual audio metering above 2×.

## Approach

- Store playback rate as transient editor state and apply it through the existing `VideoEngine`; it is not persisted or added to undo history.
- Use `AVPlayer.defaultRate` so timeline and source-preview playback share the selected rate.
- Scale the periodic observer interval with the selected rate to hold playhead/UI work near 30 updates per wall-clock second.
- Stop and reset the visual audio-meter decoder above 2× while leaving playback audio unchanged.
- Generate the speed menu from a single preset enum covering 0.5×, 0.75×, 1×, 1.5×, 2×, 4×, and 10×.

## Testing

- `swift build` — passed.
- `swift test` — passed, 1,199 tests in 184 suites.
- Focused playback-rate coverage verifies presets, observer cadence, player rate selection, and the audio-meter cutoff.
- Time Profiler samples at 4× and 10× guided the metering cutoff; a follow-up 10× sample showed no audio-meter decode or offline-mixer stacks.
- Manual visual review of the transport controls was completed during development. Automated UI testing and the full mouse/keyboard/focus matrix across every preview type were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core preview playback (`VideoEngine`, playhead sync, and audio metering) with behavior changes at high speeds and end-of-playback handling; scope is preview-only with solid test coverage.
> 
> **Overview**
> Adds **preview playback speed** from **0.5× through 10×** for timeline and source video review, wired through transient editor state and `AVPlayer.defaultRate` (not persisted or undoable).
> 
> The preview transport bar gets a **speedometer** menu showing the current rate with checkmarks; **canvas zoom** badges now use a **magnifying-glass** icon and shared badge styling with accessibility labels.
> 
> **`VideoEngine`** scales the periodic playhead observer with the selected rate (~30 UI updates per wall-clock second), applies rate changes to active playback without starting deferred play, and handles **end-of-item** via `didPlayToEndTime` (ignoring other items). Above **2×**, **visual audio metering** is disabled and reset via `ScrubAudioEngine.stopPlaybackMetering()`; `refreshVisuals` avoids seeks during fast playback.
> 
> New **`PreviewPlaybackRate`** enum and focused unit tests cover presets, observer cadence, player rates, metering cutoff, and end-of-playback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e4286728a1a2fcb64a1451fa7817f54413d77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->