### PR TITLE
[feat] Reusable caption-style profile — measured filler policy + typography defaults

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -51,6 +51,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case addTexts = "add_texts"
     case updateText = "update_text"
     case addCaptions = "add_captions"
+    case captionStyle = "caption_style"
 
     // Color & effects
     case applyColor = "apply_color"
@@ -785,7 +786,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addCaptions,
-            description: "Transcribes the timeline's spoken audio and creates styled caption text clips on their own track — no targeting needed; it finds the spoken content itself. The app uses cloud only when the signed-in account has enough credits for the uncached request; otherwise it uses local transcription. Cloud auto-detects language. Per-word animations are timed from the transcript. Returns the caption group summary (captionGroupId, clipCount, frameRange, shared style, textPreview) — restyle it later with update_text and that captionGroupId.",
+            description: "Transcribes the timeline's spoken audio and creates styled caption text clips on their own track — no targeting needed; it finds the spoken content itself. The app uses cloud only when the signed-in account has enough credits for the uncached request; otherwise it uses local transcription. Cloud auto-detects language. Per-word animations are timed from the transcript. Style, transform, and maxWords omitted here fall back to the resolved caption_style profile (typography defaults + position); any param you pass wins. fillerPolicy:'removeAlways' drops only removeAlways-classified filler tokens from the caption TEXT (display only — audio is never cut); caseByCase tokens are never auto-removed. Returns the caption group summary (captionGroupId, clipCount, frameRange, shared style, textPreview) — restyle it later with update_text and that captionGroupId.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "language": ["type": "string", "description": "BCP-47 speech language. Applies to local only; cloud auto-detects."],
@@ -802,8 +803,14 @@ enum ToolDefinitions {
                 ], textStyleProperties(detailed: false), [
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset."],
                     "highlightColor": ["type": "string", "description": "Active-word hex."],
+                    "fillerPolicy": ["type": "string", "enum": ["off", "removeAlways"], "description": "Default off. 'removeAlways' drops only removeAlways-classified filler tokens from caption text (display only, no audio cut). caseByCase tokens are never auto-removed — see caption_style."],
                 ])
             )
