### PR TITLE
[fix] Rebuild preview after adding text

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -855,7 +855,7 @@ extension EditorViewModel {
                 }
             }
             selectedClipIds = [clipId]
-            videoEngine?.refreshVisuals()
+            notifyTimelineChanged()
             return clipId
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -820,43 +820,32 @@ extension EditorViewModel {
 
     @discardableResult
     func addTextClip(content: String = "Text", style: TextStyle = TextStyle()) -> String? {
-        undo.perform("Add Text") {
-            let durationFrames = max(1, secondsToFrame(seconds: Defaults.textDurationSeconds, fps: timeline.fps))
+        let durationFrames = max(1, secondsToFrame(seconds: Defaults.textDurationSeconds, fps: timeline.fps))
+        let canvasW = Double(timeline.width)
+        let canvasH = Double(timeline.height)
+        let natural = TextLayout.naturalSize(content: content, style: style, maxWidth: CGFloat(canvasW) * 0.9, canvasHeight: CGFloat(canvasH))
+        let w = Double(natural.width) / canvasW
+        let h = Double(natural.height) / canvasH
+        let transform = Transform(topLeft: ((1 - w) / 2, (1 - h) / 2), width: w, height: h)
 
-            // Index 0 is the topmost slot in the timeline UI.
+        var clip = Clip(
+            mediaRef: "",
+            mediaType: .text,
+            sourceClipType: .text,
+            startFrame: max(0, currentFrame),
+            durationFrames: durationFrames,
+            transform: transform
+        )
+        clip.textContent = content
+        clip.textStyle = style
+        let clipId = clip.id
+
+        withTimelineSwap(actionName: "Add Text") {
             let trackIdx = insertTrack(at: 0, type: .video)
-
-            let canvasW = Double(timeline.width)
-            let canvasH = Double(timeline.height)
-            let natural = TextLayout.naturalSize(content: content, style: style, maxWidth: CGFloat(canvasW) * 0.9, canvasHeight: CGFloat(canvasH))
-            let w = Double(natural.width) / canvasW
-            let h = Double(natural.height) / canvasH
-            let transform = Transform(topLeft: ((1 - w) / 2, (1 - h) / 2), width: w, height: h)
-
-            var clip = Clip(
-                mediaRef: "",
-                mediaType: .text,
-                sourceClipType: .text,
-                startFrame: max(0, currentFrame),
-                durationFrames: durationFrames,
-                transform: transform
-            )
-            clip.textContent = content
-            clip.textStyle = style
-            let clipId = clip.id
-
             timeline.tracks[trackIdx].clips.append(clip)
             sortClips(trackIndex: trackIdx)
-
-            undo.register("Add Text", withTarget: self) { vm in
-                if let loc = vm.findClip(id: clipId) {
-                    vm.timeline.tracks[loc.trackIndex].clips.remove(at: loc.clipIndex)
-                    vm.notifyTimelineChanged()
-                }
-            }
-            selectedClipIds = [clipId]
-            notifyTimelineChanged()
-            return clipId
         }
+        selectedClipIds = [clipId]
+        return clipId
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -851,7 +851,7 @@ extension EditorViewModel {
             undo.register("Add Text", withTarget: self) { vm in
                 if let loc = vm.findClip(id: clipId) {
                     vm.timeline.tracks[loc.trackIndex].clips.remove(at: loc.clipIndex)
-                    vm.videoEngine?.refreshVisuals()
+                    vm.notifyTimelineChanged()
                 }
             }
             selectedClipIds = [clipId]

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -19,7 +19,7 @@ final class VideoEngine {
     weak var editor: EditorViewModel?
 
     private var timeObserver: Any?
-    private var rebuildTask: Task<Void, Never>?
+    private(set) var rebuildTask: Task<Void, Never>?
     private(set) var sourcePreviewTask: Task<Void, Never>?
     private var sourcePreviewGeneration = 0
     private var sourceTrackStart: CMTime = .zero

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -27,6 +27,7 @@ final class VideoEngine {
     private var timeObserver: Any?
     private var playbackEndObserver: NSObjectProtocol?
     private(set) var rebuildTask: Task<Void, Never>?
+    private var rebuildGeneration = 0
     private(set) var sourcePreviewTask: Task<Void, Never>?
     private var sourcePreviewGeneration = 0
     private var sourceTrackStart: CMTime = .zero
@@ -62,8 +63,7 @@ final class VideoEngine {
     }
 
     func teardown() {
-        rebuildTask?.cancel()
-        rebuildTask = nil
+        invalidateRebuild()
         cancelSourcePreviewLoad()
         compositionCache.removeAll()
         invalidateSeekState()
@@ -214,8 +214,7 @@ final class VideoEngine {
 
     func activateTab(_ tab: PreviewTab) {
         guard let editor else { return }
-        rebuildTask?.cancel()
-        rebuildTask = nil
+        invalidateRebuild()
         cancelSourcePreviewLoad()
         sourceTrackStart = .zero
         invalidateSeekState()
@@ -289,7 +288,7 @@ final class VideoEngine {
 
     func rebuild() {
         guard let editor, editor.activePreviewTab == .timeline else { return }
-        rebuildTask?.cancel()
+        let generation = invalidateRebuild()
 
         let mediaURLs = editor.mediaResolver.expectedURLMap()
         let missingMediaRefs = editor.missingMediaRefs
@@ -309,7 +308,6 @@ final class VideoEngine {
             missingMediaRefs: missingMediaRefs
         )
         if let cached = compositionCache[timelineId], cached.inputs == inputs {
-            rebuildTask = nil
             apply(cached.result, resolveTimeline: resolveTimeline, editor: editor)
             return
         }
@@ -327,13 +325,15 @@ final class VideoEngine {
                     renderSize: CGSize(width: snapshot.width, height: snapshot.height)
                 )
             } catch {
+                guard generation == rebuildGeneration else { return }
+                rebuildTask = nil
                 if !Task.isCancelled {
                     Log.preview.error("rebuild failed: \(error.localizedDescription)")
                 }
-                rebuildTask = nil
                 return
             }
 
+            guard generation == rebuildGeneration else { return }
             rebuildTask = nil
             guard !Task.isCancelled else { return }
 
@@ -343,6 +343,14 @@ final class VideoEngine {
             compositionCache = compositionCache.filter { editor.openTimelineIds.contains($0.key) }
             apply(result, resolveTimeline: resolveTimeline, editor: editor)
         }
+    }
+
+    @discardableResult
+    private func invalidateRebuild() -> Int {
+        rebuildGeneration &+= 1
+        rebuildTask?.cancel()
+        rebuildTask = nil
+        return rebuildGeneration
     }
 
     private var compositionCache: [String: (inputs: RebuildInputs, result: CompositionResult)] = [:]

--- a/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
@@ -1,0 +1,55 @@
+import AVFoundation
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Text clip playback", .serialized)
+@MainActor
+struct TextClipPlaybackTests {
+    @Test func addingTextAtTimelineEndExtendsPreviewComposition() async throws {
+        var existingText = Fixtures.clip(
+            id: "existing-text",
+            mediaRef: "",
+            mediaType: .text,
+            start: 0,
+            duration: 30
+        )
+        existingText.textContent = "Existing"
+
+        let editor = EditorViewModel()
+        let undoManager = UndoManager()
+        editor.undo.attach(undoManager)
+        editor.timeline = Fixtures.timeline(
+            fps: 30,
+            tracks: [Fixtures.videoTrack(clips: [existingText])]
+        )
+        editor.timeline.width = 64
+        editor.timeline.height = 64
+
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+
+        engine.rebuild()
+        try await #require(engine.rebuildTask).value
+        let initialItem = try #require(engine.player.currentItem)
+        let initialDuration = try await initialItem.asset.load(.duration)
+        #expect(CMTimeCompare(initialDuration, CMTime(value: 30, timescale: 30)) == 0)
+
+        editor.currentFrame = 30
+        let addedClipId = try #require(editor.addTextClip())
+        try await #require(engine.rebuildTask).value
+
+        let updatedItem = try #require(engine.player.currentItem)
+        let updatedDuration = try await updatedItem.asset.load(.duration)
+        #expect(CMTimeCompare(updatedDuration, CMTime(value: 120, timescale: 30)) == 0)
+        let instructions = try #require(updatedItem.videoComposition).instructions
+            .compactMap { $0 as? CompositorInstruction }
+        #expect(instructions.contains { instruction in
+            instruction.layers.contains { $0.clip.id == addedClipId }
+        })
+    }
+}

--- a/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
@@ -51,5 +51,17 @@ struct TextClipPlaybackTests {
         #expect(instructions.contains { instruction in
             instruction.layers.contains { $0.clip.id == addedClipId }
         })
+
+        #expect(editor.undo.undoLatest() == "Add Text")
+        try await #require(engine.rebuildTask).value
+
+        let restoredItem = try #require(engine.player.currentItem)
+        let restoredDuration = try await restoredItem.asset.load(.duration)
+        #expect(CMTimeCompare(restoredDuration, CMTime(value: 30, timescale: 30)) == 0)
+        let restoredInstructions = try #require(restoredItem.videoComposition).instructions
+            .compactMap { $0 as? CompositorInstruction }
+        #expect(restoredInstructions.allSatisfy { instruction in
+            instruction.layers.allSatisfy { $0.clip.id != addedClipId }
+        })
     }
 }

--- a/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
@@ -63,5 +63,17 @@ struct TextClipPlaybackTests {
         #expect(restoredInstructions.allSatisfy { instruction in
             instruction.layers.allSatisfy { $0.clip.id != addedClipId }
         })
+
+        undoManager.redo()
+        try await #require(engine.rebuildTask).value
+
+        let redoneItem = try #require(engine.player.currentItem)
+        let redoneDuration = try await redoneItem.asset.load(.duration)
+        #expect(CMTimeCompare(redoneDuration, CMTime(value: 120, timescale: 30)) == 0)
+        let redoneInstructions = try #require(redoneItem.videoComposition).instructions
+            .compactMap { $0 as? CompositorInstruction }
+        #expect(redoneInstructions.contains { instruction in
+            instruction.layers.contains { $0.clip.id == addedClipId }
+        })
     }
 }


