### PR TITLE
[perf] Keep large caption workflows responsive

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -73,9 +73,14 @@ extension EditorViewModel {
     }
 
     func captionTargets(ids: [String]) -> [Clip] {
-        let pool: [Clip] = ids.isEmpty
-            ? timeline.tracks.flatMap(\.clips)
-            : ids.compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+        let clips = timeline.tracks.flatMap(\.clips)
+        let pool: [Clip]
+        if ids.isEmpty {
+            pool = clips
+        } else {
+            let selectedIds = Set(ids)
+            pool = clips.filter { selectedIds.contains($0.id) }
+        }
         return captionTargets(in: pool)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -36,19 +36,13 @@ extension EditorViewModel {
         }
     }
 
-    func captionLineFits(_ line: String, style: TextStyle) -> Bool {
-        let size = TextLayout.naturalSize(
-            content: line, style: style, maxWidth: .greatestFiniteMagnitude, canvasHeight: CGFloat(timeline.height)
-        )
-        return size.width <= CGFloat(timeline.width) * AppTheme.ComponentSize.captionPreviewMaxTextWidthRatio
-    }
-
     enum CaptionError: LocalizedError {
-        case noSource
+        case noSource, timelineChanged
 
         var errorDescription: String? {
             switch self {
             case .noSource: "No audio clips to caption."
+            case .timelineChanged: "The timeline changed while captions were being prepared. Generate captions again."
             }
         }
     }