+        ),
+        AgentTool(
+            name: .captionStyle,
+            description: "Returns the resolved caption-style profile for the active project — the measured filler policy and typography defaults, merged from global → library → project layers (later wins). Read this before captioning to honor project-specific policy. fillers.removeAlways is safe to strip; neverRemove must be kept; caseByCase must NEVER be auto-removed — surface those tokens and decide per occurrence with update_text/remove_words. neverDedupe marks CJK reduplication (存存钱) and comic repetition (太酷了×3) as grammar/intent, not stutters — never dedupe them. protectedPhrases are never touched by any pass. `layers` shows each source file and whether it loaded, was missing, or was malformed; `provenance` records how the policy was measured. Read-only; takes no arguments.",
+            inputSchema: objectSchema()
         ),
         AgentTool(
             name: .applyColor,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionStyle.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+CaptionStyle.swift
@@ -1,0 +1,56 @@
+// caption_style tool — returns the resolved caption-style profile, its provenance, and the layer
+// origins that produced it, so agents can read the measured filler policy and decide caseByCase themselves.
+
+import Foundation
+
+extension ToolExecutor {
+    func captionStyle(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: [], path: "caption_style")
+        let resolved = CaptionStyleStore.resolve(projectPackageURL: editor.projectURL)
+        guard let json = Self.jsonString(Self.captionStylePayload(resolved)) else {
+            return .error("caption_style: could not serialize the resolved profile.")
+        }
+        return .ok(json)
+    }
+
+    private static func captionStylePayload(_ resolved: CaptionStyleStore.Resolved) -> [String: Any] {
+        let profile = resolved.profile
+
+        var typography: [String: Any] = [:]
+        if let v = profile.typography.fontName { typography["fontName"] = v }
+        if let v = profile.typography.fontSize { typography["fontSize"] = v }
+        if let v = profile.typography.color { typography["color"] = v }
+        if let v = profile.typography.outline { typography["outline"] = v }
+        if let v = profile.typography.shadow { typography["shadow"] = v }
+        if let v = profile.typography.position { typography["position"] = ["x": v.x, "y": v.y] }
+        if let v = profile.typography.maxWords { typography["maxWords"] = v }
+
+        var payload: [String: Any] = [
+            "version": profile.version,
+            "fillers": [
+                "removeAlways": profile.fillers.removeAlways,
+                "neverRemove": profile.fillers.neverRemove,
+                "caseByCase": profile.fillers.caseByCase,
+                "neverDedupe": [
+                    "cjkReduplication": profile.fillers.neverDedupe.cjkReduplication,
+                    "comicRepetition": profile.fillers.neverDedupe.comicRepetition,
+                ],
+            ],
+            "protectedPhrases": profile.protectedPhrases,
+            "typography": typography,
+            "provenance": profile.provenance,
+            "layers": resolved.origins.map { origin in
+                ["scope": origin.scope.rawValue, "path": origin.path, "status": origin.status.rawValue]
+            },
+            "semantics": [
+                "removeAlways": "Safe to strip mechanically.",
+                "neverRemove": "Never strip even though generic rules would.",
+                "caseByCase": "NEVER auto-remove — stop and surface for judgement; decide per occurrence via update_text/remove_words.",
+                "neverDedupe": "Repeated CJK tokens and deliberate comic repetition are not stutters — never dedupe them.",
+                "protectedPhrases": "Never touched by any filler or dedup pass.",
+            ],
+        ]
+        if !resolved.warnings.isEmpty { payload["warnings"] = resolved.warnings }
+        return payload
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -3,21 +3,30 @@ import Foundation
 
 extension ToolExecutor {
     private static let addCaptionsAllowedKeys: Set<String> = Set([
-        "style", "transform", "censorProfanity", "language", "animation", "highlightColor", "maxWords",
+        "style", "transform", "censorProfanity", "language", "animation", "highlightColor", "maxWords", "fillerPolicy",
     ])
 
     func addCaptions(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.addCaptionsAllowedKeys, path: "add_captions")
 
+        let profile = CaptionStyleStore.resolve(projectPackageURL: editor.projectURL).profile
+
+        // Explicit style/maxWords/transform params always win; the profile fills only when absent.
         let stylePatch = try parseTextStylePatch(args, path: "add_captions")
         var style = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
-        if let stylePatch { Self.applyTextStylePatch(stylePatch, to: &style) }
+        if let stylePatch {
+            Self.applyTextStylePatch(stylePatch, to: &style)
+        } else {
+            Self.applyProfileTypography(profile.typography, to: &style)
+        }
 
         var center = AppTheme.Caption.defaultCenter
         if let t = args["transform"] as? [String: Any] {
             try validateUnknownKeys(t, allowed: ["centerX", "centerY"], path: "add_captions.transform")
             if let x = t.double("centerX") { center.x = CGFloat(x) }
             if let y = t.double("centerY") { center.y = CGFloat(y) }
+        } else if let position = profile.typography.position {
+            center = CGPoint(x: position.x, y: position.y)
         }
 
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "add_captions") ?? TextAnimation()
@@ -26,7 +35,11 @@ extension ToolExecutor {
         if let n = args.int("maxWords") {
             guard n >= 1 else { throw ToolError("add_captions: maxWords must be >= 1 (got \(n))") }
             maxWords = n
+        } else if let profileMax = profile.typography.maxWords, profileMax >= 1 {
+            maxWords = profileMax
         }
+
+        let fillerPolicy = try parseFillerPolicy(args.string("fillerPolicy"), path: "add_captions")
 
         let context = try await transcriptionContext(args, path: "add_captions") {
             await editor.captionCloudCreditCost(for: .init(autoDetect: true, provider: .cloud))
@@ -48,7 +61,9 @@ extension ToolExecutor {
             locale: context.preferredLocale,
             maxWords: maxWords,
             provider: provider,
-            animation: animation
+            animation: animation,
+            fillerProfile: fillerPolicy == .removeAlways ? profile : nil,
+            dropRemoveAlwaysFillers: fillerPolicy == .removeAlways
         )
 
         try await Self.validateCloudTranscriptionAccess(for: request, in: editor)
@@ -59,5 +74,24 @@ extension ToolExecutor {
         })
         guard !ids.isEmpty else { throw ToolError("No speech detected to caption.") }
         return mutationResult(editor, since: snapshot)
+    }
+
+    private enum FillerPolicyMode: String { case off, removeAlways }
+
+    private func parseFillerPolicy(_ raw: String?, path: String) throws -> FillerPolicyMode {
+        guard let raw else { return .off }
+        guard let mode = FillerPolicyMode(rawValue: raw) else {
+            throw ToolError("\(path): invalid fillerPolicy '\(raw)'. Expected 'off' or 'removeAlways'.")
+        }
+        return mode
+    }
+
+    /// Fill caption typography defaults from a resolved profile. Only non-nil profile keys override.
+    static func applyProfileTypography(_ typography: CaptionStyleProfile.Typography, to style: inout TextStyle) {
+        if let fontName = typography.fontName { style.fontName = fontName }
+        if let fontSize = typography.fontSize { style.fontSize = fontSize }
+        if let hex = typography.color, let color = TextStyle.RGBA(hex: hex) { style.color = color }
+        if let outline = typography.outline { style.border.enabled = outline }
+        if let shadow = typography.shadow { style.shadow.enabled = shadow }
     }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -11,22 +11,21 @@ extension ToolExecutor {
 
         let profile = CaptionStyleStore.resolve(projectPackageURL: editor.projectURL).profile
 
-        // Explicit style/maxWords/transform params always win; the profile fills only when absent.
+        // Explicit style/maxWords/transform params always win FIELD-WISE; the profile fills every
+        // field the caller left unspecified (a partial style must not discard the whole profile).
         let stylePatch = try parseTextStylePatch(args, path: "add_captions")
         var style = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
+        Self.applyProfileTypography(profile.typography, to: &style)
         if let stylePatch {
             Self.applyTextStylePatch(stylePatch, to: &style)
-        } else {
-            Self.applyProfileTypography(profile.typography, to: &style)
         }
 
         var center = AppTheme.Caption.defaultCenter
+        if let position = profile.typography.position { center = CGPoint(x: position.x, y: position.y) }
         if let t = args["transform"] as? [String: Any] {
             try validateUnknownKeys(t, allowed: ["centerX", "centerY"], path: "add_captions.transform")
             if let x = t.double("centerX") { center.x = CGFloat(x) }
             if let y = t.double("centerY") { center.y = CGFloat(y) }
-        } else if let position = profile.typography.position {
-            center = CGPoint(x: position.x, y: position.y)
         }
 
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "add_captions") ?? TextAnimation()

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -180,7 +180,8 @@ final class ToolExecutor {
     private static func canReadInactiveProject(_ tool: ToolName) -> Bool {
         switch tool {
         case .getTimeline, .inspectTimeline, .getMedia, .inspectMedia, .searchMedia,
-             .getMulticam, .getTranscript, .detectBeats, .inspectColor, .listModels, .sendFeedback:
+             .getMulticam, .getTranscript, .detectBeats, .inspectColor, .listModels, .sendFeedback,
+             .captionStyle:
             true
         default:
             false
@@ -253,6 +254,7 @@ final class ToolExecutor {
         case .addTexts:      return try addTexts(editor, args)
         case .updateText:    return try updateText(editor, args)
         case .addCaptions:   return try await addCaptions(editor, args)
+        case .captionStyle:  return try captionStyle(editor, args)
         case .exportProject: return try await exportProject(editor, args)
         case .manageExports: return try manageExports(editor, args)
         case .generateVideo: return try generate(editor, args, type: .video)

--- a/Sources/PalmierPro/CaptionStyle/CaptionStyleProfile.swift
+++ b/Sources/PalmierPro/CaptionStyle/CaptionStyleProfile.swift
@@ -1,0 +1,205 @@
+// Reusable caption-style profile: measured filler policy + typography defaults, persisted per project/library/global.
+// The resolved profile records where JUDGEMENT is required (caseByCase) rather than pretending to automate it.
+
+import Foundation
+
+/// Fully resolved caption-style profile after all layers merge. Typography fields stay optional
+/// (nil = keep the app's caption default); filler lists resolve to concrete arrays.
+struct CaptionStyleProfile: Codable, Equatable, Sendable {
+    var version: Int
+    var fillers: Fillers
+    var protectedPhrases: [String]
+    var typography: Typography
+    var provenance: [String: String]
+
+    struct Fillers: Codable, Equatable, Sendable {
+        /// Safe to strip mechanically.
+        var removeAlways: [String]
+        /// Never strip even though generic rules would.
+        var neverRemove: [String]
+        /// NEVER auto-remove — surface for agent/human judgement.
+        var caseByCase: [String]
+        var neverDedupe: NeverDedupe
+    }
+
+    struct NeverDedupe: Codable, Equatable, Sendable {
+        /// Repeated CJK tokens are grammar (存存钱/试试看), not stutters.
+        var cjkReduplication: Bool
+        /// Deliberate repetition (太酷了×3) is comic timing.
+        var comicRepetition: Bool
+    }
+
+    /// nil field = keep the caption generator's own default for that attribute.
+    struct Typography: Codable, Equatable, Sendable {
+        var fontName: String? = nil
+        var fontSize: Double? = nil
+        var color: String? = nil
+        var outline: Bool? = nil
+        var shadow: Bool? = nil
+        var position: Position? = nil
+        var maxWords: Int? = nil
+    }
+
+    /// Normalized 0–1 caption box center.
+    struct Position: Codable, Equatable, Sendable {
+        var x: Double
+        var y: Double
+    }
+
+    /// Shipped starting policy. Measured profiles layer on top and override wholesale per provided key.
+    static let builtInDefault = CaptionStyleProfile(
+        version: 1,
+        fillers: Fillers(
+            removeAlways: ["呃", "哎", "um", "uh", "er", "ah"],
+            neverRemove: ["然后", "oh", "so", "right", "basically"],
+            caseByCase: ["啊", "哦", "嗯", "那个", "这个", "like", "就是", "you know"],
+            neverDedupe: NeverDedupe(cjkReduplication: true, comicRepetition: true)
+        ),
+        protectedPhrases: [],
+        typography: Typography(),
+        provenance: [:]
+    )
+}
+
+/// A single layer's contribution before merge. Every field is optional so "absent" (inherit) is
+/// distinguishable from "provided" (replace). Decoded tolerantly — unknown keys and type
+/// mismatches are ignored rather than throwing.
+struct CaptionStyleProfilePartial: Equatable {
+    var version: Int?
+    var removeAlways: [String]?
+    var neverRemove: [String]?
+    var caseByCase: [String]?
+    var cjkReduplication: Bool?
+    var comicRepetition: Bool?
+    var protectedPhrases: [String]?
+    var typography: CaptionStyleProfile.Typography?
+    var provenance: [String: String]?
+
+    /// Later layer's provided keys replace earlier wholesale; absent keys inherit.
+    /// Typography merges per individual key; provenance unions (later wins).
+    func overlaid(by o: CaptionStyleProfilePartial) -> CaptionStyleProfilePartial {
+        var r = self
+        if let v = o.version { r.version = v }
+        if let x = o.removeAlways { r.removeAlways = x }
+        if let x = o.neverRemove { r.neverRemove = x }
+        if let x = o.caseByCase { r.caseByCase = x }
+        if let x = o.cjkReduplication { r.cjkReduplication = x }
+        if let x = o.comicRepetition { r.comicRepetition = x }
+        if let x = o.protectedPhrases { r.protectedPhrases = x }
+        r.typography = Self.overlayTypography(base: r.typography, over: o.typography)
+        if let x = o.provenance { r.provenance = (r.provenance ?? [:]).merging(x) { _, new in new } }
+        return r
+    }
+
+    private static func overlayTypography(
+        base: CaptionStyleProfile.Typography?,
+        over: CaptionStyleProfile.Typography?
+    ) -> CaptionStyleProfile.Typography? {
+        guard let over else { return base }
+        guard let base else { return over }
+        return CaptionStyleProfile.Typography(
+            fontName: over.fontName ?? base.fontName,
+            fontSize: over.fontSize ?? base.fontSize,
+            color: over.color ?? base.color,
+            outline: over.outline ?? base.outline,
+            shadow: over.shadow ?? base.shadow,
+            position: over.position ?? base.position,
+            maxWords: over.maxWords ?? base.maxWords
+        )
+    }
+
+    func resolved() -> CaptionStyleProfile {
+        CaptionStyleProfile(
+            version: version ?? 1,
+            fillers: CaptionStyleProfile.Fillers(
+                removeAlways: removeAlways ?? [],
+                neverRemove: neverRemove ?? [],
+                caseByCase: caseByCase ?? [],
+                neverDedupe: CaptionStyleProfile.NeverDedupe(
+                    cjkReduplication: cjkReduplication ?? true,
+                    comicRepetition: comicRepetition ?? true
+                )
+            ),
+            protectedPhrases: protectedPhrases ?? [],
+            typography: typography ?? CaptionStyleProfile.Typography(),
+            provenance: provenance ?? [:]
+        )
+    }
+
+    /// Seed a partial from a concrete profile so the built-in default can be the base of the overlay chain.
+    init(from profile: CaptionStyleProfile) {
+        version = profile.version
+        removeAlways = profile.fillers.removeAlways
+        neverRemove = profile.fillers.neverRemove
+        caseByCase = profile.fillers.caseByCase
+        cjkReduplication = profile.fillers.neverDedupe.cjkReduplication
+        comicRepetition = profile.fillers.neverDedupe.comicRepetition
+        protectedPhrases = profile.protectedPhrases
+        typography = profile.typography
+        provenance = profile.provenance
+    }
+
+    init() {}
+
+    /// Tolerant decode from a parsed JSON object. Missing sections/keys stay nil; wrong types are ignored.
+    init(jsonObject obj: [String: Any]) {
+        version = obj.csInt("version")
+        if let fillers = obj["fillers"] as? [String: Any] {
+            removeAlways = fillers.csStringArrayIfPresent("removeAlways")
+            neverRemove = fillers.csStringArrayIfPresent("neverRemove")
+            caseByCase = fillers.csStringArrayIfPresent("caseByCase")
+            if let dedupe = fillers["neverDedupe"] as? [String: Any] {
+                cjkReduplication = dedupe.csBool("cjkReduplication")
+                comicRepetition = dedupe.csBool("comicRepetition")
+            }
+        }
+        protectedPhrases = obj.csStringArrayIfPresent("protectedPhrases")
+        if let typo = obj["typography"] as? [String: Any] {
+            var position: CaptionStyleProfile.Position?
+            if let p = typo["position"] as? [String: Any], let x = p.csDouble("x"), let y = p.csDouble("y") {
+                position = CaptionStyleProfile.Position(x: x, y: y)
+            }
+            typography = CaptionStyleProfile.Typography(
+                fontName: typo.csString("fontName"),
+                fontSize: typo.csDouble("fontSize"),
+                color: typo.csString("color"),
+                outline: typo.csBool("outline"),
+                shadow: typo.csBool("shadow"),
+                position: position,
+                maxWords: typo.csInt("maxWords")
+            )
+        }
+        if let prov = obj["provenance"] as? [String: Any] {
+            provenance = prov.compactMapValues { $0 as? String }
+        }
+    }
+}
+
+// Tolerant accessors — return nil when absent or the wrong type, distinguishing absent from empty.
+private extension Dictionary where Key == String, Value == Any {
+    func csString(_ key: String) -> String? {
+        guard let v = self[key] as? String, !v.isEmpty else { return nil }
+        return v
+    }
+    func csInt(_ key: String) -> Int? {
+        if let v = self[key] as? Int { return v }
+        if let v = self[key] as? NSNumber { return v.intValue }
+        return nil
+    }
+    func csDouble(_ key: String) -> Double? {
+        if let v = self[key] as? Double { return v }
+        if let v = self[key] as? Int { return Double(v) }
+        if let v = self[key] as? NSNumber { return v.doubleValue }
+        return nil
+    }
+    func csBool(_ key: String) -> Bool? {
+        if let v = self[key] as? Bool { return v }
+        if let v = self[key] as? NSNumber { return v.boolValue }
+        return nil
+    }
+    func csStringArrayIfPresent(_ key: String) -> [String]? {
+        guard let raw = self[key] else { return nil }
+        guard let arr = raw as? [Any] else { return nil }
+        return arr.compactMap { $0 as? String }
+    }
+}

--- a/Sources/PalmierPro/CaptionStyle/CaptionStyleStore.swift
+++ b/Sources/PalmierPro/CaptionStyle/CaptionStyleStore.swift
@@ -1,0 +1,80 @@
+// Layered load-and-merge for the caption-style profile: global → library → project, later wins.
+// Malformed or missing files fall back to defaults with a warning; a bad file never crashes or blocks.
+
+import Foundation
+
+enum CaptionStyleStore {
+    enum Scope: String, Sendable { case builtIn, global, library, project }
+    enum Status: String, Sendable { case loaded, missing, malformed }
+
+    struct Origin: Sendable {
+        let scope: Scope
+        let path: String
+        let status: Status
+    }
+
+    struct Resolved: Sendable {
+        let profile: CaptionStyleProfile
+        let origins: [Origin]
+        let warnings: [String]
+    }
+
+    /// `~/.config/caption-style/global.json` — the pattern's first ~/.config user in the app.
+    static var globalURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/caption-style/global.json", isDirectory: false)
+    }
+
+    /// `<library>/caption-style.json` — the shared media library root.
+    static var libraryURL: URL {
+        Project.storageDirectory.appendingPathComponent(Project.captionStyleFilename, isDirectory: false)
+    }
+
+    /// `<project>.palmier/caption-style.json` — sidecar inside the project package.
+    static func projectURL(package: URL?) -> URL? {
+        package?.appendingPathComponent(Project.captionStyleFilename, isDirectory: false)
+    }
+
+    /// Resolve the effective profile for a project. Reads at most three small files.
+    static func resolve(projectPackageURL: URL?) -> Resolved {
+        var accumulated = CaptionStyleProfilePartial(from: .builtInDefault)
+        var origins: [Origin] = [Origin(scope: .builtIn, path: "(built-in default)", status: .loaded)]
+        var warnings: [String] = []
+
+        let layers: [(Scope, URL?)] = [
+            (.global, globalURL),
+            (.library, libraryURL),
+            (.project, projectURL(package: projectPackageURL)),
+        ]
+
+        for (scope, url) in layers {
+            guard let url else { continue }
+            switch load(url) {
+            case .loaded(let partial):
+                accumulated = accumulated.overlaid(by: partial)
+                origins.append(Origin(scope: scope, path: url.path, status: .loaded))
+            case .missing:
+                origins.append(Origin(scope: scope, path: url.path, status: .missing))
+            case .malformed(let reason):
+                warnings.append("\(scope.rawValue) profile ignored (\(reason)): \(url.path)")
+                origins.append(Origin(scope: scope, path: url.path, status: .malformed))
+            }
+        }
+
+        return Resolved(profile: accumulated.resolved(), origins: origins, warnings: warnings)
+    }
+
+    private enum LoadResult {
+        case loaded(CaptionStyleProfilePartial)
+        case missing
+        case malformed(String)
+    }
+
+    private static func load(_ url: URL) -> LoadResult {
+        guard FileManager.default.fileExists(atPath: url.path) else { return .missing }
+        guard let data = try? Data(contentsOf: url) else { return .malformed("unreadable") }
+        guard let json = try? JSONSerialization.jsonObject(with: data) else { return .malformed("invalid JSON") }
+        guard let obj = json as? [String: Any] else { return .malformed("not a JSON object") }
+        return .loaded(CaptionStyleProfilePartial(jsonObject: obj))
+    }
+}

--- a/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
+++ b/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
@@ -224,7 +224,10 @@ struct FillerPolicy: Sendable {
         out: inout [FillerAction?]
     ) {
         // Only multi-token entries need span matching; single tokens are handled per-token later.
-        let multiword = phrases.map(Self.parts).filter { $0.count > 1 }
+        // Entries are matched in BOTH tokenizations (whitespace and per-character CJK), so a
+        // multi-character entry like 嗯嗯 strips whether the stream carries it as one blob or
+        // as flattened per-character tokens.
+        let multiword = phrases.flatMap(Self.candidateForms).filter { $0.count > 1 }
         guard !multiword.isEmpty else { return }
         var i = 0
         while i < norm.count {

--- a/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
+++ b/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
@@ -1,0 +1,221 @@
+// Pure filler-policy engine over a resolved profile: classifies tokens and plans per-token
+// remove/keep/flag decisions, honoring protected phrases and the neverDedupe grammar guards.
+// Never auto-removes caseByCase tokens — those are surfaced for judgement.
+
+import Foundation
+
+enum FillerClassification: String, Equatable, Sendable {
+    case removeAlways
+    case neverRemove
+    case caseByCase
+    case none
+}
+
+enum FillerDecision: String, Equatable, Sendable {
+    case remove
+    case keep
+    /// Requires judgement (caseByCase) — a tool must stop and surface it, never auto-remove.
+    case flag
+    /// An unguarded adjacent duplicate a dedup pass may drop.
+    case removeDuplicate
+}
+
+struct FillerAction: Equatable, Sendable {
+    let index: Int
+    let token: String
+    let classification: FillerClassification
+    let decision: FillerDecision
+    let reason: String
+}
+
+struct FillerPolicy: Sendable {
+    let profile: CaptionStyleProfile
+    private let removeAlwaysSet: Set<String>
+    private let neverRemoveSet: Set<String>
+    private let caseByCaseSet: Set<String>
+
+    init(profile: CaptionStyleProfile) {
+        self.profile = profile
+        removeAlwaysSet = Set(profile.fillers.removeAlways.map(Self.normalize))
+        neverRemoveSet = Set(profile.fillers.neverRemove.map(Self.normalize))
+        caseByCaseSet = Set(profile.fillers.caseByCase.map(Self.normalize))
+    }
+
+    /// Classify a single token. removeAlways > neverRemove > caseByCase; anything else is none.
+    func classify(_ token: String) -> FillerClassification {
+        let t = Self.normalize(token)
+        guard !t.isEmpty else { return .none }
+        if removeAlwaysSet.contains(t) { return .removeAlways }
+        if neverRemoveSet.contains(t) { return .neverRemove }
+        if caseByCaseSet.contains(t) { return .caseByCase }
+        return .none
+    }
+
+    /// Per-token decisions for a caption's words. Multi-word filler entries and protected phrases
+    /// are matched as spans; adjacent duplicates are only removable when no grammar guard applies.
+    func plan(words: [String]) -> [FillerAction] {
+        let n = words.count
+        guard n > 0 else { return [] }
+        let norm = words.map(Self.normalize)
+        var out = [FillerAction?](repeating: nil, count: n)
+
+        // 1. Protected phrases win over everything — covered tokens are kept verbatim.
+        markSpans(profile.protectedPhrases, norm: norm) { i in
+            out[i] = FillerAction(index: i, token: words[i], classification: .none, decision: .keep, reason: "protectedPhrase")
+        }
+
+        // 2. Multi-word filler entries (e.g. "you know") matched as spans, in priority order.
+        markFillerSpans(profile.fillers.removeAlways, classification: .removeAlways, decision: .remove, words: words, norm: norm, out: &out)
+        markFillerSpans(profile.fillers.neverRemove, classification: .neverRemove, decision: .keep, words: words, norm: norm, out: &out)
+        markFillerSpans(profile.fillers.caseByCase, classification: .caseByCase, decision: .flag, words: words, norm: norm, out: &out)
+
+        // 3. Single-token classification for anything still unassigned.
+        for i in 0..<n where out[i] == nil {
+            switch classify(words[i]) {
+            case .removeAlways:
+                out[i] = FillerAction(index: i, token: words[i], classification: .removeAlways, decision: .remove, reason: "removeAlways")
+            case .neverRemove:
+                out[i] = FillerAction(index: i, token: words[i], classification: .neverRemove, decision: .keep, reason: "neverRemove")
+            case .caseByCase:
+                out[i] = FillerAction(index: i, token: words[i], classification: .caseByCase, decision: .flag, reason: "caseByCase")
+            case .none:
+                break
+            }
+        }
+
+        // 4. Dedup pass over remaining unclassified tokens, guarded by neverDedupe rules.
+        applyDedup(words: words, norm: norm, out: &out)
+
+        // 5. Everything left is an ordinary kept word.
+        for i in 0..<n where out[i] == nil {
+            out[i] = FillerAction(index: i, token: words[i], classification: .none, decision: .keep, reason: "keep")
+        }
+        return out.compactMap { $0 }
+    }
+
+    /// A phrase (in `phrase.words` order) with removeAlways tokens dropped, or nil if nothing remains.
+    /// Display-only: it rebuilds caption text and word timings; it never touches audio.
+    func strippingRemoveAlways(_ phrase: CaptionBuilder.Phrase) -> CaptionBuilder.Phrase? {
+        if !phrase.words.isEmpty {
+            let actions = plan(words: phrase.words.map(\.text))
+            let kept = zip(phrase.words, actions).filter { $0.1.decision != .remove }.map(\.0)
+            guard let first = kept.first, let last = kept.last else { return nil }
+            let text = kept.map(\.text).joined(separator: " ")
+            return CaptionBuilder.Phrase(text: text, start: first.start, end: last.end, words: kept)
+        }
+        let tokens = phrase.text.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !tokens.isEmpty else { return phrase }
+        let actions = plan(words: tokens)
+        let kept = zip(tokens, actions).filter { $0.1.decision != .remove }.map(\.0)
+        guard !kept.isEmpty else { return nil }
+        return CaptionBuilder.Phrase(text: kept.joined(separator: " "), start: phrase.start, end: phrase.end)
+    }
+
+    // MARK: - Helpers
+
+    static func normalize(_ token: String) -> String {
+        token
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: strippedPunctuation)
+            .lowercased()
+    }
+
+    private static let strippedPunctuation: CharacterSet = {
+        var set = CharacterSet.punctuationCharacters
+        set.formUnion(.symbols)
+        return set
+    }()
+
+    static func containsCJK(_ s: String) -> Bool {
+        s.unicodeScalars.contains { sc in
+            (0x4E00...0x9FFF).contains(sc.value)   // CJK unified ideographs
+                || (0x3400...0x4DBF).contains(sc.value) // extension A
+                || (0x3040...0x30FF).contains(sc.value) // hiragana + katakana
+        }
+    }
+
+    /// Split a possibly multi-token phrase into its normalized parts.
+    private static func parts(_ phrase: String) -> [String] {
+        phrase.split(whereSeparator: \.isWhitespace).map { normalize(String($0)) }.filter { !$0.isEmpty }
+    }
+
+    private func markSpans(_ phrases: [String], norm: [String], mark: (Int) -> Void) {
+        let candidates = phrases.map(Self.parts).filter { !$0.isEmpty }
+        var i = 0
+        while i < norm.count {
+            if let len = matchAt(i, norm: norm, candidates: candidates) {
+                for j in i..<(i + len) { mark(j) }
+                i += len
+            } else {
+                i += 1
+            }
+        }
+    }
+
+    private func markFillerSpans(
+        _ phrases: [String],
+        classification: FillerClassification,
+        decision: FillerDecision,
+        words: [String],
+        norm: [String],
+        out: inout [FillerAction?]
+    ) {
+        // Only multi-token entries need span matching; single tokens are handled per-token later.
+        let multiword = phrases.map(Self.parts).filter { $0.count > 1 }
+        guard !multiword.isEmpty else { return }
+        var i = 0
+        while i < norm.count {
+            if out[i] == nil, let len = matchAt(i, norm: norm, candidates: multiword),
+               (i..<(i + len)).allSatisfy({ out[$0] == nil }) {
+                for j in i..<(i + len) {
+                    out[j] = FillerAction(index: j, token: words[j], classification: classification, decision: decision, reason: classification.rawValue)
+                }
+                i += len
+            } else {
+                i += 1
+            }
+        }
+    }
+
+    /// Longest candidate whose parts match `norm` starting at `start`; nil if none.
+    private func matchAt(_ start: Int, norm: [String], candidates: [[String]]) -> Int? {
+        var best: Int?
+        for cand in candidates {
+            let len = cand.count
+            guard start + len <= norm.count else { continue }
+            if Array(norm[start..<start + len]) == cand, len > (best ?? 0) {
+                best = len
+            }
+        }
+        return best
+    }
+
+    private func applyDedup(words: [String], norm: [String], out: inout [FillerAction?]) {
+        let guardCJK = profile.fillers.neverDedupe.cjkReduplication
+        let guardComic = profile.fillers.neverDedupe.comicRepetition
+
+        var i = 0
+        while i < norm.count {
+            guard out[i] == nil, !norm[i].isEmpty else { i += 1; continue }
+            // Measure the run of identical adjacent tokens starting at i.
+            var end = i + 1
+            while end < norm.count, norm[end] == norm[i] { end += 1 }
+            let runLength = end - i
+            if runLength >= 2 {
+                let isCJK = Self.containsCJK(norm[i])
+                let isComic = runLength >= 3
+                let guarded = (isCJK && guardCJK) || (isComic && guardComic)
+                for j in i..<end where out[j] == nil {
+                    if guarded {
+                        let reason = isCJK ? "cjkReduplication" : "comicRepetition"
+                        out[j] = FillerAction(index: j, token: words[j], classification: .none, decision: .keep, reason: reason)
+                    } else if j > i {
+                        // Keep the first occurrence; later exact repeats are removable duplicates.
+                        out[j] = FillerAction(index: j, token: words[j], classification: .none, decision: .removeDuplicate, reason: "duplicate")
+                    }
+                }
+            }
+            i = end
+        }
+    }
+}

--- a/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
+++ b/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
@@ -103,12 +103,54 @@ struct FillerPolicy: Sendable {
             let text = kept.map(\.text).joined(separator: " ")
             return CaptionBuilder.Phrase(text: text, start: first.start, end: last.end, words: kept)
         }
-        let tokens = phrase.text.split(whereSeparator: \.isWhitespace).map(String.init)
+        // Whitespace splitting misses unsegmented CJK ("呃你好" arrives as one token, so a
+        // single-character removeAlways entry like 呃 never matches). Split CJK per character,
+        // keep Latin whitespace runs whole, and rejoin without spaces inside CJK runs.
+        let tokens = Self.fallbackTokens(phrase.text)
         guard !tokens.isEmpty else { return phrase }
         let actions = plan(words: tokens)
         let kept = zip(tokens, actions).filter { $0.1.decision != .remove }.map(\.0)
         guard !kept.isEmpty else { return nil }
-        return CaptionBuilder.Phrase(text: kept.joined(separator: " "), start: phrase.start, end: phrase.end)
+        return CaptionBuilder.Phrase(text: Self.joinTokens(kept), start: phrase.start, end: phrase.end)
+    }
+
+    private static func isCJKScalar(_ scalar: Unicode.Scalar) -> Bool {
+        let value = Int(scalar.value)
+        return ((0x2E80...0x9FFF).contains(value) && !(0x3000...0x303F).contains(value))
+            || (0xF900...0xFAFF).contains(value)
+    }
+
+    private static func isCJKToken(_ token: String) -> Bool {
+        token.count == 1 && token.unicodeScalars.allSatisfy(isCJKScalar)
+    }
+
+    static func fallbackTokens(_ text: String) -> [String] {
+        var tokens: [String] = []
+        var latin = ""
+        for ch in text {
+            if ch.isWhitespace {
+                if !latin.isEmpty { tokens.append(latin); latin = "" }
+            } else if ch.unicodeScalars.allSatisfy(isCJKScalar) {
+                if !latin.isEmpty { tokens.append(latin); latin = "" }
+                tokens.append(String(ch))
+            } else {
+                latin.append(ch)
+            }
+        }
+        if !latin.isEmpty { tokens.append(latin) }
+        return tokens
+    }
+
+    static func joinTokens(_ tokens: [String]) -> String {
+        var out = ""
+        var prevCJK = false
+        for token in tokens {
+            let cjk = isCJKToken(token)
+            if !out.isEmpty, !(cjk && prevCJK) { out += " " }
+            out += token
+            prevCJK = cjk
+        }
+        return out
     }
 
     // MARK: - Helpers

--- a/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
+++ b/Sources/PalmierPro/CaptionStyle/FillerPolicy.swift
@@ -97,10 +97,23 @@ struct FillerPolicy: Sendable {
     /// Display-only: it rebuilds caption text and word timings; it never touches audio.
     func strippingRemoveAlways(_ phrase: CaptionBuilder.Phrase) -> CaptionBuilder.Phrase? {
         if !phrase.words.isEmpty {
-            let actions = plan(words: phrase.words.map(\.text))
-            let kept = zip(phrase.words, actions).filter { $0.1.decision != .remove }.map(\.0)
+            // Flatten each word's text with the shared tokenizer so single-character CJK fillers
+            // match inside multi-character word blobs, then map decisions back per timing: a timing
+            // is removed only when ALL its subtokens are removals (a timing cannot be split).
+            let subtokens = phrase.words.map { Self.fallbackTokens($0.text) }
+            let actions = plan(words: subtokens.flatMap { $0 })
+            var cursor = 0
+            var kept: [CaptionBuilder.WordSpan] = []
+            for (word, tokens) in zip(phrase.words, subtokens) {
+                let decisions = actions[cursor..<(cursor + tokens.count)]
+                cursor += tokens.count
+                if tokens.isEmpty || !decisions.allSatisfy({ $0.decision == .remove }) {
+                    kept.append(word)
+                }
+            }
             guard let first = kept.first, let last = kept.last else { return nil }
-            let text = kept.map(\.text).joined(separator: " ")
+            // CJK-aware rebuild: per-character word spans must not introduce spaces (你 好).
+            let text = Self.joinTokens(kept.map(\.text))
             return CaptionBuilder.Phrase(text: text, start: first.start, end: last.end, words: kept)
         }
         // Whitespace splitting misses unsegmented CJK ("呃你好" arrives as one token, so a
@@ -181,8 +194,16 @@ struct FillerPolicy: Sendable {
         phrase.split(whereSeparator: \.isWhitespace).map { normalize(String($0)) }.filter { !$0.isEmpty }
     }
 
+    /// Both tokenizations of a phrase, so span matching works against whitespace-token streams
+    /// (CaptionBuilder words, blobs) AND per-character CJK streams (the fallback/flattened paths).
+    private static func candidateForms(_ phrase: String) -> [[String]] {
+        let whitespace = parts(phrase)
+        let perChar = fallbackTokens(phrase).map { normalize($0) }.filter { !$0.isEmpty }
+        return whitespace == perChar ? [whitespace] : [whitespace, perChar]
+    }
+
     private func markSpans(_ phrases: [String], norm: [String], mark: (Int) -> Void) {
-        let candidates = phrases.map(Self.parts).filter { !$0.isEmpty }
+        let candidates = phrases.flatMap(Self.candidateForms).filter { !$0.isEmpty }
         var i = 0
         while i < norm.count {
             if let len = matchAt(i, norm: norm, candidates: candidates) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -14,6 +14,10 @@ extension EditorViewModel {
         var provider: TranscriptionProvider = .local
         /// Animation applied to every generated caption clip (timed from the transcript).
         var animation: TextAnimation = TextAnimation()
+        /// Resolved caption-style profile driving filler removal; nil disables it.
+        var fillerProfile: CaptionStyleProfile? = nil
+        /// When true, removeAlways-classified tokens are dropped from caption TEXT (display only).
+        var dropRemoveAlwaysFillers: Bool = false
     }
 
     enum CaptionCase: String, CaseIterable, Sendable {
@@ -148,7 +152,8 @@ extension EditorViewModel {
             center: request.center,
             textCase: request.textCase,
             maxWords: request.maxWords,
-            animation: animation
+            animation: animation,
+            fillerProfile: request.dropRemoveAlwaysFillers ? request.fillerProfile : nil
         )
         let specs = try await CaptionSpecBuilder.build(input)
         try Task.checkCancellation()

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -17,6 +17,8 @@ enum CaptionSpecBuilder {
         let textCase: EditorViewModel.CaptionCase
         let maxWords: Int?
         let animation: TextAnimation?
+        /// Resolved caption-style profile for display-side filler stripping; nil skips stripping.
+        var fillerProfile: CaptionStyleProfile? = nil
     }
 
     @concurrent
@@ -54,8 +56,10 @@ enum CaptionSpecBuilder {
                     words: $0.words
                 )
             }
+            let fillerPolicy = input.fillerProfile.map { FillerPolicy(profile: $0) }
+            let filtered = fillerPolicy.map { policy in cased.compactMap { policy.strippingRemoveAlways($0) } } ?? cased
             specs.append(contentsOf: CaptionBuilder.specs(
-                for: cased,
+                for: filtered,
                 sourceClip: target.clip,
                 trackIndex: 0,
                 fps: input.fps,

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -291,6 +291,8 @@ final class VideoProject: NSDocument {
         } else {
             try copyPreservedFile(Project.thumbnailFilename, from: sourceURL, to: packageURL, fm: fm)
         }
+        // Caption-style profile is a user/agent-authored sidecar the app never generates; preserve it across saves.
+        try copyPreservedFile(Project.captionStyleFilename, from: sourceURL, to: packageURL, fm: fm)
         try writeChatDirectory(snapshot.chatSessionFiles, to: packageURL, fm: fm)
         try copyMediaDirectoryIfNeeded(from: sourceURL, to: packageURL, fm: fm)
         try fm.createDirectory(

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -110,6 +110,7 @@ enum Project {
     static let manifestFilename = "media.json"
     static let generationLogFilename = "generation-log.json"
     static let thumbnailFilename = "thumbnail.jpg"
+    static let captionStyleFilename = "caption-style.json"
     static let mediaDirectoryName = "media"
 
     static var storageDirectory: URL {

--- a/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
@@ -82,9 +82,9 @@ struct CaptionStyleTests {
 
     @Test func nonFillerWordsPassThroughVerbatim() {
         let policy = FillerPolicy(profile: .builtInDefault)
-        let actions = policy.plan(words: ["black", "citizens"])
+        let actions = policy.plan(words: ["local", "citizens"])
         #expect(actions.allSatisfy { $0.decision == .keep })
-        #expect(actions.map(\.token) == ["black", "citizens"])
+        #expect(actions.map(\.token) == ["local", "citizens"])
     }
 
     // MARK: - Phrase stripping (add_captions removeAlways path)
@@ -111,9 +111,9 @@ struct CaptionStyleTests {
 
     @Test func strippingLeavesNonFillerContentUntouched() {
         let policy = FillerPolicy(profile: .builtInDefault)
-        let phrase = CaptionBuilder.Phrase(text: "black citizens", start: 0, end: 1)
+        let phrase = CaptionBuilder.Phrase(text: "local citizens", start: 0, end: 1)
         let stripped = policy.strippingRemoveAlways(phrase)
-        #expect(stripped?.text == "black citizens")
+        #expect(stripped?.text == "local citizens")
     }
 
     // MARK: - Layered merge

--- a/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
@@ -225,3 +225,38 @@ struct CaptionStyleTests {
         #expect(FillerPolicy.joinTokens(["你", "好", "hello"]) == "你好 hello")
     }
 }
+
+// Round-2 review: the timed path must behave like the fallback path — CJK fillers matched inside
+// word blobs, protected phrases matched across per-char streams, no spaces introduced into CJK.
+@Suite struct FillerPolicyTimedPathTests {
+    private func timedPhrase(_ words: [(String, Double, Double)]) -> CaptionBuilder.Phrase {
+        let spans = words.map { CaptionBuilder.WordSpan(text: $0.0, start: $0.1, end: $0.2) }
+        return CaptionBuilder.Phrase(text: words.map(\.0).joined(), start: words.first!.1, end: words.last!.2, words: spans)
+    }
+
+    @Test func timedCJKFillerBlobIsRemoved() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.fillers.removeAlways = ["呃"]
+        let policy = FillerPolicy(profile: profile)
+        let phrase = timedPhrase([("呃", 0, 0.3), ("你", 0.3, 0.6), ("好", 0.6, 0.9)])
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "你好")
+        #expect(stripped?.words.map(\.text) == ["你", "好"])
+    }
+
+    @Test func timedCJKKeepsNoSpuriousSpaces() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let phrase = timedPhrase([("你", 0, 0.3), ("好", 0.3, 0.6)])
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "你好")
+    }
+
+    @Test func protectedPhraseMatchesPerCharStream() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.protectedPhrases = ["兄弟牛逼"]
+        profile.fillers.removeAlways = ["逼"]
+        let policy = FillerPolicy(profile: profile)
+        let phrase = CaptionBuilder.Phrase(text: "兄弟牛逼", start: 0, end: 1)
+        #expect(policy.strippingRemoveAlways(phrase)?.text == "兄弟牛逼")
+    }
+}

--- a/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("CaptionStyle")
+struct CaptionStyleTests {
+    // MARK: - Filler classification & planning
+
+    @Test func removeAlwaysStripsSafeFillersKeepsNeverRemove() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let actions = policy.plan(words: ["呃", "哎", "um", "然后", "oh", "hello"])
+        let byToken = Dictionary(uniqueKeysWithValues: actions.map { ($0.token, $0.decision) })
+        #expect(byToken["呃"] == .remove)
+        #expect(byToken["哎"] == .remove)
+        #expect(byToken["um"] == .remove)
+        #expect(byToken["然后"] == .keep)
+        #expect(byToken["oh"] == .keep)
+        #expect(byToken["hello"] == .keep)
+    }
+
+    @Test func caseByCaseIsFlaggedNeverRemoved() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        #expect(policy.classify("啊") == .caseByCase)
+        let actions = policy.plan(words: ["啊", "我们", "走"])
+        let ah = actions.first { $0.token == "啊" }
+        #expect(ah?.decision == .flag)
+        #expect(actions.allSatisfy { !($0.token == "啊" && $0.decision == .remove) })
+        #expect(!actions.contains { $0.decision == .remove })
+    }
+
+    @Test func protectedPhraseSurvivesEveryPass() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.protectedPhrases = ["兄弟牛逼"]
+        let policy = FillerPolicy(profile: profile)
+
+        let single = policy.plan(words: ["兄弟牛逼"])
+        #expect(single.allSatisfy { $0.decision == .keep })
+
+        // Repeated as comic timing — still never removed or deduped.
+        let repeated = policy.plan(words: ["兄弟牛逼", "兄弟牛逼", "兄弟牛逼"])
+        #expect(repeated.allSatisfy { $0.decision == .keep })
+        #expect(!repeated.contains { $0.decision == .removeDuplicate })
+    }
+
+    @Test func multiWordProtectedPhraseOverridesFillerClassification() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.protectedPhrases = ["you know"]
+        let policy = FillerPolicy(profile: profile)
+        let actions = policy.plan(words: ["you", "know", "um"])
+        #expect(actions[0].decision == .keep)
+        #expect(actions[0].reason == "protectedPhrase")
+        #expect(actions[1].decision == .keep)
+        #expect(actions[2].decision == .remove)
+    }
+
+    @Test func cjkReduplicationIsNeverDuplicateRemovable() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        for tokens in [["存", "存", "钱"], ["试", "试", "看"]] {
+            let actions = policy.plan(words: tokens)
+            #expect(!actions.contains { $0.decision == .removeDuplicate })
+            #expect(!actions.contains { $0.decision == .remove })
+        }
+    }
+
+    @Test func comicRepetitionIsPreserved() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let actions = policy.plan(words: ["True,", "true,", "true,", "true"])
+        #expect(actions.allSatisfy { $0.decision == .keep })
+        #expect(!actions.contains { $0.decision == .removeDuplicate })
+    }
+
+    @Test func unguardedStutterIsDuplicateRemovable() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.fillers.neverDedupe = .init(cjkReduplication: true, comicRepetition: true)
+        let policy = FillerPolicy(profile: profile)
+        // A two-token English stutter is not comic (needs 3+) and not CJK — removable.
+        let actions = policy.plan(words: ["the", "the", "cat"])
+        #expect(actions[0].decision == .keep)
+        #expect(actions[1].decision == .removeDuplicate)
+        #expect(actions[2].decision == .keep)
+    }
+
+    @Test func nonFillerWordsPassThroughVerbatim() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let actions = policy.plan(words: ["black", "citizens"])
+        #expect(actions.allSatisfy { $0.decision == .keep })
+        #expect(actions.map(\.token) == ["black", "citizens"])
+    }
+
+    // MARK: - Phrase stripping (add_captions removeAlways path)
+
+    @Test func strippingRemovesOnlyRemoveAlwaysTokens() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let phrase = CaptionBuilder.Phrase(
+            text: "um hello uh there",
+            start: 0,
+            end: 1.0,
+            words: [
+                .init(text: "um", start: 0, end: 0.2),
+                .init(text: "hello", start: 0.2, end: 0.5),
+                .init(text: "uh", start: 0.5, end: 0.6),
+                .init(text: "there", start: 0.6, end: 1.0),
+            ]
+        )
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "hello there")
+        #expect(stripped?.words.map(\.text) == ["hello", "there"])
+        #expect(stripped?.start == 0.2)
+        #expect(stripped?.end == 1.0)
+    }
+
+    @Test func strippingLeavesNonFillerContentUntouched() {
+        let policy = FillerPolicy(profile: .builtInDefault)
+        let phrase = CaptionBuilder.Phrase(text: "black citizens", start: 0, end: 1)
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "black citizens")
+    }
+
+    // MARK: - Layered merge
+
+    @Test func projectLayerOverridesGlobalPerProvidedKey() {
+        var global = CaptionStyleProfilePartial()
+        global.removeAlways = ["um"]
+        global.typography = .init(fontName: "Helvetica", fontSize: 40, color: nil, outline: nil, shadow: nil, position: nil, maxWords: nil)
+
+        var project = CaptionStyleProfilePartial()
+        project.removeAlways = ["呃"]
+        project.typography = .init(fontName: nil, fontSize: 60, color: nil, outline: nil, shadow: nil, position: nil, maxWords: nil)
+
+        let base = CaptionStyleProfilePartial(from: .builtInDefault)
+        let resolved = base.overlaid(by: global).overlaid(by: project).resolved()
+
+        // Provided keys replace wholesale...
+        #expect(resolved.fillers.removeAlways == ["呃"])
+        #expect(resolved.typography.fontSize == 60)
+        // ...absent typography keys inherit the earlier layer.
+        #expect(resolved.typography.fontName == "Helvetica")
+    }
+
+    // MARK: - File-based resolution
+
+    @Test func resolveReadsProjectSidecar() throws {
+        let pkg = try makeTempPackage()
+        defer { try? FileManager.default.removeItem(at: pkg) }
+        let json = #"{"version":1,"protectedPhrases":["兄弟牛逼"],"fillers":{"removeAlways":["嗯嗯"]}}"#
+        try json.data(using: .utf8)!.write(to: pkg.appendingPathComponent(Project.captionStyleFilename))
+
+        let resolved = CaptionStyleStore.resolve(projectPackageURL: pkg)
+        #expect(resolved.profile.protectedPhrases.contains("兄弟牛逼"))
+        #expect(resolved.profile.fillers.removeAlways == ["嗯嗯"])
+        #expect(resolved.origins.contains { $0.scope == .project && $0.status == .loaded })
+    }
+
+    @Test func malformedProjectSidecarFallsBackWithWarning() throws {
+        let pkg = try makeTempPackage()
+        defer { try? FileManager.default.removeItem(at: pkg) }
+        try "{ this is not json".data(using: .utf8)!.write(to: pkg.appendingPathComponent(Project.captionStyleFilename))
+
+        let resolved = CaptionStyleStore.resolve(projectPackageURL: pkg)
+        // Never crashes; falls back to a usable profile with default dedupe guards.
+        #expect(resolved.profile.fillers.neverDedupe.cjkReduplication)
+        #expect(resolved.origins.contains { $0.scope == .project && $0.status == .malformed })
+        #expect(resolved.warnings.contains { $0.contains(pkg.path) })
+    }
+
+    @Test func missingProjectSidecarUsesDefaults() throws {
+        let pkg = try makeTempPackage()
+        defer { try? FileManager.default.removeItem(at: pkg) }
+        let resolved = CaptionStyleStore.resolve(projectPackageURL: pkg)
+        #expect(resolved.origins.contains { $0.scope == .project && $0.status == .missing })
+        #expect(resolved.profile.version == 1)
+    }
+
+    // MARK: - Typography application
+
+    @MainActor
+    @Test func profileTypographyFillsCaptionStyle() {
+        let typography = CaptionStyleProfile.Typography(
+            fontName: "Georgia", fontSize: 72, color: "#FF0000",
+            outline: true, shadow: false, position: nil, maxWords: nil
+        )
+        var style = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
+        ToolExecutor.applyProfileTypography(typography, to: &style)
+        #expect(style.fontName == "Georgia")
+        #expect(style.fontSize == 72)
+        #expect(style.color == TextStyle.RGBA(r: 1, g: 0, b: 0, a: 1))
+        #expect(style.border.enabled == true)
+        #expect(style.shadow.enabled == false)
+    }
+
+    @MainActor
+    @Test func nilTypographyKeysLeaveDefaultsIntact() {
+        let typography = CaptionStyleProfile.Typography(fontSize: 96)
+        var style = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
+        let originalFont = style.fontName
+        ToolExecutor.applyProfileTypography(typography, to: &style)
+        #expect(style.fontSize == 96)
+        #expect(style.fontName == originalFont)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempPackage() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("caption-style-test-\(UUID().uuidString).palmier", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
@@ -260,3 +260,19 @@ struct CaptionStyleTests {
         #expect(policy.strippingRemoveAlways(phrase)?.text == "兄弟牛逼")
     }
 }