### PR DESCRIPTION
## Summary

Text clips placed exactly at the end of the timeline could fail to appear or play until moved because the preview composition retained the previous timeline duration.

Adding text also started overlapping rebuilds: inserting its track notified the preview before the clip existed, then appending the clip started another rebuild. A canceled older rebuild could later clear the active rebuild handle, allowing playback to use stale preview state.

## Approach

- Apply track insertion and text insertion as one atomic timeline mutation with one undo entry and one preview notification.
- Restore the complete timeline state through the same path on undo and redo.
- Assign each preview rebuild a generation so canceled or superseded work cannot clear or apply over the current rebuild.
- Add deterministic regression coverage for composition duration and compositor layers after add, undo, and redo.

## Testing

- `swift test --filter TextClipPlaybackTests` — 1 test passed.
- `swift test --filter PreviewPlaybackRateTests` — 10 tests passed.
- `swift build` — passed.
- `swift test` — 1,205 tests passed in 185 suites.
- Manual UI verification remains: add text at the previous timeline end and immediately play, then undo and redo; repeat after rapidly adding several text clips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview composition rebuild concurrency and the add-text timeline mutation path; regression test covers the main failure mode but rapid multi-clip UI edge cases may still need manual checks.
> 
> **Overview**
> Fixes **stale or missing preview** when adding text at the previous timeline end, and when rapid rebuilds overlap.
> 
> **`addTextClip`** now runs **track insert + clip append** inside **`withTimelineSwap`** so the timeline changes once, registers one **“Add Text”** undo, and triggers **one** preview notification instead of separate steps that could rebuild before the clip existed.
> 
> **`VideoEngine`** assigns each **`rebuild()`** a **generation** via **`invalidateRebuild()`**; canceled or superseded async work no longer clears **`rebuildTask`** or **`apply`**s over a newer rebuild. **`rebuildTask`** is exposed read-only for tests to await completion.
> 
> Adds **`TextClipPlaybackTests`** asserting composition **duration** and compositor **layers** after add, undo, and redo when text is placed at frame 30 after a 30-frame clip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f88eff24bf4f598dedff6f2549bb70bdeff771f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->