### PR TITLE
[fix] Convert HEIC generation references to JPEG

### DIFF
--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -341,20 +341,37 @@ final class GenerationService {
             for (i, url) in urls.enumerated() {
                 let type = types.indices.contains(i) ? types[i] : .image
                 let cacheKey = cacheKeys.indices.contains(i) ? cacheKeys[i] : nil
-                if let cacheKey, let hit = cacheKey.freshRemoteURL {
+                let requiresConversion = type == .image
+                    && ImageConverter.requiresConversion(url)
+                if !requiresConversion, let cacheKey, let hit = cacheKey.freshRemoteURL {
                     group.addTask { (i, hit) }
                     continue
                 }
-                let contentType = Self.contentType(for: url, fallback: type)
+                let contentType = requiresConversion
+                    ? "image/jpeg"
+                    : Self.contentType(for: url, fallback: type)
                 group.addTask {
-                    let uploaded = try await GenerationBackend.uploadReference(
-                        fileURL: url,
-                        contentType: contentType,
-                    )
-                    if let cacheKey {
-                        await Self.recordUploadCache(asset: cacheKey, url: uploaded)
+                    let convertedURL = requiresConversion
+                        ? try await ImageConverter.convertToJPEG(url)
+                        : nil
+                    do {
+                        let uploaded = try await GenerationBackend.uploadReference(
+                            fileURL: convertedURL ?? url,
+                            contentType: contentType,
+                        )
+                        if let convertedURL {
+                            await ImageConverter.removeConvertedFile(convertedURL)
+                        }
+                        if !requiresConversion, let cacheKey {
+                            await Self.recordUploadCache(asset: cacheKey, url: uploaded)
+                        }
+                        return (i, uploaded)
+                    } catch {
+                        if let convertedURL {
+                            await ImageConverter.removeConvertedFile(convertedURL)
+                        }
+                        throw error
                     }
-                    return (i, uploaded)
                 }
             }
             var results = [(Int, String)]()

--- a/Sources/PalmierPro/Generation/Preprocessing/ImageConverter.swift
+++ b/Sources/PalmierPro/Generation/Preprocessing/ImageConverter.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum ImageConverter {
+    struct ConversionError: LocalizedError {
+        let filename: String
+
+        var errorDescription: String? {
+            "Could not convert reference image \(filename) to JPEG."
+        }
+    }
+
+    nonisolated static func requiresConversion(_ url: URL) -> Bool {
+        ["heic", "heif"].contains(url.pathExtension.lowercased())
+    }
+
+    @concurrent
+    static func convertToJPEG(_ url: URL) async throws -> URL {
+        try Task.checkCancellation()
+        let metadata = ImageEncoder.metadata(url: url)
+        guard let width = metadata.width,
+              let height = metadata.height,
+              let image = ImageEncoder.thumbnail(url: url, maxPixelSize: max(width, height)),
+              let data = ImageEncoder.encodeJPEG(image, quality: 0.92) else {
+            throw ConversionError(filename: url.lastPathComponent)
+        }
+
+        let outputURL = FileIO.temporaryFileURL(pathExtension: "jpg")
+        do {
+            try data.write(to: outputURL, options: .atomic)
+            try Task.checkCancellation()
+            return outputURL
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
+    }
+
+    @concurrent
+    static func removeConvertedFile(_ url: URL) async {
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/Tests/PalmierProTests/Media/ImageConverterTests.swift
+++ b/Tests/PalmierProTests/Media/ImageConverterTests.swift
@@ -1,0 +1,73 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import PalmierPro
+
+@Suite("Generation reference image conversion")
+struct ImageConverterTests {
+    @Test func recognizesHEICAndHEIFExtensions() {
+        #expect(ImageConverter.requiresConversion(URL(fileURLWithPath: "/tmp/ref.HEIC")))
+        #expect(ImageConverter.requiresConversion(URL(fileURLWithPath: "/tmp/ref.heif")))
+        #expect(!ImageConverter.requiresConversion(URL(fileURLWithPath: "/tmp/ref.jpg")))
+        #expect(!ImageConverter.requiresConversion(URL(fileURLWithPath: "/tmp/ref.png")))
+    }
+
+    @Test func convertsOrientedHEICToJPEG() async throws {
+        let receipt = try await Self.convertOrientedHEIC()
+        #expect(receipt.type == UTType.jpeg.identifier)
+        #expect(receipt.width == 8)
+        #expect(receipt.height == 12)
+    }
+
+    private struct Receipt: Sendable {
+        let type: String?
+        let width: Int?
+        let height: Int?
+    }
+
+    @concurrent
+    private static func convertOrientedHEIC() async throws -> Receipt {
+        let sourceURL = FileIO.temporaryFileURL(pathExtension: "heic")
+        let outputURL: URL
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let context = try #require(CGContext(
+            data: nil,
+            width: 12,
+            height: 8,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        ))
+        context.setFillColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: 12, height: 8))
+        let image = try #require(context.makeImage())
+        let destination = try #require(CGImageDestinationCreateWithURL(
+            sourceURL as CFURL,
+            UTType.heic.identifier as CFString,
+            1,
+            nil
+        ))
+        CGImageDestinationAddImage(
+            destination,
+            image,
+            [kCGImagePropertyOrientation: 6] as CFDictionary
+        )
+        #expect(CGImageDestinationFinalize(destination))
+
+        outputURL = try await ImageConverter.convertToJPEG(sourceURL)
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        let output = try #require(CGImageSourceCreateWithURL(outputURL as CFURL, nil))
+        let properties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(output, 0, nil) as? [CFString: Any]
+        )
+        return Receipt(
+            type: CGImageSourceGetType(output) as String?,
+            width: properties[kCGImagePropertyPixelWidth] as? Int,
+            height: properties[kCGImagePropertyPixelHeight] as? Int
+        )
+    }
+}


