### PR TITLE
[fix] Unblock main thread when write() throws

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -28,7 +28,7 @@ private typealias DocumentCloseCallback = @convention(c) (
     AnyObject, Selector, NSDocument, Bool, UnsafeMutableRawPointer?
 ) -> Void
 
-final class VideoProject: NSDocument {
+class VideoProject: NSDocument {
 
     static let typeIdentifier = Project.typeIdentifier
 
@@ -198,6 +198,9 @@ final class VideoProject: NSDocument {
     }
 
     override func write(to url: URL, ofType typeName: String) throws {
+        var mainThreadUnblocked = false
+        defer { if !mainThreadUnblocked { unblockUserInteraction() } }
+
         if !snapshotPreparedForWrite {
             guard Thread.isMainThread else {
                 Log.project.error("save: snapshot not prepared for off-main write()")
@@ -218,6 +221,7 @@ final class VideoProject: NSDocument {
         snapshotPreparedForWrite = false
         snapshotSourceProjectURL = nil
         unblockUserInteraction()
+        mainThreadUnblocked = true
 
         guard let file, let data = try? JSONEncoder().encode(file) else {
             Log.project.error("save: project snapshot missing at write()")

--- a/Tests/PalmierProTests/Project/VideoProjectWriteUnblockTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectWriteUnblockTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+private final class UnblockCountingProject: VideoProject {
+    nonisolated(unsafe) private(set) var unblockCount = 0
+    override func unblockUserInteraction() { unblockCount += 1 }
+}
+
+/// With `canAsynchronouslyWrite` enabled, AppKit parks the main thread in
+/// `_waitForUserInteractionUnblocking` until `write()` calls `unblockUserInteraction()`.
+/// A throw that skips the unblock freezes the app permanently (issue #402).
+@Suite("VideoProject write() main-thread unblocking")
+struct VideoProjectWriteUnblockTests {
+
+    private func temporaryBundleURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("vp-unblock-\(UUID().uuidString).palmier", isDirectory: true)
+    }
+
+    @Test func offMainWriteWithoutSnapshotThrowsButStillUnblocks() async {
+        let doc = await MainActor.run { UnblockCountingProject() }
+        let url = temporaryBundleURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // The racing-save shape: a second save's write() lands off-main after the
+        // first write() consumed the shared snapshot.
+        await Task.detached {
+            #expect(throws: CocoaError.self) {
+                try doc.write(to: url, ofType: VideoProject.typeIdentifier)
+            }
+        }.value
+
+        #expect(doc.unblockCount == 1)
+    }
+
+    @Test func successfulWriteUnblocksExactlyOnce() async throws {
+        let doc = await MainActor.run {
+            let doc = UnblockCountingProject()
+            doc.editorViewModel.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+            return doc
+        }
+        let url = temporaryBundleURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await MainActor.run {
+            try doc.write(to: url, ofType: VideoProject.typeIdentifier)
+        }
+
+        #expect(doc.unblockCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #402. `VideoProject` opts into asynchronous saving (`canAsynchronouslyWrite` returns true), so AppKit parks the main thread in `_waitForUserInteractionUnblocking` until the background `write()` calls `unblockUserInteraction()`. The off-main "snapshot not prepared" guard in `write(to:ofType:)` threw before that call, leaving the main thread blocked on the condition lock forever — a permanent beachball with no error.

The path is reachable through an ordinary save race: two overlapping saves (autosave vs. manual ⌘S) share one snapshot slot. The first `write()` consumes `snapshotPreparedForWrite`; the second enters off-main with the flag false and throws. Large projects widen the save window, which matches the report of frequent freezes on an ~80-clip multi-timeline project.

## Approach

`write()` now guarantees the unblock on every exit with a `defer` guarded by a `mainThreadUnblocked` flag. The existing happy-path call stays where it is — unblocking at the snapshot handoff, before encoding and disk I/O, is the point of async saving — and just sets the flag so nothing double-unblocks. Any throw, current or future, now surfaces as a visible failed save instead of a freeze.

The underlying single-snapshot race is intentionally not restructured here; the loser now fails visibly and the next save succeeds. `VideoProject` drops `final` so the test can subclass it to count `unblockUserInteraction()` calls, which otherwise go straight into AppKit.

## Testing

- `swift build` — clean.
- `swift test` — 1228 tests in 191 suites pass.
- New `VideoProjectWriteUnblockTests`:
  - `offMainWriteWithoutSnapshotThrowsButStillUnblocks` reproduces the race shape (off-main `write()` with no prepared snapshot) and asserts it throws and unblocks exactly once. Verified red against unfixed `main`.
  - `successfulWriteUnblocksExactlyOnce` guards against a double-unblock on the happy path.
- Manual verification suggested before release: normal save/autosave/Save As/close paths in the app; the race itself is timing-dependent and is covered by the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the document save path and main-thread/AppKit interaction contract; change is narrow but failure modes previously caused total UI freeze.
> 
> **Overview**
> Fixes **#402** by ensuring `VideoProject.write(to:ofType:)` always calls `unblockUserInteraction()` when it exits with an error. With async saves, AppKit blocks the main thread until that unblock runs; the off-main “snapshot not prepared” path (e.g. overlapping saves consuming one snapshot) used to throw **before** unblocking, causing a permanent beachball.
> 
> `write()` now uses a **`defer`** plus a `mainThreadUnblocked` flag so any throw still unblocks once, while the existing early unblock after snapshot handoff remains and avoids double-unblock on success. **`VideoProject`** is no longer `final` so tests can subclass and count unblock calls.
> 
> Adds **`VideoProjectWriteUnblockTests`** for the off-main throw path (unblock exactly once) and the successful write path (no double-unblock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da168bda885e929a46ecf5df143f8cd13e8bef35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->