### PR TITLE
[feat/ui] Prepare source videos and group video models

### DIFF
--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -136,6 +136,7 @@ struct CatalogEntry: Decodable, Sendable {
     let id: String
     let kind: Kind
     let displayName: String
+    let providerName: String?
     let description: String?
     let allowedEndpoints: [String]
     let responseShape: ResponseShape
@@ -190,7 +191,7 @@ struct CatalogEntry: Decodable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, kind, displayName, description, allowedEndpoints, responseShape, uiCapabilities
+        case id, kind, displayName, providerName, description, allowedEndpoints, responseShape, uiCapabilities
         case creditsPerSecond, audioDiscountRate, creditsPerImage, qualities
         case audioPricing, creditsPerSecondUpscale, upscalePricing, paidOnly
     }
@@ -200,6 +201,7 @@ struct CatalogEntry: Decodable, Sendable {
         self.id = try c.decode(String.self, forKey: .id)
         self.kind = try c.decode(Kind.self, forKey: .kind)
         self.displayName = try c.decode(String.self, forKey: .displayName)
+        self.providerName = try c.decodeIfPresent(String.self, forKey: .providerName)
         self.description = try c.decodeIfPresent(String.self, forKey: .description)
         self.allowedEndpoints = try c.decode([String].self, forKey: .allowedEndpoints)
         self.responseShape = try c.decode(ResponseShape.self, forKey: .responseShape)
@@ -239,7 +241,12 @@ struct VideoCaps: Decodable, Sendable {
     let framesAndReferencesExclusive: Bool
     let referenceTagNoun: String
     let requiresSourceVideo: Bool
+    let maxSourceVideoResolution: SourceVideoResolution?
     let requiresReferenceImage: Bool
+}
+
+enum SourceVideoResolution: String, Decodable, Sendable {
+    case p720 = "720p", p1080 = "1080p", p4k = "4k"
 }
 
 struct ImageCaps: Decodable, Sendable {

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -13,6 +13,7 @@ struct VideoModelConfig: Identifiable, Sendable {
 
     var id: String { entry.id }
     var displayName: String { entry.displayName }
+    var providerName: String? { entry.providerName }
     var paidOnly: Bool { entry.paidOnly }
     var creditsPerSecond: [String: Double] { entry.creditsPerSecond ?? [:] }
     var audioDiscountRate: [String: Double]? { entry.audioDiscountRate }

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -39,6 +39,7 @@ final class GenerationService {
         buildParams: @escaping ([String]) -> BackendGenerationParams,
         snapshotRefs: (@Sendable (inout GenerationInput, [String]) -> Void)? = nil,
         preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)? = nil,
+        preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)? = nil,
         fileExtension: String,
         projectURL: URL?,
         editor: EditorViewModel,
@@ -77,7 +78,8 @@ final class GenerationService {
                     references: references,
                     trimmedSourceOverride: trimmedSourceOverride,
                     preUploadedURLs: preUploadedURLs,
-                    preprocessRef: preprocessRef
+                    preprocessRef: preprocessRef,
+                    preprocessSourceVideo: preprocessSourceVideo
                 )
                 defer { Self.cleanupTempFiles(prepared.tempFiles) }
                 let uploaded = prepared.uploaded
@@ -126,7 +128,8 @@ final class GenerationService {
         references: [MediaAsset],
         trimmedSourceOverride: TrimmedSource?,
         preUploadedURLs: [String]?,
-        preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+        preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?,
+        preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)?
     ) async throws -> PreparedReferences {
         if let preUploadedURLs, !preUploadedURLs.isEmpty {
             return PreparedReferences(uploaded: preUploadedURLs, tempFiles: [])
@@ -142,6 +145,11 @@ final class GenerationService {
                 urlsToUpload[0] = extracted
                 tempFiles.append(extracted)
             }
+            if let preprocessSourceVideo, let sourceURL = urlsToUpload.first,
+               let processed = try await preprocessSourceVideo(sourceURL) {
+                urlsToUpload[0] = processed
+                tempFiles.append(processed)
+            }
             if let preprocessRef, !references.isEmpty {
                 let rewrites = try await preprocessedReferenceURLs(references: references, preprocessRef: preprocessRef)
                 for (i, rewritten) in rewrites {
@@ -156,7 +164,7 @@ final class GenerationService {
                 cacheKeys: uploadCacheKeys(
                     references: references,
                     trimmedFirstReference: trimmedSourceOverride?.hasTrim == true,
-                    hasPreprocess: preprocessRef != nil
+                    hasPreprocess: preprocessRef != nil || preprocessSourceVideo != nil
                 ),
             )
             return PreparedReferences(uploaded: uploaded, tempFiles: tempFiles)

--- a/Sources/PalmierPro/Generation/Preprocessing/VideoCompressor.swift
+++ b/Sources/PalmierPro/Generation/Preprocessing/VideoCompressor.swift
@@ -1,37 +1,80 @@
 import AVFoundation
 import Foundation
 
-/// Downscales a video to fit within a target long-side bound. Used to keep reference videos
-/// inside model size caps (e.g. Seedance's ~1112 px max long side).
 enum VideoCompressor {
     struct CompressionError: LocalizedError {
         let reason: String
         var errorDescription: String? { "Video compression failed: \(reason)" }
     }
 
-    /// Returns a temp URL with a downscaled copy when the source exceeds `maxLongSide`, else `nil`.
     static func compressIfNeeded(url: URL, maxLongSide: Int = 1100) async throws -> URL? {
-        let asset = AVURLAsset(url: url)
-        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
-            return nil
+        try await compressIfNeeded(
+            url: url, maxLongSide: CGFloat(maxLongSide), maxShortSide: nil,
+            preset: AVAssetExportPreset960x540
+        )
+    }
+
+    static func compressIfNeeded(url: URL, maxResolution: SourceVideoResolution) async throws -> URL? {
+        let limits: (long: CGFloat, short: CGFloat, preset: String) = switch maxResolution {
+        case .p720: (1280, 720, AVAssetExportPreset1280x720)
+        case .p1080: (1920, 1080, AVAssetExportPreset1920x1080)
+        case .p4k: (3840, 2160, AVAssetExportPreset3840x2160)
         }
+        return try await compressIfNeeded(
+            url: url, maxLongSide: limits.long, maxShortSide: limits.short, preset: limits.preset)
+    }
+
+    @concurrent
+    private static func compressIfNeeded(
+        url: URL,
+        maxLongSide: CGFloat,
+        maxShortSide: CGFloat?,
+        preset: String
+    ) async throws -> URL? {
+        let asset = AVURLAsset(url: url)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else { return nil }
         let size = try await track.load(.naturalSize)
         let transform = try await track.load(.preferredTransform)
         let display = size.applying(transform)
         let longSide = max(abs(display.width), abs(display.height))
-        if longSide <= CGFloat(maxLongSide) { return nil }
+        let shortSide = min(abs(display.width), abs(display.height))
+        guard longSide > maxLongSide
+                || maxShortSide.map({ shortSide > $0 }) == true else { return nil }
 
-        // 960x540 preset keeps long side at 960, safely under Seedance's ~1112 cap and
-        // cuts file size. Scales down only; smaller sources (ruled out above) pass through.
-        guard let session = AVAssetExportSession(asset: asset, presetName: AVAssetExportPreset960x540) else {
+        guard let session = AVAssetExportSession(asset: asset, presetName: preset) else {
             throw CompressionError(reason: "export preset unsupported")
         }
-        let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("ref-compressed-\(UUID().uuidString).mp4")
-
-        Log.generation.notice("compress start url=\(url.lastPathComponent) longside=\(Int(longSide))")
-        try await session.export(to: outputURL, as: .mp4)
-        Log.generation.notice("compress ok url=\(outputURL.lastPathComponent)")
-        return outputURL
+        let scale = min(maxLongSide / longSide, (maxShortSide ?? maxLongSide) / shortSide)
+        let renderSize = CGSize(
+            width: max(2, floor(abs(display.width) * scale / 2) * 2),
+            height: max(2, floor(abs(display.height) * scale / 2) * 2)
+        )
+        var layerConfig = AVVideoCompositionLayerInstruction.Configuration(assetTrack: track)
+        layerConfig.setTransform(
+            transform.concatenating(CGAffineTransform(scaleX: scale, y: scale)), at: .zero)
+        let layer = AVVideoCompositionLayerInstruction(configuration: layerConfig)
+        let instructionConfig = AVVideoCompositionInstruction.Configuration(
+            backgroundColor: nil,
+            enablePostProcessing: false,
+            layerInstructions: [layer],
+            requiredSourceSampleDataTrackIDs: [],
+            timeRange: CMTimeRange(start: .zero, duration: try await asset.load(.duration))
+        )
+        let instruction = AVVideoCompositionInstruction(configuration: instructionConfig)
+        var compositionConfig = try await AVVideoComposition.Configuration(
+            for: asset,
+            prototypeInstruction: instruction
+        )
+        compositionConfig.renderSize = renderSize
+        compositionConfig.instructions = [instruction]
+        session.videoComposition = AVVideoComposition(configuration: compositionConfig)
+        let outputURL = FileIO.temporaryFileURL(pathExtension: "mp4")
+        do {
+            try await session.export(to: outputURL, as: .mp4)
+            return outputURL
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
     }
 }

--- a/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
@@ -11,6 +11,7 @@ struct VideoGenerationSubmission {
     let buildParams: ([String]) -> BackendGenerationParams
     let snapshotRefs: (@Sendable (inout GenerationInput, [String]) -> Void)?
     let preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+    let preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)?
 
     @MainActor
     @discardableResult
@@ -32,6 +33,7 @@ struct VideoGenerationSubmission {
             buildParams: buildParams,
             snapshotRefs: snapshotRefs,
             preprocessRef: preprocessRef,
+            preprocessSourceVideo: preprocessSourceVideo,
             fileExtension: "mp4",
             projectURL: projectURL,
             editor: editor,
@@ -55,6 +57,10 @@ struct VideoGenerationSubmission {
         if model.requiresSourceVideo {
             let references = inputAssets.editReferences
             genInput.imageURLAssetIds = assetIds(references)
+            let preprocessSourceVideo = model.caps.maxSourceVideoResolution.map { resolution in
+                { @Sendable url in try await VideoCompressor.compressIfNeeded(
+                    url: url, maxResolution: resolution) }
+            }
 
             return VideoGenerationSubmission(
                 genInput: genInput,
@@ -77,7 +83,8 @@ struct VideoGenerationSubmission {
                     ))
                 },
                 snapshotRefs: nil,
-                preprocessRef: nil
+                preprocessRef: nil,
+                preprocessSourceVideo: preprocessSourceVideo
             )
         }
 
@@ -131,7 +138,8 @@ struct VideoGenerationSubmission {
                 return .video(params)
             },
             snapshotRefs: snapshotRefs,
-            preprocessRef: preprocessRef
+            preprocessRef: preprocessRef,
+            preprocessSourceVideo: nil
         )
     }
 

--- a/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+struct VideoModelProviderGroup: Identifiable {
+    let name: String
+    let models: [(index: Int, model: VideoModelConfig)]
+    var id: String { name }
+}
+
 // Model catalog selection and per-model capability state.
 extension GenerationView {
 
@@ -47,6 +53,16 @@ extension GenerationView {
         videoModels.enumerated()
             .filter { ModelPreferences.shared.isEnabled($0.element.id) && isAvailable($0.element.paidOnly) }
             .map { (index: $0.offset, model: $0.element) }
+    }
+    var enabledVideoModelsByProvider: [VideoModelProviderGroup] {
+        var names: [String] = []
+        var modelsByName: [String: [(index: Int, model: VideoModelConfig)]] = [:]
+        for item in enabledVideoModels {
+            let name = item.model.providerName ?? "Other"
+            if modelsByName[name] == nil { names.append(name) }
+            modelsByName[name, default: []].append(item)
+        }
+        return names.map { VideoModelProviderGroup(name: $0, models: modelsByName[$0] ?? []) }
     }
     var enabledImageModels: [(index: Int, model: ImageModelConfig)] {
         imageModels.enumerated()

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
@@ -67,8 +67,12 @@ extension GenerationView {
         Menu {
             switch selectedType {
             case .video:
-                ForEach(enabledVideoModels, id: \.index) { item in
-                    Button(item.model.displayName) { selectedVideoModelIndex = item.index }
+                ForEach(enabledVideoModelsByProvider) { group in
+                    Section(group.name) {
+                        ForEach(group.models, id: \.index) { item in
+                            Button(item.model.displayName) { selectedVideoModelIndex = item.index }
+                        }
+                    }
                 }
             case .image:
                 ForEach(enabledImageModels, id: \.index) { item in

--- a/Tests/PalmierProTests/Media/VideoCompressorTests.swift
+++ b/Tests/PalmierProTests/Media/VideoCompressorTests.swift
@@ -1,0 +1,13 @@
+import AVFoundation
+import Testing
+@testable import PalmierPro
+@Test @concurrent
+func catalogResolutionCapsDimensions() async throws {
+    let sourceURL = try await FixtureVideo.write(scenes: [.init(rgb: (32, 64, 128), seconds: 0.2)], size: 800)
+    defer { try? FileManager.default.removeItem(at: sourceURL) }
+    let outputURL = try #require(await VideoCompressor.compressIfNeeded(url: sourceURL, maxResolution: .p720))
+    defer { try? FileManager.default.removeItem(at: outputURL) }
+    let track = try #require(await AVURLAsset(url: outputURL).loadTracks(withMediaType: .video).first)
+    let size = try await track.load(.naturalSize)
+    #expect(max(size.width, size.height) <= 1280 && min(size.width, size.height) <= 720)
+}


### PR DESCRIPTION
## Summary

- Resize source videos to each model's catalog-declared resolution limit before upload, allowing Runway Aleph 2.0 to accept source media above 1080p.
- Preserve trimmed source ranges, orientation, and aspect ratio while creating temporary upload files.
- Group the video model picker by backend-provided provider names so related models appear together.

## Approach

- Decode `maxSourceVideoResolution` and `providerName` from the shared model catalog instead of hardcoding Runway or inferring providers from model IDs.
- Extend `VideoCompressor` with 720p, 1080p, and 4K bounds. Compression uses AVFoundation's asynchronous loading and export APIs and applies the source transform through an explicit video composition.
- Preprocess the source URL after any existing trim extraction, bypass the upload cache for transformed media, and clean up temporary files after submission.
- Build provider sections from enabled models while preserving catalog order within and across groups. Models without provider metadata fall back to an `Other` section.

The source-video path remains separate from ordinary reference preprocessing because it operates on the potentially trim-extracted URL and uses a model-specific resolution limit. A hardcoded Runway check and frontend provider mapping were rejected because the catalog already owns model capabilities and presentation metadata.

## Testing

- `swift build` — passed.
- `swift test` — passed, 1,229 tests across 191 suites.
- `git diff --check` — passed.
- Manual UI verification remains: open the Video model menu and confirm provider headings, ordering, model selection, and the Add models item.
- Manual generation verification remains: submit a greater-than-1080p source to Runway Aleph 2.0 and confirm generation completes with the source orientation and selected timeline range preserved.

## Change statistics

- Production code: 112 additions, 25 deletions.
- Tests: 13 additions, 0 deletions.
- Total: 125 additions, 25 deletions across 8 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the upload path for source-video generations (trim → compress → upload) and AVFoundation export; failures could block submissions for capped models, though behavior is gated on catalog caps and existing temp-file cleanup.
> 
> **Overview**
> Adds **catalog-driven source-video preprocessing** and **provider-grouped video model UI** so edit-style models can accept oversized sources without hardcoding provider logic.
> 
> The model catalog now decodes optional `providerName` and `maxSourceVideoResolution` (`720p` / `1080p` / `4k`). Source-video edit flows wire a new `preprocessSourceVideo` hook through `GenerationService` and `VideoGenerationSubmission`: after trim extraction, the first reference URL is downscaled when it exceeds the model cap, temp files are tracked, and upload caching is skipped when any preprocessing ran.
> 
> `VideoCompressor` gains resolution-aware bounds with explicit `AVVideoComposition` scaling (orientation preserved) instead of only a fixed long-side preset. The video model menu groups enabled models by `providerName`, with an **Other** section when metadata is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822a3adb8c284a9378b0475c256c1258673eb6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->