### PR TITLE
[feat] Add invert colors effect

### DIFF
--- a/Sources/PalmierPro/Compositing/EffectRegistry.swift
+++ b/Sources/PalmierPro/Compositing/EffectRegistry.swift
@@ -272,6 +272,19 @@ enum EffectRegistry {
 
     private static let stylize: [EffectDescriptor] = [
         EffectDescriptor(
+            id: "stylize.invert", displayName: "Invert", category: "Stylize",
+            params: [],
+            apply: { image, _, _ in
+                return image.applyingFilter("CIColorMatrix", parameters: [
+                    "inputRVector": CIVector(x: -1, y: 0, z: 0, w: 0),
+                    "inputGVector": CIVector(x: 0, y: -1, z: 0, w: 0),
+                    "inputBVector": CIVector(x: 0, y: 0, z: -1, w: 0),
+                    "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+                    "inputBiasVector": CIVector(x: 1, y: 1, z: 1, w: 0),
+                ])
+            }
+        ),
+        EffectDescriptor(
             id: "stylize.grain", displayName: "Film Grain", category: "Stylize",
             params: [
                 EffectParamSpec(key: "amount", label: "Amount", range: 0...1, defaultValue: 0, unit: ""),
@@ -351,7 +364,8 @@ enum EffectRegistry {
         "color.exposure", "color.contrast", "color.highlightsShadows", "color.blacksWhites",
         "color.temperature", "color.vibrance", "color.saturation", "color.wheels", "color.curves",
         "color.hueCurves", "color.lut", "detail.clarity", "key.chroma", "blur.gaussian", "blur.sharpen",
-        "blur.noiseReduction", "blur.motion", "stylize.grain", "stylize.vignette", "stylize.glow",
+        "blur.noiseReduction", "blur.motion", "stylize.invert", "stylize.grain", "stylize.vignette",
+        "stylize.glow",
     ]
 
     static func insertIndex(_ effects: [Effect], for id: String) -> Int {

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -136,7 +136,8 @@ extension InspectorView {
                     isOn: Binding(
                         get: { invertApplied(to: clips) },
                         set: { setInvertApplied($0, clips: clips) }
-                    )
+                    ),
+                    isEnabled: invertApplied(to: clips) || sectionEnabled(effectsEffectIds, clips: clips)
                 )
             }
         }
@@ -189,11 +190,7 @@ extension InspectorView {
                 .accessibilityLabel("Enable \(title)")
             }
         ) {
-            Group {
-                content()
-            }
-            .disabled(!isOn)
-            .opacity(isOn ? AppTheme.Opacity.opaque : AppTheme.Opacity.medium)
+            content()
         }
     }
 
@@ -265,7 +262,7 @@ extension InspectorView {
             .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
     }
 
