### PR TITLE
[fix] Keep multicam ripple trims synchronized

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -109,6 +109,17 @@ extension EditorViewModel {
         return (max(0, left), max(0, right))
     }
 
+    func multicamRippleCohort(for clip: Clip, edge: TrimEdge) -> [Clip] {
+        guard let groupId = clip.multicamGroupId else { return [clip] }
+        let boundary = edge == .left ? clip.startFrame : clip.endFrame
+        return multicamClips(of: groupId).compactMap { item in
+            let sharesEdge = edge == .left
+                ? item.clip.startFrame == boundary
+                : item.clip.endFrame == boundary
+            return sharesEdge ? item.clip : nil
+        }
+    }
+
     // MARK: - Source sync
     func syncMulticamMembers(
         specs: [MulticamMemberSpec],

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -44,11 +44,9 @@ extension EditorViewModel {
     func planRippleTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) -> RippleTrimPlan? {
         guard deltaFrames != 0, let leadLoc = findClip(id: clipId) else { return nil }
         let leadEnd = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex].endFrame
-
-        var targets: [String] = [clipId]
-        if propagateToLinked { targets.append(contentsOf: linkedPartnerIds(of: clipId)) }
-        let targetIds = Set(targets)
-        let targetClips = targets.compactMap { findClip(id: $0).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] } }
+        let targetClips = rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
+        let targetIds = Set(targetClips.map(\.id))
+        guard rippleTrimRefusal(leadLoc: leadLoc, edge: edge, targetIds: targetIds) == nil else { return nil }
 
         // Each target's own source headroom caps how far it can ripple; bind to the smallest.
         let sourceDelta = targetClips
