### PR TITLE
[perf] Disable content-driven sizing for editor panel hosting controllers

### DIFF
--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -379,6 +379,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
                         .allowsHitTesting(false)
                 }
         )
+        hc.sizingOptions = []
         hc.view.setAccessibilityIdentifier(panel.accessibilityID)
         return hc
     }


### PR DESCRIPTION
## Summary

The top hang group in Sentry [PALMIER-PRO-Q](https://palmier.sentry.io/issues/7501079223/))is dominated by 8+ second main-thread stalls inside the AutoLayout solver: `NSHostingView.beginTransaction` → `ViewLeafView.sizeThatFits` → `AppKitPlatformViewHost.intrinsicLayoutTraits` → `NSISEngine optimize`.

The five editor panel `NSHostingController`s created by `EditorSplitViewController.makeHosting` use the default `sizingOptions` (`[.minSize, .intrinsicContentSize, .maxSize]`), so each hosting view installs AutoLayout constraints mirroring its SwiftUI content's measured min/ideal/max size and re-updates them on every SwiftUI content change. All five live in nested split views sharing one window-wide `NSISEngine`, and high-frequency content updates (audio metering, playback) re-trigger expensive solver passes continuously. The root view's `maxWidth: .infinity` also produces the near-infinite constraint constant behind the PALMIER-PRO-19F crash ("NSLayoutConstraint is being configured with a constant that exceeds internal limits", culprit `buildDefaultLayout`).

This sets `sizingOptions = []` on the editor panel hosting controllers. Panel sizing is fully owned by the `NSSplitViewItem` minimum thicknesses and divider positions, so the content-driven constraints were pure overhead.

## Approach

- One line in `makeHosting`, applying to all five panels (media, preview, inspector, agent, timeline).
- `[]` rather than `.minSize` (the pattern used in Settings/Home/VideoProject windows): every panel already has an explicit `minimumThickness` on its split item, so a content-driven minimum would only reintroduce constraint churn.
- SwiftUI content changes no longer invalidate the window's constraint engine; layout of the panels is frame-driven by the split views.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line layout behavior change with explicit split minimums already in place; low risk aside from verifying panel resize/collapse still feels correct.
> 
> **Overview**
> Sets **`hc.sizingOptions = []`** in `EditorSplitViewController.makeHosting`, so all five editor panel `NSHostingController`s (media, preview, inspector, agent, timeline) no longer publish min/intrinsic/max size into AutoLayout on every SwiftUI update.
> 
> Panel geometry stays **split-driven** via existing `NSSplitViewItem` minimum thicknesses and divider positions; the change only removes redundant hosting-view constraint churn that was contributing to main-thread AutoLayout stalls during frequent UI updates (e.g. metering/playback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe5b848042a595cb458f29d2279fdc062357a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->