-    private func adjustToggleRow(title: String, isOn: Binding<Bool>) -> some View {
+    private func adjustToggleRow(title: String, isOn: Binding<Bool>, isEnabled: Bool) -> some View {
         HStack(spacing: AppTheme.Spacing.xs) {
             Color.clear
                 .frame(width: AppTheme.IconSize.xxs, height: AppTheme.IconSize.xxs)
@@ -277,6 +274,7 @@ extension InspectorView {
                 .accessibilityLabel(title)
         }
         .padding(.leading, adjustSubgroupInset)
+        .disabled(!isEnabled)
     }
 
     private func invertApplied(to clips: [Clip]) -> Bool {

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -144,24 +144,34 @@ extension InspectorView {
 
     // MARK: Section chrome
 
+    private var adjustSectionChildLabelInset: CGFloat { AppTheme.IconSize.xs }
+
+    private var adjustSubgroupInset: CGFloat { AppTheme.Spacing.smMd }
+
+    private var adjustSubgroupChildLabelInset: CGFloat {
+        adjustSubgroupInset + AppTheme.IconSize.xxs + AppTheme.Spacing.xs
+    }
+
     @ViewBuilder
     private func adjustSection<Content: View>(
         title: String,
         effectIds: Set<String>,
         clips: [Clip],
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        let expanded = !collapsedAdjustSections.contains(title)
         let hasEffects = anyAdjusted(effectIds, clips: clips)
         let isOn = !hasEffects || sectionEnabled(effectIds, clips: clips)
-        VStack(spacing: 0) {
-            HStack(spacing: AppTheme.Spacing.sm) {
-                Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                    .font(.system(size: AppTheme.FontSize.xxs))
-                    .foregroundStyle(AppTheme.Text.mutedColor)
-                    .frame(width: AppTheme.IconSize.xxs, alignment: .center)
-                sectionTitleLabel(title: title)
-                Spacer(minLength: AppTheme.Spacing.sm)
+        EditorPanelGroup(
+            title,
+            isExpanded: adjustSectionExpandedBinding(title),
+            contentSpacing: AppTheme.Spacing.md,
+            contentInsets: EdgeInsets(
+                top: AppTheme.Spacing.md,
+                leading: AppTheme.Spacing.lg,
+                bottom: AppTheme.Spacing.md,
+                trailing: AppTheme.Spacing.lg
+            ),
+            headerAccessory: {
                 if hasEffects {
                     EditorResetButton(
                         title: title,
@@ -178,31 +188,22 @@ extension InspectorView {
                 .help(hasEffects ? "Enable \(title.lowercased())" : "No adjustments yet")
                 .accessibilityLabel("Enable \(title)")
             }
-            .padding(.horizontal, AppTheme.Spacing.lg)
-            .padding(.vertical, AppTheme.Spacing.smMd)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(AppTheme.Background.surfaceColor)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                if expanded { collapsedAdjustSections.insert(title) }
-                else { collapsedAdjustSections.remove(title) }
-            }
-            if expanded {
-                VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
-                    content()
-                }
-                .padding(.horizontal, AppTheme.Spacing.lg)
-                .padding(.vertical, AppTheme.Spacing.md)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
+        ) {
+            content()
         }
-        .overlay(alignment: .bottom) { sectionDivider }
     }
 
-    private var sectionDivider: some View {
-        Rectangle()
-            .fill(AppTheme.Border.primaryColor)
-            .frame(height: AppTheme.BorderWidth.thin)
+    private func adjustSectionExpandedBinding(_ title: String) -> Binding<Bool> {
+        Binding(
+            get: { !collapsedAdjustSections.contains(title) },
+            set: { expanded in
+                if expanded {
+                    collapsedAdjustSections.remove(title)
+                } else {
+                    collapsedAdjustSections.insert(title)
+                }
+            }
+        )
     }
 
     @ViewBuilder
@@ -214,7 +215,7 @@ extension InspectorView {
                     .font(.system(size: AppTheme.FontSize.xxs))
                     .foregroundStyle(AppTheme.Text.mutedColor)
                     .frame(width: AppTheme.IconSize.xxs, alignment: .center)
-                sectionTitleLabel(title: title)
+                adjustSubgroupTitleLabel(title: title)
                 Spacer(minLength: 0)
                 if title == "Chroma Key", clips.count == 1, let clip = clips.first {
                     let sampling = editor.chromaKeySamplingClipId == clip.id
@@ -228,6 +229,7 @@ extension InspectorView {
                     .accessibilityLabel(sampling ? "Cancel Key Color Sampling" : "Sample Key Color")
                 }
             }
+            .padding(.leading, adjustSubgroupInset)
             .contentShape(Rectangle())
             .onTapGesture {
                 if expanded { collapsedAdjustSubgroups.insert(title) }
@@ -243,18 +245,34 @@ extension InspectorView {
         }
     }
 
+    private func adjustSubgroupTitleLabel(title: String) -> some View {
+        Text(title)
+            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+            .foregroundStyle(AppTheme.Text.secondaryColor)
+            .fixedSize()
+    }
+
+    private func adjustRowLabel(_ title: String, inset: CGFloat) -> some View {
+        Text(title)
+            .font(.system(size: AppTheme.FontSize.sm))
+            .foregroundStyle(AppTheme.Text.secondaryColor)
+            .lineLimit(1)
+            .padding(.leading, inset)
+            .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
+    }
+
     private func adjustToggleRow(title: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: AppTheme.Spacing.xs) {
             Color.clear
                 .frame(width: AppTheme.IconSize.xxs, height: AppTheme.IconSize.xxs)
-            sectionTitleLabel(title: title)
+            adjustSubgroupTitleLabel(title: title)
             Spacer(minLength: 0)
             Toggle("", isOn: isOn)
                 .toggleStyle(.checkbox)
                 .labelsHidden()
                 .accessibilityLabel(title)
         }
-        .frame(height: KeyframesMetrics.rowHeight)
+        .padding(.leading, adjustSubgroupInset)
     }
 
     private func invertApplied(to clips: [Clip]) -> Bool {
@@ -432,10 +450,7 @@ extension InspectorView {
 
     private func lutFileRow(path: String?, clips: [Clip]) -> some View {
         HStack(spacing: AppTheme.Spacing.sm) {
-            Text("File")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
-                .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
+            adjustRowLabel("File", inset: adjustSectionChildLabelInset)
             Button { chooseLUT(clips: clips) } label: {
                 HStack(spacing: AppTheme.Spacing.xs) {
                     Image(systemName: "square.stack.3d.up")
@@ -467,11 +482,7 @@ extension InspectorView {
         let range = spec?.range ?? 0...1
         let value = lutIntensity(in: clips)
         return HStack(spacing: AppTheme.Spacing.sm) {
-            Text("Intensity")
-                .font(.system(size: AppTheme.FontSize.sm))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
-                .lineLimit(1)
-                .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
+            adjustRowLabel("Intensity", inset: adjustSectionChildLabelInset)
             AdjustSlider(
                 value: value, range: range, defaultValue: spec?.defaultValue ?? 1,
                 onChanged: { setLUTIntensity($0, clips: clips, commit: false) },
@@ -542,11 +553,7 @@ extension InspectorView {
            let spec = descriptor.params.first(where: { $0.key == control.paramKey }) {
             let label = control.label ?? spec.label
             HStack(spacing: AppTheme.Spacing.sm) {
-                Text(label)
-                    .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(AppTheme.Text.secondaryColor)
-                    .lineLimit(1)
-                    .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
+                adjustRowLabel(label, inset: adjustSubgroupChildLabelInset)
                 AdjustSlider(
                     value: sharedClipValue(clips) { controlValue($0, control, spec) } ?? spec.defaultValue,
                     range: spec.range,

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -189,7 +189,11 @@ extension InspectorView {
                 .accessibilityLabel("Enable \(title)")
             }
         ) {
-            content()
+            Group {
+                content()
+            }
+            .disabled(!isOn)
+            .opacity(isOn ? AppTheme.Opacity.opaque : AppTheme.Opacity.medium)
         }
     }
 
@@ -277,11 +281,16 @@ extension InspectorView {
 
     private func invertApplied(to clips: [Clip]) -> Bool {
         !clips.isEmpty && clips.allSatisfy { clip in
-            (clip.effects ?? []).contains { $0.type == "stylize.invert" }
+            (clip.effects ?? []).contains { $0.type == "stylize.invert" && $0.enabled }
         }
     }
 
     private func setInvertApplied(_ applied: Bool, clips: [Clip]) {
+        let currentClips = clips.compactMap { editor.clipFor(id: $0.id) }
+        guard !applied || (
+            currentClips.count == clips.count
+                && sectionEnabled(effectsEffectIds, clips: currentClips)
+        ) else { return }
         commitEffects(
             clips,
             actionName: applied ? "Apply Invert Colors" : "Remove Invert Colors"

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -100,6 +100,7 @@ extension InspectorView {
 
     private var effectsEffectIds: Set<String> {
         Set((detailControls + blurControls + motionBlurControls + vignetteControls + grainControls + glowControls + chromaKeyControls).map(\.effectId))
+            .union(["stylize.invert"])
     }
 
     @ViewBuilder
@@ -130,6 +131,13 @@ extension InspectorView {
                 adjustSubgroup(title: "Film Grain", controls: grainControls, clips: clips)
                 adjustSubgroup(title: "Glow", controls: glowControls, clips: clips)
                 adjustSubgroup(title: "Chroma Key", controls: chromaKeyControls, clips: clips)
+                adjustToggleRow(
+                    title: "Invert Colors",
+                    isOn: Binding(
+                        get: { invertApplied(to: clips) },
+                        set: { setInvertApplied($0, clips: clips) }
+                    )
+                )
             }
         }
     }
@@ -231,6 +239,46 @@ extension InspectorView {
                         adjustmentRow(control, clips: clips)
                     }
                 }
+            }
+        }
+    }
+
+    private func adjustToggleRow(title: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            Color.clear
+                .frame(width: AppTheme.IconSize.xxs, height: AppTheme.IconSize.xxs)
+            sectionTitleLabel(title: title)
+            Spacer(minLength: 0)
+            Toggle("", isOn: isOn)
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .accessibilityLabel(title)
+        }
+        .frame(height: KeyframesMetrics.rowHeight)
+    }
+
+    private func invertApplied(to clips: [Clip]) -> Bool {
+        !clips.isEmpty && clips.allSatisfy { clip in
+            (clip.effects ?? []).contains { $0.type == "stylize.invert" }
+        }
+    }
+
+    private func setInvertApplied(_ applied: Bool, clips: [Clip]) {
+        commitEffects(
+            clips,
+            actionName: applied ? "Apply Invert Colors" : "Remove Invert Colors"
+        ) { [self] effects in
+            if applied {
+                if let index = effects.firstIndex(where: { $0.type == "stylize.invert" }) {
+                    effects[index].enabled = true
+                } else if let descriptor = EffectRegistry.descriptor(id: "stylize.invert") {
+                    effects.insert(
+                        descriptor.makeEffect(),
+                        at: alwaysOnInsertIndex(effects, for: "stylize.invert")
+                    )
+                }
+            } else {
+                effects.removeAll { $0.type == "stylize.invert" }
             }
         }
     }

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -2,6 +2,26 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct AdjustSectionState {
+    let hasEffects: Bool
+    let isEnabled: Bool
+
+    init(effectIds: Set<String>, clips: [Clip], chromaKeySamplingClipId: String?) {
+        var hasEffects = false
+        var hasEnabledEffect = false
+        for clip in clips {
+            for effect in clip.effects ?? [] where effectIds.contains(effect.type) {
+                hasEffects = true
+                hasEnabledEffect = hasEnabledEffect || effect.enabled
+            }
+        }
+        self.hasEffects = hasEffects
+        let isSamplingChromaKey = effectIds.contains("key.chroma")
+            && clips.contains { $0.id == chromaKeySamplingClipId }
+        isEnabled = !hasEffects || hasEnabledEffect || isSamplingChromaKey
+    }
+}
+
 extension InspectorView {
 
     // MARK: - Effects Tab
@@ -136,8 +156,7 @@ extension InspectorView {
                     isOn: Binding(
                         get: { invertApplied(to: clips) },
                         set: { setInvertApplied($0, clips: clips) }
-                    ),
-                    isEnabled: invertApplied(to: clips) || sectionEnabled(effectsEffectIds, clips: clips)
+                    )
                 )
             }
         }
@@ -160,8 +179,7 @@ extension InspectorView {
         clips: [Clip],
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        let hasEffects = anyAdjusted(effectIds, clips: clips)
-        let isOn = !hasEffects || sectionEnabled(effectIds, clips: clips)
+        let state = adjustSectionState(effectIds, clips: clips)
         EditorPanelGroup(
             title,
             isExpanded: adjustSectionExpandedBinding(title),
@@ -173,24 +191,28 @@ extension InspectorView {
                 trailing: AppTheme.Spacing.lg
             ),
             headerAccessory: {
-                if hasEffects {
+                if state.hasEffects {
                     EditorResetButton(
                         title: title,
                         action: { resetEffects(effectIds, clips: clips, actionName: "Reset \(title)") }
                     )
                 }
                 Toggle("", isOn: Binding(
-                    get: { isOn },
+                    get: { state.isEnabled },
                     set: { setSectionEnabled(effectIds, clips: clips, enabled: $0) }
                 ))
                 .toggleStyle(.checkbox)
                 .labelsHidden()
-                .disabled(!hasEffects)
-                .help(hasEffects ? "Enable \(title.lowercased())" : "No adjustments yet")
+                .disabled(!state.hasEffects)
+                .help(state.hasEffects ? "Enable \(title.lowercased())" : "No adjustments yet")
                 .accessibilityLabel("Enable \(title)")
             }
         ) {
-            content()
+            Group {
+                content()
+            }
+            .disabled(!state.isEnabled)
+            .opacity(state.isEnabled ? AppTheme.Opacity.opaque : AppTheme.Opacity.medium)
         }
     }
 
@@ -262,7 +284,7 @@ extension InspectorView {
             .frame(width: AppTheme.Slider.labelColumn, alignment: .leading)
     }
 
-    private func adjustToggleRow(title: String, isOn: Binding<Bool>, isEnabled: Bool) -> some View {
+    private func adjustToggleRow(title: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: AppTheme.Spacing.xs) {
             Color.clear
                 .frame(width: AppTheme.IconSize.xxs, height: AppTheme.IconSize.xxs)
@@ -274,7 +296,6 @@ extension InspectorView {
                 .accessibilityLabel(title)
         }
         .padding(.leading, adjustSubgroupInset)
-        .disabled(!isEnabled)
     }
 
     private func invertApplied(to clips: [Clip]) -> Bool {
@@ -625,10 +646,6 @@ extension InspectorView {
         EffectRegistry.insertIndex(effects, for: effectId)
     }
 
-    private func anyAdjusted(_ ids: Set<String>, clips: [Clip]) -> Bool {
-        clips.contains { ($0.effects ?? []).contains { ids.contains($0.type) } }
-    }
-
     private func resetEffects(_ ids: Set<String>, clips: [Clip], actionName: String) {
         commitEffects(clips, actionName: actionName) { effects in
             effects.removeAll { ids.contains($0.type) }
@@ -636,7 +653,15 @@ extension InspectorView {
     }
 
     private func sectionEnabled(_ ids: Set<String>, clips: [Clip]) -> Bool {
-        !clips.contains { ($0.effects ?? []).contains { ids.contains($0.type) && !$0.enabled } }
+        adjustSectionState(ids, clips: clips).isEnabled
+    }
+
+    private func adjustSectionState(_ ids: Set<String>, clips: [Clip]) -> AdjustSectionState {
+        AdjustSectionState(
+            effectIds: ids,
+            clips: clips,
+            chromaKeySamplingClipId: editor.chromaKeySamplingClipId
+        )
     }
 
     private func setSectionEnabled(_ ids: Set<String>, clips: [Clip], enabled: Bool) {

--- a/Sources/PalmierPro/UI/EditorPanel/EditorPanelGroup.swift
+++ b/Sources/PalmierPro/UI/EditorPanel/EditorPanelGroup.swift
@@ -4,6 +4,7 @@ struct EditorPanelGroup<Content: View, HeaderAccessory: View>: View {
     let title: String
     private let isExpanded: Binding<Bool>?
     private let contentSpacing: CGFloat
+    private let contentInsets: EdgeInsets
     private let onReset: (() -> Void)?
     @ViewBuilder private let headerAccessory: () -> HeaderAccessory
     @ViewBuilder private let content: () -> Content
@@ -13,6 +14,12 @@ struct EditorPanelGroup<Content: View, HeaderAccessory: View>: View {
         _ title: String,
         isExpanded: Binding<Bool>? = nil,
         contentSpacing: CGFloat = AppTheme.Spacing.smMd,
+        contentInsets: EdgeInsets = EdgeInsets(
+            top: AppTheme.Spacing.smMd,
+            leading: AppTheme.Spacing.smMd,
+            bottom: AppTheme.Spacing.smMd,
+            trailing: AppTheme.Spacing.smMd
+        ),
         onReset: (() -> Void)? = nil,
         @ViewBuilder headerAccessory: @escaping () -> HeaderAccessory,
         @ViewBuilder content: @escaping () -> Content
@@ -20,6 +27,7 @@ struct EditorPanelGroup<Content: View, HeaderAccessory: View>: View {
         self.title = title
         self.isExpanded = isExpanded
         self.contentSpacing = contentSpacing
+        self.contentInsets = contentInsets
         self.onReset = onReset
         self.headerAccessory = headerAccessory
         self.content = content
@@ -33,7 +41,7 @@ struct EditorPanelGroup<Content: View, HeaderAccessory: View>: View {
                     content()
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(AppTheme.Spacing.smMd)
+                .padding(contentInsets)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -110,6 +118,12 @@ extension EditorPanelGroup where HeaderAccessory == EmptyView {
         _ title: String,
         isExpanded: Binding<Bool>? = nil,
         contentSpacing: CGFloat = AppTheme.Spacing.smMd,
+        contentInsets: EdgeInsets = EdgeInsets(
+            top: AppTheme.Spacing.smMd,
+            leading: AppTheme.Spacing.smMd,
+            bottom: AppTheme.Spacing.smMd,
+            trailing: AppTheme.Spacing.smMd
+        ),
         onReset: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) {
@@ -117,6 +131,7 @@ extension EditorPanelGroup where HeaderAccessory == EmptyView {
             title,
             isExpanded: isExpanded,
             contentSpacing: contentSpacing,
+            contentInsets: contentInsets,
             onReset: onReset,
             headerAccessory: { EmptyView() },
             content: content

--- a/Tests/PalmierProTests/Agent/MCPInvertEffectTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPInvertEffectTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP — invert effect", .serialized)
+@MainActor
+struct MCPInvertEffectTests {
+    @Test func discoveryMutationReadbackValidationAndUndo() async throws {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [clip]),
+        ]))
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        let server = Server(
+            name: "invert-effect-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "invert-effect-test", version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            let tool = try #require(tools.first { $0.name == "apply_effect" })
+            #expect(tool.description?.contains("stylize.invert — Invert: no params") == true)
+
+            let mutation = try await client.callTool(name: "apply_effect", arguments: [
+                "clipIds": .array([.string(clip.id)]),
+                "effects": .array([.object([
+                    "type": .string("stylize.invert"),
+                ])]),
+            ])
+            #expect(mutation.isError != true)
+            let mutationEffect = invertEffect(in: try json(text(mutation.content)))
+            #expect(mutationEffect != nil)
+            #expect(mutationEffect?["params"] == nil)
+
+            let timeline = try json(text(try await client.callTool(name: "get_timeline").content))
+            #expect(invertEffect(in: timeline) != nil)
+
+            let invalid = try await client.callTool(name: "apply_effect", arguments: [
+                "clipIds": .array([.string(clip.id)]),
+                "effects": .array([.object([
+                    "type": .string("stylize.invert"),
+                    "params": .object(["amount": .double(1)]),
+                ])]),
+            ])
+            #expect(invalid.isError == true)
+            #expect(invertEffect(in: try json(text(try await client.callTool(name: "get_timeline").content))) != nil)
+
+            let undo = try await client.callTool(name: "undo")
+            #expect(undo.isError != true)
+            let restored = try json(text(try await client.callTool(name: "get_timeline").content))
+            #expect(invertEffect(in: restored) == nil)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
+    private func invertEffect(in payload: [String: Any]) -> [String: Any]? {
+        let clips: [[String: Any]]
+        if let changed = payload["clips"] as? [[String: Any]] {
+            clips = changed
+        } else {
+            let tracks = payload["tracks"] as? [[String: Any]]
+            clips = tracks?.flatMap { $0["clips"] as? [[String: Any]] ?? [] } ?? []
+        }
+        let effects = clips.first?["effects"] as? [[String: Any]]
+        return effects?.first { $0["type"] as? String == "stylize.invert" }
+    }
+
+    private func json(_ text: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+
+    private func text(_ content: [Tool.Content]) throws -> String {
+        for item in content {
+            if case .text(let text, _, _) = item { return text }
+        }
+        throw CocoaError(.coderReadCorrupt)
+    }
+}

--- a/Tests/PalmierProTests/Inspector/AdjustSectionStateTests.swift
+++ b/Tests/PalmierProTests/Inspector/AdjustSectionStateTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import PalmierPro
+
+@Suite struct AdjustSectionStateTests {
+    @Test func sectionInteractionDistinguishesBypassMixedAndSamplingStates() {
+        let ids: Set<String> = ["blur.gaussian", "key.chroma", "stylize.invert"]
+        func state(_ effects: [Effect], sampling: Bool = false) -> AdjustSectionState {
+            var clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
+            clip.effects = effects
+            return AdjustSectionState(
+                effectIds: ids,
+                clips: [clip],
+                chromaKeySamplingClipId: sampling ? clip.id : nil
+            )
+        }
+
+        #expect(!state([Effect(type: "blur.gaussian", enabled: false)]).isEnabled)
+        #expect(state([
+            Effect(type: "blur.gaussian", enabled: false),
+            Effect(type: "stylize.invert"),
+        ]).isEnabled)
+        #expect(state([Effect(type: "key.chroma", enabled: false)], sampling: true).isEnabled)
+    }
+}

--- a/Tests/PalmierProTests/Rendering/EffectTests.swift
+++ b/Tests/PalmierProTests/Rendering/EffectTests.swift
@@ -101,6 +101,32 @@ struct EffectModelTests {
             }
         }
     }
+
+    @Test func invertEffectReturnsComplementaryChannels() throws {
+        let descriptor = try #require(EffectRegistry.descriptor(id: "stylize.invert"))
+        let input = CIImage(color: CIColor(red: 0.2, green: 0.4, blue: 0.75))
+            .cropped(to: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let output = descriptor.render(
+            input,
+            effect: descriptor.makeEffect(),
+            atOffset: 0
+        )
+        let context = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
+        var pixel = [Float](repeating: 0, count: 4)
+        context.render(
+            output,
+            toBitmap: &pixel,
+            rowBytes: MemoryLayout<Float>.size * 4,
+            bounds: output.extent,
+            format: .RGBAf,
+            colorSpace: nil
+        )
+
+        #expect(abs(Double(pixel[0]) - 0.8) < 0.001)
+        #expect(abs(Double(pixel[1]) - 0.6) < 0.001)
+        #expect(abs(Double(pixel[2]) - 0.25) < 0.001)
+        #expect(abs(Double(pixel[3]) - 1) < 0.001)
+    }
 }
 
 @Suite("Effects — rendering")
@@ -163,6 +189,7 @@ struct EffectRenderingTests {
             "detail.clarity": ["clarity": 1, "dehaze": 0],
             "key.chroma": ["keyHue": 0.333, "tolerance": 0.5],
             "stylize.glow": ["intensity": 1, "radius": 20, "threshold": 0],
+            "stylize.invert": [:],
             "blur.noiseReduction": ["amount": 1],
             "blur.motion": ["radius": 20, "angle": 0],
         ]


### PR DESCRIPTION
## Summary

Adds a parameterless Invert Colors effect for flash-style edits. The effect complements RGB channels while preserving alpha, appears as a checkbox at the end of Adjust > Effects, and is available through the existing Agent effect workflow.

Also clarifies the Adjust panel hierarchy so top-level sections, nested effect groups, and control labels read as distinct levels. Top-level section chrome now reuses `EditorPanelGroup`.

## Approach

- Registers `stylize.invert` in `EffectRegistry` and renders it with `CIColorMatrix`, preserving the existing shared render and Agent paths.
- Uses the existing effect mutation and undo operations for UI changes, including multi-clip selections and canonical effect ordering.
- Keeps Invert Colors as a simple leaf checkbox after Chroma Key, without introducing parameters or a dedicated expandable group.
- Reuses `EditorPanelGroup` for Adjust sections and adds configurable content insets so existing callers retain their layout while Adjust preserves its slider columns.
- Indents and softens nested subgroup labels, aligns their child labels, and normalizes the Invert Colors row spacing.
- Uses one shared section-state calculation so a full bypass disables and dims controls, mixed child states remain interactive, and temporary Chroma Key sampling still permits cancellation.

## Testing

- `swift build` — passed.
- `swift test --filter 'MCPInvertEffectTests|EffectModelTests|EffectRenderingTests|sampledChromaKeyUndoes'` — 15 tests in 4 suites passed.
- `swift test --filter 'AdjustSectionStateTests|sampledChromaKeyUndoes'` — 2 focused tests in 2 suites passed.
- Manual UI verification — confirmed the Adjust hierarchy, LUT label alignment, Invert Colors placement and spacing, and the checkbox interaction.
- Manual follow-up — start Chroma Key sampling with Invert Colors active; confirm sampling can be canceled and Invert can be removed. Disable Effects and confirm Invert cannot be enabled until the section is re-enabled.

The build continues to emit pre-existing `libconvexmobile` deployment-target linker warnings and `HDRVideoExporter` sendable-capture warnings.

## Change statistics

- Effect/rendering logic: +15 / -1
- Inspector UI and shared panel component: +160 / -58
- Tests: +143 / -0
- Total: +318 / -59