@@ -58,12 +56,16 @@ extension EditorViewModel {
         // Shrinking shifts sync-locked followers left; clamp to the tightest available room.
         var durationDelta = sourceDelta
         var blockedAtFrame: Int?
-        if sourceDelta < 0 {
+        if durationDelta < 0 {
+            let targetShrinkRoom = targetClips
+                .map { $0.durationFrames > 1 ? $0.durationFrames - 1 : 0 }
+                .min() ?? 0
+            durationDelta = max(durationDelta, -targetShrinkRoom)
             let limits = timeline.tracks.compactMap { track -> (room: Int, obstacle: Int)? in
                 guard track.syncLocked, !track.clips.contains(where: { targetIds.contains($0.id) }) else { return nil }
                 return syncLockedLeftRoom(track: track, insertFrame: leadEnd)
             }
-            if let tightest = limits.min(by: { $0.room < $1.room }), sourceDelta < -tightest.room {
+            if let tightest = limits.min(by: { $0.room < $1.room }), durationDelta < -tightest.room {
                 durationDelta = -tightest.room
                 blockedAtFrame = tightest.obstacle
             }
@@ -74,7 +76,7 @@ extension EditorViewModel {
         let resizes = targetClips.map { c -> RippleTrimPlan.Resize in
             let fields = trimValues(for: c, edge: edge, delta: edge == .right ? durationDelta : -durationDelta)
             return .init(clipId: c.id, trimStart: fields.trimStart, trimEnd: fields.trimEnd,
-                         duration: max(1, c.durationFrames + durationDelta))
+                         duration: c.durationFrames + durationDelta)
         }
 
         var shifts: [ClipShift] = []
@@ -98,12 +100,9 @@ extension EditorViewModel {
 
     /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
     func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
-        if let loc = findClip(id: clipId) {
-            let lead = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-            var trimShifting = Set(timeline.tracks.filter(\.syncLocked).map(\.id))
-            trimShifting.insert(timeline.tracks[loc.trackIndex].id)
-            let shiftPoint = edge == .left ? lead.startFrame : lead.endFrame
-            if let reason = multicamManualRippleViolation(shiftingTrackIds: trimShifting, atFrame: shiftPoint) {
+        if let leadLoc = findClip(id: clipId) {
+            let targets = rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
+            if let reason = rippleTrimRefusal(leadLoc: leadLoc, edge: edge, targetIds: Set(targets.map(\.id))) {
                 refuseRipple(reason: reason)
                 return
             }
@@ -123,6 +122,41 @@ extension EditorViewModel {
                 sortClips(trackIndex: ti)
             }
         }
+    }
+
+    func rippleTrimTargets(clipId: String, edge: TrimEdge, propagateToLinked: Bool) -> [Clip] {
+        guard clipFor(id: clipId) != nil else { return [] }
+        var targetIds: Set<String> = [clipId]
+        var frontier = targetIds
+        while !frontier.isEmpty {
+            var added: Set<String> = []
+            for id in frontier {
+                guard let clip = clipFor(id: id) else { continue }
+                for cohortClip in multicamRippleCohort(for: clip, edge: edge)
+                where targetIds.insert(cohortClip.id).inserted {
+                    added.insert(cohortClip.id)
+                }
+                if propagateToLinked {
+                    for partnerId in linkedPartnerIds(of: id) where targetIds.insert(partnerId).inserted {
+                        added.insert(partnerId)
+                    }
+                }
+            }
+            frontier = added
+        }
+        return timeline.tracks.flatMap(\.clips).filter { targetIds.contains($0.id) }
+    }
+
+    private func rippleTrimRefusal(leadLoc: ClipLocation, edge: TrimEdge, targetIds: Set<String>) -> String? {
+        let lead = timeline.tracks[leadLoc.trackIndex].clips[leadLoc.clipIndex]
+        var shiftingTrackIds = Set(timeline.tracks.filter(\.syncLocked).map(\.id))
+        shiftingTrackIds.insert(timeline.tracks[leadLoc.trackIndex].id)
+        for targetId in targetIds {
+            guard let loc = findClip(id: targetId) else { continue }
+            shiftingTrackIds.insert(timeline.tracks[loc.trackIndex].id)
+        }
+        let shiftPoint = edge == .left ? lead.startFrame : lead.endFrame
+        return multicamManualRippleViolation(shiftingTrackIds: shiftingTrackIds, atFrame: shiftPoint)
     }
 
     /// Timeline delta from a ripple trim of `clip` by `delta` frames.

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -38,18 +38,24 @@ final class TimelineInputController {
     // MARK: - Mouse down
 
 
-    private func trimHeadroom(for clip: Clip, linked: Bool) -> (left: Int, right: Int) {
-        var clips = [clip]
-        if linked {
-            clips += editor.linkedPartnerIds(of: clip.id).compactMap { editor.clipFor(id: $0) }
+    private func trimHeadroom(for clip: Clip, edge: EditorViewModel.TrimEdge, linked: Bool, ripple: Bool) -> (left: Int, right: Int) {
+        let clips: [Clip]
+        if ripple {
+            clips = editor.rippleTrimTargets(clipId: clip.id, edge: edge, propagateToLinked: linked)
+        } else {
+            var resolved = [clip]
+            if linked {
+                resolved += editor.linkedPartnerIds(of: clip.id).compactMap { editor.clipFor(id: $0) }
+            }
+            clips = resolved
         }
         var left = Int.max
         var right = Int.max
         for c in clips {
-            if let bounds = editor.multicamTrimBounds(for: c) {
+            if !ripple, let bounds = editor.multicamTrimBounds(for: c) {
                 left = min(left, bounds.left)
                 right = min(right, bounds.right)
-            } else if c.id == clip.id {
+            } else {
                 left = min(left, c.trimStartFrame)
                 right = min(right, editor.effectiveTrimEnd(for: c))
             }
@@ -220,7 +226,8 @@ final class TimelineInputController {
                 dragState = .idle
             } else if let edge = trimEdge {
                 Self.trimCursor(for: edge).set()
-                let headroom = trimHeadroom(for: clip, linked: linkedOn)
+                let modelEdge: EditorViewModel.TrimEdge = edge == .left ? .left : .right
+                let headroom = trimHeadroom(for: clip, edge: modelEdge, linked: linkedOn, ripple: rippleTrim)
                 let drag = DragState.TrimDrag(
                     clipId: clip.id,
                     trackIndex: hit.trackIndex,

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -427,7 +427,7 @@ final class TimelineView: NSView {
                 }
 
                 if let (drag, isLeft) = trimDrag,
-                   clip.id == drag.clipId || trimPartnerIds.contains(clip.id),
+                   clip.id == drag.clipId || trimPartnerIds.contains(clip.id) || rippleResizeByClip[clip.id] != nil,
                    // Ripple drags with no resize preview at rest.
                    !(drag.isRipple && rippleResizeByClip[clip.id] == nil) {
                     var previewClip = clip

--- a/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
@@ -48,6 +48,25 @@ struct MulticamTests {
         h.editor.multicamClips(of: groupId).first { $0.clip.mediaType == .audio }!.clip
     }
 
+    private func rippleSeam(
+        _ h: ToolHarness, groupId: String
+    ) throws -> (leftProgram: Clip, rightProgram: Clip, leftMic: Clip, rightMic: Clip) {
+        guard case .ok = h.editor.rippleDeleteRangesOnTrack(
+            trackIndex: 0, ranges: [FrameRange(start: 600, end: 700)]
+        ) else {
+            Issue.record("ripple refused")
+            throw CancellationError()
+        }
+        let program = programClips(h, groupId)
+        let mic = h.editor.multicamClips(of: groupId).map(\.clip).filter { $0.mediaType == .audio }
+        return (
+            try #require(program.first { $0.endFrame == 600 }),
+            try #require(program.first { $0.startFrame == 600 }),
+            try #require(mic.first { $0.endFrame == 600 }),
+            try #require(mic.first { $0.startFrame == 600 })
+        )
+    }
+
     // MARK: - Model
 
     @Test func groupMetadataRoundTripsThroughProjectFile() throws {
@@ -433,6 +452,103 @@ struct MulticamTests {
             Issue.record("range ripple should pass")
             return
         }
+    }
+
+    @Test func alignedRippleTrimShrinksProgramAndMicTogether() throws {
+        let h = harness()
+        let (groupId, _) = try createGroup(h)
+        let seam = try rippleSeam(h, groupId: groupId)
+
+        h.editor.rippleTrimClip(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: -60, propagateToLinked: false
+        )
+
+        #expect(h.editor.clipFor(id: seam.leftProgram.id)?.endFrame == 540)
+        #expect(h.editor.clipFor(id: seam.rightProgram.id)?.startFrame == 540)
+        #expect(h.editor.clipFor(id: seam.leftMic.id)?.endFrame == 540)
+        #expect(h.editor.clipFor(id: seam.rightMic.id)?.startFrame == 540)
+        #expect(h.editor.linkGroupOffsets().isEmpty)
+    }
+
+    @Test func alignedRippleExtendGrowsProgramAndMicTogether() throws {
+        let h = harness()
+        let (groupId, _) = try createGroup(h)
+        let seam = try rippleSeam(h, groupId: groupId)
+
+        let plan = try #require(h.editor.planRippleTrim(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: 40, propagateToLinked: false
+        ))
+        #expect(plan.targetIds == Set([seam.leftProgram.id, seam.leftMic.id]))
+        h.editor.rippleTrimClip(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: 40, propagateToLinked: false
+        )
+
+        #expect(h.editor.clipFor(id: seam.leftProgram.id)?.endFrame == 640)
+        #expect(h.editor.clipFor(id: seam.rightProgram.id)?.startFrame == 640)
+        #expect(h.editor.clipFor(id: seam.leftMic.id)?.endFrame == 640)
+        #expect(h.editor.clipFor(id: seam.rightMic.id)?.startFrame == 640)
+        #expect(h.editor.linkGroupOffsets().isEmpty)
+    }
+
+    @Test func alignedRippleShrinkStopsAtShortestMember() throws {
+        let h = harness()
+        let (groupId, _) = try createGroup(h)
+        let seam = try rippleSeam(h, groupId: groupId)
+        let micLoc = try #require(h.editor.findClip(id: seam.leftMic.id))
+        let shortenedDuration = 30
+        let removedHead = seam.leftMic.durationFrames - shortenedDuration
+        h.editor.timeline.tracks[micLoc.trackIndex].clips[micLoc.clipIndex].startFrame += removedHead
+        h.editor.timeline.tracks[micLoc.trackIndex].clips[micLoc.clipIndex].trimStartFrame += removedHead
+        h.editor.timeline.tracks[micLoc.trackIndex].clips[micLoc.clipIndex].setDuration(shortenedDuration)
+
+        let plan = try #require(h.editor.planRippleTrim(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: -60, propagateToLinked: false
+        ))
+        #expect(plan.durationDelta == -(shortenedDuration - 1))
+        h.editor.rippleTrimClip(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: -60, propagateToLinked: false
+        )
+
+        let expectedEdge = seam.leftProgram.endFrame - (shortenedDuration - 1)
+        #expect(h.editor.clipFor(id: seam.leftProgram.id)?.endFrame == expectedEdge)
+        #expect(h.editor.clipFor(id: seam.leftMic.id)?.durationFrames == 1)
+        #expect(h.editor.clipFor(id: seam.leftMic.id)?.endFrame == expectedEdge)
+        #expect(h.editor.clipFor(id: seam.rightProgram.id)?.startFrame == expectedEdge)
+        #expect(h.editor.clipFor(id: seam.rightMic.id)?.startFrame == expectedEdge)
+        #expect(h.editor.linkGroupOffsets().isEmpty)
+    }
+
+    @Test func alignedLeftRippleTargetsProgramAndMicTogether() throws {
+        let h = harness()
+        let (groupId, _) = try createGroup(h)
+        let seam = try rippleSeam(h, groupId: groupId)
+        let programTrim = seam.rightProgram.trimStartFrame
+        let micTrim = seam.rightMic.trimStartFrame
+
+        h.editor.rippleTrimClip(
+            clipId: seam.rightProgram.id, edge: .left, deltaFrames: 30, propagateToLinked: false
+        )
+
+        #expect(h.editor.clipFor(id: seam.rightProgram.id)?.trimStartFrame == programTrim + 30)
+        #expect(h.editor.clipFor(id: seam.rightMic.id)?.trimStartFrame == micTrim + 30)
+        #expect(h.editor.linkGroupOffsets().isEmpty)
+    }
+
+    @Test func alignedRippleTrimUndoesAsOneAction() throws {
+        let h = harness()
+        let (groupId, _) = try createGroup(h)
+        let seam = try rippleSeam(h, groupId: groupId)
+        let before = h.editor.timeline
+        let manager = UndoManager()
+        h.editor.undo.attach(manager)
+
+        h.editor.rippleTrimClip(
+            clipId: seam.leftProgram.id, edge: .right, deltaFrames: -60, propagateToLinked: false
+        )
+
+        #expect(manager.undoActionName == "Ripple Trim")
+        #expect(h.editor.undo.undoLatest() == "Ripple Trim")
+        #expect(h.editor.timeline == before)
     }
 
     @Test func manualRippleAfterGroupStaysAllowed() throws {


### PR DESCRIPTION
## Summary

Allow Shift-drag ripple trims at aligned multicam edit points while keeping program video, microphone audio, linked clips, and downstream sync-locked tracks synchronized.

Manual ripple trims previously targeted only the lead and linked clips. At multicam seams created by Remove Silence, that either triggered the partial-group guard or left matching stamped fragments outside the trim. Editors could not safely fine-tune conservative or aggressive silence cuts.

## Approach

- Resolve a ripple cohort from all multicam fragments sharing the dragged edge, then close over linked partners.
- Use the same cohort, refusal rules, source-headroom clamp, and ripple plan for live preview and commit.
- Keep straddling multicam members blocked; only exact aligned boundaries are eligible.
- Clamp shrinking to the shortest cohort member so every fragment remains at least one frame.
- Resize matching program and audio fragments, shift downstream clips once, and preserve the existing single-action timeline-swap undo.

## Design

The existing ripple planner remains the source of truth. Multicam target resolution feeds that planner, and both the AppKit preview and commit consume its resize and shift results.

## Testing

- `swift test --filter Multicam` — 46 tests passed.
- `swift test --filter RippleTrimTests` — 12 tests passed.
- `swift build` — passed with existing `libconvexmobile` deployment-target linker warnings.
- `git diff --check` — passed.
- Manual: the Shift-drag multicam ripple interaction was confirmed on a Remove Silence seam. The unequal-duration one-frame clamp was not manually exercised.

## Change statistics

- Code logic: 74 additions, 22 deletions.
- Tests: 116 additions, 0 deletions.
- Total: 190 additions, 22 deletions across 5 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ripple-trim planning and multicam boundary rules; mistakes could desync program/audio or block valid trims, but scope is limited to aligned seams with new test coverage.
> 
> **Overview**
> Shift-drag ripple trims at **aligned multicam edit points** (e.g. after Remove Silence) now resize **every group fragment on the dragged boundary**—program video and mic audio—instead of only the lead clip and linked partners.
> 
> **`multicamRippleCohort`** finds clips in the same group that share the trim edge frame. **`rippleTrimTargets`** expands that cohort (plus linked partners) and feeds **`planRippleTrim`** / **`rippleTrimClip`**. **`rippleTrimRefusal`** runs the same multicam guards using the full target set and all affected tracks. Shrinking is clamped to the **shortest cohort member** (minimum one frame); resize duration no longer forces `max(1, …)` in the plan—clamping happens earlier.
> 
> Timeline **trim headroom** for ripple drags uses the same target list (multicam bounds skipped for ripple). **Live preview** draws resize on all cohort clips via `rippleResizeByClip`.
> 
> **Tests** cover shrink/extend, left-edge trim, shortest-member clamp, and single undo action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f6f738570e50da01f189d632c41334e3d8b2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->