+
+// Round-3: a multi-character CJK removeAlways entry (one profile string, e.g. 嗯嗯) must strip on
+// the timed path, where the stream is flattened to per-character tokens.
+@Suite struct FillerPolicyMultiCharEntryTests {
+    @Test func multiCharCJKEntryStripsOnTimedPath() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.fillers.removeAlways = ["嗯嗯"]
+        let policy = FillerPolicy(profile: profile)
+        let spans = [CaptionBuilder.WordSpan(text: "嗯嗯", start: 0, end: 0.4),
+                     CaptionBuilder.WordSpan(text: "好", start: 0.4, end: 0.8)]
+        let phrase = CaptionBuilder.Phrase(text: "嗯嗯好", start: 0, end: 0.8, words: spans)
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "好")
+        #expect(stripped?.words.map(\.text) == ["好"])
+    }
+}

--- a/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionStyleTests.swift
@@ -207,3 +207,21 @@ struct CaptionStyleTests {
         return url
     }
 }
+
+// Review regressions: a partial explicit style must not discard the rest of the profile, and
+// removeAlways must match single-character CJK fillers inside unsegmented phrase text.
+@Suite struct CaptionStyleReviewRegressionTests {
+    @Test func cjkFillerStrippedFromUnsegmentedPhrase() {
+        var profile = CaptionStyleProfile.builtInDefault
+        profile.fillers.removeAlways = ["呃"]
+        let policy = FillerPolicy(profile: profile)
+        let phrase = CaptionBuilder.Phrase(text: "呃你好 ok", start: 0, end: 1)
+        let stripped = policy.strippingRemoveAlways(phrase)
+        #expect(stripped?.text == "你好 ok")
+    }
+
+    @Test func fallbackTokensSplitCJKKeepLatinRuns() {
+        #expect(FillerPolicy.fallbackTokens("呃你好 hello there") == ["呃", "你", "好", "hello", "there"])
+        #expect(FillerPolicy.joinTokens(["你", "好", "hello"]) == "你好 hello")
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> **Part of an 18-PR caption-system series** (full map at the bottom). This PR has **no dependencies** — it is based directly on `main` and reviewable standalone.

## Summary

Filler distributions are corpus-specific: on real zh/en footage, English hesitation fillers totaled 5 tokens in 7601 words — the actual filler load was CJK particles and "like". A generic "strip um/uh" pass is a no-op, and worse, naive dedup rules destroy Chinese grammar (存存钱, 试试看 are reduplication, not stutters) and comic timing (太酷了×3). This adds a layered, portable style profile that records measured policy — including where judgment is required instead of pretending to automate it.

## Design

- **Profile JSON**, layered later-wins: `~/.config/caption-style/global.json` → library → `<project>.palmier/caption-style.json`. Tolerant decoding; malformed/missing → defaults + warning, never a crash.
- **Filler policy:** `removeAlways` (safe to strip), `neverRemove`, and `caseByCase` — tokens that must NEVER be auto-removed (啊 is usually a sentence-final particle, only sometimes filler); tools surface them for per-occurrence judgment. `neverDedupe` guards CJK reduplication and comic repetition. `protectedPhrases` are untouchable by any pass.
- **Typography defaults** (font, size, color, outline, shadow, position, maxWords) fill in when `add_captions` is called without explicit params; explicit params always win.
- `add_captions` gains `fillerPolicy: off | removeAlways` (default off) — display-text only, never cuts audio.
- New read-only `caption_style` tool returns the resolved profile + provenance + per-layer origin, so agents honor project policy before captioning.

## Testing

16 unit tests: policy classification, phrase protection through filler AND dedup passes, reduplication guards, layering precedence, malformed tolerance, verbatim pass-through of non-filler content, profile-vs-explicit precedence. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change statistics

| Scope | Files | Additions | Deletions |
| --- | --- | --- | --- |
| Raw PR diff vs upstream `main` (source) | 10 | +620 | −6 |
| Raw PR diff vs upstream `main` (tests) | 1 | +209 | −0 |

This branch is based directly on upstream `main`, so the raw diff IS the change set.

## The series

| Wave | PR | Branch | What it adds |
| --- | --- | --- | --- |
| 1 | #375 | `multilingual-asr` | On-device multilingual ASR engines (qwen3 + Whisper timing anchor) |
| 1 | #376 | `feature/glossary` | Layered correction glossary, read-time materialisation |
| 1 | #377 | `feature/caption-resync` | Caption↔transcript resync engine |
| 1 | #378 | `feature/caption-style` | Caption-style profiles (layered, per-project) |
| 2 | #379 | `fix/caption-segmentation` | CJK-aware natural segmentation; bias-free recognition |
| 2 | #380 | `fix/caption-timing` | Word-timing correctness (anchored, no fabricated times) |
| 3 | #381 | `fix/caption-anim-onset` | Karaoke animation timing + acoustic onset refinement |
| 3 | #382 | `feature/transcription-model` | Cloud/local transcription routing per project |
| 3 | #383 | `feature/caption-lint` | Caption lint for suspected mis-recognitions |
| 4 | #384 | `fix/resync-materialisation` | Resync reads corrected transcripts; cache correctness |
| 4 | #385 | `feature/glossary-persistence` | Corrections persist across projects; auto-promotion hardening |
| 4 | #386 | `feature/style-lint-persistence` | Style/lint policy persistence + set_caption_style |
| 4 | #387 | `feature/tool-ergonomics` | Caption tool-surface safety and batching |
| 5 | #388 | `fix/punctuated-segmentation` | zh-en punctuation restoration as segmentation signal |
| 5 | #389 | `feature/local-model-selection` | Per-project local engine override |
| 5 | #390 | `feature/indexing-throughput` | Prioritized, preemptible transcription indexing + audio cache |
| 6 | #391 | `feature/caption-ui-resync` | Editor UI for resync (toast, conflict badge, freeze) |
| 6 | #392 | `feature/caption-ui-settings` | Editor UI for caption settings + glossary review |

Waves gate on each other: a PR opens for review once everything it depends on has merged. Drafts flip to ready as their dependencies land and they are rebased.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caption text can change when fillerPolicy is enabled or profile typography merges with partial agent args; malformed sidecars are ignored but could surprise users expecting custom policy.
> 
> **Overview**
> Adds a **layered caption-style profile** (built-in → `~/.config/caption-style/global.json` → library → project `caption-style.json`) that carries measured **filler policy** and **typography defaults**, with tolerant JSON loading and per-layer provenance.
> 
> Introduces **`FillerPolicy`** to classify tokens (`removeAlways`, `neverRemove`, `caseByCase`), honor **protected phrases** and **neverDedupe** (CJK reduplication, comic repetition), and optionally strip only `removeAlways` tokens from **caption display text** (not audio), including CJK-aware tokenization on timed and untimed phrase paths.
> 
> **`add_captions`** now merges resolved profile typography/position/`maxWords` when args omit them (explicit params win per field), adds **`fillerPolicy: off | removeAlways`**, and wires stripping through `CaptionSpecBuilder`. New read-only agent tool **`caption_style`** returns the merged profile, layer status, and semantics for agents.
> 
> Project save **preserves** `caption-style.json` as a user sidecar; extensive unit tests cover policy, layering, and regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e89252345ff33ecdde4cc9c705de5e0341f177b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->