### PR TITLE
[fix] Move AVAssetReader teardown off the cooperative thread pool

### DIFF
--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -48,6 +48,20 @@ final class ScrubAudioEngine {
     nonisolated private static let fillStride = cacheFrameCount - grainFrameCount
     nonisolated private static let mixInvalidationDebounce = Duration.milliseconds(250)
 
+    nonisolated private static let readerTeardownQueue = DispatchQueue(
+        label: "io.palmier.pro.scrub-reader-teardown",
+        qos: .userInitiated
+    )
+
+    private struct ReaderBox: @unchecked Sendable {
+        let reader: AVAssetReader
+    }
+
+    nonisolated private static func finishReading(_ reader: AVAssetReader) {
+        let box = ReaderBox(reader: reader)
+        readerTeardownQueue.async { box.reader.cancelReading() }
+    }
+
     private let meter: AudioMeterHub
     private let output = ScrubAudioOutput(sampleRate: sampleRate)
 
@@ -456,13 +470,19 @@ final class ScrubAudioEngine {
         ])
         output.audioMix = source.audioMix
         output.alwaysCopiesSampleData = false
-        guard reader.canAdd(output) else { return nil }
+        guard reader.canAdd(output) else {
+            finishReading(reader)
+            return nil
+        }
         reader.add(output)
         reader.timeRange = CMTimeRange(
             start: CMTime(value: startSample, timescale: sampleTimescale),
             duration: CMTime(value: frameCount, timescale: sampleTimescale)
         )
-        guard reader.startReading() else { return nil }
+        guard reader.startReading() else {
+            finishReading(reader)
+            return nil
+        }
         return (reader, output)
     }
 
@@ -483,13 +503,11 @@ final class ScrubAudioEngine {
         guard let (reader, output) = makeReader(
             source: source, tracks: tracks, startSample: startSample, frameCount: Int64(frameCount)
         ) else { return nil }
+        defer { finishReading(reader) }
 
         var runningOffset = 0
         while let sampleBuffer = output.copyNextSampleBuffer() {
-            if Task.isCancelled {
-                reader.cancelReading()
-                return nil
-            }
+            if Task.isCancelled { return nil }
             guard let description = CMSampleBufferGetFormatDescription(sampleBuffer),
                   let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description),
                   let sampleFormat = AVAudioFormat(streamDescription: streamDescription)
@@ -545,6 +563,7 @@ final class ScrubAudioEngine {
               let (reader, output) = makeReader(
                 source: source, tracks: tracks, startSample: from, frameCount: to - from
               ) else { return }
+        defer { finishReading(reader) }
 
         let windowLen = cacheFrameCount
         let stride = Int64(fillStride)
@@ -570,7 +589,7 @@ final class ScrubAudioEngine {
         }
 
         while let sampleBuffer = output.copyNextSampleBuffer() {
-            if Task.isCancelled { reader.cancelReading(); return }
+            if Task.isCancelled { return }
             guard let description = CMSampleBufferGetFormatDescription(sampleBuffer),
                   let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description),
                   let sampleFormat = AVAudioFormat(streamDescription: streamDescription)
@@ -605,7 +624,7 @@ final class ScrubAudioEngine {
                 right[base + sourceIndex] = quantize(rightChannel[sourceIndex])
             }
             filledEnd = max(filledEnd, abs + Int64(sampleCount))
-            if !(await drainFull()) { reader.cancelReading(); return }
+            if !(await drainFull()) { return }
         }
 
         guard reader.status == .completed else { return }


### PR DESCRIPTION
## Summary

Fixes the ScrubAudioEngine crash family in Sentry: [PALMIER-PRO-17W](https://palmier.sentry.io/issues/?query=PALMIER-PRO-17W) (`ScrubAudioEngine.streamWindows` → `cancelReading` → `__DISPATCH_WAIT_FOR_QUEUE__`) and the same trap observed from Apple's audio thread as PALMIER-PRO-DR (`AudioQueueXPC_Bridge::ScheduleParameters` → `_dispatch_sync_f_slow`).

`streamWindows` and `decodeWindow` are `@concurrent`, so they run on the Swift cooperative thread pool. They called `reader.cancelReading()` inline, and readers that completed normally were released on the pool as well. `AVAssetReader` teardown performs synchronous `dispatch_sync` waits onto CoreMedia/AudioQueue serial queues (`_tearDownFigAssetReader` → `FigAudioQueueInvalidate` → `AudioQueueXPC_Bridge::RemovePropertyListener`). Blocking a cooperative-pool thread in that wait can form an ownership cycle with concurrent reader creation/teardown, which dispatch detects and traps (`EXC_BREAKPOINT` in `__DISPATCH_WAIT_FOR_QUEUE__`).

## Approach

- Add a dedicated serial `readerTeardownQueue` and a `finishReading(_:)` helper; all `cancelReading()` calls are dispatched onto it asynchronously.
- Route every reader exit path through `finishReading`: cancellation, early stop from the emit closure, `makeReader` failures (`canAdd`/`startReading`), and normal completion (`defer`). The completion path matters: a completed reader's deinit performs the same Fig teardown, so dropping it on the pool thread had the same blocking hazard as explicit cancel.
- The closure capture keeps the reader alive until the queue block runs, so the final release also lands on the teardown queue.
- The serial queue additionally prevents two readers from being in Fig teardown concurrently, removing the create/invalidate overlap visible in the DR crash's `figThreadMain` thread.
- Decode loops, window caching, grain synthesis, and metering are unchanged; teardown is fire-and-forget, so scrub latency and fill throughput are unaffected.

## Testing

- `swift build` passes.
- `swift test --filter ScrubAudio` passes (6 tests).
- A deterministic unit regression test is not practical: the trap requires AudioQueue XPC timing inside Apple frameworks. The structural guarantee (no `cancelReading` and no final reader release on the cooperative pool) is enforced by routing all exits through `finishReading`.
- Manual verification: scrub rapidly across a project with audio (including immediately after open, while background fill is active), switch clips/timelines repeatedly to cancel fills mid-read, adjust mix during playback; scrub audio and metering behave as before.

## Change statistics

- Code: +27 / −8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent audio decode teardown timing during rapid scrub/fill cancellation; logic is localized but race-sensitive around reader lifetime.
> 
> **Overview**
> Fixes scrub-audio crashes from **`AVAssetReader`** teardown blocking Swift’s cooperative thread pool on CoreMedia/AudioQueue **`dispatch_sync`** waits.
> 
> **`ScrubAudioEngine`** now routes every reader exit through a dedicated serial **`readerTeardownQueue`** via **`finishReading(_:)`**, which asynchronously calls **`cancelReading()`** and keeps the reader alive until that block runs so deinit also happens off the pool. **`makeReader`** failures, **`decodeWindow`** / **`streamWindows`** completion (**`defer`**), and cancellation/early-stop paths no longer call **`cancelReading()`** inline on **`@concurrent`** work; decode loops only return early.
> 
> Scrub decoding, caching, and metering behavior are unchanged aside from where teardown runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37aa2b6d81943040137ffce0ea00d183bc4fbc2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->