@@ -127,13 +121,35 @@ extension EditorViewModel {
 
         guard timeline(for: owningTimelineId) != nil else { return [] }
         if activeTimelineId != owningTimelineId { activateTimeline(owningTimelineId) }
+        targets = resolvedCaptionTargets(for: request)
+        guard !targets.isEmpty else { throw CaptionError.noSource }
 
         if request.autoDetect {
             guard let winner = dominantSpeechTrack(targets, results) else { return [] }
             targets = targets.filter { $0.trackId == winner }
         }
 
-        let specs = captionSpecs(targets, results: results, request: request)
+        let preparationRevision = timelineRenderRevision
+        let animation: TextAnimation? = request.animation.isActive ? request.animation : nil
+        let input = CaptionSpecBuilder.Input(
+            targets: targets.compactMap { target in
+                results[target.clip.mediaRef].map { CaptionSpecBuilder.Target(clip: target.clip, result: $0) }
+            },
+            fps: timeline.fps,
+            canvasWidth: timeline.width,
+            canvasHeight: timeline.height,
+            style: request.style,
+            center: request.center,
+            textCase: request.textCase,
+            maxWords: request.maxWords,
+            animation: animation
+        )
+        let specs = try await CaptionSpecBuilder.build(input)
+        try Task.checkCancellation()
+        guard activeTimelineId == owningTimelineId,
+              timelineRenderRevision == preparationRevision else {
+            throw CaptionError.timelineChanged
+        }
         guard !specs.isEmpty else { return [] }
         if let mutation {
             return try await mutation { self.placeCaptionTrack(specs) }
@@ -249,42 +265,6 @@ extension EditorViewModel {
             wordsByTrack[t.trackId, default: 0] += CaptionTranscriptMapper.spokenWordCount(in: t.clip, result: result, fps: timeline.fps)
         }
         return wordsByTrack.filter { $0.value > 0 }.max { $0.value < $1.value }?.key
-    }
-
-    private func captionSpecs(_ targets: [CaptionTarget], results: [String: TranscriptionResult], request: CaptionRequest) -> [TextClipSpec] {
-        let fps = timeline.fps
-        let groupId = UUID().uuidString
-        let transformFor = captionTransform(style: request.style, center: request.center)
-
-        let animation: TextAnimation? = request.animation.isActive ? request.animation : nil
-        return targets.flatMap { t -> [TextClipSpec] in
-            guard let result = results[t.clip.mediaRef] else { return [] }
-            let phrases = CaptionTranscriptMapper.phrases(
-                for: t.clip,
-                result: result,
-                fps: fps,
-                maxWords: request.maxWords,
-                minDuration: AppTheme.Caption.minDisplayDuration,
-                fits: { captionLineFits($0, style: request.style) }
-            )
-            guard !phrases.isEmpty else { return [] }
-            let cased = phrases.map { CaptionBuilder.Phrase(text: request.textCase.apply($0.text), start: $0.start, end: $0.end, words: $0.words) }
-            return CaptionBuilder.specs(for: cased, sourceClip: t.clip, trackIndex: 0, fps: fps, style: request.style, captionGroupId: groupId, animation: animation, transformFor: transformFor)
-        }
-    }
-
-    private func captionTransform(style: TextStyle, center: CGPoint) -> (String) -> Transform? {
-        let canvasW = Double(timeline.width), canvasH = Double(timeline.height)
-        return { text in
-            let natural = TextLayout.naturalSize(
-                content: text, style: style, maxWidth: CGFloat(canvasW) * AppTheme.ComponentSize.captionPreviewMaxTextWidthRatio, canvasHeight: CGFloat(canvasH)
-            )
-            return Transform(
-                center: (Double(center.x), Double(center.y)),
-                width: Double(natural.width) / canvasW,
-                height: Double(natural.height) / canvasH
-            )
-        }
     }
 
     private func placeCaptionTrack(_ specs: [TextClipSpec]) -> [String] {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -129,12 +129,13 @@ extension EditorViewModel {
         targets = resolvedCaptionTargets(for: request)
         guard !targets.isEmpty else { throw CaptionError.noSource }
 
+        let preparationTimeline = timeline
+
         if request.autoDetect {
             guard let winner = dominantSpeechTrack(targets, results) else { return [] }
             targets = targets.filter { $0.trackId == winner }
         }
 
-        let preparationRevision = timelineRenderRevision
         let animation: TextAnimation? = request.animation.isActive ? request.animation : nil
         let input = CaptionSpecBuilder.Input(
             targets: targets.compactMap { target in
@@ -151,8 +152,10 @@ extension EditorViewModel {
         )
         let specs = try await CaptionSpecBuilder.build(input)
         try Task.checkCancellation()
-        guard activeTimelineId == owningTimelineId,
-              timelineRenderRevision == preparationRevision else {
+        guard captionPreparationIsCurrent(
+            timelineId: owningTimelineId,
+            snapshot: preparationTimeline
+        ) else {
             throw CaptionError.timelineChanged
         }
         guard !specs.isEmpty else { return [] }
@@ -197,6 +200,13 @@ extension EditorViewModel {
                 CaptionTarget(id: c.id, trackId: timeline.tracks[$0.trackIndex].id, clip: timeline.tracks[$0.trackIndex].clips[$0.clipIndex])
             }
         }
+    }
+
+    func captionPreparationIsCurrent(
+        timelineId: String,
+        snapshot: Timeline
+    ) -> Bool {
+        activeTimelineId == timelineId && timeline == snapshot
     }
 
     private struct TranscribeJob {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -743,7 +743,7 @@ extension EditorViewModel {
         }
     }
 
-    struct TextClipSpec {
+    struct TextClipSpec: Sendable {
         let trackIndex: Int
         let startFrame: Int
         let durationFrames: Int
@@ -766,51 +766,72 @@ extension EditorViewModel {
         let canvasW = Double(timeline.width)
         let canvasH = Double(timeline.height)
         var createdIds = [String?](repeating: nil, count: specs.count)
+        var batchTimeline = clearExistingRegions ? nil : timeline
 
-        let indicesByTrack = Dictionary(grouping: specs.indices, by: { specs[$0].trackIndex })
-        for (_, indices) in indicesByTrack {
-            let ordered = indices.sorted { specs[$0].startFrame < specs[$1].startFrame }
-            for i in ordered {
-                let spec = specs[i]
-                guard timeline.tracks.indices.contains(spec.trackIndex) else { continue }
-                let start = max(0, spec.startFrame)
-                let duration = max(1, spec.durationFrames)
-                if clearExistingRegions {
-                    clearRegion(trackIndex: spec.trackIndex, start: start, end: start + duration, prune: false)
+        let orderedIndices: [Int]
+        if clearExistingRegions {
+            orderedIndices = Dictionary(grouping: specs.indices, by: { specs[$0].trackIndex })
+                .values.flatMap { indices in
+                    indices.sorted { specs[$0].startFrame < specs[$1].startFrame }
                 }
-
-                let resolved: Transform
-                if let t = spec.transform {
-                    resolved = t
-                } else {
-                    let natural = TextLayout.naturalSize(
-                        content: spec.content, style: spec.style, maxWidth: CGFloat(canvasW) * 0.9, canvasHeight: CGFloat(canvasH)
-                    )
-                    let w = Double(natural.width) / canvasW
-                    let h = Double(natural.height) / canvasH
-                    resolved = Transform(topLeft: ((1 - w) / 2, (1 - h) / 2), width: w, height: h)
-                }
-                var clip = Clip(
-                    mediaRef: "",
-                    mediaType: .text,
-                    sourceClipType: .text,
-                    startFrame: start,
-                    durationFrames: duration,
-                    transform: resolved
-                )
-                clip.textContent = spec.content
-                clip.textStyle = spec.style
-                clip.captionGroupId = spec.captionGroupId
-                clip.wordTimings = spec.words
-                clip.textAnimation = spec.animation
-                clip.textFillMode = spec.fillMode == .footage ? .footage : nil
-                timeline.tracks[spec.trackIndex].clips.append(clip)
-                createdIds[i] = clip.id
-            }
+        } else {
+            orderedIndices = Array(specs.indices)
         }
 
-        for i in Set(specs.map(\.trackIndex)) where timeline.tracks.indices.contains(i) {
-            sortClips(trackIndex: i)
+        for i in orderedIndices {
+            let spec = specs[i]
+            let trackExists = batchTimeline?.tracks.indices.contains(spec.trackIndex)
+                ?? timeline.tracks.indices.contains(spec.trackIndex)
+            guard trackExists else { continue }
+            let start = max(0, spec.startFrame)
+            let duration = max(1, spec.durationFrames)
+            if clearExistingRegions {
+                clearRegion(trackIndex: spec.trackIndex, start: start, end: start + duration, prune: false)
+            }
+
+            let resolved: Transform
+            if let t = spec.transform {
+                resolved = t
+            } else {
+                let natural = TextLayout.naturalSize(
+                    content: spec.content, style: spec.style, maxWidth: CGFloat(canvasW) * 0.9, canvasHeight: CGFloat(canvasH)
+                )
+                let w = Double(natural.width) / canvasW
+                let h = Double(natural.height) / canvasH
+                resolved = Transform(topLeft: ((1 - w) / 2, (1 - h) / 2), width: w, height: h)
+            }
+            var clip = Clip(
+                mediaRef: "",
+                mediaType: .text,
+                sourceClipType: .text,
+                startFrame: start,
+                durationFrames: duration,
+                transform: resolved
+            )
+            clip.textContent = spec.content
+            clip.textStyle = spec.style
+            clip.captionGroupId = spec.captionGroupId
+            clip.wordTimings = spec.words
+            clip.textAnimation = spec.animation
+            clip.textFillMode = spec.fillMode == .footage ? .footage : nil
+            if batchTimeline != nil {
+                batchTimeline!.tracks[spec.trackIndex].clips.append(clip)
+            } else {
+                timeline.tracks[spec.trackIndex].clips.append(clip)
+            }
+            createdIds[i] = clip.id
+        }
+
+        if var updatedTimeline = batchTimeline {
+            guard createdIds.contains(where: { $0 != nil }) else { return [] }
+            for i in Set(specs.map(\.trackIndex)) where updatedTimeline.tracks.indices.contains(i) {
+                updatedTimeline.tracks[i].clips.sort { $0.startFrame < $1.startFrame }
+            }
+            timeline = updatedTimeline
+        } else {
+            for i in Set(specs.map(\.trackIndex)) where timeline.tracks.indices.contains(i) {
+                sortClips(trackIndex: i)
+            }
         }
         if refreshVisuals {
             videoEngine?.refreshVisuals()

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -1,6 +1,41 @@
 import AppKit
 import SwiftUI
 
+struct InspectorClipSelection {
+    private(set) var textClips: [Clip] = []
+    private(set) var nonTextVisualClips: [Clip] = []
+    private(set) var audioClips: [Clip] = []
+    private(set) var firstVisualClip: Clip?
+
+    var clipCount: Int {
+        textClips.count + nonTextVisualClips.count + audioClips.count
+    }
+
+    var firstAudioClip: Clip? { audioClips.first }
+
+    static func resolve(timeline: Timeline, selectedIds: Set<String>) -> InspectorClipSelection {
+        guard !selectedIds.isEmpty else { return InspectorClipSelection() }
+        var selection = InspectorClipSelection()
+        for track in timeline.tracks {
+            for clip in track.clips where selectedIds.contains(clip.id) {
+                if clip.mediaType == .audio {
+                    selection.audioClips.append(clip)
+                } else if clip.mediaType.isVisual {
+                    if selection.firstVisualClip == nil {
+                        selection.firstVisualClip = clip
+                    }
+                    if clip.mediaType == .text {
+                        selection.textClips.append(clip)
+                    } else {
+                        selection.nonTextVisualClips.append(clip)
+                    }
+                }
+            }
+        }
+        return selection
+    }
+}
+
 struct InspectorView: View {
     @Environment(EditorViewModel.self) var editor
 
@@ -33,12 +68,8 @@ struct InspectorView: View {
         VStack(alignment: .leading, spacing: 0) {
             if editor.isMarqueeSelecting {
                 marqueeSelectionSummary
-            } else if selectedVisualClip != nil || selectedAudioClip != nil {
-                clipInspectorContent()
-            } else if let asset = selectedMediaAsset {
-                mediaAssetInspectorContent(asset)
             } else {
-                projectMetadataContent
+                resolvedInspectorContent
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -54,6 +85,21 @@ struct InspectorView: View {
         }
     }
 
+    @ViewBuilder
+    private var resolvedInspectorContent: some View {
+        let selection = InspectorClipSelection.resolve(
+            timeline: editor.timeline,
+            selectedIds: editor.selectedClipIds
+        )
+        if selection.clipCount > 0 {
+            clipInspectorContent(selection: selection)
+        } else if let asset = selectedMediaAsset {
+            mediaAssetInspectorContent(asset)
+        } else {
+            projectMetadataContent
+        }
+    }
+
     private var marqueeSelectionSummary: some View {
         VStack {
             Spacer()
@@ -66,8 +112,8 @@ struct InspectorView: View {
     }
 
     private func resolvePreferredTab() {
-        let isSingleText = selectedVisualClips.count + selectedAudioClips.count == 1
-            && selectedVisualClip?.mediaType == .text
+        let isSingleText = editor.selectedClipIds.count == 1
+            && editor.selectedClipIds.first.flatMap { editor.clipFor(id: $0) }?.mediaType == .text
         if isSingleText {
             preferredTab = .text
         } else if preferredTab == .text {
@@ -222,10 +268,14 @@ struct InspectorView: View {
 
     // MARK: - Clip Inspector
 
-    private var availableTabs: [ClipTab] {
-        let audios = selectedAudioClips
-        let texts = selectedTextClips
-        let nonText = nonTextVisualClips
+    private func availableTabs(
+        for selection: InspectorClipSelection,
+        resolvedClipAsset: MediaAsset?,
+        selectedMulticamGroupId: String?
+    ) -> [ClipTab] {
+        let audios = selection.audioClips
+        let texts = selection.textClips
+        let nonText = selection.nonTextVisualClips
         let isTextOnly = !texts.isEmpty && nonText.isEmpty && audios.isEmpty
 
         var tabs: [ClipTab] = []
@@ -236,76 +286,86 @@ struct InspectorView: View {
         }
         if !audios.isEmpty { tabs.append(.audio) }
         if selectedMulticamGroupId != nil { tabs.append(.multicam) }
-        if aiEditEligible && !AccountService.shared.isMisconfigured { tabs.append(.ai) }
+        if aiEditEligible(selection: selection, resolvedClipAsset: resolvedClipAsset)
+            && !AccountService.shared.isMisconfigured {
+            tabs.append(.ai)
+        }
         return tabs
     }
 
-    /// Group of the first stamped clip in the selection, if it still resolves.
-    var selectedMulticamGroupId: String? {
-        (nonTextVisualClips + selectedAudioClips)
-            .compactMap(\.multicamGroupId)
-            .first { editor.multicamGroup(id: $0) != nil }
+    private func selectedMulticamGroupId(for selection: InspectorClipSelection) -> String? {
+        for clips in [selection.nonTextVisualClips, selection.audioClips] {
+            for clip in clips {
+                if let groupId = clip.multicamGroupId, editor.multicamGroup(id: groupId) != nil {
+                    return groupId
+                }
+            }
+        }
+        return nil
     }
 
-    /// True when the selection resolves to one AI-editable media source.
-    /// A linked video+audio pair counts as one source.
-    private var aiEditEligible: Bool {
-        let visuals = selectedVisualClips
-        let audios = selectedAudioClips
+    private func aiEditEligible(
+        selection: InspectorClipSelection,
+        resolvedClipAsset: MediaAsset?
+    ) -> Bool {
+        let visualCount = selection.textClips.count + selection.nonTextVisualClips.count
+        let audios = selection.audioClips
         guard resolvedClipAsset != nil else { return false }
-        if visuals.isEmpty { return audios.count == 1 }
-        guard visuals.count == 1 else { return false }
+        if visualCount == 0 { return audios.count == 1 }
+        guard visualCount == 1, let visual = selection.firstVisualClip else { return false }
         if audios.isEmpty { return true }
-        let partners = Set(editor.linkedPartnerIds(of: visuals[0].id))
+        let partners = Set(editor.linkedPartnerIds(of: visual.id))
         return audios.allSatisfy { partners.contains($0.id) }
     }
 
-    /// Tab the view actually renders (preferred if valid, else first available).
-    private var activeTab: ClipTab? {
-        let tabs = availableTabs
+    private func activeTab(in tabs: [ClipTab]) -> ClipTab? {
         return tabs.contains(preferredTab) ? preferredTab : tabs.first
     }
 
-    /// Media asset backing the selected visual clip, or a standalone audio clip.
-    private var resolvedClipAsset: MediaAsset? {
-        guard let clip = selectedVisualClip ?? selectedAudioClip else { return nil }
+    private func resolvedClipAsset(for selection: InspectorClipSelection) -> MediaAsset? {
+        guard let clip = selection.firstVisualClip ?? selection.firstAudioClip else { return nil }
         return editor.mediaAssets.first { $0.id == clip.mediaRef }
     }
 
-    var nonTextVisualClips: [Clip] {
-        selectedVisualClips.filter { $0.mediaType != .text }
-    }
-
-    private var selectedTextClips: [Clip] {
-        selectedVisualClips.filter { $0.mediaType == .text }
-    }
-
     @ViewBuilder
-    private func clipInspectorContent() -> some View {
-        let tabs = availableTabs
+    private func clipInspectorContent(selection: InspectorClipSelection) -> some View {
+        let clipAsset = resolvedClipAsset(for: selection)
+        let multicamGroupId = selectedMulticamGroupId(for: selection)
+        let tabs = availableTabs(
+            for: selection,
+            resolvedClipAsset: clipAsset,
+            selectedMulticamGroupId: multicamGroupId
+        )
+        let selectedTab = activeTab(in: tabs)
         VStack(spacing: 0) {
             if tabs.count > 1 {
-                tabBar(tabs)
+                tabBar(tabs, selectedTab: selectedTab)
             }
             Group {
-                if activeTab == .ai, let asset = resolvedClipAsset {
-                    AIEditTab(asset: asset, clipId: selectedVisualClip?.id ?? selectedAudioClip?.id)
-                } else if activeTab == .effects {
-                    ScrollView { effectsTabContent() }
+                if selectedTab == .ai, let asset = clipAsset {
+                    AIEditTab(asset: asset, clipId: selection.firstVisualClip?.id ?? selection.firstAudioClip?.id)
+                } else if selectedTab == .effects {
+                    ScrollView { effectsTabContent(clips: selection.nonTextVisualClips) }
                 } else {
                     ScrollView {
                         VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-                            switch activeTab {
+                            switch selectedTab {
                             case .text:
-                                if !selectedTextClips.isEmpty { TextTab(clips: selectedTextClips) }
+                                if !selection.textClips.isEmpty { TextTab(clips: selection.textClips) }
                             case .textAnimate:
-                                if !selectedTextClips.isEmpty { TextAnimateTab(clips: selectedTextClips) }
+                                if !selection.textClips.isEmpty { TextAnimateTab(clips: selection.textClips) }
                             case .video:
-                                videoTabContent()
+                                videoTabContent(
+                                    clips: selection.nonTextVisualClips,
+                                    audioClips: selection.audioClips
+                                )
                             case .audio:
-                                audioTabContent()
+                                audioTabContent(
+                                    audioClips: selection.audioClips,
+                                    hasNonTextVisualClips: !selection.nonTextVisualClips.isEmpty
+                                )
                             case .multicam:
-                                if let groupId = selectedMulticamGroupId {
+                                if let groupId = multicamGroupId {
                                     MulticamTab(groupId: groupId)
                                 }
                             case .effects, .ai, .none:
@@ -318,10 +378,10 @@ struct InspectorView: View {
         }
     }
 
-    private func tabBar(_ tabs: [ClipTab]) -> some View {
+    private func tabBar(_ tabs: [ClipTab], selectedTab: ClipTab?) -> some View {
         TitleTabBar(
             titles: tabs.map(\.rawValue),
-            selected: activeTab?.rawValue
+            selected: selectedTab?.rawValue
         ) { title in
             if let tab = tabs.first(where: { $0.rawValue == title }) { preferredTab = tab }
         }
@@ -337,11 +397,10 @@ struct InspectorView: View {
     }
 
     @ViewBuilder
-    private func videoTabContent() -> some View {
-        let clips = nonTextVisualClips
+    private func videoTabContent(clips: [Clip], audioClips: [Clip]) -> some View {
         transformSection(clips: clips)
         imageAdjustmentSection(clips: clips)
-        speedSection(clips: (clips + selectedAudioClips).filter(\.supportsRetiming))
+        speedSection(clips: (clips + audioClips).filter(\.supportsRetiming))
     }
 
     func keyframesToggleButton(enabled: Bool) -> some View {
@@ -1062,31 +1121,6 @@ struct InspectorView: View {
     }
 
     // MARK: - Helpers
-
-    private var selectedVisualClips: [Clip] {
-        guard !editor.selectedClipIds.isEmpty else { return [] }
-        var out: [Clip] = []
-        for track in editor.timeline.tracks {
-            for clip in track.clips where editor.selectedClipIds.contains(clip.id) && clip.mediaType.isVisual {
-                out.append(clip)
-            }
-        }
-        return out
-    }
-
-    var selectedAudioClips: [Clip] {
-        guard !editor.selectedClipIds.isEmpty else { return [] }
-        var out: [Clip] = []
-        for track in editor.timeline.tracks {
-            for clip in track.clips where editor.selectedClipIds.contains(clip.id) && clip.mediaType == .audio {
-                out.append(clip)
-            }
-        }
-        return out
-    }
-
-    private var selectedVisualClip: Clip? { selectedVisualClips.first }
-    private var selectedAudioClip: Clip? { selectedAudioClips.first }
 
     private var selectedMediaAsset: MediaAsset? {
         guard editor.selectedMediaAssetIds.count == 1,

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -103,8 +103,7 @@ extension InspectorView {
     }
 
     @ViewBuilder
-    func effectsTabContent() -> some View {
-        let clips = nonTextVisualClips
+    func effectsTabContent(clips: [Clip]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             adjustSection(title: "Basic Correction", effectIds: basicEffectIds, clips: clips) {
                 adjustSubgroup(title: "Tone", controls: toneControls, clips: clips)

--- a/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AudioTab.swift
@@ -3,16 +3,14 @@ import SwiftUI
 extension InspectorView {
 
     @ViewBuilder
-    func audioTabContent() -> some View {
-        let audios = selectedAudioClips
-
+    func audioTabContent(audioClips: [Clip], hasNonTextVisualClips: Bool) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-            levelsSection(audios: audios)
+            levelsSection(audios: audioClips)
             EditorPanelGroup("Enhance", contentSpacing: AppTheme.Spacing.smMd) {
-                denoiseRow(audios: audios)
+                denoiseRow(audios: audioClips)
             }
-            if nonTextVisualClips.isEmpty {
-                speedSection(clips: audios)
+            if !hasNonTextVisualClips {
+                speedSection(clips: audioClips)
             }
         }
     }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+import Foundation
+
+enum CaptionSpecBuilder {
+    struct Target: Sendable {
+        let clip: Clip
+        let result: TranscriptionResult
+    }
+
+    struct Input: Sendable {
+        let targets: [Target]
+        let fps: Int
+        let canvasWidth: Int
+        let canvasHeight: Int
+        let style: TextStyle
+        let center: CGPoint
+        let textCase: EditorViewModel.CaptionCase
+        let maxWords: Int?
+        let animation: TextAnimation?
+    }
+
+    @concurrent
+    static func build(_ input: Input) async throws -> [EditorViewModel.TextClipSpec] {
+        try Task.checkCancellation()
+        let groupId = UUID().uuidString
+        var specs: [EditorViewModel.TextClipSpec] = []
+
+        for target in input.targets {
+            try Task.checkCancellation()
+            let phrases = CaptionTranscriptMapper.phrases(
+                for: target.clip,
+                result: target.result,
+                fps: input.fps,
+                maxWords: input.maxWords,
+                minDuration: AppTheme.Caption.minDisplayDuration,
+                fits: { text in
+                    if Task.isCancelled { return true }
+                    return lineFits(
+                        text,
+                        style: input.style,
+                        canvasWidth: input.canvasWidth,
+                        canvasHeight: input.canvasHeight
+                    )
+                }
+            )
+            try Task.checkCancellation()
+            guard !phrases.isEmpty else { continue }
+
+            let cased = phrases.map {
+                CaptionBuilder.Phrase(
+                    text: input.textCase.apply($0.text),
+                    start: $0.start,
+                    end: $0.end,
+                    words: $0.words
+                )
+            }
+            specs.append(contentsOf: CaptionBuilder.specs(
+                for: cased,
+                sourceClip: target.clip,
+                trackIndex: 0,
+                fps: input.fps,
+                style: input.style,
+                captionGroupId: groupId,
+                animation: input.animation,
+                transformFor: { text in
+                    guard !Task.isCancelled else { return nil }
+                    return transform(
+                        for: text,
+                        style: input.style,
+                        center: input.center,
+                        canvasWidth: input.canvasWidth,
+                        canvasHeight: input.canvasHeight
+                    )
+                }
+            ))
+            try Task.checkCancellation()
+        }
+        return specs
+    }
+
+    private static func lineFits(
+        _ text: String,
+        style: TextStyle,
+        canvasWidth: Int,
+        canvasHeight: Int
+    ) -> Bool {
+        let size = TextLayout.naturalSize(
+            content: text,
+            style: style,
+            maxWidth: .greatestFiniteMagnitude,
+            canvasHeight: CGFloat(canvasHeight)
+        )
+        return size.width <= CGFloat(canvasWidth) * AppTheme.ComponentSize.captionPreviewMaxTextWidthRatio
+    }
+
+    private static func transform(
+        for text: String,
+        style: TextStyle,
+        center: CGPoint,
+        canvasWidth: Int,
+        canvasHeight: Int
+    ) -> Transform {
+        let width = Double(canvasWidth)
+        let height = Double(canvasHeight)
+        let natural = TextLayout.naturalSize(
+            content: text,
+            style: style,
+            maxWidth: CGFloat(width) * AppTheme.ComponentSize.captionPreviewMaxTextWidthRatio,
+            canvasHeight: CGFloat(height)
+        )
+        return Transform(
+            center: (Double(center.x), Double(center.y)),
+            width: Double(natural.width) / width,
+            height: Double(natural.height) / height
+        )
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -116,7 +116,14 @@ struct CaptionTab: View {
                 .sorted { languageName($0) < languageName($1) }
         }
         .onAppear { rememberSelectedClipTargets() }
-        .onChange(of: editor.selectedClipIds) { _, _ in rememberSelectedClipTargets() }
+        .onChange(of: editor.selectedClipIds) { _, _ in
+            guard !editor.isMarqueeSelecting else { return }
+            rememberSelectedClipTargets()
+        }
+        .onChange(of: editor.isMarqueeSelecting) { wasSelecting, isSelecting in
+            guard wasSelecting, !isSelecting else { return }
+            rememberSelectedClipTargets()
+        }
         .task(id: costEstimateKey) {
             estimatedCloudCost = nil
             guard provider == .cloud, effectiveCount > 0 else { return }

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -599,7 +599,7 @@ final class VideoEngine {
                     fps: editor.timeline.fps,
                     trackStart: self.sourceTrackStart
                 )
-                let duration = editor.activePreviewDurationFrames
+                let duration = self.playbackDurationFrames(for: editor)
                 let clamped = duration > 0 ? min(frame, duration) : frame
                 if editor.activePreviewTab == .timeline {
                     editor.currentFrame = clamped
@@ -614,7 +614,7 @@ final class VideoEngine {
     }
 
     private func playbackStartFrame(for editor: EditorViewModel) -> Int {
-        let duration = editor.activePreviewDurationFrames
+        let duration = playbackDurationFrames(for: editor)
         guard duration > 0 else { return 0 }
         let current = editor.activePreviewTab == .timeline ? editor.currentFrame : editor.sourcePlayheadFrame
         guard current >= duration else { return current }
@@ -624,6 +624,17 @@ final class VideoEngine {
             editor.sourcePlayheadFrame = 0
         }
         return 0
+    }
+
+    private func playbackDurationFrames(for editor: EditorViewModel) -> Int {
+        guard editor.activePreviewTab == .timeline else {
+            return editor.activePreviewDurationFrames
+        }
+        return SourceMediaTimebase.relativeFrame(
+            absoluteTime: compositionDuration,
+            fps: editor.timeline.fps,
+            trackStart: .zero
+        )
     }
 
     private static let interactiveSeekInterval: TimeInterval = 1.0 / 30.0

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -45,6 +45,22 @@ enum ClipRenderer {
         return min(clipRect.maxX - edgeInset, max(clipRect.minX + edgeInset, actual))
     }
 
+    static func usesCompactRendering(in rect: NSRect) -> Bool {
+        rect.width < AppTheme.ComponentSize.timelineClipBorderMinWidth
+    }
+
+    static func showsLabel(isSelected: Bool, in rect: NSRect) -> Bool {
+        let minimumWidth = isSelected
+            ? AppTheme.ComponentSize.timelineClipDetailMinWidth
+            : AppTheme.ComponentSize.timelineClipLabelMinWidth
+        return rect.width >= minimumWidth
+    }
+
+    static func showsFadeControls(isSelected: Bool, isHovered: Bool, in rect: NSRect) -> Bool {
+        guard !usesCompactRendering(in: rect) else { return false }
+        return isHovered || (isSelected && rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth)
+    }
+
     static func draw(
         _ clip: Clip,
         type: ClipType,
@@ -66,11 +82,20 @@ enum ClipRenderer {
             context.setAlpha(opacity)
         }
 
+        let colorType = clip.sourceClipType
+        if usesCompactRendering(in: rect) {
+            let color = isMissing && !isGenerating
+                ? AppTheme.Status.error
+                : (isSelected ? AppTheme.Text.primary : colorType.themeColor)
+            context.setFillColor(color.cgColor)
+            context.fill(rect)
+            if opacity < 1.0 { context.restoreGState() }
+            return
+        }
+
         let cornerRadius = Trim.clipCornerRadius
         let path = CGPath(roundedRect: rect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
 
-
-        let colorType = clip.sourceClipType
         context.setFillColor(colorType.themeColor.cgColor)
         context.addPath(path)
         context.fillPath()
@@ -101,7 +126,7 @@ enum ClipRenderer {
                          clip: clip, type: colorType, in: audioRect, context: context)
         }
 
-        let showsFadeControls = isSelected || isHovered
+        let showsFadeControls = showsFadeControls(isSelected: isSelected, isHovered: isHovered, in: rect)
         if type == .audio {
             drawVolumeRubberBand(clip: clip, in: rect, isSelected: isSelected, showsFadeControls: showsFadeControls, context: context)
         } else {
@@ -141,8 +166,8 @@ enum ClipRenderer {
             context.strokePath()
         }
 
-        let showDetailChrome = isSelected || rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth
-        let showLabel = isSelected || rect.width >= AppTheme.ComponentSize.timelineClipLabelMinWidth
+        let showDetailChrome = rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth
+        let showLabel = showsLabel(isSelected: isSelected, in: rect)
 
         if showLabel {
             drawLabelBar(clip: clip, type: type, in: labelRect, clipRect: rect, context: context,
@@ -783,8 +808,6 @@ enum ClipRenderer {
     }
 
     private static func drawLabelBar(clip: Clip, type: ClipType, in labelRect: NSRect, clipRect: NSRect, context: CGContext, displayName: String? = nil, badge: String? = nil, fps: Int) {
-        guard clipRect.width > 20 else { return }
-
         var labelRect = labelRect
         if let badge,
            let chipRect = drawPill(badge, textColor: NSColor.black.withAlphaComponent(AppTheme.Opacity.prominent),

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -487,13 +487,14 @@ final class TimelineInputController {
             }
             dragState = .marquee(marq)
             // Touch only what changed.
-            view.setNeedsDisplay(previousRect.union(marq.current).insetBy(dx: -2, dy: -2))
+            let padding = AppTheme.BorderWidth.thick
+            view.setNeedsDisplay(previousRect.union(marq.current).insetBy(dx: -padding, dy: -padding))
             if selected != editor.selectedClipIds {
                 let flipped = selected.symmetricDifference(editor.selectedClipIds)
                 editor.selectedClipIds = selected
                 for (ti, track) in editor.timeline.tracks.enumerated() {
                     for clip in track.clips where flipped.contains(clip.id) {
-                        view.setNeedsDisplay(geometry.clipRect(for: clip, trackIndex: ti).insetBy(dx: -2, dy: -2))
+                        view.setNeedsDisplay(geometry.clipRect(for: clip, trackIndex: ti).insetBy(dx: -padding, dy: -padding))
                     }
                 }
             }
@@ -542,6 +543,7 @@ final class TimelineInputController {
 
     func mouseUp(with event: NSEvent, geometry: TimelineGeometry) {
         stopPlayheadAutoScroll()
+        var finalDirtyRect: NSRect?
 
         switch dragState {
         case .moveClip(let drag):
@@ -644,8 +646,10 @@ final class TimelineInputController {
                 editor.revertClipProperty(clipId: drag.clipId)
             }
 
-        case .marquee:
+        case .marquee(let marquee):
             editor.isMarqueeSelecting = false
+            let padding = AppTheme.BorderWidth.thick
+            finalDirtyRect = marquee.current.insetBy(dx: -padding, dy: -padding)
 
         case .scrubPlayhead:
             finishPlayheadScrub()
@@ -659,7 +663,11 @@ final class TimelineInputController {
 
         dragState = .idle
         snapIndicatorX = nil
-        view.needsDisplay = true
+        if let finalDirtyRect {
+            view.setNeedsDisplay(finalDirtyRect)
+        } else {
+            view.needsDisplay = true
+        }
     }
 
     /// Escape during an in-progress slip drag: drop the preview and the pending
@@ -865,7 +873,11 @@ final class TimelineInputController {
     }
 
     func fadeKneeHit(at point: NSPoint, clip: Clip, clipRect: NSRect) -> FadeEdge? {
-        guard editor.selectedClipIds.contains(clip.id) || view.hoveredClipId == clip.id else { return nil }
+        guard ClipRenderer.showsFadeControls(
+            isSelected: editor.selectedClipIds.contains(clip.id),
+            isHovered: view.hoveredClipId == clip.id,
+            in: clipRect
+        ) else { return nil }
         let geo = view.geometry
         if geo.fadeKneeRect(clip: clip, edge: .left, in: clipRect).contains(point) { return .left }
         if geo.fadeKneeRect(clip: clip, edge: .right, in: clipRect).contains(point) { return .right }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -350,16 +350,22 @@ final class TimelineView: NSView {
         }
         let linkOffsets = cachedLinkOffsets
         let anglesByGroup = cachedAngleLabels
+        let selectedClipIds = editor.selectedClipIds
         func angleLabel(_ clip: Clip) -> String? {
             guard let groupId = clip.multicamGroupId else { return nil }
             return anglesByGroup[groupId]?[clip.mediaRef]
+        }
+
+        func displayName(_ clip: Clip, in rect: NSRect, isSelected: Bool) -> String? {
+            guard ClipRenderer.showsLabel(isSelected: isSelected, in: rect) else { return nil }
+            return editor.clipDisplayLabel(for: clip)
         }
 
         clipDisplayRects.removeAll(keepingCapacity: true)
         var deferredDraws: [() -> Void] = []
         for (ti, track) in editor.timeline.tracks.enumerated() {
             for clip in track.clips {
-                let isSelected = editor.selectedClipIds.contains(clip.id)
+                let isSelected = selectedClipIds.contains(clip.id)
                 let clipMissing = editor.isClipMediaOffline(clip)
                 let clipGenerating = editor.isClipMediaGenerating(clip)
 
@@ -372,7 +378,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
                                           isSelected: isSelected, opacity: CGFloat(AppTheme.Opacity.prominent), context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          displayName: displayName(clip, in: previewRect, isSelected: isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
                     }
@@ -387,7 +393,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(clip, type: clip.mediaType, in: originalRect,
                                           isSelected: drag.isDuplicate && isSelected, opacity: originalOpacity, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          displayName: displayName(clip, in: originalRect, isSelected: drag.isDuplicate && isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
                     }
@@ -413,7 +419,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(ghostClip, type: clip.mediaType, in: ghostRect,
                                           isSelected: true, opacity: 0.7, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          displayName: displayName(clip, in: ghostRect, isSelected: true),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
                     }
@@ -446,7 +452,7 @@ final class TimelineView: NSView {
                     if previewRect.intersects(dirtyRect) {
                         let chip = angleLabel(clip)
                         let cache = editor.mediaVisualCache
-                        let name = editor.clipDisplayLabel(for: clip)
+                        let name = displayName(clip, in: previewRect, isSelected: isSelected)
                         let fps = editor.timeline.fps
                         deferredDraws.append {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
@@ -484,7 +490,7 @@ final class TimelineView: NSView {
                     if rect.intersects(dirtyRect) {
                         let chip = angleLabel(clip)
                         let cache = editor.mediaVisualCache
-                        let name = editor.clipDisplayLabel(for: clip)
+                        let name = displayName(clip, in: rect, isSelected: isSelected)
                         let fps = editor.timeline.fps
                         deferredDraws.append {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: rect,
@@ -506,7 +512,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(shiftedClip, type: clip.mediaType, in: shiftedRect,
                                           isSelected: isSelected, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          displayName: editor.clipDisplayLabel(for: clip),
+                                          displayName: displayName(clip, in: shiftedRect, isSelected: isSelected),
                                           linkOffset: linkOffsets[clip.id],
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -520,7 +526,7 @@ final class TimelineView: NSView {
                 ClipRenderer.draw(clip, type: clip.mediaType, in: rect,
                                   isSelected: isSelected, isHovered: hoveredClipId == clip.id, context: ctx,
                                   cache: editor.mediaVisualCache,
-                                  displayName: editor.clipDisplayLabel(for: clip),
+                                  displayName: displayName(clip, in: rect, isSelected: isSelected),
                                   linkOffset: linkOffsets[clip.id],
                                   multicamAngleLabel: angleLabel(clip),
                                   fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -116,6 +116,27 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
 @MainActor
 @Suite struct CaptionTargetTests {
+    @Test func largeCaptionSelectionResolvesWithinInteractionBudget() {
+        let captions = (0..<10_000).map {
+            Fixtures.clip(
+                id: "caption-\($0)",
+                mediaRef: "caption-media-\($0)",
+                mediaType: .text,
+                start: $0 * 30,
+                duration: 30
+            )
+        }
+        let e = editor([Fixtures.videoTrack(clips: captions)])
+        var targets: [Clip] = []
+
+        let duration = ContinuousClock().measure {
+            targets = e.captionTargets(ids: captions.map(\.id))
+        }
+
+        #expect(targets.isEmpty)
+        #expect(duration < .seconds(1))
+    }
+
     @Test func linkedAndTrackTargetsChooseAudioSide() {
         let groupId = "linked-1"
         var video = Fixtures.clip(id: "video", mediaRef: "media-1", mediaType: .video, start: 0, duration: 100)

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -26,6 +26,20 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
 @MainActor
 @Suite struct CaptionPlacementTests {
+    @Test func bulkNonOverwritingPlacementMutatesTimelineOnce() {
+        let e = editor([Fixtures.videoTrack()])
+        let specs = (0..<1_000).map {
+            textSpec(start: $0 * 30, duration: 30, content: "caption \($0)")
+        }
+        let revision = e.timelineRenderRevision
+
+        let ids = e.placeTextClips(specs, clearExistingRegions: false, refreshVisuals: false)
+
+        #expect(ids.count == specs.count)
+        #expect(e.timelineRenderRevision == revision + 1)
+        #expect(e.timeline.tracks[0].clips.map(\.startFrame) == specs.map(\.startFrame))
+    }
+
     @Test func textClipsStayOnInsertedTrackWhenAClipIsOverwritten() {
         let e = editor([Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 300)])])
         e.timeline.tracks.insert(Track(type: .video), at: 0)
@@ -55,6 +69,48 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         _ = e.placeTextClips([textSpec(start: 0, duration: 50, content: "hi")])
         #expect(e.timeline.tracks.count == 2)
         #expect(e.timeline.tracks[0].clips.count == 1)
+    }
+}
+
+@Suite struct CaptionSpecBuilderTests {
+    @Test func buildsCaptionSpecsFromImmutableInput() async throws {
+        let clip = Fixtures.clip(
+            id: "source",
+            mediaRef: "media",
+            mediaType: .audio,
+            start: 0,
+            duration: 300
+        )
+        let result = TranscriptionResult(
+            text: "hello world",
+            language: "en",
+            words: [
+                TranscriptionWord(text: "hello", start: 1, end: 1.4),
+                TranscriptionWord(text: "world", start: 1.5, end: 2),
+            ],
+            segments: []
+        )
+        let input = CaptionSpecBuilder.Input(
+            targets: [.init(clip: clip, result: result)],
+            fps: 30,
+            canvasWidth: 1920,
+            canvasHeight: 1080,
+            style: TextStyle(),
+            center: CGPoint(x: 0.5, y: 0.8),
+            textCase: .upper,
+            maxWords: nil,
+            animation: nil
+        )
+
+        let specs = try await CaptionSpecBuilder.build(input)
+        let spec = try #require(specs.first)
+
+        #expect(specs.count == 1)
+        #expect(spec.content == "HELLO WORLD")
+        #expect(spec.startFrame == 30)
+        #expect(spec.durationFrames == 30)
+        #expect(spec.transform != nil)
+        #expect(spec.words?.map(\.text) == ["hello", "world"])
     }
 }
 

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -116,6 +116,27 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
 @MainActor
 @Suite struct CaptionTargetTests {
+    @Test func preparationTracksTimelineValueInsteadOfRenderRevision() {
+        let source = Fixtures.clip(
+            id: "source",
+            mediaRef: "source-media",
+            mediaType: .audio,
+            start: 0,
+            duration: 90
+        )
+        let e = editor([Fixtures.audioTrack(clips: [source])])
+        let timelineId = e.activeTimelineId
+        let snapshot = e.timeline
+
+        e.timelineRenderRevision &+= 1
+
+        #expect(e.captionPreparationIsCurrent(timelineId: timelineId, snapshot: snapshot))
+
+        e.timeline.tracks[0].clips[0].startFrame += 1
+
+        #expect(!e.captionPreparationIsCurrent(timelineId: timelineId, snapshot: snapshot))
+    }
+
     @Test func largeCaptionSelectionResolvesWithinInteractionBudget() {
         let captions = (0..<10_000).map {
             Fixtures.clip(

--- a/Tests/PalmierProTests/Inspector/InspectorClipSelectionTests.swift
+++ b/Tests/PalmierProTests/Inspector/InspectorClipSelectionTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import PalmierPro
+
+@Suite struct InspectorClipSelectionTests {
+    @Test func resolvesSelectedClipsByInspectorCategory() {
+        let text = Fixtures.clip(id: "text", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        let video = Fixtures.clip(id: "video", mediaRef: "video", mediaType: .video, start: 30, duration: 30)
+        let audio = Fixtures.clip(id: "audio", mediaRef: "audio", mediaType: .audio, start: 0, duration: 60)
+        let unselected = Fixtures.clip(id: "other", mediaRef: "other", mediaType: .text, start: 60, duration: 30)
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [text, video, unselected]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        let selection = InspectorClipSelection.resolve(
+            timeline: timeline,
+            selectedIds: [text.id, video.id, audio.id]
+        )
+
+        #expect(selection.textClips.map(\.id) == [text.id])
+        #expect(selection.nonTextVisualClips.map(\.id) == [video.id])
+        #expect(selection.audioClips.map(\.id) == [audio.id])
+        #expect(selection.firstVisualClip?.id == text.id)
+        #expect(selection.clipCount == 3)
+    }
+
+    @Test func largeCaptionSelectionResolvesWithinInteractionBudget() {
+        let captions = (0..<10_000).map { index in
+            Fixtures.clip(
+                id: "caption-\(index)",
+                mediaRef: "caption-media",
+                mediaType: .text,
+                start: index * 30,
+                duration: 30
+            )
+        }
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: captions)])
+        let selectedIds = Set(captions.map(\.id))
+
+        var selection = InspectorClipSelection()
+        let duration = ContinuousClock().measure {
+            selection = InspectorClipSelection.resolve(timeline: timeline, selectedIds: selectedIds)
+        }
+
+        #expect(selection.textClips.count == captions.count)
+        #expect(duration < .milliseconds(250))
+    }
+}

--- a/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
@@ -1,0 +1,40 @@
+import CoreGraphics
+import Testing
+@testable import PalmierPro
+
+@Suite struct ClipRendererPerformanceTests {
+    @Test func compactSelectedClipsRenderWithinInteractionBudget() throws {
+        let context = try #require(CGContext(
+            data: nil,
+            width: 1_000,
+            height: 64,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        let clip = Fixtures.clip(
+            id: "caption",
+            mediaRef: "caption-media",
+            mediaType: .text,
+            start: 0,
+            duration: 30
+        )
+
+        let duration = ContinuousClock().measure {
+            for index in 0..<50_000 {
+                ClipRenderer.draw(
+                    clip,
+                    type: .text,
+                    in: CGRect(x: CGFloat(index % 1_000), y: 0, width: 0.5, height: 64),
+                    isSelected: true,
+                    context: context,
+                    displayName: "Caption",
+                    fps: 30
+                )
+            }
+        }
+
+        #expect(duration < .seconds(2))
+    }
+}


### PR DESCRIPTION
## Summary

Large caption projects could block the main thread during caption preparation and repeated timeline mutation. Selecting or marquee-selecting thousands of captions also triggered repeated full-timeline scans, broad redraws, and unnecessary inspector synchronization.

This PR optimizes caption generation, bulk placement, selection, playback, and timeline rendering while preserving undo boundaries, selection behavior, preview consistency, and visible interaction rules.

## Approach

### Caption preparation

- Build caption phrases, text measurements, transforms, and clip specifications from immutable snapshots on a cooperative executor.
- Revalidate cancellation, active timeline identity, and timeline revision before committing prepared captions.

### Bulk placement and playback

- Batch non-overwriting text placement into one timeline assignment while preserving one undo action and one preview rebuild.
- Use the installed preview composition duration during timeline playback instead of scanning every clip on each playhead update.
- Convert composition duration directly through `CMTime` frame scaling so frame-aligned timelines do not stop or restart one frame early.
- Resolve caption targets from one flattened timeline snapshot instead of scanning the timeline once per selected clip.

### Marquee selection and inspector updates

- Resolve every selected clip category for the inspector in one timeline pass.
- Enter marquee-selection state before clearing selection so caption sources remain pinned throughout the gesture.
- Defer caption-panel target synchronization while a marquee gesture is active, then synchronize once after selection settles.
- Invalidate only the previous and current marquee regions during drag and the final marquee region on mouse-up.

### Timeline rendering

- Snapshot selected clip IDs once per draw pass.
- Skip labels, detail rendering, and fade-control work when a clip is too narrow to display them.
- Share volume-keyframe visibility rules between rendering and hit testing so hidden controls cannot intercept input.
- Keep fade-control hit testing aligned with the same renderer visibility rules.

### Coverage

- Add large-project regression and performance coverage for caption targeting, inspector selection, compact clip rendering, immutable caption preparation, and bulk placement.
- Cover exact composition frame counts and volume-keyframe visibility at compact widths.

## Testing

- `swift build` — passed.
- `swift test` — 1,213 tests passed in 188 suites.
- `swift build --traits BundledSpeech` — passed.
- Focused playback, caption generation, inspector selection, text preview, and clip-renderer suites — passed.
- Caption generation: a 3-hour podcast sample moved about 405 ms of caption layout work off the main thread and reduced main-thread placement from about 73 ms to 26 ms.
- Marquee and inspector: the latest comparable sample reduced inspector work from about 811 ms to 24 ms, with selection resolution at about 7 ms.
- Timeline rendering: remaining sampled time is primarily continuous timeline and waveform drawing rather than selection finalization or inspector resolution.
- Manual UI verification completed for large caption marquee selection, modifier selection, caption-source stability, inspector updates, compact timeline rendering and hit testing, final-frame playback, labels, keyframes, text fade handles, caption playback, and undo/redo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caption commit semantics, bulk timeline mutation, playback end frames, and selection/marquee ordering; regressions could affect undo, stale caption placement, or scrub/playhead bounds, though coverage targets large-project paths.
> 
> **Overview**
> Improves **responsiveness** when projects have thousands of caption clips by moving heavy work off the main thread, batching mutations, and narrowing redraw/selection work.
> 
> **Caption generation** builds phrase layout, text fitting, and `TextClipSpec` values in new **`CaptionSpecBuilder`** (cooperative/concurrent) from immutable input. Before placing clips, the flow re-resolves targets, checks cancellation, and compares the active timeline to a snapshot—throwing **`CaptionError.timelineChanged`** if the edit changed mid-flight. Caption target resolution for large ID lists uses one flattened clip pass with a `Set` instead of per-id lookups.
> 
> **Bulk text placement** (`placeTextClips` with `clearExistingRegions: false`) accumulates clips on a local timeline and assigns **`timeline` once**, cutting repeated render revisions while keeping a single undo boundary for caption track generation.
> 
> **Inspector** resolves selection in one pass via **`InspectorClipSelection`**; tab/content helpers take explicit clip lists instead of rescanning the timeline from computed properties.
> 
> **Marquee selection**: sets `isMarqueeSelecting` before clearing selection, defers caption-panel source updates until marquee ends, and invalidates only marquee dirty regions (including on mouse-up).
> 
> **Timeline preview playback** uses installed **composition duration** (frame-aligned via `CMTime` scaling) instead of scanning all clips each playhead tick.
> 
> **Timeline rendering / hit testing** share rules for compact clips (minimal fill), label visibility, fade handles, and volume keyframes so narrow selected captions skip expensive chrome and hidden controls do not receive hits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f83231602a5ba6e289f9cccba2feab775223b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->