### PR TITLE
[ai audio] Support Sonilo audio generation

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -324,6 +324,15 @@ extension ToolExecutor {
             targetLanguage: params.targetLanguage
         )
         if let sourceAsset {
+            genInput.audioInput = sourceAsset.type == .video
+                ? AudioModelConfig.Input.video.rawValue
+                : AudioModelConfig.Input.audio.rawValue
+        } else {
+            genInput.audioInput = videoURL == nil
+                ? AudioModelConfig.Input.text.rawValue
+                : AudioModelConfig.Input.video.rawValue
+        }
+        if let sourceAsset {
             genInput.setAudioSourceAsset(sourceAsset)
         }
 

--- a/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/AudioModelConfig.swift
@@ -82,6 +82,8 @@ struct AudioModelConfig: Identifiable, Sendable {
     var supportsInstrumental: Bool { caps.supportsInstrumental }
     var supportsStyleInstructions: Bool { caps.supportsStyleInstructions }
     var durations: [Int]? { caps.durations }
+    var durationRange: AudioDurationRange? { caps.durationRange }
+    var hasDurationControl: Bool { durations != nil || durationRange != nil }
     var minPromptLength: Int { caps.minPromptLength }
 
     var inputs: [Input] { (caps.inputs ?? ["text"]).compactMap(Input.init(rawValue:)) }
@@ -121,10 +123,18 @@ struct AudioModelConfig: Identifiable, Sendable {
     var pricing: Pricing {
         switch entry.audioPricing {
         case .perThousandChars(let rate): return .perThousandChars(rate)
-        case .perSecond(let rate): return .perSecond(rate)
+        case .perSecond(let rate, _): return .perSecond(rate)
         case .flat(let price): return .flat(price)
         case .none: return .unknown
         }
+    }
+
+    func pricing(for input: Input?) -> Pricing {
+        if input == .text,
+           case .perSecond(_, let textRate?) = entry.audioPricing {
+            return .perSecond(textRate)
+        }
+        return pricing
     }
 
     func validate(params: AudioGenerationParams) -> String? {
@@ -141,6 +151,10 @@ struct AudioModelConfig: Identifiable, Sendable {
                 model: displayName, field: "duration",
                 value: "\(d)s", allowed: allowed.map { "\($0)s" }
             )
+        }
+        if let range = durationRange, let duration = params.durationSeconds,
+           !(range.minimum...range.maximum).contains(duration) {
+            return "\(displayName) duration must be \(range.minimum)-\(range.maximum) seconds."
         }
         if let allowed = targetLanguages {
             guard let language = params.targetLanguage, !language.isEmpty else {

--- a/Sources/PalmierPro/Generation/Catalog/CostEstimator.swift
+++ b/Sources/PalmierPro/Generation/Catalog/CostEstimator.swift
@@ -39,9 +39,10 @@ enum CostEstimator {
     static func audioCost(
         model: AudioModelConfig,
         prompt: String,
-        durationSeconds: Int?
+        durationSeconds: Int?,
+        input: AudioModelConfig.Input? = nil
     ) -> Int? {
-        switch model.pricing {
+        switch model.pricing(for: input) {
         case .perThousandChars(let rate):
             let chars = prompt.count
             guard chars > 0 else { return nil }
@@ -85,8 +86,14 @@ enum CostEstimator {
                 numImages: genInput.numImages ?? 1
             )
         case .audio(let m):
-            let duration = (m.durations != nil || m.acceptsSourceMedia) ? genInput.duration : nil
-            return audioCost(model: m, prompt: genInput.prompt, durationSeconds: duration)
+            let input = genInput.audioInput.flatMap(AudioModelConfig.Input.init(rawValue:))
+            let duration = (m.hasDurationControl || m.acceptsSourceMedia) ? genInput.duration : nil
+            return audioCost(
+                model: m,
+                prompt: genInput.prompt,
+                durationSeconds: duration,
+                input: input
+            )
         case .upscale(let m):
             return upscaleCost(model: m, durationSeconds: genInput.duration)
         case .none:

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -161,10 +161,10 @@ struct CatalogEntry: Decodable, Sendable {
 
     enum AudioPricing: Decodable, Sendable {
         case perThousandChars(rate: Double)
-        case perSecond(rate: Double)
+        case perSecond(rate: Double, textRate: Double?)
         case flat(price: Double)
 
-        private enum K: String, CodingKey { case mode, rate, price }
+        private enum K: String, CodingKey { case mode, rate, textRate, price }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: K.self)
@@ -172,7 +172,10 @@ struct CatalogEntry: Decodable, Sendable {
             case "perThousandChars":
                 self = .perThousandChars(rate: try c.decode(Double.self, forKey: .rate))
             case "perSecond":
-                self = .perSecond(rate: try c.decode(Double.self, forKey: .rate))
+                self = .perSecond(
+                    rate: try c.decode(Double.self, forKey: .rate),
+                    textRate: try c.decodeIfPresent(Double.self, forKey: .textRate)
+                )
             case "flat":
                 self = .flat(price: try c.decode(Double.self, forKey: .price))
             default:
@@ -251,6 +254,7 @@ struct AudioCaps: Decodable, Sendable {
     let supportsInstrumental: Bool
     let supportsStyleInstructions: Bool
     let durations: [Int]?
+    let durationRange: AudioDurationRange?
     let minPromptLength: Int
     let inputs: [String]?
     let promptLabel: String?
@@ -258,6 +262,12 @@ struct AudioCaps: Decodable, Sendable {
     let maxSeconds: Int?
     let targetLanguages: [String]?
     let defaultTargetLanguage: String?
+}
+
+struct AudioDurationRange: Decodable, Sendable {
+    let minimum: Int
+    let maximum: Int
+    let defaultValue: Int
 }
 
 struct UpscaleCaps: Decodable, Sendable {

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter+Rerun.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter+Rerun.swift
@@ -164,7 +164,7 @@ extension EditSubmitter {
                 lyrics: gen.lyrics,
                 styleInstructions: gen.styleInstructions,
                 instrumental: gen.instrumental ?? false,
-                durationSeconds: (audioModel.durations != nil || expectsSource) && gen.duration > 0
+                durationSeconds: (audioModel.hasDurationControl || expectsSource) && gen.duration > 0
                     ? gen.duration
                     : nil,
                 videoURL: videoURL,

--- a/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/MusicGenerationSubmission.swift
@@ -71,6 +71,9 @@ struct MusicGenerationSubmission {
             duration: durationSeconds,
             aspectRatio: ""
         )
+        genInput.audioInput = mode == .textToMusic
+            ? AudioModelConfig.Input.text.rawValue
+            : AudioModelConfig.Input.video.rawValue
         genInput.createdAt = Date()
 
         onPhase(.generating)

--- a/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
@@ -78,6 +78,14 @@ extension GenerationView {
 
     var trimmedPrompt: String { prompt.trimmingCharacters(in: .whitespaces) }
     var isPromptEmpty: Bool { trimmedPrompt.isEmpty }
+    var audioUsesSource: Bool {
+        audioModel.acceptsSourceMedia
+            && (!audioModel.inputs.contains(.text) || audioSource != nil)
+    }
+    var activeAudioInput: AudioModelConfig.Input {
+        guard audioUsesSource, let audioSource else { return .text }
+        return audioSource.type == .video ? .video : .audio
+    }
     var isPromptEnabled: Bool {
         selectedType != .audio || audioModel.inputs.contains(.text)
     }
@@ -96,7 +104,8 @@ extension GenerationView {
         case .video: return !videoModel.durations.isEmpty || !videoModel.aspectRatios.isEmpty || videoModel.resolutions != nil || videoModel.audioDiscountRate != nil
         case .image: return !imageModel.aspectRatios.isEmpty || imageModel.resolutions != nil || imageModel.qualities != nil || imageModel.maxImages > 1
         case .audio:
-            return audioModel.supportsInstrumental || audioModel.durations != nil
+            return audioModel.supportsInstrumental
+                || (!audioUsesSource && audioModel.hasDurationControl)
         }
     }
 

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
@@ -157,7 +157,9 @@ extension GenerationView {
     var settingsSummary: String {
         var parts: [String] = []
         if selectedType == .audio {
-            if audioModel.durations != nil { parts.append("\(selectedAudioDuration)s") }
+            if audioModel.hasDurationControl, !audioUsesSource {
+                parts.append("\(selectedAudioDuration)s")
+            }
             if audioModel.supportsInstrumental && instrumental { parts.append("Instrumental") }
             return parts.isEmpty ? "Settings" : parts.joined(separator: " \u{00B7} ")
         }
@@ -210,8 +212,25 @@ extension GenerationView {
             if selectedType == .video {
                 settingsPicker("Duration", selection: $selectedDuration, options: videoModel.durations) { "\($0)s" }
             }
-            if selectedType == .audio, let durations = audioModel.durations {
-                settingsPicker("Duration", selection: $selectedAudioDuration, options: durations) { "\($0)s" }
+            if selectedType == .audio, !audioUsesSource {
+                if let durations = audioModel.durations {
+                    settingsPicker("Duration", selection: $selectedAudioDuration, options: durations) { "\($0)s" }
+                } else if let range = audioModel.durationRange {
+                    VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+                        Text("Duration")
+                            .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        ScrubbableNumberField(
+                            value: Double(selectedAudioDuration),
+                            range: Double(range.minimum)...Double(range.maximum),
+                            format: "%.0f",
+                            valueSuffix: " s",
+                            dragValueAdjustment: { $0.rounded() },
+                            onChanged: { selectedAudioDuration = Int($0.rounded()) }
+                        ) { selectedAudioDuration = Int($0.rounded()) }
+                        .help("Duration (\(range.minimum)-\(range.maximum) seconds)")
+                    }
+                }
             }
             if !currentAspectRatios.isEmpty {
                 settingsPicker(

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -17,12 +17,12 @@ extension GenerationView {
             return false
         }
         if selectedType == .audio {
-            if audioModel.acceptsSourceMedia {
+            if audioUsesSource {
                 guard audioSource != nil else { return false }
                 guard let languages = audioModel.targetLanguages else { return true }
                 return languages.contains(selectedTargetLanguage)
             }
-            return trimmedPrompt.count >= audioModel.minPromptLength
+            return trimmedPrompt.count >= max(1, audioModel.minPromptLength)
         }
         return !isPromptEmpty
     }
@@ -46,11 +46,14 @@ extension GenerationView {
                 numImages: selectedNumImages
             )
         case .audio:
-            let duration: Int? = audioModel.acceptsSourceMedia
+            let duration: Int? = audioUsesSource
                 ? (audioSource == nil ? nil : effectiveAudioSourceSeconds)
-                : (audioModel.durations != nil ? selectedAudioDuration : nil)
+                : (audioModel.hasDurationControl ? selectedAudioDuration : nil)
             return CostEstimator.audioCost(
-                model: audioModel, prompt: trimmedPrompt, durationSeconds: duration
+                model: audioModel,
+                prompt: trimmedPrompt,
+                durationSeconds: duration,
+                input: activeAudioInput
             )
         }
     }
@@ -165,7 +168,7 @@ extension GenerationView {
                 numImages: imageCount
             )
         case .audio:
-            if audioModel.acceptsSourceMedia {
+            if audioUsesSource {
                 guard audioSource != nil else { return "Add source media." }
                 return audioModel.validate(spanSeconds: effectiveAudioSourceSpanSeconds)
                     ?? audioModel.validate(params: audioParams(audioDuration: audioDuration))
@@ -182,7 +185,7 @@ extension GenerationView {
             styleInstructions: audioModel.supportsStyleInstructions && !styleInstructions.isEmpty
                 ? styleInstructions : nil,
             instrumental: audioModel.supportsInstrumental ? instrumental : false,
-            durationSeconds: (audioModel.durations != nil || audioModel.acceptsSourceMedia) ? audioDuration : nil,
+            durationSeconds: (audioModel.hasDurationControl || audioModel.acceptsSourceMedia) ? audioDuration : nil,
             videoURL: videoURL,
             sourceURL: nil,
             targetLanguage: audioModel.targetLanguages != nil ? selectedTargetLanguage : nil
@@ -196,8 +199,8 @@ extension GenerationView {
         }
         let audioDuration: Int = {
             guard selectedType == .audio else { return 0 }
-            if audioModel.acceptsSourceMedia { return effectiveAudioSourceSeconds }
-            return audioModel.durations != nil ? selectedAudioDuration : 0
+            if audioUsesSource { return effectiveAudioSourceSeconds }
+            return audioModel.hasDurationControl ? selectedAudioDuration : 0
         }()
         if let err = preflightValidation(audioDuration: audioDuration) {
             flashDropError(err)
@@ -228,6 +231,9 @@ extension GenerationView {
         }()
         if imageCount > 1 {
             genInput.numImages = imageCount
+        }
+        if selectedType == .audio {
+            genInput.audioInput = activeAudioInput.rawValue
         }
 
         let replacementClipId = editor.pendingEditReplacementClipId
@@ -474,7 +480,10 @@ extension GenerationView {
         if !model.supportsLyrics { lyrics = "" }
         if !model.supportsStyleInstructions { styleInstructions = "" }
         if !model.supportsInstrumental { instrumental = false }
-        if let durations = model.durations, !durations.contains(selectedAudioDuration) {
+        if let range = model.durationRange,
+           !(range.minimum...range.maximum).contains(selectedAudioDuration) {
+            selectedAudioDuration = range.defaultValue
+        } else if let durations = model.durations, !durations.contains(selectedAudioDuration) {
             selectedAudioDuration = durations.first ?? 30
         }
     }

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -480,6 +480,11 @@ extension GenerationView {
         if !model.supportsLyrics { lyrics = "" }
         if !model.supportsStyleInstructions { styleInstructions = "" }
         if !model.supportsInstrumental { instrumental = false }
+        normalizeAudioDuration()
+    }
+
+    private func normalizeAudioDuration() {
+        let model = audioModel
         if let range = model.durationRange,
            !(range.minimum...range.maximum).contains(selectedAudioDuration) {
             selectedAudioDuration = range.defaultValue
@@ -505,5 +510,6 @@ extension GenerationView {
         if selectedType == .image {
             selectedNumImages = min(max(1, selectedNumImages), imageModel.maxImages)
         }
+        if selectedType == .audio { normalizeAudioDuration() }
     }
 }

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
@@ -74,6 +74,15 @@ struct MusicTab: View {
         guard let model else { return "No music models available." }
         if isTextMode {
             if trimmedPrompt.isEmpty { return "Describe the music to generate." }
+            let params = AudioGenerationParams(
+                prompt: trimmedPrompt,
+                voice: nil,
+                lyrics: nil,
+                styleInstructions: nil,
+                instrumental: false,
+                durationSeconds: costDuration
+            )
+            if let issue = model.validate(params: params) { return issue }
         } else {
             guard source != nil else {
                 return "Add video to the timeline, then mark a range to score only part of it."
@@ -173,16 +182,28 @@ struct MusicTab: View {
     }
 
     private var modelControl: some View {
-        InspectorRow(label: "Model", onReset: { selectedModelId = nil }) {
+        InspectorRow(label: "Model", onReset: { selectModel(nil) }) {
             Menu {
                 ForEach(models, id: \.id) { m in
-                    Button(m.displayName) { selectedModelId = m.id }
+                    Button(m.displayName) { selectModel(m) }
                 }
             } label: {
                 EditorMenuValue(text: model?.displayName ?? "None", expanded: true)
             }
             .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).focusable(false)
             .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func selectModel(_ selectedModel: AudioModelConfig?) {
+        selectedModelId = selectedModel?.id
+        guard let selectedModel = selectedModel ?? models.first else { return }
+        if let range = selectedModel.durationRange,
+           !(Double(range.minimum)...Double(range.maximum)).contains(textDuration) {
+            textDuration = Double(range.defaultValue)
+        } else if let durations = selectedModel.durations,
+                  !durations.contains(Int(textDuration.rounded())) {
+            textDuration = Double(durations.first ?? 90)
         }
     }
 

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
@@ -31,6 +31,15 @@ struct MusicTab: View {
     }
     private var isTextMode: Bool { effectiveMode == .textToMusic }
 
+    private var textDurationRange: ClosedRange<Double> {
+        guard let range = model?.durationRange else { return 1...600 }
+        return Double(range.minimum)...Double(range.maximum)
+    }
+
+    private var defaultTextDuration: Double {
+        Double(model?.durationRange?.defaultValue ?? 90)
+    }
+
     private var source: EditorViewModel.TimelineSpan? { editor.selectedTimelineSpan() }
 
     private var spanSeconds: Double {
@@ -53,7 +62,12 @@ struct MusicTab: View {
 
     private var estimatedCost: Int? {
         guard let model, costDuration > 0 else { return nil }
-        return CostEstimator.audioCost(model: model, prompt: trimmedPrompt, durationSeconds: costDuration)
+        return CostEstimator.audioCost(
+            model: model,
+            prompt: trimmedPrompt,
+            durationSeconds: costDuration,
+            input: isTextMode ? .text : .video
+        )
     }
 
     private var validationNote: String? {
@@ -132,15 +146,16 @@ struct MusicTab: View {
             InspectorRow(
                 label: "Duration",
                 labelHelp: "Length of the generated music. It's placed at the playhead, or at the marked range start.",
-                onReset: { textDuration = 90 }
+                onReset: { textDuration = defaultTextDuration }
             ) {
                 ScrubbableNumberField(
                     value: textDuration,
-                    range: 1...600,
+                    range: textDurationRange,
                     format: "%.0f",
                     valueSuffix: " s",
-                    onChanged: { textDuration = $0 }
-                ) { textDuration = $0 }
+                    dragValueAdjustment: { $0.rounded() },
+                    onChanged: { textDuration = $0.rounded() }
+                ) { textDuration = $0.rounded() }
             }
         } else {
             InspectorRow(

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
@@ -208,10 +208,7 @@ struct MusicTab: View {
     }
 
     private var promptControl: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
-            Text(model?.promptLabel ?? "Prompt")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
+        InspectorRow(label: "Prompt") {
             TextField(model?.promptLabel ?? "", text: $prompt, axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(2...5)

--- a/Sources/PalmierPro/Models/MediaManifest.swift
+++ b/Sources/PalmierPro/Models/MediaManifest.swift
@@ -57,6 +57,7 @@ struct GenerationInput: Codable, Sendable, Equatable {
     var styleInstructions: String?
     var instrumental: Bool?
     var targetLanguage: String?
+    var audioInput: String?
     /// Video-only
     var generateAudio: Bool?
     var referenceImageURLs: [String]?


### PR DESCRIPTION
## Summary

- support catalog models that accept either a text prompt or source media, allowing one Sonilo model per music/SFX capability
- render catalog-provided duration ranges as whole-second scrub fields inside generation settings
- estimate text and video inputs at their respective rates and preserve the input mode for reruns
- use catalog duration bounds and defaults in the dedicated Music inspector
- keep Mirelo as the contextual video-SFX shortcut provider

## Why

The backend now exposes Sonilo music and sound-effects models that route to separate provider endpoints based on whether the request contains source video. The frontend needs to represent that optional-source behavior, flexible duration ranges, and input-aware pricing without duplicating endpoint-specific models.

Depends on backend PR https://github.com/palmier-io/palmier-pro-backend/pull/19.

## Impact

Users can generate Sonilo music or sound effects from text or video, enter any supported whole-second duration through Settings, and see the correct estimate for the selected input mode. Existing discrete-duration and source-required audio models keep their current behavior.

## Validation

- `swift build --quiet --disable-automatic-resolution`
- `swift test --quiet --disable-automatic-resolution` — 1,221 tests passed

Manual UI smoke testing remains outstanding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generation submission, cost estimation, and validation across agent, main UI, and music panel; billing accuracy depends on correct audioInput and catalog pricing, but changes are additive for existing discrete-duration models.
> 
> **Overview**
> Adds **catalog-driven audio** behavior for models that can run from **text or source media** (e.g. Sonilo music/SFX): the UI distinguishes **text vs video/audio source** via `audioUsesSource` / `activeAudioInput`, hides duration controls when scoring from media, and **persists `audioInput`** on `GenerationInput` / manifest for agent, main generation flow, music submission, and reruns.
> 
> **Duration** can come from a new **`durationRange`** (min/max/default) in addition to fixed duration lists—shown as a **scrubbable whole-second field** in generation settings and the Music inspector, with validation and normalization on model change.
> 
> **Pricing** decodes optional **`textRate`** on per-second audio pricing and estimates credits through **`pricing(for:)`** so text-to-music and video-to-music can bill at different rates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2cab524f0d1017c13425aa54b71ed178812f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->