### PR DESCRIPTION
common use case for using iphone footage. most gen models fail with HEIC. so we convert it to jpg first

## Summary

- Convert HEIC and HEIF generation references to JPEG before upload.
- Prevent image and video generation models from receiving unsupported `image/heic` inputs.
- Preserve reference orientation without changing the source media asset.

The shared upload path previously forwarded HEIC files and labeled them `image/heic`. Generation providers that do not accept HEIC rejected otherwise valid reference images.

## Approach

- Detect `.heic` and `.heif` references at the shared `GenerationService` upload boundary used by UI and Agent generation.
- Decode and re-encode references off the main actor through `ImageConverter`, preserving the displayed orientation and original pixel dimensions.
- Upload the temporary file as `image/jpeg` and remove it on success, failure, or cancellation.
- Bypass the remote upload cache for HEIC references so a previously cached raw HEIC URL cannot be reused. JPEG, PNG, and other existing reference paths are unchanged.

Historical reruns that contain only a previously uploaded HEIC URL are intentionally outside this focused fix; starting a new generation with the local reference uses the conversion path.

## Testing

- `swift build` — passed.
- `swift test --filter ImageConverterTests` — 2 tests passed.
- `swift test` — 1,216 tests across 189 suites passed.
- Manual verification — the reporter confirmed HEIC reference generation works.

Not completed: a provider-by-provider generation matrix across every image and video model.

## Change statistics

- Code logic: +68 / -9 lines.
- Tests: +73 / -0 lines.
- Total: +141 / -9 lines across 3 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to reference upload preprocessing with cleanup on errors; JPEG/PNG paths and generation job logic are unchanged.
> 
> **Overview**
> **HEIC and HEIF image references are converted to JPEG in the shared generation upload path** so providers that reject `image/heic` still receive usable reference inputs (common for iPhone photos).
> 
> `GenerationService.uploadReferences` now detects `.heic`/`.heif` image refs, skips the remote upload cache for those (so a cached raw HEIC URL is not reused), decodes via new `ImageConverter` (orientation and full resolution via existing `ImageEncoder`), uploads as `image/jpeg`, and deletes the temp file on success, failure, or cancellation. Other formats and caching behavior are unchanged.
> 
> Tests cover extension detection and oriented HEIC → JPEG output dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbe3720e39ed6e7be6d718a567b586d779e3c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->