### PR TITLE
[feat] Reactive caption resync — captions follow the audio under them

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -51,6 +51,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case addTexts = "add_texts"
     case updateText = "update_text"
     case addCaptions = "add_captions"
+    case resyncCaptions = "resync_captions"
 
     // Color & effects
     case applyColor = "apply_color"
@@ -803,6 +804,19 @@ enum ToolDefinitions {
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset."],
                     "highlightColor": ["type": "string", "description": "Active-word hex."],
                 ])
+            )
+        ),
+        AgentTool(
+            name: .resyncCaptions,
+            description: "Repair path for captions after audio edits: rebuilds caption text/timing from the cached transcript so each caption again shows the words currently under it. Captions normally resync automatically when you trim, ripple-delete, insert, or retime audio — call this only to force a rebuild, fix drift, or preview changes. Scope with captionGroupId (whole group), a startFrame/endFrame window, both (intersection), or neither (every caption group). onManualEdits controls hand-edited captions: preserve (keep, default), overwrite (replace), or flag. Reads the transcript cache only — it never re-transcribes, never edits asset transcripts. Returns the resync report (updated/removed/created/conflicts); dryRun returns the report without changing anything.",
+            inputSchema: objectSchema(
+                properties: [
+                    "captionGroupId": ["type": "string", "description": "Resync only this caption group."],
+                    "startFrame": ["type": "integer", "description": "Window start (inclusive). Pair with endFrame."],
+                    "endFrame": ["type": "integer", "description": "Window end (exclusive). Pair with startFrame."],
+                    "dryRun": ["type": "boolean", "description": "Report what would change without mutating. Default false."],
+                    "onManualEdits": ["type": "string", "enum": ["preserve", "overwrite", "flag"], "description": "How to treat hand-edited captions. Defaults to the project's conflict policy (preserve)."],
+                ]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionResync.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionResync.swift
@@ -16,8 +16,16 @@ extension ToolExecutor {
         // Resolve the spans to rebuild: an explicit group, an explicit range, their intersection,
         // or — when neither is given — every caption group in the project.
         let groupId = args.string("captionGroupId")
-        let rangeStart = args["startFrame"] as? Int
-        let rangeEnd = args["endFrame"] as? Int
+        // args.int handles MCP numeric shapes (Double-encoded ints); a raw `as? Int` cast would
+        // silently drop the window and fall through to every caption group.
+        let rangeStart = args.int("startFrame")
+        let rangeEnd = args.int("endFrame")
+        if args.keys.contains("startFrame"), rangeStart == nil {
+            throw ToolError("resync_captions: startFrame must be an integer frame")
+        }
+        if args.keys.contains("endFrame"), rangeEnd == nil {
+            throw ToolError("resync_captions: endFrame must be an integer frame")
+        }
         if let s = rangeStart, let e = rangeEnd, e <= s {
             throw ToolError("resync_captions: endFrame must be greater than startFrame")
         }
@@ -30,8 +38,11 @@ extension ToolExecutor {
             if let lo = clips.map(\.startFrame).min(), let hi = clips.map(\.endFrame).max(), hi > lo {
                 spans.append(lo..<hi)
             }
-        } else if let s = rangeStart, let e = rangeEnd {
-            spans.append(s..<e)
+        } else if rangeStart != nil || rangeEnd != nil {
+            // One-sided windows are valid: missing side spans to the timeline edge.
+            let s = rangeStart ?? 0
+            let e = rangeEnd ?? max(s + 1, editor.timeline.totalFrames)
+            if e > s { spans.append(s..<e) }
         } else {
             let groups = Set(editor.timeline.tracks.flatMap(\.clips)
                 .filter { $0.mediaType == .text }.compactMap(\.captionGroupId))
@@ -43,8 +54,10 @@ extension ToolExecutor {
                 }
             }
         }
-        // Clip the resolved spans to the requested window when both a group and a range are given.
-        if groupId != nil, let s = rangeStart, let e = rangeEnd {
+        // Clip the resolved spans to the requested window when a group and a range are given.
+        if groupId != nil, rangeStart != nil || rangeEnd != nil {
+            let s = rangeStart ?? 0
+            let e = rangeEnd ?? Int.max
             spans = spans.compactMap { span in
                 let lo = max(span.lowerBound, s), hi = min(span.upperBound, e)
                 return lo < hi ? lo..<hi : nil

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionResync.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionResync.swift
@@ -1,0 +1,97 @@
+// ToolExecutor+CaptionResync — the resync_captions escape hatch. Rebuilds caption text from the
+// cached transcript for a group or span using the same engine as the reactive triggers; dryRun
+// reports what would change without mutating. Also serializes CaptionResyncReport for tool payloads.
+
+import Foundation
+
+extension ToolExecutor {
+    static let resyncCaptionsAllowedKeys: Set<String> = ["captionGroupId", "startFrame", "endFrame", "dryRun", "onManualEdits"]
+
+    func resyncCaptions(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.resyncCaptionsAllowedKeys, path: "resync_captions")
+
+        let dryRun = args["dryRun"] as? Bool ?? false
+        let policyOverride = try parseConflictPolicy(args.string("onManualEdits"))
+
+        // Resolve the spans to rebuild: an explicit group, an explicit range, their intersection,
+        // or — when neither is given — every caption group in the project.
+        let groupId = args.string("captionGroupId")
+        let rangeStart = args["startFrame"] as? Int
+        let rangeEnd = args["endFrame"] as? Int
+        if let s = rangeStart, let e = rangeEnd, e <= s {
+            throw ToolError("resync_captions: endFrame must be greater than startFrame")
+        }
+
+        var spans: [Range<Int>] = []
+        if let groupId {
+            let ids = editor.captionGroupTextClipIds(groupId: groupId)
+            guard !ids.isEmpty else { throw ToolError("No caption clips found for captionGroupId: \(groupId)") }
+            let clips = ids.compactMap { editor.findClip(id: $0).map { editor.timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+            if let lo = clips.map(\.startFrame).min(), let hi = clips.map(\.endFrame).max(), hi > lo {
+                spans.append(lo..<hi)
+            }
+        } else if let s = rangeStart, let e = rangeEnd {
+            spans.append(s..<e)
+        } else {
+            let groups = Set(editor.timeline.tracks.flatMap(\.clips)
+                .filter { $0.mediaType == .text }.compactMap(\.captionGroupId))
+            for g in groups {
+                let clips = editor.captionGroupTextClipIds(groupId: g)
+                    .compactMap { editor.findClip(id: $0).map { editor.timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+                if let lo = clips.map(\.startFrame).min(), let hi = clips.map(\.endFrame).max(), hi > lo {
+                    spans.append(lo..<hi)
+                }
+            }
+        }
+        // Clip the resolved spans to the requested window when both a group and a range are given.
+        if groupId != nil, let s = rangeStart, let e = rangeEnd {
+            spans = spans.compactMap { span in
+                let lo = max(span.lowerBound, s), hi = min(span.upperBound, e)
+                return lo < hi ? lo..<hi : nil
+            }
+        }
+        guard !spans.isEmpty else { throw ToolError("resync_captions: nothing to resync in the requested range") }
+
+        if dryRun {
+            let report = editor.runCaptionResync(spans: spans, trigger: "resync_captions", dryRun: true, policyOverride: policyOverride)
+            let payload: [String: Any] = ["dryRun": true, "captionResync": report?.agentPayload ?? [:]]
+            return .ok(Self.jsonString(payload) ?? "{}")
+        }
+
+        let snapshot = timelineSnapshot(editor)
+        editor.undo.perform("Resync Captions") {
+            editor.runCaptionResync(spans: spans, trigger: "resync_captions", policyOverride: policyOverride)
+        }
+        return mutationResult(editor, since: snapshot)
+    }
+
+    private func parseConflictPolicy(_ raw: String?) throws -> CaptionConflictPolicy? {
+        guard let raw else { return nil }
+        guard let policy = CaptionConflictPolicy(rawValue: raw) else {
+            throw ToolError("resync_captions.onManualEdits must be one of: preserve, overwrite, flag")
+        }
+        return policy
+    }
+}
+
+extension CaptionResyncReport {
+    /// Compact dictionary for MCP payloads.
+    var agentPayload: [String: Any] {
+        var out: [String: Any] = ["trigger": trigger]
+        if !spans.isEmpty { out["spans"] = spans }
+        if !updated.isEmpty { out["updated"] = updated.map { ["clipId": $0.clipId, "before": $0.before, "after": $0.after] } }
+        if !removed.isEmpty { out["removed"] = removed.map { ["clipId": $0.clipId, "text": $0.text] } }
+        if !created.isEmpty {
+            out["created"] = created.map { c -> [String: Any] in
+                var row: [String: Any] = ["text": c.text, "startFrame": c.startFrame, "endFrame": c.endFrame]
+                if let id = c.clipId { row["clipId"] = id }
+                return row
+            }
+        }
+        if !conflicts.isEmpty {
+            out["conflicts"] = conflicts.map { ["clipId": $0.clipId, "manualText": $0.manualText, "newTranscript": $0.newTranscript] }
+        }
+        if !skippedRefs.isEmpty { out["skippedNoTranscript"] = skippedRefs }
+        return out
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -619,6 +619,7 @@ extension ToolExecutor {
         }
 
         let snapshot = timelineSnapshot(editor)
+        let beforeTimeline = editor.timeline
         let setActionName = clipIds.count == 1 ? "Set Clip Property (Agent)" : "Set Clip Properties (Agent)"
         editor.undo.perform(setActionName) {
             for id in clipIds {
@@ -660,6 +661,9 @@ extension ToolExecutor {
                     editor: editor
                 )
             }
+            // set_clip_properties bypasses withTimelineSwap; reconcile captions in the same undo group.
+            // A no-op unless a timing field (trim/speed/duration) actually changed an audible clip.
+            editor.resyncCaptionsAfterSwap(before: beforeTimeline, trigger: setActionName)
         }
         let changed = beforeClips.contains { id, clip in editor.clipFor(id: id) != clip }
         return mutationResult(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
@@ -74,6 +74,9 @@ extension ToolExecutor {
         shifts.sort { (($0["track"] as? Int) ?? 0, ($0["fromFrame"] as? Int) ?? 0) < (($1["track"] as? Int) ?? 0, ($1["fromFrame"] as? Int) ?? 0) }
 
         var payload = extra
+        if payload["captionResync"] == nil, let resync = editor.takeResyncReport(), !resync.isEmpty {
+            payload["captionResync"] = resync.agentPayload
+        }
         let captionGroups = collapseCaptionGroups(editor, changed: &changed)
         if !captionGroups.isEmpty { payload["captionGroups"] = captionGroups }
         var clips = readShapedClips(editor, ids: changed)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Transcription.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Transcription.swift
@@ -495,16 +495,7 @@ extension ToolExecutor {
     }
 
     private static func spanFrames(start: Double, end: Double, clip: Clip, fps: Int) -> (start: Int, end: Int)? {
-        let rate = Double(fps)
-        let visible = CaptionTranscriptMapper.sourceSpan(for: clip)
-        let startFrame = max(start * rate, visible.start)
-        let endFrame = min(end * rate, visible.end)
-        guard endFrame > startFrame else { return nil }
-        func toTimeline(_ sourceFrame: Double) -> Int {
-            Int((Double(clip.startFrame) + (sourceFrame - visible.start) / max(clip.speed, 0.0001)).rounded())
-        }
-        let mappedStart = toTimeline(startFrame)
-        return (mappedStart, max(mappedStart, toTimeline(endFrame)))
+        CaptionTranscriptMapper.timelineFrames(sourceStart: start, sourceEnd: end, clip: clip, fps: fps)
     }
 
     private static func round2OrNull(_ x: Double?) -> Any {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -103,6 +103,7 @@ final class ToolExecutor {
             return .error("Editor not available")
         }
         let before = editor.timelines
+        editor.lastResyncReport = nil
         let idsBefore = currentIdUniverse(editor)
         let result: ToolResult
         Log.agent.notice(
@@ -253,6 +254,7 @@ final class ToolExecutor {
         case .addTexts:      return try addTexts(editor, args)
         case .updateText:    return try updateText(editor, args)
         case .addCaptions:   return try await addCaptions(editor, args)
+        case .resyncCaptions: return try resyncCaptions(editor, args)
         case .exportProject: return try await exportProject(editor, args)
         case .manageExports: return try manageExports(editor, args)
         case .generateVideo: return try generate(editor, args, type: .video)

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -122,17 +122,17 @@ enum CaptionResyncEngine {
         let clipWords = words.filter { $0.startFrame < clip.endFrame && $0.endFrame > clip.startFrame }
         let current = clip.textContent ?? ""
 
-        // A ref without a cached transcript yields empty/partial words that mean "missing read",
-        // not "speech cut" — destructive resolution here would silently delete or shrink the
-        // caption. Preserve it and surface a conflict instead.
-        if uncached {
-            plan.report.conflicts.append(.init(
-                clipId: clip.id, manualText: current,
-                newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
-            return
-        }
-
         guard !clipWords.isEmpty else {
+            // Empty words with an uncached overlapping ref mean "missing read", not "speech cut" —
+            // deleting here would silently destroy the caption. Preserve it and surface a conflict.
+            // (When cached words exist the resync proceeds normally: an unrelated uncached ref — a
+            // music bed, b-roll — must not freeze caption resync.)
+            if uncached {
+                plan.report.conflicts.append(.init(
+                    clipId: clip.id, manualText: current,
+                    newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
+                return
+            }
             plan.removals.append(clip.id)
             removed.insert(clip.id)
             plan.report.removed.append(.init(clipId: clip.id, text: current))
@@ -145,6 +145,12 @@ enum CaptionResyncEngine {
         if newText == current {
             // Match — no text change. Clear a stale conflict flag if the manual text now agrees.
             if clip.resyncConflict == true { plan.clearedFlags.append(clip.id) }
+            // A speed change can remap word timings without changing text; refresh stale karaoke.
+            if let existing = clip.wordTimings, existing != newTimings {
+                plan.replacements.append(.init(
+                    clipId: clip.id, text: newText, wordTimings: newTimings,
+                    generatedText: clip.generatedText ?? newText))
+            }
             return
         }
 
@@ -186,6 +192,7 @@ enum CaptionResyncEngine {
               let modal = groupClips.first else { return }
 
         let covered = groupClips.filter { !removedIds.contains($0.id) }.map { $0.startFrame..<$0.endFrame }
+            .sorted { $0.lowerBound < $1.lowerBound }
         let uncovered = words.filter { w in
             let mid = (w.startFrame + w.endFrame) / 2
             guard mid >= span.lowerBound, mid < span.upperBound else { return false }
@@ -196,7 +203,21 @@ enum CaptionResyncEngine {
         let maxWords = inferredMaxWords(groupClips)
         let style = modal.textStyle ?? TextStyle()
         let animation = modal.textAnimation
-        for group in chunk(uncovered, maxWords) {
+        // Words on opposite sides of a SURVIVING caption must never chunk together — the built
+        // clip would span (and overlap) the preserved island. Split into per-gap regions first.
+        func gapIndex(_ w: WordTiming) -> Int {
+            let mid = (w.startFrame + w.endFrame) / 2
+            return covered.filter { $0.upperBound <= mid }.count
+        }
+        var regions: [[WordTiming]] = []
+        for w in uncovered {
+            if let lastWord = regions.last?.last, gapIndex(lastWord) == gapIndex(w) {
+                regions[regions.count - 1].append(w)
+            } else {
+                regions.append([w])
+            }
+        }
+        for group in regions.flatMap({ chunk($0, maxWords) }) {
             guard let first = group.first, let last = group.last, last.endFrame > first.startFrame else { continue }
             let start = first.startFrame
             let duration = max(1, last.endFrame - start)

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -122,17 +122,24 @@ enum CaptionResyncEngine {
         let clipWords = words.filter { $0.startFrame < clip.endFrame && $0.endFrame > clip.startFrame }
         let current = clip.textContent ?? ""
 
-        guard !clipWords.isEmpty else {
-            // Empty words with an uncached overlapping ref mean "missing read", not "speech cut" —
-            // deleting here would silently destroy the caption. Preserve it and surface a conflict.
-            // (When cached words exist the resync proceeds normally: an unrelated uncached ref — a
-            // music bed, b-roll — must not freeze caption resync.)
-            if uncached {
+        // Cold-cache gate, span-scoped: with an uncached overlapping ref, resync proceeds only when
+        // the cached words already SPAN the caption (the uncached ref demonstrably contributed
+        // nothing — e.g. a music bed). Empty or partial word coverage means the missing read
+        // plausibly owns part of this caption; destructive resolution would delete or shrink it, so
+        // preserve and surface a conflict instead.
+        if uncached {
+            let spanStart = clipWords.map(\.startFrame).min() ?? clip.endFrame
+            let spanEnd = clipWords.map(\.endFrame).max() ?? clip.startFrame
+            let spanCovered = max(0, min(spanEnd, clip.endFrame) - max(spanStart, clip.startFrame))
+            if Double(spanCovered) < 0.8 * Double(max(1, clip.durationFrames)) {
                 plan.report.conflicts.append(.init(
                     clipId: clip.id, manualText: current,
                     newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
                 return
             }
+        }
+
+        guard !clipWords.isEmpty else {
             plan.removals.append(clip.id)
             removed.insert(clip.id)
             plan.report.removed.append(.init(clipId: clip.id, text: current))

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -29,7 +29,9 @@ struct CaptionResyncPlan {
         var clipId: String
         var text: String
         var wordTimings: [WordTiming]
-        var generatedText: String
+        /// nil leaves the clip's provenance untouched (timing-only refresh); non-nil records the
+        /// transcript this replacement was generated from.
+        var generatedText: String?
     }
     var replacements: [Replacement] = []
     var removals: [String] = []
@@ -113,6 +115,24 @@ enum CaptionResyncEngine {
         return plan
     }
 
+    /// Total duration of spans after merging gaps of <=12 frames (a natural speech pause).
+    static func mergedSpanDuration(_ spans: [(Int, Int)]) -> Int {
+        var covered = 0
+        var runStart: Int? = nil
+        var runEnd = 0
+        for (s, e) in spans.sorted(by: { $0.0 < $1.0 }) where e > s {
+            if runStart != nil, s <= runEnd + 12 {
+                runEnd = max(runEnd, e)
+            } else {
+                if let rs = runStart { covered += runEnd - rs }
+                runStart = s
+                runEnd = e
+            }
+        }
+        if let rs = runStart { covered += runEnd - rs }
+        return covered
+    }
+
     // MARK: - Per-clip REPLACE / REMOVE / conflict
 
     private static func resolveClip(
@@ -128,31 +148,17 @@ enum CaptionResyncEngine {
         // plausibly owns part of this caption; destructive resolution would delete or shrink it, so
         // preserve and surface a conflict instead.
         if uncached {
-            // Denominator: the clip's SPEECH extent — existing karaoke timings bound it so display
-            // padding (minDisplayDuration) can't inflate the requirement. Numerator: cached word
-            // spans with natural pauses (<=12 frames) merged, so genuine holes count as missing but
-            // ordinary inter-word gaps don't.
-            let speechExtent = clip.wordTimings.flatMap { timings in
-                timings.map(\.endFrame).max()
-            } ?? clip.durationFrames
-            let denominator = max(1, min(clip.durationFrames, speechExtent))
-            var covered = 0
-            var runStart: Int? = nil
-            var runEnd = 0
-            for w in clipWords.sorted(by: { $0.startFrame < $1.startFrame }) {
-                let s = max(w.startFrame, clip.startFrame) - clip.startFrame
-                let e = min(w.endFrame, clip.endFrame) - clip.startFrame
-                guard e > s else { continue }
-                if let _ = runStart, s <= runEnd + 12 {
-                    runEnd = max(runEnd, e)
-                } else {
-                    if let rs = runStart { covered += runEnd - rs }
-                    runStart = s
-                    runEnd = e
-                }
-            }
-            if let rs = runStart { covered += runEnd - rs }
-            if Double(covered) < 0.8 * Double(denominator) {
+            // Apples-to-apples coverage: cached words' pause-merged span duration vs the SAME
+            // measure over the clip's existing karaoke timings (falling back to the clip span when
+            // none exist). Computing both sides identically cancels leading silence, display
+            // padding, and natural pauses — only genuinely missing speech lowers the ratio.
+            let denominator = clip.wordTimings.map { Self.mergedSpanDuration($0.map { ($0.startFrame, $0.endFrame) }) }
+                ?? max(1, clip.durationFrames)
+            let covered = Self.mergedSpanDuration(clipWords.map {
+                (max($0.startFrame, clip.startFrame) - clip.startFrame,
+                 min($0.endFrame, clip.endFrame) - clip.startFrame)
+            })
+            if Double(covered) < 0.8 * Double(max(1, denominator)) {
                 plan.report.conflicts.append(.init(
                     clipId: clip.id, manualText: current,
                     newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
@@ -173,13 +179,13 @@ enum CaptionResyncEngine {
         if newText == current {
             // Match — no text change. Clear a stale conflict flag if the manual text now agrees.
             if clip.resyncConflict == true { plan.clearedFlags.append(clip.id) }
-            // A speed change can remap word timings without changing text; refresh stale karaoke.
-            // Provenance is preserved as-is: fabricating generatedText here would silently promote
-            // hand-authored (nil-provenance) captions to clean and expose them to later overwrites.
-            if let existing = clip.wordTimings, existing != newTimings, let provenance = clip.generatedText {
+            // A speed change can remap word timings without changing text; refresh stale karaoke
+            // for EVERY clip — including hand-authored ones — while leaving provenance untouched
+            // (generatedText: nil means "don't write provenance").
+            if let existing = clip.wordTimings, existing != newTimings {
                 plan.replacements.append(.init(
                     clipId: clip.id, text: newText, wordTimings: newTimings,
-                    generatedText: provenance))
+                    generatedText: nil))
             }
             return
         }

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -1,0 +1,264 @@
+// CaptionResyncEngine — recomputes caption text/timings from cached transcripts (L2) after an
+// audible-content edit and writes only caption clips (L3). Pure and provider-driven so it unit-tests
+// with a synthetic timeline and a read-only word source; never touches asset transcripts or the cache.
+
+import Foundation
+
+/// How resync treats a manually-edited (dirty) caption clip whose transcript has since changed.
+enum CaptionConflictPolicy: String, Codable, Sendable, CaseIterable {
+    case preserve   // keep the manual text, record a conflict (default)
+    case overwrite  // replace the manual text with the new transcript
+    case flag       // keep the manual text and mark the clip for review
+
+    static let `default`: CaptionConflictPolicy = .preserve
+}
+
+/// Read-only source of transcript words. The protocol exposes no write API, so an engine holding one
+/// cannot mutate transcripts (L1) or the transcript cache (L2) — the L1/L2 isolation is enforced by type.
+protocol CaptionWordSource {
+    /// Transcript words audible on audible tracks within project-frame span [range), mapped to absolute
+    /// project frames, sorted by start. Cache-only: assets without a cached transcript contribute nothing.
+    func audibleWords(in range: Range<Int>) -> [WordTiming]
+    /// Media refs overlapping [range) whose transcript was not cached, so they were skipped (not resynced).
+    func uncachedRefs(in range: Range<Int>) -> [String]
+}
+
+/// What the engine decided; the VM applies it inside the trigger's undo transaction.
+struct CaptionResyncPlan {
+    struct Replacement: Equatable {
+        var clipId: String
+        var text: String
+        var wordTimings: [WordTiming]
+        var generatedText: String
+    }
+    var replacements: [Replacement] = []
+    var removals: [String] = []
+    var creations: [EditorViewModel.TextClipSpec] = []
+    var flagged: [String] = []       // set resyncConflict = true
+    var clearedFlags: [String] = []  // clear resyncConflict
+    var report: CaptionResyncReport
+
+    var hasWork: Bool {
+        !replacements.isEmpty || !removals.isEmpty || !creations.isEmpty || !flagged.isEmpty || !clearedFlags.isEmpty
+    }
+}
+
+/// User- and agent-facing summary of a resync pass.
+struct CaptionResyncReport: Equatable, Sendable {
+    struct Updated: Equatable, Sendable { var clipId: String; var before: String; var after: String }
+    struct Removed: Equatable, Sendable { var clipId: String; var text: String }
+    struct Created: Equatable, Sendable { var clipId: String?; var text: String; var startFrame: Int; var endFrame: Int }
+    struct Conflict: Equatable, Sendable { var clipId: String; var manualText: String; var newTranscript: String }
+
+    var trigger: String
+    var spans: [[Int]] = []            // [[lower, upper), …] — array form so it is Sendable/Codable-friendly
+    var updated: [Updated] = []
+    var removed: [Removed] = []
+    var created: [Created] = []
+    var conflicts: [Conflict] = []
+    var skippedRefs: [String] = []
+
+    var isEmpty: Bool { updated.isEmpty && removed.isEmpty && created.isEmpty && conflicts.isEmpty }
+}
+
+@MainActor
+enum CaptionResyncEngine {
+    /// Splits audible words (absolute project frames) into caption-sized phrase groups for newly
+    /// uncovered spans. Injected so tests can substitute a trivial splitter for CaptionBuilder.
+    typealias Chunker = (_ words: [WordTiming], _ maxWords: Int?) -> [[WordTiming]]
+
+    static func plan(
+        timeline: Timeline,
+        triggerSpans: [Range<Int>],
+        trigger: String,
+        fps: Int,
+        policy: CaptionConflictPolicy,
+        wordSource: CaptionWordSource,
+        chunk: Chunker
+    ) -> CaptionResyncPlan {
+        let spans = mergeSpans(triggerSpans)
+        var report = CaptionResyncReport(trigger: trigger)
+        report.spans = spans.map { [$0.lowerBound, $0.upperBound] }
+        var plan = CaptionResyncPlan(report: report)
+        guard !spans.isEmpty else { return plan }
+
+        // Groups a user opted out of are never touched.
+        let exemptGroups = exemptGroupIds(timeline)
+        var skipped = Set<String>()
+
+        for span in spans {
+            let captionClips = captionClipsIntersecting(span, timeline: timeline, excludingGroups: exemptGroups)
+
+            // Expand the word lookup to the extents of the caption clips touching this span, so a clip
+            // that reaches past the edited region still recomputes from all of its own words — while
+            // staying confined to the edited region (downstream, shifted captions are never queried).
+            var lo = span.lowerBound, hi = span.upperBound
+            for c in captionClips { lo = min(lo, c.startFrame); hi = max(hi, c.endFrame) }
+            let words = wordSource.audibleWords(in: lo..<hi)
+            for ref in wordSource.uncachedRefs(in: lo..<hi) where skipped.insert(ref).inserted {
+                plan.report.skippedRefs.append(ref)
+            }
+
+            var removedIds = Set<String>()
+            for clip in captionClips {
+                resolveClip(clip, words: words, policy: policy, into: &plan, removed: &removedIds)
+            }
+
+            createUncovered(
+                span: span, words: words, captionClips: captionClips, removedIds: removedIds,
+                timeline: timeline, fps: fps, chunk: chunk, into: &plan
+            )
+        }
+        return plan
+    }
+
+    // MARK: - Per-clip REPLACE / REMOVE / conflict
+
+    private static func resolveClip(
+        _ clip: Clip, words: [WordTiming], policy: CaptionConflictPolicy,
+        into plan: inout CaptionResyncPlan, removed: inout Set<String>
+    ) {
+        let clipWords = words.filter { $0.startFrame < clip.endFrame && $0.endFrame > clip.startFrame }
+        let current = clip.textContent ?? ""
+
+        guard !clipWords.isEmpty else {
+            plan.removals.append(clip.id)
+            removed.insert(clip.id)
+            plan.report.removed.append(.init(clipId: clip.id, text: current))
+            return
+        }
+
+        let newText = joinWords(clipWords)
+        let newTimings = relativeTimings(clipWords, clipStart: clip.startFrame, duration: clip.durationFrames)
+
+        if newText == current {
+            // Match — no text change. Clear a stale conflict flag if the manual text now agrees.
+            if clip.resyncConflict == true { plan.clearedFlags.append(clip.id) }
+            return
+        }
+
+        let dirty = clip.generatedText != nil && clip.textContent != clip.generatedText
+        if !dirty {
+            // Clean, or unknown provenance (generatedText == nil). Both replace; unknown provenance is
+            // additionally conflict-logged for visibility since we can't prove the text was generated.
+            plan.replacements.append(.init(clipId: clip.id, text: newText, wordTimings: newTimings, generatedText: newText))
+            plan.report.updated.append(.init(clipId: clip.id, before: current, after: newText))
+            if clip.generatedText == nil {
+                plan.report.conflicts.append(.init(clipId: clip.id, manualText: current, newTranscript: newText))
+            }
+            return
+        }
+
+        switch policy {
+        case .overwrite:
+            plan.replacements.append(.init(clipId: clip.id, text: newText, wordTimings: newTimings, generatedText: newText))
+            plan.report.updated.append(.init(clipId: clip.id, before: current, after: newText))
+        case .preserve:
+            plan.report.conflicts.append(.init(clipId: clip.id, manualText: current, newTranscript: newText))
+        case .flag:
+            plan.flagged.append(clip.id)
+            plan.report.conflicts.append(.init(clipId: clip.id, manualText: current, newTranscript: newText))
+        }
+    }
+
+    // MARK: - CREATE for newly uncovered speech
+
+    private static func createUncovered(
+        span: Range<Int>, words: [WordTiming], captionClips: [Clip], removedIds: Set<String>,
+        timeline: Timeline, fps: Int, chunk: Chunker, into plan: inout CaptionResyncPlan
+    ) {
+        // Only create when a single caption group owns this region — otherwise the target group is ambiguous.
+        let groups = Set(captionClips.compactMap(\.captionGroupId))
+        guard groups.count == 1, let groupId = groups.first else { return }
+        let groupClips = captionClips.filter { $0.captionGroupId == groupId }
+        guard let trackIndex = trackIndex(ofGroup: groupId, timeline: timeline),
+              let modal = groupClips.first else { return }
+
+        let covered = groupClips.filter { !removedIds.contains($0.id) }.map { $0.startFrame..<$0.endFrame }
+        let uncovered = words.filter { w in
+            let mid = (w.startFrame + w.endFrame) / 2
+            guard mid >= span.lowerBound, mid < span.upperBound else { return false }
+            return !covered.contains { $0.contains(mid) }
+        }
+        guard !uncovered.isEmpty else { return }
+
+        let maxWords = inferredMaxWords(groupClips)
+        let style = modal.textStyle ?? TextStyle()
+        let animation = modal.textAnimation
+        for group in chunk(uncovered, maxWords) {
+            guard let first = group.first, let last = group.last, last.endFrame > first.startFrame else { continue }
+            let start = first.startFrame
+            let duration = max(1, last.endFrame - start)
+            let text = joinWords(group)
+            let spec = EditorViewModel.TextClipSpec(
+                trackIndex: trackIndex,
+                startFrame: start,
+                durationFrames: duration,
+                content: text,
+                style: style,
+                transform: nil,
+                captionGroupId: groupId,
+                words: relativeTimings(group, clipStart: start, duration: duration),
+                animation: animation,
+                generatedText: text
+            )
+            plan.creations.append(spec)
+            plan.report.created.append(.init(clipId: nil, text: text, startFrame: start, endFrame: start + duration))
+        }
+    }
+
+    // MARK: - Helpers
+
+    static func mergeSpans(_ spans: [Range<Int>]) -> [Range<Int>] {
+        let valid = spans.filter { $0.lowerBound < $0.upperBound }.sorted { $0.lowerBound < $1.lowerBound }
+        guard var cur = valid.first else { return [] }
+        var out: [Range<Int>] = []
+        for s in valid.dropFirst() {
+            if s.lowerBound <= cur.upperBound {
+                cur = cur.lowerBound..<max(cur.upperBound, s.upperBound)
+            } else {
+                out.append(cur); cur = s
+            }
+        }
+        out.append(cur)
+        return out
+    }
+
+    private static func captionClipsIntersecting(_ span: Range<Int>, timeline: Timeline, excludingGroups exempt: Set<String>) -> [Clip] {
+        timeline.tracks.flatMap(\.clips).filter { clip in
+            guard clip.mediaType == .text, let g = clip.captionGroupId, !exempt.contains(g) else { return false }
+            return clip.startFrame < span.upperBound && clip.endFrame > span.lowerBound
+        }
+    }
+
+    private static func exemptGroupIds(_ timeline: Timeline) -> Set<String> {
+        Set(timeline.tracks.flatMap(\.clips)
+            .filter { $0.mediaType == .text && $0.resyncExempt == true }
+            .compactMap(\.captionGroupId))
+    }
+
+    private static func trackIndex(ofGroup groupId: String, timeline: Timeline) -> Int? {
+        timeline.tracks.firstIndex { track in
+            track.clips.contains { $0.captionGroupId == groupId && $0.mediaType == .text }
+        }
+    }
+
+    private static func inferredMaxWords(_ clips: [Clip]) -> Int? {
+        let counts = clips.map { ($0.textContent ?? "").split(whereSeparator: \.isWhitespace).count }.filter { $0 > 0 }
+        return counts.max()
+    }
+
+    static func joinWords(_ words: [WordTiming]) -> String {
+        words.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Absolute-frame words → clip-relative timings clamped to the clip's duration.
+    static func relativeTimings(_ words: [WordTiming], clipStart: Int, duration: Int) -> [WordTiming] {
+        words.compactMap { w in
+            let rs = min(max(0, w.startFrame - clipStart), duration)
+            let re = min(max(rs, w.endFrame - clipStart), duration)
+            guard re > rs else { return nil }
+            return WordTiming(text: w.text, startFrame: rs, endFrame: re)
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -101,7 +101,8 @@ enum CaptionResyncEngine {
 
             var removedIds = Set<String>()
             for clip in captionClips {
-                resolveClip(clip, words: words, policy: policy, into: &plan, removed: &removedIds)
+                let uncached = !wordSource.uncachedRefs(in: clip.startFrame..<clip.endFrame).isEmpty
+                resolveClip(clip, words: words, policy: policy, uncached: uncached, into: &plan, removed: &removedIds)
             }
 
             createUncovered(
@@ -115,11 +116,21 @@ enum CaptionResyncEngine {
     // MARK: - Per-clip REPLACE / REMOVE / conflict
 
     private static func resolveClip(
-        _ clip: Clip, words: [WordTiming], policy: CaptionConflictPolicy,
+        _ clip: Clip, words: [WordTiming], policy: CaptionConflictPolicy, uncached: Bool,
         into plan: inout CaptionResyncPlan, removed: inout Set<String>
     ) {
         let clipWords = words.filter { $0.startFrame < clip.endFrame && $0.endFrame > clip.startFrame }
         let current = clip.textContent ?? ""
+
+        // A ref without a cached transcript yields empty/partial words that mean "missing read",
+        // not "speech cut" — destructive resolution here would silently delete or shrink the
+        // caption. Preserve it and surface a conflict instead.
+        if uncached {
+            plan.report.conflicts.append(.init(
+                clipId: clip.id, manualText: current,
+                newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
+            return
+        }
 
         guard !clipWords.isEmpty else {
             plan.removals.append(clip.id)

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -161,15 +161,13 @@ enum CaptionResyncEngine {
             return
         }
 
-        let dirty = clip.generatedText != nil && clip.textContent != clip.generatedText
-        if !dirty {
-            // Clean, or unknown provenance (generatedText == nil). Both replace; unknown provenance is
-            // additionally conflict-logged for visibility since we can't prove the text was generated.
+        // Clean requires PROOF the text is transcript-generated. Unknown provenance (generatedText
+        // == nil — hand-authored or pre-feature captions) must follow the conflict policy like any
+        // edited clip: unconditional replacement would overwrite hand-authored text under .preserve.
+        let clean = clip.generatedText != nil && clip.textContent == clip.generatedText
+        if clean {
             plan.replacements.append(.init(clipId: clip.id, text: newText, wordTimings: newTimings, generatedText: newText))
             plan.report.updated.append(.init(clipId: clip.id, before: current, after: newText))
-            if clip.generatedText == nil {
-                plan.report.conflicts.append(.init(clipId: clip.id, manualText: current, newTranscript: newText))
-            }
             return
         }
 

--- a/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/CaptionResyncEngine.swift
@@ -128,10 +128,31 @@ enum CaptionResyncEngine {
         // plausibly owns part of this caption; destructive resolution would delete or shrink it, so
         // preserve and surface a conflict instead.
         if uncached {
-            let spanStart = clipWords.map(\.startFrame).min() ?? clip.endFrame
-            let spanEnd = clipWords.map(\.endFrame).max() ?? clip.startFrame
-            let spanCovered = max(0, min(spanEnd, clip.endFrame) - max(spanStart, clip.startFrame))
-            if Double(spanCovered) < 0.8 * Double(max(1, clip.durationFrames)) {
+            // Denominator: the clip's SPEECH extent — existing karaoke timings bound it so display
+            // padding (minDisplayDuration) can't inflate the requirement. Numerator: cached word
+            // spans with natural pauses (<=12 frames) merged, so genuine holes count as missing but
+            // ordinary inter-word gaps don't.
+            let speechExtent = clip.wordTimings.flatMap { timings in
+                timings.map(\.endFrame).max()
+            } ?? clip.durationFrames
+            let denominator = max(1, min(clip.durationFrames, speechExtent))
+            var covered = 0
+            var runStart: Int? = nil
+            var runEnd = 0
+            for w in clipWords.sorted(by: { $0.startFrame < $1.startFrame }) {
+                let s = max(w.startFrame, clip.startFrame) - clip.startFrame
+                let e = min(w.endFrame, clip.endFrame) - clip.startFrame
+                guard e > s else { continue }
+                if let _ = runStart, s <= runEnd + 12 {
+                    runEnd = max(runEnd, e)
+                } else {
+                    if let rs = runStart { covered += runEnd - rs }
+                    runStart = s
+                    runEnd = e
+                }
+            }
+            if let rs = runStart { covered += runEnd - rs }
+            if Double(covered) < 0.8 * Double(denominator) {
                 plan.report.conflicts.append(.init(
                     clipId: clip.id, manualText: current,
                     newTranscript: "(transcript not cached — resync skipped; run resync_captions after transcription completes)"))
@@ -153,10 +174,12 @@ enum CaptionResyncEngine {
             // Match — no text change. Clear a stale conflict flag if the manual text now agrees.
             if clip.resyncConflict == true { plan.clearedFlags.append(clip.id) }
             // A speed change can remap word timings without changing text; refresh stale karaoke.
-            if let existing = clip.wordTimings, existing != newTimings {
+            // Provenance is preserved as-is: fabricating generatedText here would silently promote
+            // hand-authored (nil-provenance) captions to clean and expose them to later overwrites.
+            if let existing = clip.wordTimings, existing != newTimings, let provenance = clip.generatedText {
                 plan.replacements.append(.init(
                     clipId: clip.id, text: newText, wordTimings: newTimings,
-                    generatedText: clip.generatedText ?? newText))
+                    generatedText: provenance))
             }
             return
         }

--- a/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
@@ -60,6 +60,10 @@ final class TimelineTranscriptProvider: CaptionWordSource {
     /// invalidate naturally when the file changes; bounded to keep memory flat.
     private static let diskMemo = Mutex<[String: TranscriptionResult]>([:])
 
+    /// Invalidate alongside a transcript-cache clear or analysis reset — the memo must never
+    /// outlive the entries it mirrors.
+    static func clearDiskMemo() { diskMemo.withLock { $0.removeAll() } }
+
     private static func diskMemoized(_ url: URL) -> TranscriptionResult? {
         guard let key = TranscriptCache.identityKey(for: url) else { return TranscriptCache.cachedOnDisk(for: url) }
         if let memo = diskMemo.withLock({ $0[key] }) { return memo }

--- a/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
@@ -3,6 +3,7 @@
 // which is the L1/L2 read-only guarantee the resync engine depends on.
 
 import Foundation
+import Synchronization
 
 final class TimelineTranscriptProvider: CaptionWordSource {
     private struct Fragment { let clip: Clip; let url: URL; let mediaRef: String }
@@ -49,8 +50,27 @@ final class TimelineTranscriptProvider: CaptionWordSource {
 
     private func transcript(for url: URL) -> TranscriptionResult? {
         if let memo = transcripts[url] { return memo }
-        let loaded = TranscriptCache.cachedOnDisk(for: url)
+        let loaded = Self.diskMemoized(url)
         transcripts[url] = loaded
+        return loaded
+    }
+
+    /// Cross-run memo keyed by the cache's file-identity key (path|mtime|size), so an edit burst
+    /// (drag, repeated trims) pays one disk read per asset, not one per resync run. Identity keys
+    /// invalidate naturally when the file changes; bounded to keep memory flat.
+    private static let diskMemo = Mutex<[String: TranscriptionResult]>([:])
+
+    private static func diskMemoized(_ url: URL) -> TranscriptionResult? {
+        guard let key = TranscriptCache.identityKey(for: url) else { return TranscriptCache.cachedOnDisk(for: url) }
+        if let memo = diskMemo.withLock({ $0[key] }) { return memo }
+        let loaded = TranscriptCache.cachedOnDisk(for: url)
+        // Never memoize a miss: a transcript that lands moments later must be visible to the next run.
+        if let loaded {
+            diskMemo.withLock {
+                if $0.count >= 64 { $0.removeAll() }
+                $0[key] = loaded
+            }
+        }
         return loaded
     }
 }

--- a/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
+++ b/Sources/PalmierPro/Editor/CaptionResync/TimelineTranscriptProvider.swift
@@ -1,0 +1,56 @@
+// TimelineTranscriptProvider — cache-only CaptionWordSource for reactive resync. Reads transcripts
+// already on disk and maps their words to project frames; never triggers ASR and never writes,
+// which is the L1/L2 read-only guarantee the resync engine depends on.
+
+import Foundation
+
+final class TimelineTranscriptProvider: CaptionWordSource {
+    private struct Fragment { let clip: Clip; let url: URL; let mediaRef: String }
+    private let fragments: [Fragment]
+    private let fps: Int
+    private var transcripts: [URL: TranscriptionResult?] = [:]  // memoized disk reads; stored nil = no cache
+
+    /// Snapshots the editor's audible source clips (the same set get_transcript uses) on the main actor.
+    @MainActor
+    init(editor: EditorViewModel) {
+        var frags: [Fragment] = []
+        for clip in editor.captionTargets(ids: []) {
+            guard let url = editor.mediaResolver.resolveURL(for: clip.mediaRef) else { continue }
+            frags.append(Fragment(clip: clip, url: url, mediaRef: clip.mediaRef))
+        }
+        self.fragments = frags
+        self.fps = editor.timeline.fps
+    }
+
+    func audibleWords(in range: Range<Int>) -> [WordTiming] {
+        var out: [WordTiming] = []
+        for frag in fragmentsIntersecting(range) {
+            guard let transcript = transcript(for: frag.url) else { continue }
+            for w in CaptionTranscriptMapper.timelineWords(from: transcript, clip: frag.clip, fps: fps)
+            where w.startFrame < range.upperBound && w.endFrame > range.lowerBound {
+                out.append(w)
+            }
+        }
+        return out.sorted { ($0.startFrame, $0.endFrame) < ($1.startFrame, $1.endFrame) }
+    }
+
+    func uncachedRefs(in range: Range<Int>) -> [String] {
+        var refs: [String] = []
+        var seen = Set<String>()
+        for frag in fragmentsIntersecting(range) where transcript(for: frag.url) == nil {
+            if seen.insert(frag.mediaRef).inserted { refs.append(frag.mediaRef) }
+        }
+        return refs
+    }
+
+    private func fragmentsIntersecting(_ range: Range<Int>) -> [Fragment] {
+        fragments.filter { $0.clip.startFrame < range.upperBound && $0.clip.endFrame > range.lowerBound }
+    }
+
+    private func transcript(for url: URL) -> TranscriptionResult? {
+        if let memo = transcripts[url] { return memo }
+        let loaded = TranscriptCache.cachedOnDisk(for: url)
+        transcripts[url] = loaded
+        return loaded
+    }
+}

--- a/Sources/PalmierPro/Editor/EditorUndo.swift
+++ b/Sources/PalmierPro/Editor/EditorUndo.swift
@@ -64,6 +64,8 @@ final class EditorUndo {
 
     var isRegistrationEnabled: Bool { manager?.isUndoRegistrationEnabled ?? true }
 
+    var isUndoingOrRedoing: Bool { (manager?.isUndoing ?? false) || (manager?.isRedoing ?? false) }
+
     func undoLatest() -> String? {
         guard let manager, manager.canUndo else { return nil }
         let actionName = manager.undoActionName

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AudioEnhance.swift
@@ -3,6 +3,7 @@ import Foundation
 extension EditorViewModel {
     /// Called after Settings clears disk caches: session memoization must not outlive them.
     func resetAnalysisSessionState() {
+        TimelineTranscriptProvider.clearDiskMemo()
         denoiseBaked.removeAll()
         denoiseFailed.removeAll()
         mediaVisualCache.resetSessionState()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
@@ -117,14 +117,17 @@ extension EditorViewModel {
         let durationFrames: Int
     }
 
-    /// Ranges of the timeline whose audible content changed. Pure ripple shifts (a same-delta group
-    /// of clips moving together) are excluded — the captions above them shifted identically and stay
-    /// aligned, so recomputing them would be wasted work outside the genuinely edited region.
+    /// Ranges of the timeline whose audible content changed. A clip that only shifted is excluded as a
+    /// pure ripple ONLY when the captions above it shifted by the same delta — i.e. they stayed aligned
+    /// with it. Captions left behind (a block-swap, a stationary caption) or captions the clip landed
+    /// under (a move onto occupied territory) fail that test, so the clip is resynced. The rule is
+    /// content-grounded and order-independent, so a two-direction swap resolves the same way every run.
     func captionResyncAffectedSpans(before: Timeline, after: Timeline) -> [Range<Int>] {
         let b = audibleClips(before)
         let a = audibleClips(after)
+        let beforeCaps = captionSpans(before)
+        let afterCaps = captionSpans(after)
         var spans: [Range<Int>] = []
-        var shifts: [(delta: Int, before: Range<Int>, after: Range<Int>)] = []
 
         for id in Set(b.keys).union(a.keys) {
             switch (b[id], a[id]) {
@@ -133,11 +136,11 @@ extension EditorViewModel {
             case let (nil, new?):
                 spans.append(new.range)
             case let (old?, new?):
-                if old.sig == new.sig {
-                    if old.range.lowerBound != new.range.lowerBound {
-                        shifts.append((new.range.lowerBound - old.range.lowerBound, old.range, new.range))
-                    }
-                } else {
+                if old.sig != new.sig {
+                    spans.append(old.range)
+                    spans.append(new.range)
+                } else if old.range.lowerBound != new.range.lowerBound,
+                          !captionsMoved(with: old.range, to: new.range, beforeCaps: beforeCaps, afterCaps: afterCaps) {
                     spans.append(old.range)
                     spans.append(new.range)
                 }
@@ -145,16 +148,38 @@ extension EditorViewModel {
                 break
             }
         }
-
-        if !shifts.isEmpty {
-            let byDelta = Dictionary(grouping: shifts, by: \.delta)
-            let rippleDelta = byDelta.filter { $0.value.count >= 2 }.max { $0.value.count < $1.value.count }?.key
-            for s in shifts where s.delta != rippleDelta {
-                spans.append(s.before)
-                spans.append(s.after)
-            }
-        }
         return spans
+    }
+
+    private struct CaptionKey: Equatable, Comparable {
+        let id: String
+        let relStart: Int
+        let relEnd: Int
+        static func < (l: CaptionKey, r: CaptionKey) -> Bool {
+            (l.relStart, l.relEnd, l.id) < (r.relStart, r.relEnd, r.id)
+        }
+    }
+
+    /// True iff the caption clips overlapping `oldSpan`, translated by the shift, exactly match those
+    /// overlapping `newSpan` — same caption id at the same offset relative to the clip.
+    private func captionsMoved(
+        with oldSpan: Range<Int>, to newSpan: Range<Int>,
+        beforeCaps: [(id: String, range: Range<Int>)], afterCaps: [(id: String, range: Range<Int>)]
+    ) -> Bool {
+        captionKeys(overlapping: oldSpan, in: beforeCaps) == captionKeys(overlapping: newSpan, in: afterCaps)
+    }
+
+    private func captionKeys(overlapping span: Range<Int>, in caps: [(id: String, range: Range<Int>)]) -> [CaptionKey] {
+        caps
+            .filter { $0.range.lowerBound < span.upperBound && $0.range.upperBound > span.lowerBound }
+            .map { CaptionKey(id: $0.id, relStart: $0.range.lowerBound - span.lowerBound, relEnd: $0.range.upperBound - span.lowerBound) }
+            .sorted()
+    }
+
+    private func captionSpans(_ timeline: Timeline) -> [(id: String, range: Range<Int>)] {
+        timeline.tracks.flatMap(\.clips)
+            .filter { $0.mediaType == .text && $0.captionGroupId != nil }
+            .map { ($0.id, $0.startFrame..<$0.endFrame) }
     }
 
     private func audibleClips(_ timeline: Timeline) -> [String: (range: Range<Int>, sig: AudibleSig)] {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
@@ -36,7 +36,7 @@ extension EditorViewModel {
     func runCaptionResync(spans: [Range<Int>], trigger: String, dryRun: Bool = false, policyOverride: CaptionConflictPolicy? = nil) -> CaptionResyncReport? {
         let merged = CaptionResyncEngine.mergeSpans(spans)
         guard !merged.isEmpty else { return nil }
-        let source = TimelineTranscriptProvider(editor: self)
+        let source = captionWordSourceProvider?(self) ?? TimelineTranscriptProvider(editor: self)
         let plan = CaptionResyncEngine.plan(
             timeline: timeline,
             triggerSpans: merged,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
@@ -1,0 +1,224 @@
+// EditorViewModel+CaptionResync — reactive glue between timeline mutations and CaptionResyncEngine.
+// Diffs before/after occupancy on audible tracks into affected spans, runs the engine cache-only,
+// and applies its plan inside the trigger's undo transaction so one undo reverts trigger + resync.
+
+import Foundation
+
+extension EditorViewModel {
+    // MARK: - Trigger entry points
+
+    /// Reactive resync after a `withTimelineSwap` mutation. Runs inside `work` (registration disabled),
+    /// so its writes land in the same before→after swap the caller registers.
+    func resyncCaptionsAfterSwap(before: Timeline, trigger: String) {
+        guard shouldResync else { return }
+        let spans = captionResyncAffectedSpans(before: before, after: timeline)
+        runCaptionResync(spans: spans, trigger: trigger)
+    }
+
+    /// Reactive resync after a plain (non-ripple) trim, whose geometry gives the affected span directly.
+    func resyncCaptionsAfterTrim(before: Range<Int>, after: Range<Int>, trigger: String) {
+        guard shouldResync else { return }
+        runCaptionResync(spans: [before, after], trigger: trigger)
+    }
+
+    private var shouldResync: Bool {
+        !isResyncingCaptions
+            && !undo.isUndoingOrRedoing
+            && timeline.tracks.contains { track in
+                track.clips.contains { $0.mediaType == .text && $0.captionGroupId != nil }
+            }
+    }
+
+    // MARK: - Core
+
+    /// Build the plan and apply it. Stashes the report on `lastResyncReport` for the agent tool layer.
+    @discardableResult
+    func runCaptionResync(spans: [Range<Int>], trigger: String, dryRun: Bool = false, policyOverride: CaptionConflictPolicy? = nil) -> CaptionResyncReport? {
+        let merged = CaptionResyncEngine.mergeSpans(spans)
+        guard !merged.isEmpty else { return nil }
+        let source = TimelineTranscriptProvider(editor: self)
+        let plan = CaptionResyncEngine.plan(
+            timeline: timeline,
+            triggerSpans: merged,
+            trigger: trigger,
+            fps: timeline.fps,
+            policy: policyOverride ?? captionConflictPolicy,
+            wordSource: source,
+            chunk: captionResyncChunker()
+        )
+        guard !dryRun else { return plan.report }
+        guard plan.hasWork else {
+            lastResyncReport = plan.report.isEmpty ? nil : plan.report
+            return plan.report
+        }
+        let report = applyResyncPlan(plan)
+        lastResyncReport = report
+        return report
+    }
+
+    /// Reads and clears the stashed report so a tool wrapper reports each resync at most once.
+    func takeResyncReport() -> CaptionResyncReport? {
+        defer { lastResyncReport = nil }
+        return lastResyncReport
+    }
+
+    // MARK: - Apply
+
+    @discardableResult
+    private func applyResyncPlan(_ plan: CaptionResyncPlan) -> CaptionResyncReport {
+        isResyncingCaptions = true
+        defer { isResyncingCaptions = false }
+        var report = plan.report
+
+        let before = timeline
+        let removals = Set(plan.removals)
+        if !removals.isEmpty {
+            for ti in timeline.tracks.indices {
+                timeline.tracks[ti].clips.removeAll { removals.contains($0.id) }
+            }
+        }
+        for r in plan.replacements {
+            guard let loc = findClip(id: r.clipId) else { continue }
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].textContent = r.text
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].wordTimings = r.wordTimings.isEmpty ? nil : r.wordTimings
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].generatedText = r.generatedText
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].resyncConflict = nil
+        }
+        for id in plan.flagged {
+            guard let loc = findClip(id: id) else { continue }
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].resyncConflict = true
+        }
+        for id in plan.clearedFlags {
+            guard let loc = findClip(id: id) else { continue }
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].resyncConflict = nil
+        }
+        if !plan.creations.isEmpty {
+            let created = placeTextClips(plan.creations, clearExistingRegions: false, refreshVisuals: false)
+            for (i, id) in created.enumerated() where i < report.created.count {
+                report.created[i].clipId = id
+            }
+        }
+
+        guard before != timeline else { return report }
+        // No-op when registration is disabled (withTimelineSwap path — captured by its own swap);
+        // joins the active group when enabled (trim path), so undo reverts trigger + resync together.
+        registerTimelineSwap(undoState: before, redoState: timeline, actionName: "Resync Captions")
+        videoEngine?.refreshVisuals()
+        return report
+    }
+
+    // MARK: - Affected span diff
+
+    private struct AudibleSig: Equatable {
+        let mediaRef: String
+        let trimStartFrame: Int
+        let trimEndFrame: Int
+        let speed: Double
+        let durationFrames: Int
+    }
+
+    /// Ranges of the timeline whose audible content changed. Pure ripple shifts (a same-delta group
+    /// of clips moving together) are excluded — the captions above them shifted identically and stay
+    /// aligned, so recomputing them would be wasted work outside the genuinely edited region.
+    func captionResyncAffectedSpans(before: Timeline, after: Timeline) -> [Range<Int>] {
+        let b = audibleClips(before)
+        let a = audibleClips(after)
+        var spans: [Range<Int>] = []
+        var shifts: [(delta: Int, before: Range<Int>, after: Range<Int>)] = []
+
+        for id in Set(b.keys).union(a.keys) {
+            switch (b[id], a[id]) {
+            case let (old?, nil):
+                spans.append(old.range)
+            case let (nil, new?):
+                spans.append(new.range)
+            case let (old?, new?):
+                if old.sig == new.sig {
+                    if old.range.lowerBound != new.range.lowerBound {
+                        shifts.append((new.range.lowerBound - old.range.lowerBound, old.range, new.range))
+                    }
+                } else {
+                    spans.append(old.range)
+                    spans.append(new.range)
+                }
+            case (nil, nil):
+                break
+            }
+        }
+
+        if !shifts.isEmpty {
+            let byDelta = Dictionary(grouping: shifts, by: \.delta)
+            let rippleDelta = byDelta.filter { $0.value.count >= 2 }.max { $0.value.count < $1.value.count }?.key
+            for s in shifts where s.delta != rippleDelta {
+                spans.append(s.before)
+                spans.append(s.after)
+            }
+        }
+        return spans
+    }
+
+    private func audibleClips(_ timeline: Timeline) -> [String: (range: Range<Int>, sig: AudibleSig)] {
+        var out: [String: (range: Range<Int>, sig: AudibleSig)] = [:]
+        for track in timeline.tracks {
+            for clip in track.clips where isAudibleSource(clip) {
+                out[clip.id] = (
+                    clip.startFrame..<clip.endFrame,
+                    AudibleSig(
+                        mediaRef: clip.mediaRef,
+                        trimStartFrame: clip.trimStartFrame,
+                        trimEndFrame: clip.trimEndFrame,
+                        speed: clip.speed,
+                        durationFrames: clip.durationFrames
+                    )
+                )
+            }
+        }
+        return out
+    }
+
+    func isAudibleSource(_ clip: Clip) -> Bool {
+        switch clip.mediaType {
+        case .audio: return true
+        case .video: return mediaAssetsById[clip.mediaRef]?.hasAudio ?? true
+        default: return false
+        }
+    }
+
+    // MARK: - Chunker (production wraps CaptionBuilder)
+
+    /// Splits newly uncovered words into caption-sized groups using the same phrase logic as generation,
+    /// so created clips respect the group's visual fit and implied maxWords.
+    func captionResyncChunker() -> CaptionResyncEngine.Chunker {
+        let fps = Double(timeline.fps)
+        let style = captionResyncModalStyle()
+        return { [weak self] words, maxWords in
+            guard let self, !words.isEmpty, fps > 0 else { return words.isEmpty ? [] : [words] }
+            let synthetic = words.map {
+                TranscriptionWord(text: $0.text, start: Double($0.startFrame) / fps, end: Double($0.endFrame) / fps)
+            }
+            let phrases = CaptionBuilder.phrases(
+                fromTimedWords: synthetic,
+                fits: { self.captionLineFits($0, style: style) },
+                maxWords: maxWords,
+                minDuration: AppTheme.Caption.minDisplayDuration
+            )
+            guard !phrases.isEmpty else { return [words] }
+            var out: [[WordTiming]] = []
+            var i = 0
+            for phrase in phrases {
+                let n = max(phrase.words.count, 1)
+                let group = Array(words[i..<min(i + n, words.count)])
+                if !group.isEmpty { out.append(group) }
+                i += n
+            }
+            if i < words.count { out.append(Array(words[i...])) }
+            return out
+        }
+    }
+
+    private func captionResyncModalStyle() -> TextStyle {
+        timeline.tracks.flatMap(\.clips)
+            .first { $0.mediaType == .text && $0.captionGroupId != nil }?
+            .textStyle ?? TextStyle()
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+CaptionResync.swift
@@ -81,7 +81,9 @@ extension EditorViewModel {
             guard let loc = findClip(id: r.clipId) else { continue }
             timeline.tracks[loc.trackIndex].clips[loc.clipIndex].textContent = r.text
             timeline.tracks[loc.trackIndex].clips[loc.clipIndex].wordTimings = r.wordTimings.isEmpty ? nil : r.wordTimings
-            timeline.tracks[loc.trackIndex].clips[loc.clipIndex].generatedText = r.generatedText
+            if let provenance = r.generatedText {
+                timeline.tracks[loc.trackIndex].clips[loc.clipIndex].generatedText = provenance
+            }
             timeline.tracks[loc.trackIndex].clips[loc.clipIndex].resyncConflict = nil
         }
         for id in plan.flagged {
@@ -223,7 +225,7 @@ extension EditorViewModel {
             }
             let phrases = CaptionBuilder.phrases(
                 fromTimedWords: synthetic,
-                fits: { self.captionLineFits($0, style: style) },
+                fits: { CaptionSpecBuilder.lineFits($0, style: style, canvasWidth: self.timeline.width, canvasHeight: self.timeline.height) },
                 maxWords: maxWords,
                 minDuration: AppTheme.Caption.minDisplayDuration
             )

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -249,6 +249,9 @@ extension EditorViewModel {
         for id in ids { dragBefore.removeValue(forKey: id) }
         guard before != after else { return }
         registerTimelineSwap(undoState: before, redoState: after, actionName: "Change Speed")
+        // setClipSpeed already kicked an async rebuild from a pre-resync snapshot; notify again so
+        // the player rebuilds from the post-resync timeline instead of racing it.
+        notifyTimelineChanged()
     }
 
     func registerTimelineSwap(undoState: Timeline, redoState: Timeline, actionName: String) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -239,6 +239,11 @@ extension EditorViewModel {
                 setClipSpeed(at: loc, newSpeed: newSpeed, ripple: ripple)
             }
         }
+        // Speed remaps source↔timeline for every word under the clip — captions must follow,
+        // inside the same undo swap (registration happens below).
+        undo.withoutRegistration {
+            resyncCaptionsAfterSwap(before: before, trigger: "Change Speed")
+        }
         let after = timeline
         preDragTimeline = nil
         for id in ids { dragBefore.removeValue(forKey: id) }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -257,7 +257,11 @@ extension EditorViewModel {
     /// Run `work` as a single atomic mutation, registering one timeline-swap undo
     func withTimelineSwap(actionName: String, refreshVisuals: Bool = true, _ work: () -> Void) {
         let before = timeline
-        undo.withoutRegistration(work)
+        undo.withoutRegistration {
+            work()
+            // Reactive caption resync joins the same before→after swap (registration is disabled here).
+            resyncCaptionsAfterSwap(before: before, trigger: actionName)
+        }
         let after = timeline
         guard before != after else { return }
         guard undo.isRegistrationEnabled else { return }
@@ -422,6 +426,7 @@ extension EditorViewModel {
         let canvasW = Double(timeline.width)
         let canvasH = Double(timeline.height)
         applyClipProperty(clipId: clipId, rebuild: true) { clip in
+            if clip.textContent != content { clip.wordTimings = nil }
             clip.textContent = content
             _ = self.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
         }
@@ -431,6 +436,7 @@ extension EditorViewModel {
         let canvasW = Double(timeline.width)
         let canvasH = Double(timeline.height)
         commitClipProperty(clipId: clipId, actionName: "Change Text") { clip in
+            if clip.textContent != content { clip.wordTimings = nil }
             clip.textContent = content
             _ = self.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -756,6 +756,8 @@ extension EditorViewModel {
         var words: [WordTiming]? = nil
         var animation: TextAnimation? = nil
         var fillMode: TextFillMode? = nil
+        /// Transcript-derived text recorded as caption provenance; nil for non-caption text.
+        var generatedText: String? = nil
     }
 
     /// Batch variant of `addTextClip` for agent flows.
@@ -814,6 +816,7 @@ extension EditorViewModel {
             clip.wordTimings = spec.words
             clip.textAnimation = spec.animation
             clip.textFillMode = spec.fillMode == .footage ? .footage : nil
+            clip.generatedText = spec.generatedText
             if batchTimeline != nil {
                 batchTimeline!.tracks[spec.trackIndex].clips.append(clip)
             } else {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -526,6 +526,14 @@ extension EditorViewModel {
             registerTimelineUndo("Trim Clip") { vm in
                 vm.trimClipInternal(clipId: clipId, trimStartFrame: prevStart, trimEndFrame: prevEnd, protecting: protecting)
             }
+            // A plain trim changes the audible content under its captions; resync joins this undo group.
+            if isAudibleSource(clip) {
+                resyncCaptionsAfterTrim(
+                    before: prevStartFrame..<prevEndFrame,
+                    after: newStartFrame..<newEndFrame,
+                    trigger: "Trim Clip"
+                )
+            }
             notifyTimelineChanged()
         }
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -23,6 +23,7 @@ extension EditorViewModel {
         openTimelineIds = (file.openTimelineIds ?? []).filter { ids.contains($0) }
         speakerRegistry = file.speakers ?? []
         multicamGroups = file.multicamGroups ?? []
+        captionConflictPolicy = file.captionConflictPolicy ?? .default
         syncSpeakerColors()
         if !openTimelineIds.contains(activeTimelineId) {
             openTimelineIds.append(activeTimelineId)
@@ -40,7 +41,8 @@ extension EditorViewModel {
             openTimelineIds: openTimelineIds,
             viewStates: liveViewStates.filter { ids.contains($0.key) },
             speakers: speakerRegistry.isEmpty ? nil : speakerRegistry,
-            multicamGroups: savedMulticamGroups()
+            multicamGroups: savedMulticamGroups(),
+            captionConflictPolicy: captionConflictPolicy == .default ? nil : captionConflictPolicy
         )
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -457,9 +457,10 @@ final class EditorViewModel {
     /// Last resync summary, stashed by the trigger so the agent tool layer can surface it. Read-and-cleared.
     var lastResyncReport: CaptionResyncReport?
 
-    /// Coalesced affected spans + trailing task for UI-origin (debounced) resync.
-    var pendingResyncSpans: [Range<Int>] = []
-    var pendingResyncTask: Task<Void, Never>?
+    /// Test seam: overrides the cache-only word source so triggers can be exercised without real ASR.
+    /// UI edits commit once on mouse-up, so resync runs synchronously in the trigger's transaction
+    /// (one undo reverts both) rather than on a trailing debounce that would split the undo group.
+    var captionWordSourceProvider: (@MainActor (EditorViewModel) -> CaptionWordSource)?
 
     func notifyTimelineChanged(refreshVisuals: Bool = true) {
         guard undo.isRegistrationEnabled else { return }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -448,6 +448,19 @@ final class EditorViewModel {
     /// Coalesces rapid rebuild requests so `replaceCurrentItem` doesn't fire per keystroke.
     var pendingRebuildTask: Task<Void, Never>?
 
+    /// How caption resync treats manually-edited caption clips; persisted in project.json.
+    var captionConflictPolicy: CaptionConflictPolicy = .default
+
+    /// True while resync is applying its own writes, so those writes never re-trigger resync.
+    var isResyncingCaptions = false
+
+    /// Last resync summary, stashed by the trigger so the agent tool layer can surface it. Read-and-cleared.
+    var lastResyncReport: CaptionResyncReport?
+
+    /// Coalesced affected spans + trailing task for UI-origin (debounced) resync.
+    var pendingResyncSpans: [Range<Int>] = []
+    var pendingResyncTask: Task<Void, Never>?
+
     func notifyTimelineChanged(refreshVisuals: Bool = true) {
         guard undo.isRegistrationEnabled else { return }
         enhancePendingDenoises()

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -219,7 +219,8 @@ enum CaptionBuilder {
                 transform: transformFor(p.text),
                 captionGroupId: captionGroupId,
                 words: words.isEmpty ? nil : words,
-                animation: animation
+                animation: animation,
+                generatedText: captionGroupId == nil ? nil : p.text
             )
         }
     }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -78,7 +78,7 @@ enum CaptionSpecBuilder {
         return specs
     }
 
-    private static func lineFits(
+    static func lineFits(
         _ text: String,
         style: TextStyle,
         canvasWidth: Int,

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTranscriptMapper.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTranscriptMapper.swift
@@ -14,6 +14,36 @@ enum CaptionTranscriptMapper {
         return max(lo / rate - paddingSeconds, 0)...(hi / rate + paddingSeconds)
     }
 
+    /// Map a source-seconds span to project frames through this clip's placement, trim, and speed.
+    /// Shared by get_transcript and caption resync so both compute identical timing.
+    static func timelineFrames(sourceStart start: Double, sourceEnd end: Double, clip: Clip, fps: Int) -> (start: Int, end: Int)? {
+        let rate = Double(fps)
+        let visible = sourceSpan(for: clip)
+        let startFrame = max(start * rate, visible.start)
+        let endFrame = min(end * rate, visible.end)
+        guard endFrame > startFrame else { return nil }
+        func toTimeline(_ sourceFrame: Double) -> Int {
+            Int((Double(clip.startFrame) + (sourceFrame - visible.start) / max(clip.speed, 0.0001)).rounded())
+        }
+        let mappedStart = toTimeline(startFrame)
+        return (mappedStart, max(mappedStart, toTimeline(endFrame)))
+    }
+
+    /// Transcript words landing within this clip's visible span, mapped to absolute project frames.
+    /// Cache-only callers pass a cached transcript; nothing here triggers transcription.
+    static func timelineWords(from transcript: TranscriptionResult, clip: Clip, fps: Int) -> [WordTiming] {
+        let visible = sourceSpan(for: clip)
+        let rate = Double(fps)
+        return transcript.words.compactMap { word -> WordTiming? in
+            guard let start = word.start, let end = word.end else { return nil }
+            let midFrame = (start + end) / 2 * rate
+            guard midFrame >= visible.start, midFrame < visible.end,
+                  let f = timelineFrames(sourceStart: start, sourceEnd: end, clip: clip, fps: fps) else { return nil }
+            return WordTiming(text: word.text, startFrame: f.start, endFrame: f.end)
+        }
+        .sorted { ($0.startFrame, $0.endFrame) < ($1.startFrame, $1.endFrame) }
+    }
+
     static func spokenWordCount(in clip: Clip, result: TranscriptionResult, fps: Int) -> Int {
         let visible = sourceSpan(for: clip)
         let rate = Double(fps)

--- a/Sources/PalmierPro/Models/ProjectFile.swift
+++ b/Sources/PalmierPro/Models/ProjectFile.swift
@@ -8,6 +8,8 @@ struct ProjectFile: Codable, Sendable {
     var viewStates: [String: TimelineViewState]?
     var speakers: [SpeakerRegistryEntry]?
     var multicamGroups: [MulticamSource]?
+    /// How caption resync treats manually-edited caption clips. nil decodes as `.preserve`.
+    var captionConflictPolicy: CaptionConflictPolicy?
 
     static func decode(_ data: Data) throws -> ProjectFile {
         let decoder = JSONDecoder()

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -163,6 +163,15 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     var wordTimings: [WordTiming]?
     var textFillMode: TextFillMode?
 
+    // Caption resync provenance (caption text clips only).
+    // Transcript-derived text captured at generation/resync; a clip is "dirty" (manually edited)
+    // when textContent != generatedText. nil = unknown provenance (pre-feature clip).
+    var generatedText: String?
+    // User opt-out for a whole caption group; when true resync leaves the group alone.
+    var resyncExempt: Bool?
+    // Set under the `flag` conflict policy when a dirty clip diverges; cleared on the next match.
+    var resyncConflict: Bool?
+
     // Keyframe tracks for each animatable property. Nil when no animation exists.
     var opacityTrack: KeyframeTrack<Double>?
     var positionTrack: KeyframeTrack<AnimPair>?
@@ -183,6 +192,7 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case opacity, transform, crop, edgeRounding, edgeSoftness
         case linkGroupId, captionGroupId, multicamGroupId, textContent, textStyle, textAnimation, wordTimings
         case textFillMode
+        case generatedText, resyncExempt, resyncConflict
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
         case effects, blendMode
     }
@@ -471,6 +481,9 @@ extension Clip {
             textAnimation: try? c.decode(TextAnimation.self, forKey: .textAnimation),
             wordTimings: try? c.decode([WordTiming].self, forKey: .wordTimings),
             textFillMode: try? c.decode(TextFillMode.self, forKey: .textFillMode),
+            generatedText: try? c.decode(String.self, forKey: .generatedText),
+            resyncExempt: try? c.decode(Bool.self, forKey: .resyncExempt),
+            resyncConflict: try? c.decode(Bool.self, forKey: .resyncConflict),
             opacityTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .opacityTrack),
             positionTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .positionTrack),
             scaleTrack: try? c.decode(KeyframeTrack<AnimPair>.self, forKey: .scaleTrack),

--- a/Sources/PalmierPro/Settings/StoragePane.swift
+++ b/Sources/PalmierPro/Settings/StoragePane.swift
@@ -130,6 +130,7 @@ struct StoragePane: View {
         Task.detached {
             for cache in Self.caches { cache.clear() }
             await TranscriptCache.shared.clearMemory()
+            TimelineTranscriptProvider.clearDiskMemo()
             await MainActor.run {
                 isClearing = false
                 for document in NSDocumentController.shared.documents {

--- a/Sources/PalmierPro/Settings/StoragePane.swift
+++ b/Sources/PalmierPro/Settings/StoragePane.swift
@@ -129,7 +129,10 @@ struct StoragePane: View {
         isClearing = true
         Task.detached {
             for cache in Self.caches { cache.clear() }
+            TimelineTranscriptProvider.clearDiskMemo()
             await TranscriptCache.shared.clearMemory()
+            // Cleared again after the disk wipe: a resync during the await may have repopulated
+            // the memo from files that no longer exist.
             TimelineTranscriptProvider.clearDiskMemo()
             await MainActor.run {
                 isClearing = false

--- a/Sources/PalmierPro/Transcription/TranscriptCache.swift
+++ b/Sources/PalmierPro/Transcription/TranscriptCache.swift
@@ -114,6 +114,9 @@ actor TranscriptCache {
         directory.appendingPathComponent("\(key).json")
     }
 
+    /// File-identity key (path|mtime|size) for memoization by read-side callers.
+    nonisolated static func identityKey(for url: URL) -> String? { key(for: url) }
+
     private static func key(for url: URL, variant: CacheVariant = .local) -> String? {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
               let size = (attrs[.size] as? NSNumber)?.int64Value,

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -267,45 +267,65 @@ private func timeline(_ tracks: [Track]) -> Timeline {
 
 @MainActor
 @Suite struct CaptionResyncSpanTests {
-    private func editorWithCaptions() -> EditorViewModel {
-        let e = EditorViewModel()
-        e.timeline = timeline([Fixtures.videoTrack(clips: [captionClip(id: "c", start: 0, duration: 30, text: "x", generatedText: "x")])])
-        return e
+    private func aud(_ id: String, _ start: Int, _ dur: Int = 30) -> Clip {
+        Fixtures.clip(id: id, mediaType: .audio, start: start, duration: dur)
+    }
+    private func cap(_ id: String, _ start: Int, _ dur: Int = 30) -> Clip {
+        captionClip(id: id, start: start, duration: dur, text: "x", generatedText: "x")
+    }
+    private func tl(caps: [Clip], audio: [Clip]) -> Timeline {
+        timeline([Fixtures.videoTrack(clips: caps), Fixtures.audioTrack(clips: audio)])
+    }
+    private func spans(_ before: Timeline, _ after: Timeline) -> [Range<Int>] {
+        CaptionResyncEngine.mergeSpans(EditorViewModel().captionResyncAffectedSpans(before: before, after: after))
     }
 
     @Test func trimProducesUnionSpan() {
-        let e = editorWithCaptions()
-        let before = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 90)])])
-        let after = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 60)])])
-        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
-        #expect(spans == [0..<90])
+        let before = tl(caps: [cap("c", 0, 90)], audio: [aud("a", 0, 90)])
+        let after = tl(caps: [cap("c", 0, 90)], audio: [aud("a", 0, 60)])
+        #expect(spans(before, after) == [0..<90])
     }
 
     @Test func uniformRippleShiftExcludesDownstream() {
-        let e = editorWithCaptions()
-        func audio(_ id: String, _ s: Int) -> Clip { Fixtures.clip(id: id, mediaType: .audio, start: s, duration: 30) }
-        let before = timeline([Fixtures.audioTrack(clips: [audio("A", 0), audio("B", 30), audio("C", 60), audio("D", 90)])])
-        let after = timeline([Fixtures.audioTrack(clips: [audio("B", 0), audio("C", 30), audio("D", 60)])])
-        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
-        // A removed at [0,30); B/C/D shifted uniformly by -30 → excluded. Only the seam is affected.
-        #expect(spans == [0..<30])
+        // Ripple-delete A and its caption; everything downstream (audio AND captions) shifts -30 together.
+        let before = tl(caps: [cap("cA", 0), cap("cB", 30), cap("cC", 60), cap("cD", 90)],
+                        audio: [aud("A", 0), aud("B", 30), aud("C", 60), aud("D", 90)])
+        let after = tl(caps: [cap("cB", 0), cap("cC", 30), cap("cD", 60)],
+                       audio: [aud("B", 0), aud("C", 30), aud("D", 60)])
+        // Captions stayed aligned with their audio → only the deleted seam is affected.
+        #expect(spans(before, after) == [0..<30])
     }
 
     @Test func insertAffectsOnlyInsertRegion() {
-        let e = editorWithCaptions()
-        func audio(_ id: String, _ s: Int) -> Clip { Fixtures.clip(id: id, mediaType: .audio, start: s, duration: 30) }
-        let before = timeline([Fixtures.audioTrack(clips: [audio("B", 0), audio("C", 30)])])
-        let after = timeline([Fixtures.audioTrack(clips: [audio("NEW", 0), audio("B", 30), audio("C", 60)])])
-        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
-        #expect(spans == [0..<30])
+        let before = tl(caps: [cap("cB", 0), cap("cC", 30)], audio: [aud("B", 0), aud("C", 30)])
+        let after = tl(caps: [cap("cB", 30), cap("cC", 60)], audio: [aud("NEW", 0), aud("B", 30), aud("C", 60)])
+        #expect(spans(before, after) == [0..<30])
     }
 
     @Test func captionOnlyChangesProduceNoSpan() {
-        let e = editorWithCaptions()
-        // Two timelines differing only on the text track — audible occupancy identical.
-        let before = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 90)])])
-        let after = before
-        #expect(e.captionResyncAffectedSpans(before: before, after: after).isEmpty)
+        let before = tl(caps: [cap("c", 0, 90)], audio: [aud("a", 0, 90)])
+        #expect(EditorViewModel().captionResyncAffectedSpans(before: before, after: before).isEmpty)
+    }
+
+    // F1: a two-direction block swap must resync BOTH sides, and do so identically every run.
+    @Test func blockSwapResyncsBothSidesDeterministically() {
+        // Captions stay put; the two audio blocks swap places → each now sits under the other's caption.
+        let before = tl(caps: [cap("c1", 0), cap("c2", 30)], audio: [aud("A", 0), aud("B", 30)])
+        let after = tl(caps: [cap("c1", 0), cap("c2", 30)], audio: [aud("B", 0), aud("A", 30)])
+        let expected: [Range<Int>] = [0..<60]
+        for _ in 0..<50 {
+            #expect(spans(before, after) == expected)   // stable across runs — no hash-order dependence
+        }
+    }
+
+    // F2: ≥2 same-delta clips moving onto a captioned, occupied region must resync the destination.
+    @Test func moveOntoOccupiedRegionResyncsDestination() {
+        let before = tl(caps: [cap("cZ", 200)], audio: [aud("X", 0), aud("Y", 30), aud("Z", 200)])
+        // X and Y both shift +200; Z is overwritten at the destination; the caption there stays put.
+        let after = tl(caps: [cap("cZ", 200)], audio: [aud("X", 200), aud("Y", 230)])
+        let result = spans(before, after)
+        // Destination region [200,230) (under cZ) is resynced despite X/Y sharing a delta.
+        #expect(result.contains { $0.lowerBound <= 200 && $0.upperBound >= 230 })
     }
 }
 
@@ -390,5 +410,47 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         }
         #expect(src.queriedRanges.isEmpty)
         #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two three")
+    }
+
+    // Drives the REAL set_clip_properties tool (not resyncCaptionsAfterSwap directly) to prove the wiring.
+    @Test func setClipPropertiesToolPathTriggersResync() async {
+        let audio = Fixtures.clip(id: "audio", mediaRef: "m", mediaType: .audio, start: 0, duration: 90)
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: "one two three", generatedText: "one two three")
+        let h = ToolHarness(timeline: timeline([Fixtures.videoTrack(clips: [caption]), Fixtures.audioTrack(clips: [audio])]))
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+        h.editor.captionWordSourceProvider = { _ in src }
+
+        _ = await h.runRaw("set_clip_properties", args: ["clipIds": ["audio"], "trimEndFrame": 30])
+        #expect(!src.queriedRanges.isEmpty)
+        #expect(h.editor.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two")
+    }
+}
+
+// F3: the production provider is cache-only — reads on-disk transcripts, never triggers ASR, never writes.
+@MainActor
+@Suite struct CaptionResyncIsolationTests {
+    @Test func providerReadsCacheOnlyAndWritesNothing() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("pp-resync-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("clip.mov")
+        try Data("audio".utf8).write(to: file)
+
+        let e = EditorViewModel()
+        let asset = MediaAsset(id: "m", url: file, type: .audio, name: "m", duration: 3)
+        asset.hasAudio = true
+        e.mediaAssets.append(asset)
+        e.mediaManifest.entries.append(MediaManifestEntry(id: "m", name: "m", type: .audio, source: .external(absolutePath: file.path), duration: 3))
+        e.timeline = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaRef: "m", mediaType: .audio, start: 0, duration: 90)])])
+
+        let cacheDir = TranscriptCache.directory
+        func listing() -> [String] { ((try? FileManager.default.contentsOfDirectory(atPath: cacheDir.path)) ?? []).sorted() }
+        let before = listing()
+
+        let provider = TimelineTranscriptProvider(editor: e)
+        // No transcript cached → cache-only read yields nothing and reports the ref uncached; no ASR, no write.
+        #expect(provider.audibleWords(in: 0..<90).isEmpty)
+        #expect(provider.uncachedRefs(in: 0..<90) == ["m"])
+        #expect(listing() == before)   // TranscriptCache directory untouched — resync never writes L1/L2.
     }
 }

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -454,3 +454,33 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         #expect(listing() == before)   // TranscriptCache directory untouched — resync never writes L1/L2.
     }
 }
+
+// A clean caption over a source whose transcript is not cached must be PRESERVED, not deleted —
+// the empty word span is a missing read, not a speech cut. A genuinely-cached empty span still removes.
+@MainActor
+@Suite struct CaptionResyncColdCacheTests {
+    @Test func uncachedRefPreservesCaptionInsteadOfDeleting() {
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: "开照片", generatedText: "开照片")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [], uncached: ["m"])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<90], trigger: "Trim Clip", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk)
+
+        #expect(plan.removals.isEmpty)
+        #expect(plan.report.conflicts.contains { $0.clipId == "cap" && $0.newTranscript.contains("not cached") })
+    }
+
+    @Test func cachedEmptySpanStillRemovesCaption() {
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: "开照片", generatedText: "开照片")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [], uncached: [])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<90], trigger: "Trim Clip", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk)
+
+        #expect(plan.removals == ["cap"])
+    }
+}

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -517,3 +517,23 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         #expect(repl?.wordTimings.last?.endFrame == 60)
     }
 }
+
+// Round-3: an uncached ref with only PARTIAL cached word coverage must preserve the caption —
+// resyncing on half the words would shrink it to the cached half.
+@MainActor
+@Suite struct CaptionResyncPartialCacheTests {
+    @Test func partialCoverageWithUncachedRefPreservesCaption() {
+        let caption = captionClip(id: "cap", start: 0, duration: 120, text: "前 半 后 半", generatedText: "前 半 后 半")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        // Words cover only the first half of the caption's span; a second ref is uncached.
+        let src = FakeWordSource(words: [word("前", 0, 30), word("半", 30, 55)], uncached: ["m2"])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<120], trigger: "Trim Clip", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk)
+
+        #expect(plan.removals.isEmpty)
+        #expect(plan.replacements.isEmpty)
+        #expect(plan.report.conflicts.contains { $0.clipId == "cap" && $0.newTranscript.contains("not cached") })
+    }
+}

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -369,4 +369,26 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         // preserve is the default → manual text kept, clip not overwritten.
         #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "hand edited")
     }
+
+    // set_clip_properties applies timing outside withTimelineSwap — it reconciles via the same hook.
+    @Test func agentTimingPropertyTriggersResync() {
+        let (e, _) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        let before = e.timeline
+        e.undo.perform("Set Clip Property (Agent)") {
+            e.commitClipProperty(clipId: "audio") { $0.trimEndFrame = 30; $0.setDuration(60) }
+            e.resyncCaptionsAfterSwap(before: before, trigger: "Set Clip Property (Agent)")
+        }
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two")
+    }
+
+    @Test func agentNonTimingPropertyDoesNotTriggerResync() {
+        let (e, src) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        let before = e.timeline
+        e.undo.perform("Set Clip Property (Agent)") {
+            e.commitClipProperty(clipId: "audio") { $0.opacity = 0.5 }
+            e.resyncCaptionsAfterSwap(before: before, trigger: "Set Clip Property (Agent)")
+        }
+        #expect(src.queriedRanges.isEmpty)
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two three")
+    }
 }

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -183,17 +183,25 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         #expect(plan.clearedFlags == ["cap"])
     }
 
-    @Test func unknownProvenanceReplacedAndConflictLogged() {
+    @Test func unknownProvenanceFollowsPolicyNeverBlindReplace() {
+        // generatedText == nil is hand-authored or pre-feature text: clean requires PROOF, so the
+        // conflict policy governs — .preserve keeps the text, .overwrite replaces it.
         let caption = captionClip(id: "cap", start: 0, duration: 60, text: "pre feature text", generatedText: nil)
         let tl = timeline([Fixtures.videoTrack(clips: [caption])])
         let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
 
-        let plan = CaptionResyncEngine.plan(
+        let preserved = CaptionResyncEngine.plan(
             timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
             policy: .preserve, wordSource: src, chunk: singleChunk
         )
-        #expect(plan.replacements.first?.text == "one two")
-        #expect(plan.report.conflicts.count == 1)   // logged even though replaced
+        #expect(preserved.replacements.isEmpty)
+        #expect(preserved.report.conflicts.count == 1)
+
+        let overwritten = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .overwrite, wordSource: src, chunk: singleChunk
+        )
+        #expect(overwritten.replacements.first?.text == "one two")
     }
 
     @Test func exemptGroupIsUntouched() {

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -484,3 +484,36 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         #expect(plan.removals == ["cap"])
     }
 }
+
+// Round-2 review regressions: an unrelated uncached ref must not freeze resync when cached words
+// exist, and new chunks must never span a surviving caption island.
+@MainActor
+@Suite struct CaptionResyncRoundTwoTests {
+    @Test func cachedWordsResyncDespiteUnrelatedUncachedRef() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "旧的", generatedText: "旧的")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("新", 0, 30), word("的", 30, 60)], uncached: ["music-bed"])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "Trim Clip", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk)
+
+        #expect(plan.replacements.first { $0.clipId == "cap" }?.text == "新 的")
+    }
+
+    @Test func unchangedTextStillRefreshesStaleTimings() {
+        var caption = captionClip(id: "cap", start: 0, duration: 60, text: "你 好", generatedText: "你 好")
+        caption.wordTimings = [WordTiming(text: "你", startFrame: 0, endFrame: 10),
+                               WordTiming(text: "好", startFrame: 10, endFrame: 20)]
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("你", 0, 30), word("好", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "Change Speed", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk)
+
+        let repl = plan.replacements.first { $0.clipId == "cap" }
+        #expect(repl?.text == "你 好")
+        #expect(repl?.wordTimings.last?.endFrame == 60)
+    }
+}

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -1,0 +1,372 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+// Caption resync (L2→L3): engine logic against synthetic timelines with an injected read-only word
+// source, plus trigger wiring (trim fires, split does not), undo grouping, and L1/L2 isolation.
+
+// MARK: - Fixtures
+
+/// Read-only word source. Conforming to CaptionWordSource is the only capability it has — there is no
+/// write API, so an engine holding one cannot touch asset transcripts (L1) or the cache (L2).
+private final class FakeWordSource: CaptionWordSource {
+    var words: [WordTiming]
+    var uncached: [String]
+    private(set) var queriedRanges: [Range<Int>] = []
+
+    init(words: [WordTiming], uncached: [String] = []) {
+        self.words = words
+        self.uncached = uncached
+    }
+
+    func audibleWords(in range: Range<Int>) -> [WordTiming] {
+        queriedRanges.append(range)
+        return words
+            .filter { $0.startFrame < range.upperBound && $0.endFrame > range.lowerBound }
+            .sorted { ($0.startFrame, $0.endFrame) < ($1.startFrame, $1.endFrame) }
+    }
+
+    func uncachedRefs(in range: Range<Int>) -> [String] { uncached }
+}
+
+private func word(_ text: String, _ start: Int, _ end: Int) -> WordTiming {
+    WordTiming(text: text, startFrame: start, endFrame: end)
+}
+
+@MainActor
+private func captionClip(
+    id: String, group: String = "g1", start: Int, duration: Int,
+    text: String, generatedText: String?, exempt: Bool? = nil, conflict: Bool? = nil
+) -> Clip {
+    var c = Clip(mediaRef: "", mediaType: .text, sourceClipType: .text, startFrame: start, durationFrames: duration)
+    c.id = id
+    c.captionGroupId = group
+    c.textContent = text
+    c.generatedText = generatedText
+    c.resyncExempt = exempt
+    c.resyncConflict = conflict
+    return c
+}
+
+/// One caption clip per call — the boundary-preserving default for REPLACE-oriented tests.
+private func singleChunk(_ words: [WordTiming], _ maxWords: Int?) -> [[WordTiming]] {
+    words.isEmpty ? [] : [words]
+}
+
+/// Splits into fixed groups of `maxWords` (or all) — enough for CREATE assertions.
+private func cappedChunk(_ words: [WordTiming], _ maxWords: Int?) -> [[WordTiming]] {
+    guard let cap = maxWords, cap > 0 else { return words.isEmpty ? [] : [words] }
+    return stride(from: 0, to: words.count, by: cap).map { Array(words[$0..<min($0 + cap, words.count)]) }
+}
+
+@MainActor
+private func timeline(_ tracks: [Track]) -> Timeline {
+    var t = Timeline()
+    t.fps = 30
+    t.tracks = tracks
+    return t
+}
+
+// MARK: - Engine: REPLACE / REMOVE / match
+
+@MainActor
+@Suite struct CaptionResyncEngineTests {
+    @Test func trimShrinksCleanCaptionToSurvivingWords() {
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: "one two three", generatedText: "one two three")
+        let other = captionClip(id: "far", start: 120, duration: 60, text: "four five", generatedText: "four five")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption, other])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<90], trigger: "Trim Clip", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+
+        #expect(plan.replacements.count == 1)
+        #expect(plan.replacements.first?.clipId == "cap")
+        #expect(plan.replacements.first?.text == "one two")
+        #expect(plan.report.updated == [.init(clipId: "cap", before: "one two three", after: "one two")])
+        // Far caption never queried — lookups confined to the caption touching the affected span.
+        #expect(src.queriedRanges.allSatisfy { $0.lowerBound >= 0 && $0.upperBound <= 90 })
+        #expect(plan.report.removed.isEmpty)
+    }
+
+    @Test func rebuiltTimingsAreClipRelative() {
+        let caption = captionClip(id: "cap", start: 100, duration: 90, text: "old", generatedText: "old")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("hi", 100, 130), word("there", 130, 160)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [100..<190], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.first?.wordTimings == [word("hi", 0, 30), word("there", 30, 60)])
+    }
+
+    @Test func emptySpanRemovesCaption() {
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: "gone soon", generatedText: "gone soon")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<90], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.removals == ["cap"])
+        #expect(plan.report.removed == [.init(clipId: "cap", text: "gone soon")])
+    }
+
+    @Test func matchingTextIsNoOp() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "one two", generatedText: "one two")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(!plan.hasWork)
+        #expect(plan.report.isEmpty)
+    }
+
+    // MARK: - Conflict policy
+
+    @Test func dirtyCaptionPreservedByDefault() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "my hand edit", generatedText: "one two")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.isEmpty)
+        #expect(plan.report.conflicts == [.init(clipId: "cap", manualText: "my hand edit", newTranscript: "one two")])
+    }
+
+    @Test func dirtyCaptionOverwrittenWhenPolicyOverwrite() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "my hand edit", generatedText: "one two")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .overwrite, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.first?.text == "one two")
+        #expect(plan.report.updated.first?.after == "one two")
+    }
+
+    @Test func dirtyCaptionFlaggedWhenPolicyFlag() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "my hand edit", generatedText: "one two")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .flag, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.isEmpty)
+        #expect(plan.flagged == ["cap"])
+        #expect(plan.report.conflicts.count == 1)
+    }
+
+    @Test func flagClearsWhenManualTextMatchesAgain() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "one two", generatedText: "stale", conflict: true)
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.clearedFlags == ["cap"])
+    }
+
+    @Test func unknownProvenanceReplacedAndConflictLogged() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "pre feature text", generatedText: nil)
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.first?.text == "one two")
+        #expect(plan.report.conflicts.count == 1)   // logged even though replaced
+    }
+
+    @Test func exemptGroupIsUntouched() {
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "keep me", generatedText: "keep me", exempt: true)
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [word("changed", 0, 30), word("words", 30, 60)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(!plan.hasWork)
+    }
+
+    @Test func mixedLanguageTextPreservedVerbatim() {
+        let caption = captionClip(id: "cap", start: 0, duration: 150, text: "old", generatedText: "old")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [
+            word("我掉得", 0, 30), word("really", 30, 60), word("low。", 60, 90),
+            word("oh", 90, 120), word("god。", 120, 150),
+        ])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<150], trigger: "t", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.replacements.first?.text == "我掉得 really low。 oh god。")
+    }
+
+    // MARK: - CREATE
+
+    @Test func uncoveredSpeechCreatesCaptions() {
+        // Group clip covers [0,60); words extend into [60,120) with no covering caption there.
+        let caption = captionClip(id: "cap", start: 0, duration: 60, text: "one two", generatedText: "one two")
+        let tl = timeline([Fixtures.videoTrack(clips: [caption])])
+        let src = FakeWordSource(words: [
+            word("one", 0, 30), word("two", 30, 60), word("three", 60, 90), word("four", 90, 120),
+        ])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<120], trigger: "insert", fps: 30,
+            policy: .preserve, wordSource: src, chunk: cappedChunk
+        )
+        #expect(!plan.creations.isEmpty)
+        let createdText = plan.report.created.map(\.text).joined(separator: " ")
+        #expect(createdText.contains("three"))
+        #expect(createdText.contains("four"))
+        // Existing clip matched its own words — no spurious replacement.
+        #expect(plan.replacements.isEmpty)
+    }
+
+    // MARK: - Cost / span confinement
+
+    @Test func downstreamCaptionsAreNeverQueriedOutsideSpan() {
+        let near = captionClip(id: "near", start: 0, duration: 60, text: "gone", generatedText: "gone")
+        let far = captionClip(id: "far", start: 900, duration: 60, text: "later words", generatedText: "later words")
+        let tl = timeline([Fixtures.videoTrack(clips: [near, far])])
+        let src = FakeWordSource(words: [word("later", 900, 930), word("words", 930, 960)])
+
+        let plan = CaptionResyncEngine.plan(
+            timeline: tl, triggerSpans: [0..<60], trigger: "ripple", fps: 30,
+            policy: .preserve, wordSource: src, chunk: singleChunk
+        )
+        #expect(plan.removals == ["near"])                       // empty near-span caption removed
+        #expect(src.queriedRanges.allSatisfy { $0.upperBound <= 60 })  // far caption never looked up
+        #expect(!plan.report.updated.contains { $0.clipId == "far" })
+    }
+}
+
+// MARK: - Span diff heuristic
+
+@MainActor
+@Suite struct CaptionResyncSpanTests {
+    private func editorWithCaptions() -> EditorViewModel {
+        let e = EditorViewModel()
+        e.timeline = timeline([Fixtures.videoTrack(clips: [captionClip(id: "c", start: 0, duration: 30, text: "x", generatedText: "x")])])
+        return e
+    }
+
+    @Test func trimProducesUnionSpan() {
+        let e = editorWithCaptions()
+        let before = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 90)])])
+        let after = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 60)])])
+        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
+        #expect(spans == [0..<90])
+    }
+
+    @Test func uniformRippleShiftExcludesDownstream() {
+        let e = editorWithCaptions()
+        func audio(_ id: String, _ s: Int) -> Clip { Fixtures.clip(id: id, mediaType: .audio, start: s, duration: 30) }
+        let before = timeline([Fixtures.audioTrack(clips: [audio("A", 0), audio("B", 30), audio("C", 60), audio("D", 90)])])
+        let after = timeline([Fixtures.audioTrack(clips: [audio("B", 0), audio("C", 30), audio("D", 60)])])
+        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
+        // A removed at [0,30); B/C/D shifted uniformly by -30 → excluded. Only the seam is affected.
+        #expect(spans == [0..<30])
+    }
+
+    @Test func insertAffectsOnlyInsertRegion() {
+        let e = editorWithCaptions()
+        func audio(_ id: String, _ s: Int) -> Clip { Fixtures.clip(id: id, mediaType: .audio, start: s, duration: 30) }
+        let before = timeline([Fixtures.audioTrack(clips: [audio("B", 0), audio("C", 30)])])
+        let after = timeline([Fixtures.audioTrack(clips: [audio("NEW", 0), audio("B", 30), audio("C", 60)])])
+        let spans = CaptionResyncEngine.mergeSpans(e.captionResyncAffectedSpans(before: before, after: after))
+        #expect(spans == [0..<30])
+    }
+
+    @Test func captionOnlyChangesProduceNoSpan() {
+        let e = editorWithCaptions()
+        // Two timelines differing only on the text track — audible occupancy identical.
+        let before = timeline([Fixtures.audioTrack(clips: [Fixtures.clip(id: "a", mediaType: .audio, start: 0, duration: 90)])])
+        let after = before
+        #expect(e.captionResyncAffectedSpans(before: before, after: after).isEmpty)
+    }
+}
+
+// MARK: - Trigger wiring + undo + isolation
+
+@MainActor
+@Suite struct CaptionResyncTriggerTests {
+    private func editorWithAudioAndCaption(captionText: String, generatedText: String) -> (EditorViewModel, FakeWordSource) {
+        let e = EditorViewModel()
+        let audio = Fixtures.clip(id: "audio", mediaRef: "m", mediaType: .audio, start: 0, duration: 90)
+        let caption = captionClip(id: "cap", start: 0, duration: 90, text: captionText, generatedText: generatedText)
+        e.timeline = timeline([
+            Fixtures.videoTrack(clips: [caption]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+        let src = FakeWordSource(words: [word("one", 0, 30), word("two", 30, 60)])
+        e.captionWordSourceProvider = { _ in src }
+        return (e, src)
+    }
+
+    @Test func trimTriggersResyncAndUpdatesCaption() {
+        let (e, _) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        e.trimClips([(clipId: "audio", trimStartFrame: 0, trimEndFrame: 30)])
+
+        let cap = e.timeline.tracks[0].clips.first { $0.id == "cap" }
+        #expect(cap?.textContent == "one two")
+    }
+
+    @Test func splitTriggersNoResyncAndNoLookups() {
+        let (e, src) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        _ = e.splitClip(clipId: "audio", atFrame: 45)
+
+        #expect(src.queriedRanges.isEmpty)                                  // never invoked
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two three")
+    }
+
+    @Test func undoRevertsTriggerAndResyncTogether() {
+        let (e, _) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        let manager = UndoManager()
+        e.undo.attach(manager)
+        let before = e.timeline
+
+        e.trimClips([(clipId: "audio", trimStartFrame: 0, trimEndFrame: 30)])
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "one two")
+
+        manager.undo()
+        #expect(e.timeline == before)   // one undo restores audio trim AND caption text
+    }
+
+    @Test func resyncNeverMutatesNonCaptionClips() {
+        let (e, _) = editorWithAudioAndCaption(captionText: "one two three", generatedText: "one two three")
+        let audioBefore = e.timeline.tracks[1].clips
+        e.trimClips([(clipId: "audio", trimStartFrame: 0, trimEndFrame: 0)])  // no-op trim: audio unchanged
+        // The audio (L1 source) is byte-identical; resync only ever writes caption (L3) clips.
+        #expect(e.timeline.tracks[1].clips == audioBefore)
+    }
+
+    @Test func dirtyCaptionSurvivesUnrelatedTrimUnderPreserve() {
+        let (e, _) = editorWithAudioAndCaption(captionText: "hand edited", generatedText: "one two three")
+        e.trimClips([(clipId: "audio", trimStartFrame: 0, trimEndFrame: 30)])
+        // preserve is the default → manual text kept, clip not overwritten.
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "cap" }?.textContent == "hand edited")
+    }
+}

--- a/Tests/PalmierProTests/CaptionResyncTests.swift
+++ b/Tests/PalmierProTests/CaptionResyncTests.swift
@@ -212,7 +212,7 @@ private func timeline(_ tracks: [Track]) -> Timeline {
         let caption = captionClip(id: "cap", start: 0, duration: 150, text: "old", generatedText: "old")
         let tl = timeline([Fixtures.videoTrack(clips: [caption])])
         let src = FakeWordSource(words: [
-            word("我掉得", 0, 30), word("really", 30, 60), word("low。", 60, 90),
+            word("我唱得", 0, 30), word("really", 30, 60), word("low。", 60, 90),
             word("oh", 90, 120), word("god。", 120, 150),
         ])
 
@@ -220,7 +220,7 @@ private func timeline(_ tracks: [Track]) -> Timeline {
             timeline: tl, triggerSpans: [0..<150], trigger: "t", fps: 30,
             policy: .preserve, wordSource: src, chunk: singleChunk
         )
-        #expect(plan.replacements.first?.text == "我掉得 really low。 oh god。")
+        #expect(plan.replacements.first?.text == "我唱得 really low。 oh god。")
     }
 
     // MARK: - CREATE


### PR DESCRIPTION
> [!NOTE]
> **Part of an 18-PR caption-system series** (full map at the bottom). This PR has **no dependencies** — it is based directly on `main` and reviewable standalone.

## Summary

Captions are a snapshot; the timeline is live. Trim a sentence in half and the caption keeps showing the whole original sentence. This adds a reactive invariant: **a caption's text always equals the words currently audible in its frame range** — maintained automatically on every mutation that changes what audio occupies a frame range (ripple deletes, `remove_words`, inserts, moves, trims, speed), from both the agent tools and UI drags.

## Design

- **Span-scoped, never whole-timeline:** cost scales with the edit. A clip that merely rippled is excluded by a deterministic caption-alignment test (the captions above it moved by the same delta); anything else re-derives.
- **Reconciliation, not regeneration:** per caption clip — no live words → remove; text differs and the clip is untouched → replace (text + karaoke timings); differs but hand-edited → policy (default **preserve** + conflict report with reason); uncovered speech → create, inheriting group style. Hand edits are detected via a new `generatedText` provenance field (dirty ⇔ content ≠ generatedText); unknown-provenance clips are preserved, never clobbered or deleted.
- **Same undo step as the trigger:** resync writes join the mutation's transaction; one ⌘Z reverts both.
- **L1/L2 isolation by type:** the engine's word source protocol has no write surface and reads only cached transcripts — resync can never mutate an asset transcript or trigger ASR.
- **Reporting:** results ride the existing mutation delta (`extra.captionResync`: updated/removed/created/conflicts), so agents see caption effects without re-reading.
- New `resync_captions` tool as the manual/repair escape hatch (group/window scoping, dry-run, per-call conflict policy).
- Also fixes a UI/MCP inconsistency: inspector content edits now clear stale `wordTimings` like `update_text` does.

## Testing

28 unit tests behind an injected word-source: trim/ripple/insert/split semantics, conflict policies, undo atomicity, block-swap determinism (50-run stability), move-onto-occupied, cost confinement (lookup counting), cache-isolation proof, mixed zh/en round-trip. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change statistics

| Scope | Files | Additions | Deletions |
| --- | --- | --- | --- |
| Raw PR diff vs upstream `main` (source) | 20 | +780 | −15 |
| Raw PR diff vs upstream `main` (tests) | 1 | +456 | −0 |

This branch is based directly on upstream `main`, so the raw diff IS the change set.

## The series

| Wave | PR | Branch | What it adds |
| --- | --- | --- | --- |
| 1 | #375 | `multilingual-asr` | On-device multilingual ASR engines (qwen3 + Whisper timing anchor) |
| 1 | #376 | `feature/glossary` | Layered correction glossary, read-time materialisation |
| 1 | #377 | `feature/caption-resync` | Caption↔transcript resync engine |
| 1 | #378 | `feature/caption-style` | Caption-style profiles (layered, per-project) |
| 2 | #379 | `fix/caption-segmentation` | CJK-aware natural segmentation; bias-free recognition |
| 2 | #380 | `fix/caption-timing` | Word-timing correctness (anchored, no fabricated times) |
| 3 | #381 | `fix/caption-anim-onset` | Karaoke animation timing + acoustic onset refinement |
| 3 | #382 | `feature/transcription-model` | Cloud/local transcription routing per project |
| 3 | #383 | `feature/caption-lint` | Caption lint for suspected mis-recognitions |
| 4 | #384 | `fix/resync-materialisation` | Resync reads corrected transcripts; cache correctness |
| 4 | #385 | `feature/glossary-persistence` | Corrections persist across projects; auto-promotion hardening |
| 4 | #386 | `feature/style-lint-persistence` | Style/lint policy persistence + set_caption_style |
| 4 | #387 | `feature/tool-ergonomics` | Caption tool-surface safety and batching |
| 5 | #388 | `fix/punctuated-segmentation` | zh-en punctuation restoration as segmentation signal |
| 5 | #389 | `feature/local-model-selection` | Per-project local engine override |
| 5 | #390 | `feature/indexing-throughput` | Prioritized, preemptible transcription indexing + audio cache |
| 6 | #391 | `feature/caption-ui-resync` | Editor UI for resync (toast, conflict badge, freeze) |
| 6 | #392 | `feature/caption-ui-settings` | Editor UI for caption settings + glossary review |

Waves gate on each other: a PR opens for review once everything it depends on has merged. Drafts flip to ready as their dependencies land and they are rebased.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core timeline mutation paths and can replace or remove caption clips when transcripts are missing or partial; extensive tests mitigate regressions but edge cases around uncached/partial coverage remain sensitive.
> 
> **Overview**
> **Captions stay aligned with audible speech** after timeline edits that change what audio occupies a frame range. A new **cache-only resync engine** rebuilds caption text and karaoke timings from cached transcripts (never re-transcribes), with span-scoped work, conflict policies for hand-edited captions (`generatedText` provenance, `preserve` / `overwrite` / `flag`), and optional creation/removal of caption clips.
> 
> **Reactive hooks** run inside the same undo step as the triggering edit: `withTimelineSwap`, plain trims on audible clips, speed changes, and agent `set_clip_properties` when timing fields change. Mutation tool responses can include **`captionResync`** reports; a new **`resync_captions`** agent tool supports scoped repair, dry-run, and per-call conflict policy.
> 
> **Model/project support:** clip fields `generatedText`, `resyncExempt`, `resyncConflict`; `captionConflictPolicy` on `ProjectFile`. Shared **`CaptionTranscriptMapper.timelineFrames` / `timelineWords`** unify transcript timing for tools and resync. Inspector text edits now **clear stale `wordTimings`** like `update_text`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d07b0b98d47c26b9556f1d4f15ba6bb5060eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->