### PR TITLE
[docs] Improve natural phrasing in Korean README

### DIFF
--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -4,7 +4,7 @@
 
 # Palmier Pro
 
-**AI를 위해 만든 비디오 편집기.**
+**AI를 위한 비디오 편집기.**
 
 <a href="https://github.com/palmier-io/palmier-pro/releases/latest/download/PalmierPro.dmg">
   <img src="../../assets/macos-badge.png" alt="macOS용 Palmier Pro 다운로드" width="180" />
@@ -46,7 +46,7 @@ Palmier Pro는 Mac용 오픈 소스 비디오 편집기입니다. 사용자와 a
 
 ### Swift 네이티브 비디오 편집기
 
-Palmier Pro는 Swift로 처음부터 만들었습니다. 기준은 Premiere Pro이며, AI를 워크플로에 통합하는 Palmier Pro만의 방식을 적용했습니다.
+Palmier Pro는 Swift로 처음부터 만들었습니다. Premiere Pro를 모티브로 했으며, AI를 워크플로에 통합하는 Palmier Pro만의 방식을 적용했습니다.
 
 ### 내장 생성형 AI
 
@@ -72,7 +72,7 @@ codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
 
 **Cursor**
 
-가장 쉬운 방법은 앱 안에서 `Help` -> `MCP Instructions` -> `Install in Cursor`를 여는 것입니다. 수동으로 설치하려면 `~/.cursor/mcp.json`에 다음을 추가하세요.
+가장 쉬운 방법은 앱 안에서 `Help` -> `MCP Instructions` -> `Install in Cursor`를 선택하는 것입니다. 수동으로 설치하려면 `~/.cursor/mcp.json`에 다음을 추가하세요.
 
 ```
 {
@@ -87,7 +87,7 @@ codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
 
 **Claude Desktop**
 
-앱에는 Claude Desktop에 Desktop Extension을 한 번에 설치할 수 있는 [mcpb](https://github.com/modelcontextprotocol/mcpb)가 포함되어 있습니다. `Help` -> `MCP Instructions` -> `Install in Claude Desktop`를 여세요.
+앱에는 Claude Desktop에 Desktop Extension을 한 번에 설치할 수 있는 [mcpb](https://github.com/modelcontextprotocol/mcpb)가 포함되어 있습니다. `Help` -> `MCP Instructions` -> `Install in Claude Desktop`을 선택하세요.
 
 ## FAQ
 
@@ -97,7 +97,7 @@ codex mcp add palmier-pro --url http://127.0.0.1:19789/mcp
 
 **무료인가요?**
 
-편집기는 무료입니다. 로그인 없이 다운로드할 수 있으며 CapCut이나 Adobe Premiere 같은 비디오 편집기로 사용할 수 있습니다. MCP 서버도 무료로 사용할 수 있고, Claude Code, Claude Desktop, Cursor로 타임라인 편집기와 상호작용을 시작할 수 있습니다.
+편집기는 무료입니다. 로그인 없이 다운로드할 수 있으며 CapCut이나 Adobe Premiere 같은 비디오 편집기로 사용할 수 있습니다. MCP 서버도 무료로 사용할 수 있고, Claude Code, Claude Desktop, Cursor를 타임라인 편집기와 연동할 수 있습니다.
 
 생성형 AI 기능은 로그인과 구독이 필요합니다.
 


### PR DESCRIPTION
## Summary

Hi! I'm a native Korean speaker, and I noticed a few spots in the Korean README (`docs/readme/README.ko.md`) that read slightly unnatural or contain a small grammar error — likely artifacts of the AI-generated translation (as noted in the file's header, which kindly asks for PRs like this one 🙂).

This PR polishes 5 sentences. No structural or content changes — the file stays fully in sync with the English `README.md`.

## Changes

### 1. Fix a particle (조사) error in the Claude Desktop section

> **Before:** `` `Install in Claude Desktop`를 여세요. ``
> **After:** `` `Install in Claude Desktop`을 선택하세요. ``

Korean object particles depend on the final sound of the preceding word: "Desktop" (데스크톱) ends in a consonant, so it must take **을**, not **를**. This is the one outright grammar error — every Korean reader would stumble on it. Also, for a menu item, "선택하세요" ("select") is the standard verb; "여세요" ("open") sounds odd here.

### 2. Use "select" for the Cursor menu path as well

> **Before:** `` ...`Install in Cursor`를 여는 것입니다. ``
> **After:** `` ...`Install in Cursor`를 선택하는 것입니다. ``

Same reasoning as above — menu navigation uses "select" in natural Korean UI writing, consistent with Apple's own Korean documentation style.

### 3. Translate "The north star is Premiere Pro" idiomatically

> **Before:** 기준은 Premiere Pro이며, ...
> **After:** Premiere Pro를 모티브로 했으며, ...

"기준" means "criterion/standard," which loses the aspirational nuance of "north star." "모티브로 했으며" ("took Premiere Pro as the inspiration/model") is how a Korean writer would naturally express this.

### 4. Smooth out a stiff literal translation in the FAQ

> **Before:** ...Claude Code, Claude Desktop, Cursor로 타임라인 편집기와 상호작용을 시작할 수 있습니다.
> **After:** ...Claude Code, Claude Desktop, Cursor를 타임라인 편집기와 연동할 수 있습니다.

"~와 상호작용을 시작하다" is a word-for-word rendering of "start interacting with" that no one would write in Korean. "연동하다" ("connect/integrate with") is the idiomatic term Korean developers use for exactly this kind of tool integration.

### 5. Tighten the tagline

> **Before:** **AI를 위해 만든 비디오 편집기.**
> **After:** **AI를 위한 비디오 편집기.**

Both are correct, but "AI를 위한" is punchier and matches how product taglines are written in Korean.

## Testing

Docs-only change. Verified the file renders correctly and remains structurally identical to the English README (same sections, links, badges, and code blocks).
