### PR TITLE
[ui] Improve media browser selection and actions

### DIFF
--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -40,6 +40,9 @@ enum MainMenuBuilder {
         let menu = NSMenu(title: "File")
         let newItem = menu.addItem(withTitle: "New", action: #selector(AppDelegate.newProject(_:)), keyEquivalent: "n")
         newItem.target = NSApp.delegate
+        let newFolderItem = NSMenuItem(title: "New Folder", action: #selector(EditorActions.newMediaFolder(_:)), keyEquivalent: "n")
+        newFolderItem.keyEquivalentModifierMask = [.command, .shift]
+        menu.addItem(newFolderItem)
         let openItem = menu.addItem(withTitle: "Open…", action: #selector(AppDelegate.openProject(_:)), keyEquivalent: "o")
         openItem.target = NSApp.delegate
         menu.addItem(.separator())
@@ -189,6 +192,7 @@ enum MainMenuBuilder {
     func deleteSelectedClips(_ sender: Any?)
     func rippleDeleteSelected(_ sender: Any?)
     func importMedia(_ sender: Any?)
+    func newMediaFolder(_ sender: Any?)
     func showExport(_ sender: Any?)
     func toggleMediaPanel(_ sender: Any?)
     func toggleInspectorPanel(_ sender: Any?)

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -53,6 +53,10 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         }
     }
 
+    private var handlesMediaPanelCommands: Bool {
+        editorViewModel.mediaPanelVisible && editorViewModel.focusedPanel == .media
+    }
+
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         // Don't intercept keys when a text field has focus
         if isTextInputFocused {
@@ -64,13 +68,13 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         let cmd = mods.contains(.command)
         let rangeMarkShortcut = mods.intersection([.command, .option, .control]).isEmpty
 
-        if editorViewModel.focusedPanel == .media, cmd, event.keyCode == 126,
+        if handlesMediaPanelCommands, cmd, event.keyCode == 126,
            mods.intersection([.option, .control, .shift]).isEmpty {
             editorViewModel.mediaPanelNavigateUpRequestTick &+= 1
             return true
         }
 
-        if editorViewModel.focusedPanel == .media,
+        if handlesMediaPanelCommands,
            mods.intersection([.command, .option, .control, .shift]).isEmpty,
            let direction = mediaArrowDirection(for: event.keyCode) {
             editorViewModel.moveMediaSelection(direction: direction)
@@ -79,7 +83,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
 
         switch event.keyCode {
         case 0: // A key
-            if editorViewModel.focusedPanel == .media, cmd,
+            if handlesMediaPanelCommands, cmd,
                mods.intersection([.option, .control]).isEmpty {
                 editorViewModel.selectAllMediaPanelItems()
                 return true
@@ -104,7 +108,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             return true
 
         case 51: // Delete/Backspace
-            if !editorViewModel.mediaPanelSelectedKeys().isEmpty {
+            if handlesMediaPanelCommands, !editorViewModel.mediaPanelSelectedKeys().isEmpty {
                 editorViewModel.deleteMediaPanelItems()
             } else if shift {
                 if editorViewModel.selectedGap != nil {
@@ -168,7 +172,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             return false
 
         case 36: // Return / Enter
-            if editorViewModel.focusedPanel == .media,
+            if handlesMediaPanelCommands,
                editorViewModel.selectedFolderIds.count == 1,
                let folderId = editorViewModel.selectedFolderIds.first {
                 editorViewModel.mediaPanelOpenFolderId = folderId
@@ -270,6 +274,7 @@ extension EditorWindowController: EditorActions {
     }
 
     @objc func newMediaFolder(_ sender: Any?) {
+        guard handlesMediaPanelCommands else { return }
         editorViewModel.mediaPanelNewFolderRequestTick &+= 1
     }
 
@@ -291,7 +296,7 @@ extension EditorWindowController: EditorActions {
     }
 
     @objc func paste(_ sender: Any?) {
-        if editorViewModel.focusedPanel == .media {
+        if handlesMediaPanelCommands {
             editorViewModel.mediaPanelPasteRequestTick &+= 1
             return
         }
@@ -348,9 +353,9 @@ extension EditorWindowController: EditorActions {
         case #selector(selectForwardOnTrack(_:)), #selector(selectForwardOnAllTracks(_:)):
             return editorViewModel.focusedPanel == .timeline && !editorViewModel.selectedClipIds.isEmpty
         case #selector(newMediaFolder(_:)):
-            return editorViewModel.focusedPanel == .media
+            return handlesMediaPanelCommands
         case #selector(paste(_:)):
-            if editorViewModel.focusedPanel == .media {
+            if handlesMediaPanelCommands {
                 return MediaTab.clipboardHasImportableMedia()
             }
             return canHandleClipboardShortcut() && editorViewModel.canPasteClips

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -64,7 +64,14 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         let cmd = mods.contains(.command)
         let rangeMarkShortcut = mods.intersection([.command, .option, .control]).isEmpty
 
-        if editorViewModel.focusedPanel == .media, !shift,
+        if editorViewModel.focusedPanel == .media, cmd, event.keyCode == 126,
+           mods.intersection([.option, .control, .shift]).isEmpty {
+            editorViewModel.mediaPanelNavigateUpRequestTick &+= 1
+            return true
+        }
+
+        if editorViewModel.focusedPanel == .media,
+           mods.intersection([.command, .option, .control, .shift]).isEmpty,
            let direction = mediaArrowDirection(for: event.keyCode) {
             editorViewModel.moveMediaSelection(direction: direction)
             return true
@@ -72,6 +79,11 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
 
         switch event.keyCode {
         case 0: // A key
+            if editorViewModel.focusedPanel == .media, cmd,
+               mods.intersection([.option, .control]).isEmpty {
+                editorViewModel.selectAllMediaPanelItems()
+                return true
+            }
             if editorViewModel.focusedPanel == .timeline,
                mods.intersection([.command, .option, .control]).isEmpty {
                 editorViewModel.selectForwardFromCurrentSelection(scope: shift ? .allTracks : .track)
@@ -92,18 +104,8 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             return true
 
         case 51: // Delete/Backspace
-            if !editorViewModel.selectedFolderIds.isEmpty || !editorViewModel.selectedMediaAssetIds.isEmpty
-                || !editorViewModel.selectedTimelineIds.isEmpty {
-                if !editorViewModel.selectedFolderIds.isEmpty {
-                    editorViewModel.deleteFolders(ids: editorViewModel.selectedFolderIds)
-                }
-                if !editorViewModel.selectedMediaAssetIds.isEmpty {
-                    editorViewModel.deleteSelectedMediaAssets()
-                }
-                for id in editorViewModel.selectedTimelineIds {
-                    editorViewModel.deleteTimeline(id)
-                }
-                editorViewModel.selectedTimelineIds.removeAll()
+            if !editorViewModel.mediaPanelSelectedKeys().isEmpty {
+                editorViewModel.deleteMediaPanelItems()
             } else if shift {
                 if editorViewModel.selectedGap != nil {
                     editorViewModel.rippleDeleteSelectedGap()
@@ -230,11 +232,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             if let panel = EditorViewModel.FocusedPanel(accessibilityID: v.accessibilityIdentifier()) {
                 editorViewModel.focusedPanel = panel
                 if panel == .media { editorViewModel.selectedClipIds.removeAll() }
-                if panel == .timeline {
-                    editorViewModel.selectedMediaAssetIds.removeAll()
-                    editorViewModel.selectedTimelineIds.removeAll()
-                    editorViewModel.selectedFolderIds.removeAll()
-                }
+                if panel == .timeline { editorViewModel.clearMediaPanelSelection() }
                 return
             }
             view = v.superview
@@ -269,6 +267,10 @@ extension EditorWindowController: EditorActions {
     }
     @objc func importMedia(_ sender: Any?) {
         // Handled by MediaTab directly
+    }
+
+    @objc func newMediaFolder(_ sender: Any?) {
+        editorViewModel.mediaPanelNewFolderRequestTick &+= 1
     }
 
     @objc func showExport(_ sender: Any?) {
@@ -345,6 +347,8 @@ extension EditorWindowController: EditorActions {
             return canHandleClipboardShortcut() && !editorViewModel.selectedClipIds.isEmpty
         case #selector(selectForwardOnTrack(_:)), #selector(selectForwardOnAllTracks(_:)):
             return editorViewModel.focusedPanel == .timeline && !editorViewModel.selectedClipIds.isEmpty
+        case #selector(newMediaFolder(_:)):
+            return editorViewModel.focusedPanel == .media
         case #selector(paste(_:)):
             if editorViewModel.focusedPanel == .media {
                 return MediaTab.clipboardHasImportableMedia()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -690,10 +690,6 @@ extension EditorViewModel {
         removeClips(ids: selectedClipIds)
     }
 
-    func deleteSelectedMediaAssets() {
-        deleteMediaAssets(ids: selectedMediaAssetIds)
-    }
-
     func deleteMediaAssets(ids: Set<String>) {
         guard !ids.isEmpty else { return }
         guard mediaAssets.contains(where: { ids.contains($0.id) }) else { return }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -540,69 +540,6 @@ extension EditorViewModel {
         return mediaAssetsById[clip.mediaRef]?.isGenerating ?? false
     }
 
-    enum MediaSelectionDirection {
-        case left, right, up, down
-
-        func step(columnCount: Int) -> Int {
-            switch self {
-            case .left: -1
-            case .right: +1
-            case .up: -columnCount
-            case .down: +columnCount
-            }
-        }
-
-        var startsFromEnd: Bool { self == .left || self == .up }
-    }
-
-    func moveMediaSelection(direction: MediaSelectionDirection) {
-        let ordered = mediaPanelOrderedItemIds
-        guard !ordered.isEmpty else { return }
-        let selectedKeys = mediaPanelSelectedKeys()
-
-        let next: String
-        if let anchor = ordered.last(where: { selectedKeys.contains($0) }),
-           let idx = ordered.firstIndex(of: anchor) {
-            let raw = idx + direction.step(columnCount: max(1, mediaPanelColumnCount))
-            let target = max(0, min(ordered.count - 1, raw))
-            guard target != idx else { return }
-            next = ordered[target]
-        } else {
-            next = direction.startsFromEnd ? ordered[ordered.count - 1] : ordered[0]
-        }
-
-        selectMediaPanelItem(next)
-    }
-
-    private func mediaPanelSelectedKeys() -> Set<String> {
-        var keys = selectedMediaAssetIds
-        keys.formUnion(selectedFolderIds.map(MediaPanelItemKey.folder))
-        keys.formUnion(selectedTimelineIds.map(MediaPanelItemKey.timeline))
-        return keys
-    }
-
-    func selectMediaPanelItem(_ key: String) {
-        if let folderId = MediaPanelItemKey.folderId(from: key) {
-            guard folder(id: folderId) != nil else { return }
-            mediaPanelScrollTarget = key
-            selectedFolderIds = [folderId]
-            selectedMediaAssetIds.removeAll()
-            selectedTimelineIds.removeAll()
-            return
-        }
-        if let timelineId = MediaPanelItemKey.timelineId(from: key) {
-            guard timeline(for: timelineId) != nil else { return }
-            mediaPanelScrollTarget = key
-            selectedTimelineIds = [timelineId]
-            selectedFolderIds.removeAll()
-            selectedMediaAssetIds.removeAll()
-            return
-        }
-        guard let asset = mediaAssets.first(where: { $0.id == key }) else { return }
-        mediaPanelScrollTarget = key
-        selectMediaAsset(asset)
-    }
-
     func renameMediaAsset(id: String, name: String) {
         guard let asset = mediaAssets.first(where: { $0.id == id }) else { return }
         let oldName = asset.name

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaPanel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaPanel.swift
@@ -1,0 +1,272 @@
+import AppKit
+
+enum MediaPanelSelectionMode: Equatable {
+    case replacing
+    case toggling
+    case range
+    case extendingRange
+
+    init(modifierFlags: NSEvent.ModifierFlags) {
+        let command = modifierFlags.contains(.command)
+        let shift = modifierFlags.contains(.shift)
+        switch (command, shift) {
+        case (true, true): self = .extendingRange
+        case (true, false): self = .toggling
+        case (false, true): self = .range
+        case (false, false): self = .replacing
+        }
+    }
+}
+
+private struct MediaPanelSelectionSnapshot {
+    let keys: Set<String>
+    let anchor: String?
+}
+
+extension EditorViewModel {
+    enum MediaSelectionDirection {
+        case left, right, up, down
+
+        func step(columnCount: Int) -> Int {
+            switch self {
+            case .left: -1
+            case .right: +1
+            case .up: -columnCount
+            case .down: +columnCount
+            }
+        }
+
+        var startsFromEnd: Bool { self == .left || self == .up }
+    }
+
+    func moveMediaSelection(direction: MediaSelectionDirection) {
+        let ordered = mediaPanelOrderedItemIds
+        guard !ordered.isEmpty else { return }
+        let selectedKeys = mediaPanelSelectedKeys()
+
+        let next: String
+        if let anchor = ordered.last(where: { selectedKeys.contains($0) }),
+           let index = ordered.firstIndex(of: anchor) {
+            let rawIndex = index + direction.step(columnCount: max(1, mediaPanelColumnCount))
+            let targetIndex = max(0, min(ordered.count - 1, rawIndex))
+            guard targetIndex != index else { return }
+            next = ordered[targetIndex]
+        } else {
+            next = direction.startsFromEnd ? ordered[ordered.count - 1] : ordered[0]
+        }
+
+        selectMediaPanelItem(next)
+    }
+
+    func selectMediaPanelItem(_ key: String) {
+        guard isValidMediaPanelItemKey(key) else { return }
+        mediaPanelScrollTarget = key
+        selectMediaPanelItem(key, mode: .replacing)
+    }
+
+    func selectMediaPanelItem(_ key: String, mode: MediaPanelSelectionMode) {
+        guard isValidMediaPanelItemKey(key) else { return }
+        var selection = mediaPanelSelectedKeys()
+        var anchor = mediaPanelSelectionAnchor
+
+        switch mode {
+        case .replacing:
+            selection = [key]
+            anchor = key
+        case .toggling:
+            if selection.contains(key) {
+                selection.remove(key)
+            } else {
+                selection.insert(key)
+            }
+            anchor = key
+        case .range, .extendingRange:
+            if let range = mediaPanelSelectionRange(through: key) {
+                if mode == .range {
+                    selection = range
+                } else {
+                    selection.formUnion(range)
+                }
+            } else {
+                selection = [key]
+                anchor = key
+            }
+        }
+
+        applyMediaPanelSelection(selection, anchor: anchor)
+        previewMediaPanelAsset(for: key, replacingSelection: mode == .replacing)
+    }
+
+    func selectAllMediaPanelItems() {
+        let orderedIds = mediaPanelOrderedItemIds
+        applyMediaPanelSelection(
+            Set(orderedIds),
+            anchor: orderedIds.first(where: isValidMediaPanelItemKey)
+        )
+    }
+
+    func clearMediaPanelSelection() {
+        applyMediaPanelSelection([], anchor: nil)
+    }
+
+    @discardableResult
+    func createMediaPanelFolder(in parentFolderId: String?) -> String {
+        let selectionBefore = mediaPanelSelectionSnapshot()
+        return undo.perform("New Folder") {
+            undo.register("New Folder", withTarget: self) { vm in
+                vm.restoreMediaPanelSelection(selectionBefore, actionName: "New Folder")
+            }
+            let id = createFolder(name: "New Folder", in: parentFolderId)
+            selectMediaPanelItem(MediaPanelItemKey.folder(id))
+            return id
+        }
+    }
+
+    func deleteMediaPanelItems(targeting contextKey: String? = nil) {
+        if let contextKey, isValidMediaPanelItemKey(contextKey),
+           !mediaPanelSelectedKeys().contains(contextKey) {
+            applyMediaPanelSelection([contextKey], anchor: contextKey)
+        }
+
+        let folderIds = Set(selectedFolderIds.filter { folder(id: $0) != nil })
+        let deletedFolderIds = folderIdsIncludingDescendants(folderIds)
+        let assetIds = Set(selectedMediaAssetIds.filter { id in
+            guard let asset = mediaAssetsById[id] else { return false }
+            return asset.folderId.map { !deletedFolderIds.contains($0) } ?? true
+        })
+
+        let selectedTimelines = selectedTimelineIds.intersection(Set(timelines.map(\.id)))
+        var remainingTimelineCount = timelines.count
+        var timelineIds: [String] = []
+        var refusedTimelineDeletion = false
+        for timeline in timelines where selectedTimelines.contains(timeline.id) {
+            if remainingTimelineCount > 1 {
+                timelineIds.append(timeline.id)
+                remainingTimelineCount -= 1
+            } else {
+                refusedTimelineDeletion = true
+            }
+        }
+
+        if refusedTimelineDeletion {
+            mediaPanelToast = "Can't delete every timeline — the project needs at least one."
+        }
+
+        let itemCount = folderIds.count + assetIds.count + timelineIds.count
+        guard itemCount > 0 else { return }
+        let actionName = mediaPanelDeleteActionName(
+            folderCount: folderIds.count,
+            assetCount: assetIds.count,
+            timelineCount: timelineIds.count
+        )
+        let selectionBefore = mediaPanelSelectionSnapshot()
+
+        undo.perform(actionName) {
+            undo.register(actionName, withTarget: self) { vm in
+                vm.restoreMediaPanelSelection(selectionBefore, actionName: actionName)
+            }
+            if !folderIds.isEmpty { deleteFolders(ids: folderIds) }
+            if !assetIds.isEmpty { deleteMediaAssets(ids: assetIds) }
+            for id in timelineIds { deleteTimeline(id) }
+        }
+
+        pruneMediaPanelSelectionAnchor()
+    }
+
+    /// Reset the anchor to the first visible selected item when it left the selection.
+    func pruneMediaPanelSelectionAnchor() {
+        let selection = mediaPanelSelectedKeys()
+        guard mediaPanelSelectionAnchor.map(selection.contains) != true else { return }
+        mediaPanelSelectionAnchor = mediaPanelOrderedItemIds.first(where: selection.contains)
+    }
+
+    func mediaPanelSelectedKeys() -> Set<String> {
+        var keys = selectedMediaAssetIds
+        keys.formUnion(selectedFolderIds.map(MediaPanelItemKey.folder))
+        keys.formUnion(selectedTimelineIds.map(MediaPanelItemKey.timeline))
+        return keys
+    }
+
+    private func mediaPanelSelectionRange(through key: String) -> Set<String>? {
+        guard let anchor = mediaPanelSelectionAnchor, isValidMediaPanelItemKey(anchor),
+              let anchorIndex = mediaPanelOrderedItemIds.firstIndex(of: anchor),
+              let targetIndex = mediaPanelOrderedItemIds.firstIndex(of: key) else { return nil }
+        let bounds = min(anchorIndex, targetIndex)...max(anchorIndex, targetIndex)
+        return Set(mediaPanelOrderedItemIds[bounds])
+    }
+
+    private enum MediaPanelItem {
+        case folder(String)
+        case timeline(String)
+        case asset(String)
+    }
+
+    private func mediaPanelItem(for key: String) -> MediaPanelItem? {
+        if let folderId = MediaPanelItemKey.folderId(from: key) {
+            return folder(id: folderId) != nil ? .folder(folderId) : nil
+        }
+        if let timelineId = MediaPanelItemKey.timelineId(from: key) {
+            return timeline(for: timelineId) != nil ? .timeline(timelineId) : nil
+        }
+        return mediaAssetsById[key] != nil ? .asset(key) : nil
+    }
+
+    private func isValidMediaPanelItemKey(_ key: String) -> Bool {
+        mediaPanelItem(for: key) != nil
+    }
+
+    private func applyMediaPanelSelection(_ keys: Set<String>, anchor: String?) {
+        var assetIds: Set<String> = []
+        var folderIds: Set<String> = []
+        var timelineIds: Set<String> = []
+
+        for key in keys {
+            switch mediaPanelItem(for: key) {
+            case .folder(let id): folderIds.insert(id)
+            case .timeline(let id): timelineIds.insert(id)
+            case .asset(let id): assetIds.insert(id)
+            case nil: break
+            }
+        }
+
+        if selectedMediaAssetIds != assetIds { selectedMediaAssetIds = assetIds }
+        if selectedFolderIds != folderIds { selectedFolderIds = folderIds }
+        if selectedTimelineIds != timelineIds { selectedTimelineIds = timelineIds }
+        mediaPanelSelectionAnchor = anchor
+    }
+
+    private func previewMediaPanelAsset(for key: String, replacingSelection: Bool) {
+        guard let asset = mediaAssetsById[key] else { return }
+        if replacingSelection {
+            selectMediaAsset(asset)
+        } else {
+            openPreviewTab(for: asset)
+        }
+    }
+
+    private func mediaPanelSelectionSnapshot() -> MediaPanelSelectionSnapshot {
+        MediaPanelSelectionSnapshot(
+            keys: mediaPanelSelectedKeys(),
+            anchor: mediaPanelSelectionAnchor
+        )
+    }
+
+    private func restoreMediaPanelSelection(_ snapshot: MediaPanelSelectionSnapshot, actionName: String) {
+        let inverse = mediaPanelSelectionSnapshot()
+        applyMediaPanelSelection(snapshot.keys, anchor: snapshot.anchor)
+        undo.register(actionName, withTarget: self) { vm in
+            vm.restoreMediaPanelSelection(inverse, actionName: actionName)
+        }
+    }
+
+    private func mediaPanelDeleteActionName(
+        folderCount: Int,
+        assetCount: Int,
+        timelineCount: Int
+    ) -> String {
+        guard folderCount + assetCount + timelineCount == 1 else { return "Delete Media Items" }
+        if folderCount == 1 { return "Delete Folder" }
+        if timelineCount == 1 { return "Delete Timeline" }
+        return "Delete Media"
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaPanel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaPanel.swift
@@ -1,10 +1,7 @@
 import AppKit
 
 enum MediaPanelSelectionMode: Equatable {
-    case replacing
-    case toggling
-    case range
-    case extendingRange
+    case replacing, toggling, range, extendingRange
 
     init(modifierFlags: NSEvent.ModifierFlags) {
         let command = modifierFlags.contains(.command)
@@ -18,10 +15,7 @@ enum MediaPanelSelectionMode: Equatable {
     }
 }
 
-private struct MediaPanelSelectionSnapshot {
-    let keys: Set<String>
-    let anchor: String?
-}
+private typealias MediaPanelSelectionSnapshot = (keys: Set<String>, anchor: String?)
 
 extension EditorViewModel {
     enum MediaSelectionDirection {
@@ -64,7 +58,7 @@ extension EditorViewModel {
         selectMediaPanelItem(key, mode: .replacing)
     }
 
-    func selectMediaPanelItem(_ key: String, mode: MediaPanelSelectionMode) {
+    func selectMediaPanelItem(_ key: String, mode: MediaPanelSelectionMode, atSourceFrame sourceFrame: Int = 0) {
         guard isValidMediaPanelItemKey(key) else { return }
         var selection = mediaPanelSelectedKeys()
         var anchor = mediaPanelSelectionAnchor
@@ -94,7 +88,7 @@ extension EditorViewModel {
         }
 
         applyMediaPanelSelection(selection, anchor: anchor)
-        previewMediaPanelAsset(for: key, replacingSelection: mode == .replacing)
+        previewMediaPanelAsset(for: key, replacingSelection: mode == .replacing, atSourceFrame: sourceFrame)
     }
 
     func selectAllMediaPanelItems() {
@@ -105,11 +99,8 @@ extension EditorViewModel {
         )
     }
 
-    func clearMediaPanelSelection() {
-        applyMediaPanelSelection([], anchor: nil)
-    }
+    func clearMediaPanelSelection() { applyMediaPanelSelection([], anchor: nil) }
 
-    @discardableResult
     func createMediaPanelFolder(in parentFolderId: String?) -> String {
         let selectionBefore = mediaPanelSelectionSnapshot()
         return undo.perform("New Folder") {
@@ -136,19 +127,9 @@ extension EditorViewModel {
         })
 
         let selectedTimelines = selectedTimelineIds.intersection(Set(timelines.map(\.id)))
-        var remainingTimelineCount = timelines.count
-        var timelineIds: [String] = []
-        var refusedTimelineDeletion = false
-        for timeline in timelines where selectedTimelines.contains(timeline.id) {
-            if remainingTimelineCount > 1 {
-                timelineIds.append(timeline.id)
-                remainingTimelineCount -= 1
-            } else {
-                refusedTimelineDeletion = true
-            }
-        }
-
-        if refusedTimelineDeletion {
+        let timelineIds = timelines.filter { selectedTimelines.contains($0.id) }
+            .prefix(max(0, timelines.count - 1)).map(\.id)
+        if selectedTimelines.count > timelineIds.count {
             mediaPanelToast = "Can't delete every timeline — the project needs at least one."
         }
 
@@ -173,7 +154,6 @@ extension EditorViewModel {
         pruneMediaPanelSelectionAnchor()
     }
 
-    /// Reset the anchor to the first visible selected item when it left the selection.
     func pruneMediaPanelSelectionAnchor() {
         let selection = mediaPanelSelectedKeys()
         guard mediaPanelSelectionAnchor.map(selection.contains) != true else { return }
@@ -181,10 +161,9 @@ extension EditorViewModel {
     }
 
     func mediaPanelSelectedKeys() -> Set<String> {
-        var keys = selectedMediaAssetIds
-        keys.formUnion(selectedFolderIds.map(MediaPanelItemKey.folder))
-        keys.formUnion(selectedTimelineIds.map(MediaPanelItemKey.timeline))
-        return keys
+        selectedMediaAssetIds
+            .union(selectedFolderIds.map(MediaPanelItemKey.folder))
+            .union(selectedTimelineIds.map(MediaPanelItemKey.timeline))
     }
 
     private func mediaPanelSelectionRange(through key: String) -> Set<String>? {
@@ -211,9 +190,7 @@ extension EditorViewModel {
         return mediaAssetsById[key] != nil ? .asset(key) : nil
     }
 
-    private func isValidMediaPanelItemKey(_ key: String) -> Bool {
-        mediaPanelItem(for: key) != nil
-    }
+    private func isValidMediaPanelItemKey(_ key: String) -> Bool { mediaPanelItem(for: key) != nil }
 
     private func applyMediaPanelSelection(_ keys: Set<String>, anchor: String?) {
         var assetIds: Set<String> = []
@@ -235,20 +212,17 @@ extension EditorViewModel {
         mediaPanelSelectionAnchor = anchor
     }
 
-    private func previewMediaPanelAsset(for key: String, replacingSelection: Bool) {
+    private func previewMediaPanelAsset(for key: String, replacingSelection: Bool, atSourceFrame sourceFrame: Int) {
         guard let asset = mediaAssetsById[key] else { return }
         if replacingSelection {
-            selectMediaAsset(asset)
+            selectMediaAsset(asset, atSourceFrame: sourceFrame)
         } else {
-            openPreviewTab(for: asset)
+            openPreviewTab(for: asset, atSourceFrame: sourceFrame)
         }
     }
 
     private func mediaPanelSelectionSnapshot() -> MediaPanelSelectionSnapshot {
-        MediaPanelSelectionSnapshot(
-            keys: mediaPanelSelectedKeys(),
-            anchor: mediaPanelSelectionAnchor
-        )
+        (keys: mediaPanelSelectedKeys(), anchor: mediaPanelSelectionAnchor)
     }
 
     private func restoreMediaPanelSelection(_ snapshot: MediaPanelSelectionSnapshot, actionName: String) {
@@ -259,11 +233,7 @@ extension EditorViewModel {
         }
     }
 
-    private func mediaPanelDeleteActionName(
-        folderCount: Int,
-        assetCount: Int,
-        timelineCount: Int
-    ) -> String {
+    private func mediaPanelDeleteActionName(folderCount: Int, assetCount: Int, timelineCount: Int) -> String {
         guard folderCount + assetCount + timelineCount == 1 else { return "Delete Media Items" }
         if folderCount == 1 { return "Delete Folder" }
         if timelineCount == 1 { return "Delete Timeline" }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
@@ -102,10 +102,12 @@ extension EditorViewModel {
         switch activePreviewTab {
         case .timeline:
             selectedMediaAssetIds.removeAll()
+            pruneMediaPanelSelectionAnchor()
         case .mediaAsset(let id, _, _):
             selectedClipIds.removeAll()
             selectedFolderIds.removeAll()
             selectedMediaAssetIds = [id]
+            mediaPanelSelectionAnchor = id
         }
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -250,11 +250,14 @@ final class EditorViewModel {
     // MARK: - Media panel navigation routing
 
     var mediaPanelOrderedItemIds: [String] = []
+    @ObservationIgnored var mediaPanelSelectionAnchor: String?
     var mediaPanelColumnCount: Int = 1
     var mediaPanelScrollTarget: String?
     var mediaPanelRevealAssetId: String?
     var mediaPanelOpenFolderId: String?
     var mediaPanelCurrentFolderId: String?
+    var mediaPanelNavigateUpRequestTick: Int = 0
+    var mediaPanelNewFolderRequestTick: Int = 0
     var mediaPanelPasteRequestTick: Int = 0
     var mediaPanelShowMediaTabTick: Int = 0
     var mediaPanelToast: MediaPanelToast?

--- a/Sources/PalmierPro/Help/ShortcutsPane.swift
+++ b/Sources/PalmierPro/Help/ShortcutsPane.swift
@@ -36,6 +36,7 @@ struct ShortcutsPane: View {
         ]),
         ShortcutGroup(title: "File", shortcuts: [
             ("Cmd + N", "New"),
+            ("Cmd + Shift + N", "New Folder"),
             ("Cmd + O", "Open"),
             ("Cmd + S", "Save"),
             ("Cmd + Shift + S", "Save As"),

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -94,7 +94,9 @@ struct AssetThumbnailView: View {
         Button("Reveal in Finder") { revealInFinder(ids: ids) }
         Button("Copy Path") { copyPaths(ids: ids) }
         Divider()
-        Button("Delete", role: .destructive) { deleteAssets(ids: ids) }
+        Button("Delete", role: .destructive) {
+            editor.deleteMediaPanelItems(targeting: asset.id)
+        }
     }
 
     private var contextTargetIds: [String] {
@@ -134,11 +136,6 @@ struct AssetThumbnailView: View {
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(paths.joined(separator: "\n"), forType: .string)
-    }
-
-    private func deleteAssets(ids: [String]) {
-        editor.selectedMediaAssetIds = Set(ids)
-        editor.deleteSelectedMediaAssets()
     }
 
     private var thumbnailContent: some View {
@@ -328,17 +325,7 @@ struct AssetThumbnailView: View {
             return
         }
 
-        let shiftHeld = NSEvent.modifierFlags.contains(.shift)
-
-        if shiftHeld {
-            if editor.selectedMediaAssetIds.contains(asset.id) {
-                editor.selectedMediaAssetIds.remove(asset.id)
-            } else {
-                editor.selectedMediaAssetIds.insert(asset.id)
-            }
-            editor.openPreviewTab(for: asset)   // tab follows, but keep multi-selection intact
-        } else {
-            editor.selectMediaAsset(asset)
-        }
+        let mode = MediaPanelSelectionMode(modifierFlags: NSEvent.modifierFlags)
+        editor.selectMediaPanelItem(asset.id, mode: mode)
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -67,12 +67,6 @@ extension MediaTab {
         )
     }
 
-    func clearSelections() {
-        if !editor.selectedMediaAssetIds.isEmpty { editor.selectedMediaAssetIds.removeAll() }
-        if !editor.selectedFolderIds.isEmpty { editor.selectedFolderIds.removeAll() }
-        if !editor.selectedTimelineIds.isEmpty { editor.selectedTimelineIds.removeAll() }
-    }
-
     func publishOrderedIds(_ ids: [String]) {
         if editor.mediaPanelOrderedItemIds != ids {
             editor.mediaPanelOrderedItemIds = ids
@@ -122,7 +116,7 @@ extension MediaTab {
                 }
                 editor.mediaPanelScrollTarget = nil
             }
-            .onTapGesture { clearSelections() }
+            .onTapGesture { editor.clearMediaPanelSelection() }
             .overlay { marqueeOverlay }
             .gesture(marqueeGesture)
         }
@@ -236,7 +230,7 @@ extension MediaTab {
                     }
                     editor.mediaPanelScrollTarget = nil
                 }
-                .onTapGesture { clearSelections() }
+                .onTapGesture { editor.clearMediaPanelSelection() }
                 .overlay { marqueeOverlay }
                 .gesture(marqueeGesture)
             }
@@ -300,7 +294,7 @@ extension MediaTab {
                         }
                         Divider()
                         Button("Delete", role: .destructive) {
-                            editor.deleteFolders(ids: [folderId])
+                            editor.deleteMediaPanelItems(targeting: MediaPanelItemKey.folder(folderId))
                         }
                     }
                 } else {
@@ -425,7 +419,7 @@ extension MediaTab {
                 get: { renamingTimelineId == timeline.id },
                 set: { renamingTimelineId = $0 ? timeline.id : nil }
             ),
-            onTap: { handleTimelineTap(timeline) },
+            onTap: { handleTileTap(MediaPanelItemKey.timeline(timeline.id)) },
             onOpen: { editor.activateTimeline(timeline.id) },
             onCommitRename: { newName in
                 editor.renameTimeline(timeline.id, to: newName)
@@ -433,7 +427,9 @@ extension MediaTab {
             },
             onCancelRename: { renamingTimelineId = nil },
             onDuplicate: { editor.duplicateTimeline(timeline.id) },
-            onDelete: { editor.deleteTimeline(timeline.id) }
+            onDelete: {
+                editor.deleteMediaPanelItems(targeting: MediaPanelItemKey.timeline(timeline.id))
+            }
         )
         .draggable(MediaTab.timelineDragString(forTimelineId: timeline.id)) {
             TileDragPreview(icon: "film.stack", name: timeline.name)
@@ -452,26 +448,8 @@ extension MediaTab {
         return nil
     }
 
-    fileprivate func handleTimelineTap(_ timeline: Timeline) {
-        handleTileTap(timeline.id, select: \.selectedTimelineIds,
-                      clearing: [\.selectedMediaAssetIds, \.selectedFolderIds])
-    }
-
-    fileprivate func handleTileTap(
-        _ id: String,
-        select selection: ReferenceWritableKeyPath<EditorViewModel, Set<String>>,
-        clearing others: [ReferenceWritableKeyPath<EditorViewModel, Set<String>>]
-    ) {
-        if NSEvent.modifierFlags.contains(.shift) {
-            if editor[keyPath: selection].contains(id) {
-                editor[keyPath: selection].remove(id)
-            } else {
-                editor[keyPath: selection].insert(id)
-            }
-        } else {
-            editor[keyPath: selection] = [id]
-            for other in others { editor[keyPath: other].removeAll() }
-        }
+    fileprivate func handleTileTap(_ key: String) {
+        editor.selectMediaPanelItem(key, mode: MediaPanelSelectionMode(modifierFlags: NSEvent.modifierFlags))
     }
 
     fileprivate func folderTile(_ folder: MediaFolder) -> some View {
@@ -489,14 +467,16 @@ extension MediaTab {
                     get: { renamingFolderId == folder.id },
                     set: { renamingFolderId = $0 ? folder.id : nil }
                 ),
-                onTap: { handleFolderTap(folder) },
+                onTap: { handleTileTap(MediaPanelItemKey.folder(folder.id)) },
                 onOpen: { openFolder(id: folder.id) },
                 onCommitRename: { newName in
                     editor.renameFolder(id: folder.id, name: newName)
                     renamingFolderId = nil
                 },
                 onCancelRename: { renamingFolderId = nil },
-                onDelete: { editor.deleteFolders(ids: [folder.id]) }
+                onDelete: {
+                    editor.deleteMediaPanelItems(targeting: MediaPanelItemKey.folder(folder.id))
+                }
             )
             .draggable(MediaTab.folderDragString(forFolderId: folder.id)) {
                 TileDragPreview(icon: "folder.fill", name: folder.name)
@@ -506,11 +486,6 @@ extension MediaTab {
             handleProviderDrop(providers, into: folder.id)
             return true
         }
-    }
-
-    fileprivate func handleFolderTap(_ folder: MediaFolder) {
-        handleTileTap(folder.id, select: \.selectedFolderIds,
-                      clearing: [\.selectedMediaAssetIds, \.selectedTimelineIds])
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -72,6 +72,11 @@ extension MediaTab {
             editor.mediaPanelOrderedItemIds = ids
         }
     }
+
+    func publishGridState(orderedIds: [String], columnCount: Int) {
+        publishOrderedIds(orderedIds)
+        if editor.mediaPanelColumnCount != columnCount { editor.mediaPanelColumnCount = columnCount }
+    }
 }
 
 // MARK: - Shared scroll/grid scaffolding (folder + flat modes)
@@ -107,7 +112,7 @@ extension MediaTab {
                 assetFrames = frames
                 if editor.mediaPanelColumnCount != cols { editor.mediaPanelColumnCount = cols }
             }
-            .onAppear { publishOrderedIds(orderedIds) }
+            .onAppear { publishGridState(orderedIds: orderedIds, columnCount: cols) }
             .onChange(of: orderedIds) { _, ids in publishOrderedIds(ids) }
             .onChange(of: editor.mediaPanelScrollTarget) { _, target in
                 guard let target else { return }
@@ -221,7 +226,7 @@ extension MediaTab {
                     assetFrames = frames
                     if editor.mediaPanelColumnCount != dims.cols { editor.mediaPanelColumnCount = dims.cols }
                 }
-                .onAppear { publishOrderedIds(orderedIds) }
+                .onAppear { publishGridState(orderedIds: orderedIds, columnCount: dims.cols) }
                 .onChange(of: orderedIds) { _, ids in publishOrderedIds(ids) }
                 .onChange(of: editor.mediaPanelScrollTarget) { _, target in
                     guard let target else { return }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -46,7 +46,12 @@ extension MediaTab {
             .padding(.top, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .onAppear { publishOrderedIds(orderedAssetIds) }
+        .onAppear {
+            publishOrderedIds(orderedAssetIds)
+            if editor.mediaPanelColumnCount != 1 {
+                editor.mediaPanelColumnCount = 1
+            }
+        }
         .onChange(of: orderedAssetIds) { _, ids in publishOrderedIds(ids) }
     }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -46,12 +46,7 @@ extension MediaTab {
             .padding(.top, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .onAppear {
-            publishOrderedIds(orderedAssetIds)
-            if editor.mediaPanelColumnCount != 1 {
-                editor.mediaPanelColumnCount = 1
-            }
-        }
+        .onAppear { publishGridState(orderedIds: orderedAssetIds, columnCount: 1) }
         .onChange(of: orderedAssetIds) { _, ids in publishOrderedIds(ids) }
     }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -56,13 +56,13 @@ extension MediaTab {
         fileAssetIds: [String],
         collapsedSectionTitles: Set<String>
     ) -> [String] {
-        var ids: [String] = []
-        if !collapsedSectionTitles.contains("Moments") { ids.append(contentsOf: momentAssetIds) }
-        if !collapsedSectionTitles.contains("Spoken") { ids.append(contentsOf: spokenAssetIds) }
-        ids.append(contentsOf: fileAssetIds)
-
+        let sections = [
+            collapsedSectionTitles.contains("Moments") ? [] : momentAssetIds,
+            collapsedSectionTitles.contains("Spoken") ? [] : spokenAssetIds,
+            fileAssetIds,
+        ]
         var seen: Set<String> = []
-        return ids.filter { seen.insert($0).inserted }
+        return sections.joined().filter { seen.insert($0).inserted }
     }
 
     private func resultsGrid<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
@@ -139,7 +139,8 @@ extension MediaTab {
                 .frame(width: 80, height: 45)
                 .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
         }
-        .onTapGesture { previewMoment(assetID: hit.assetID, atSeconds: range.lowerBound) }
+        .overlay { searchSelectionBorder(for: hit.assetID) }
+        .onTapGesture { selectSearchHit(assetID: hit.assetID, atSeconds: range.lowerBound) }
     }
 
     @ViewBuilder
@@ -189,7 +190,8 @@ extension MediaTab {
                 .frame(width: 80, height: 45)
                 .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
         }
-        .onTapGesture { previewMoment(assetID: hit.assetID, atSeconds: range.lowerBound) }
+        .overlay { searchSelectionBorder(for: hit.assetID) }
+        .onTapGesture { selectSearchHit(assetID: hit.assetID, atSeconds: range.lowerBound) }
     }
 
     private func fileCard(_ asset: MediaAsset) -> some View {
@@ -212,7 +214,8 @@ extension MediaTab {
                 .lineLimit(1)
         }
         .draggable(dragPayload(for: asset)) { dragPreview(for: asset) }
-        .onTapGesture { editor.selectMediaPanelItem(asset.id) }
+        .overlay { searchSelectionBorder(for: asset.id) }
+        .onTapGesture { selectSearchHit(assetID: asset.id, atSeconds: 0) }
         .task(id: searchThumbnailTaskID(for: asset)) {
             await loadSearchThumbnail(asset)
         }
@@ -227,9 +230,19 @@ extension MediaTab {
         await asset.loadLibraryThumbnail()
     }
 
-    private func previewMoment(assetID: String, atSeconds seconds: Double) {
-        guard let asset = editor.mediaAssets.first(where: { $0.id == assetID }) else { return }
-        editor.selectMediaAsset(asset, atSourceFrame: secondsToFrame(seconds: seconds, fps: editor.timeline.fps))
+    private func searchSelectionBorder(for assetID: String) -> some View {
+        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+            .strokeBorder(editor.selectedMediaAssetIds.contains(assetID) ? AppTheme.Accent.primary : .clear,
+                          lineWidth: AppTheme.BorderWidth.medium)
+            .allowsHitTesting(false)
+    }
+
+    private func selectSearchHit(assetID: String, atSeconds seconds: Double) {
+        editor.selectMediaPanelItem(
+            assetID,
+            mode: MediaPanelSelectionMode(modifierFlags: NSEvent.modifierFlags),
+            atSourceFrame: secondsToFrame(seconds: seconds, fps: editor.timeline.fps)
+        )
     }
 
     private func timecode(_ seconds: Double) -> String {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -8,6 +8,12 @@ extension MediaTab {
 
     var searchResults: some View {
         let nameMatches = sortAndFilter(editor.mediaAssets)
+        let orderedAssetIds = Self.searchOrderedAssetIds(
+            momentAssetIds: visualHits.map(\.assetID),
+            spokenAssetIds: spokenHits.map(\.assetID),
+            fileAssetIds: nameMatches.map(\.id),
+            collapsedSectionTitles: collapsedSearchSections
+        )
         return ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 if !visualHits.isEmpty {
@@ -40,6 +46,23 @@ extension MediaTab {
             .padding(.top, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .onAppear { publishOrderedIds(orderedAssetIds) }
+        .onChange(of: orderedAssetIds) { _, ids in publishOrderedIds(ids) }
+    }
+
+    static func searchOrderedAssetIds(
+        momentAssetIds: [String],
+        spokenAssetIds: [String],
+        fileAssetIds: [String],
+        collapsedSectionTitles: Set<String>
+    ) -> [String] {
+        var ids: [String] = []
+        if !collapsedSectionTitles.contains("Moments") { ids.append(contentsOf: momentAssetIds) }
+        if !collapsedSectionTitles.contains("Spoken") { ids.append(contentsOf: spokenAssetIds) }
+        ids.append(contentsOf: fileAssetIds)
+
+        var seen: Set<String> = []
+        return ids.filter { seen.insert($0).inserted }
     }
 
     private func resultsGrid<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -742,6 +742,7 @@ struct MediaTab: View {
                 }
             }
             .onEnded { _ in
+                editor.pruneMediaPanelSelectionAnchor()
                 marqueeSelection.reset()
             }
     }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -98,6 +98,10 @@ struct MediaTab: View {
                     VStack(spacing: 0) {
                         if showsEmptyState {
                             emptyStateView
+                                .onAppear {
+                                    publishGridState(orderedIds: [], columnCount: 1)
+                                    editor.clearMediaPanelSelection()
+                                }
                         } else if !trimmedSearchQuery.isEmpty {
                             searchResults
                         } else {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -108,6 +108,9 @@ struct MediaTab: View {
                             }
                         }
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .contextMenu { mediaBrowserContextMenu }
                 }
                 .overlay {
                     if isDropTargeted { dropHighlight.allowsHitTesting(false) }
@@ -136,7 +139,6 @@ struct MediaTab: View {
             mediaPanelHeight = newValue
         }
         .onExitCommand { if editor.pendingSwapClipId != nil { editor.cancelMediaSwap() } }
-        .background(KeyCommandSink(onNewFolder: createNewFolderInCurrent, onNavigateUp: navigateUp))
         .onChange(of: editor.folders.map(\.id)) { _, _ in pruneStaleFolderState() }
         .onChange(of: editor.mediaPanelRevealAssetId) { _, target in
             guard let target else { return }
@@ -147,6 +149,12 @@ struct MediaTab: View {
             guard let target else { return }
             openFolder(id: target)
             editor.mediaPanelOpenFolderId = nil
+        }
+        .onChange(of: editor.mediaPanelNavigateUpRequestTick) { _, _ in
+            navigateUp()
+        }
+        .onChange(of: editor.mediaPanelNewFolderRequestTick) { _, _ in
+            createNewFolderInCurrent()
         }
         .onChange(of: editor.mediaPanelPasteRequestTick) { _, _ in
             handleClipboardPaste()
@@ -263,7 +271,7 @@ struct MediaTab: View {
         }
         currentFolderId = id
         viewMode = .folder
-        editor.selectedFolderIds.removeAll()
+        editor.clearMediaPanelSelection()
     }
 
     // MARK: - Toolbar
@@ -625,6 +633,16 @@ struct MediaTab: View {
         }
     }
 
+    @ViewBuilder
+    private var mediaBrowserContextMenu: some View {
+        Button(action: createNewFolderInCurrent) {
+            Label("New Folder", systemImage: "folder.badge.plus")
+        }
+        Button(action: importMedia) {
+            Label("Import Media…", systemImage: "square.and.arrow.down")
+        }
+    }
+
     private func organizeWithAgent() {
         let folderHint = currentFolderId.map { _ in " Work within the current folder." } ?? ""
         let service = editor.agentService
@@ -654,7 +672,10 @@ struct MediaTab: View {
     // MARK: - Folder commands
 
     private func createNewFolderInCurrent() {
-        let id = editor.createFolder(name: "New Folder", in: currentFolderId)
+        searchQuery = ""
+        setViewMode(.folder)
+        renamingTimelineId = nil
+        let id = editor.createMediaPanelFolder(in: currentFolderId)
         renamingFolderId = id
     }
 
@@ -685,6 +706,7 @@ struct MediaTab: View {
                     let startOnCell = assetFrames.values.contains { $0.contains(value.startLocation) }
                     if startOnCell { return }
                     let extending = NSEvent.modifierFlags.contains(.shift)
+                    if !extending { editor.clearMediaPanelSelection() }
                     marqueeSelection.begin(
                         baseAssets: extending ? editor.selectedMediaAssetIds : [],
                         baseFolders: extending ? editor.selectedFolderIds : [],
@@ -827,45 +849,5 @@ struct MarqueeSelection {
         baseAssets = []
         baseFolders = []
         baseTimelines = []
-    }
-}
-
-// MARK: - Cmd+Shift+N / Cmd+Up keyboard shortcuts
-
-private struct KeyCommandSink: NSViewRepresentable {
-    let onNewFolder: () -> Void
-    let onNavigateUp: () -> Void
-
-    func makeNSView(context: Context) -> SinkView {
-        let v = SinkView()
-        v.onNewFolder = onNewFolder
-        v.onNavigateUp = onNavigateUp
-        return v
-    }
-
-    func updateNSView(_ nsView: SinkView, context: Context) {
-        nsView.onNewFolder = onNewFolder
-        nsView.onNavigateUp = onNavigateUp
-    }
-
-    final class SinkView: NSView {
-        var onNewFolder: (() -> Void)?
-        var onNavigateUp: (() -> Void)?
-
-        override var acceptsFirstResponder: Bool { true }
-
-        override func keyDown(with event: NSEvent) {
-            let cmd = event.modifierFlags.contains(.command)
-            let shift = event.modifierFlags.contains(.shift)
-            if cmd, shift, event.charactersIgnoringModifiers?.lowercased() == "n" {
-                onNewFolder?()
-                return
-            }
-            if cmd, event.keyCode == 126 {
-                onNavigateUp?()
-                return
-            }
-            super.keyDown(with: event)
-        }
     }
 }

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -580,6 +580,248 @@ struct MoveMediaSelectionTests {
     }
 }
 
+@Suite("EditorViewModel — media panel selection")
+@MainActor
+struct MediaPanelSelectionTests {
+    @Test func modifierFlagsUseMacSelectionConventions() {
+        #expect(MediaPanelSelectionMode(modifierFlags: []) == .replacing)
+        #expect(MediaPanelSelectionMode(modifierFlags: [.command]) == .toggling)
+        #expect(MediaPanelSelectionMode(modifierFlags: [.shift]) == .range)
+        #expect(MediaPanelSelectionMode(modifierFlags: [.command, .shift]) == .extendingRange)
+    }
+
+    @Test func commandSelectionTogglesItemsAcrossKinds() {
+        let e = editor()
+        let folderId = e.createFolder(name: "Bin")
+        let clip = asset(name: "clip")
+        e.importMediaAsset(clip)
+        let folderKey = MediaPanelItemKey.folder(folderId)
+        e.mediaPanelOrderedItemIds = [folderKey, clip.id]
+
+        e.selectMediaPanelItem(folderKey, mode: .replacing)
+        e.selectMediaPanelItem(clip.id, mode: .toggling)
+
+        #expect(e.selectedFolderIds == [folderId])
+        #expect(e.selectedMediaAssetIds == [clip.id])
+        #expect(e.mediaPanelSelectionAnchor == clip.id)
+
+        e.selectMediaPanelItem(folderKey, mode: .toggling)
+
+        #expect(e.selectedFolderIds.isEmpty)
+        #expect(e.selectedMediaAssetIds == [clip.id])
+        #expect(e.mediaPanelSelectionAnchor == folderKey)
+    }
+
+    @Test func shiftSelectionUsesVisibleOrderAcrossKinds() {
+        let e = editor()
+        let folderId = e.createFolder(name: "Bin")
+        let first = asset(name: "first")
+        let second = asset(name: "second")
+        e.importMediaAsset(first)
+        e.importMediaAsset(second)
+        let folderKey = MediaPanelItemKey.folder(folderId)
+        let timelineKey = MediaPanelItemKey.timeline(e.activeTimelineId)
+        e.mediaPanelOrderedItemIds = [folderKey, timelineKey, first.id, second.id]
+
+        e.selectMediaPanelItem(folderKey, mode: .replacing)
+        e.selectMediaPanelItem(first.id, mode: .range)
+
+        #expect(e.selectedFolderIds == [folderId])
+        #expect(e.selectedTimelineIds == [e.activeTimelineId])
+        #expect(e.selectedMediaAssetIds == [first.id])
+        #expect(e.mediaPanelSelectionAnchor == folderKey)
+    }
+
+    @Test func shiftSelectionFallsBackToClickedItemWhenAnchorIsHidden() {
+        let e = editor()
+        let first = asset(name: "first")
+        let second = asset(name: "second")
+        e.importMediaAsset(first)
+        e.importMediaAsset(second)
+        e.mediaPanelOrderedItemIds = [first.id]
+
+        e.selectMediaPanelItem(first.id, mode: .replacing)
+        e.mediaPanelOrderedItemIds = [second.id]
+        e.selectMediaPanelItem(second.id, mode: .range)
+
+        #expect(e.selectedMediaAssetIds == [second.id])
+        #expect(e.mediaPanelSelectionAnchor == second.id)
+    }
+
+    @Test func commandShiftAddsRangeToExistingSelection() {
+        let e = editor()
+        let clips = (0..<4).map { asset(name: "clip-\($0)") }
+        for clip in clips { e.importMediaAsset(clip) }
+        e.mediaPanelOrderedItemIds = clips.map(\.id)
+
+        e.selectMediaPanelItem(clips[0].id, mode: .replacing)
+        e.selectMediaPanelItem(clips[3].id, mode: .toggling)
+        e.selectMediaPanelItem(clips[1].id, mode: .extendingRange)
+
+        #expect(e.selectedMediaAssetIds == [clips[0].id, clips[1].id, clips[2].id, clips[3].id])
+        #expect(e.mediaPanelSelectionAnchor == clips[3].id)
+    }
+
+    @Test func selectAllUsesOnlyVisibleItems() {
+        let e = editor()
+        let visible = asset(name: "visible")
+        let hidden = asset(name: "hidden")
+        e.importMediaAsset(visible)
+        e.importMediaAsset(hidden)
+        e.mediaPanelOrderedItemIds = [visible.id]
+
+        e.selectAllMediaPanelItems()
+
+        #expect(e.selectedMediaAssetIds == [visible.id])
+        #expect(e.mediaPanelSelectionAnchor == visible.id)
+    }
+
+    @Test func selectAllClearsSelectionWhenNothingIsVisible() {
+        let e = editor()
+        let clip = asset(name: "clip")
+        e.importMediaAsset(clip)
+        e.mediaPanelOrderedItemIds = [clip.id]
+        e.selectMediaPanelItem(clip.id, mode: .replacing)
+        e.mediaPanelOrderedItemIds = []
+
+        e.selectAllMediaPanelItems()
+
+        #expect(e.selectedMediaAssetIds.isEmpty)
+        #expect(e.mediaPanelSelectionAnchor == nil)
+    }
+}
+
+@Suite("Media panel — folder creation")
+@MainActor
+struct MediaPanelFolderCreationTests {
+    @Test func creationSelectsAndRevealsFolderAndRestoresSelectionOnUndo() {
+        let e = editor()
+        let parentId = e.createFolder(name: "Parent")
+        let clip = asset(name: "clip")
+        e.importMediaAsset(clip)
+        e.selectMediaPanelItem(clip.id)
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        let folderId = e.createMediaPanelFolder(in: parentId)
+
+        #expect(e.folder(id: folderId)?.parentFolderId == parentId)
+        #expect(e.selectedFolderIds == [folderId])
+        #expect(e.selectedMediaAssetIds.isEmpty)
+        #expect(e.mediaPanelScrollTarget == MediaPanelItemKey.folder(folderId))
+        #expect(e.undo.undoLatest() == "New Folder")
+        #expect(e.folder(id: folderId) == nil)
+        #expect(e.selectedMediaAssetIds == [clip.id])
+
+        undoManager.redo()
+
+        #expect(e.folder(id: folderId)?.parentFolderId == parentId)
+        #expect(e.selectedFolderIds == [folderId])
+    }
+
+    @Test func mainMenuUsesStandardNewFolderShortcut() throws {
+        _ = NSApplication.shared
+        let mainMenu = MainMenuBuilder.buildMenu()
+        let fileMenu = try #require(mainMenu.items.compactMap(\.submenu).first { $0.title == "File" })
+        let item = try #require(fileMenu.items.first { $0.action == #selector(EditorActions.newMediaFolder(_:)) })
+
+        #expect(item.title == "New Folder")
+        #expect(item.keyEquivalent == "n")
+        #expect(item.keyEquivalentModifierMask == [.command, .shift])
+    }
+}
+
+@Suite("EditorViewModel — media panel deletion")
+@MainActor
+struct MediaPanelDeletionTests {
+    @Test func contextDeleteRemovesEverySelectedAsset() {
+        let e = editor()
+        let first = asset(name: "first")
+        let second = asset(name: "second")
+        let keep = asset(name: "keep")
+        for clip in [first, second, keep] { e.importMediaAsset(clip) }
+        e.mediaPanelOrderedItemIds = [first.id, second.id, keep.id]
+        e.selectMediaPanelItem(first.id, mode: .replacing)
+        e.selectMediaPanelItem(second.id, mode: .toggling)
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        e.deleteMediaPanelItems(targeting: first.id)
+
+        #expect(e.mediaAssets.map(\.id) == [keep.id])
+        #expect(e.undo.undoLatest() == "Delete Media Items")
+        #expect(Set(e.mediaAssets.map(\.id)) == [first.id, second.id, keep.id])
+        #expect(e.selectedMediaAssetIds == [first.id, second.id])
+    }
+
+    @Test func contextDeleteOnUnselectedItemTargetsOnlyThatItem() {
+        let e = editor()
+        let selected = asset(name: "selected")
+        let target = asset(name: "target")
+        e.importMediaAsset(selected)
+        e.importMediaAsset(target)
+        e.mediaPanelOrderedItemIds = [selected.id, target.id]
+        e.selectMediaPanelItem(selected.id, mode: .replacing)
+
+        e.deleteMediaPanelItems(targeting: target.id)
+
+        #expect(e.mediaAssets.map(\.id) == [selected.id])
+        #expect(e.selectedMediaAssetIds.isEmpty)
+    }
+
+    @Test func mixedDeleteIsOneUndoableAction() {
+        let e = editor()
+        let folderId = e.createFolder(name: "Bin")
+        let selectedAsset = asset(name: "selected")
+        let keep = asset(name: "keep")
+        e.importMediaAsset(selectedAsset)
+        e.importMediaAsset(keep)
+        let folderKey = MediaPanelItemKey.folder(folderId)
+        e.mediaPanelOrderedItemIds = [folderKey, selectedAsset.id, keep.id]
+        e.selectMediaPanelItem(folderKey, mode: .replacing)
+        e.selectMediaPanelItem(selectedAsset.id, mode: .toggling)
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        e.deleteMediaPanelItems(targeting: folderKey)
+
+        #expect(e.folder(id: folderId) == nil)
+        #expect(e.mediaAssets.map(\.id) == [keep.id])
+        #expect(e.undo.undoLatest() == "Delete Media Items")
+        #expect(e.folder(id: folderId) != nil)
+        #expect(Set(e.mediaAssets.map(\.id)) == [selectedAsset.id, keep.id])
+        #expect(e.selectedFolderIds == [folderId])
+        #expect(e.selectedMediaAssetIds == [selectedAsset.id])
+        #expect(e.mediaPanelSelectionAnchor == selectedAsset.id)
+        #expect(e.undo.undoLatest() == nil)
+
+        undoManager.redo()
+
+        #expect(e.folder(id: folderId) == nil)
+        #expect(e.mediaAssets.map(\.id) == [keep.id])
+    }
+
+    @Test func deletingEverySelectedTimelinePreservesOne() {
+        let e = editor()
+        _ = e.createTimeline(activate: false)
+        _ = e.createTimeline(activate: false)
+        let timelineIds = e.timelines.map(\.id)
+        e.mediaPanelOrderedItemIds = timelineIds.map(MediaPanelItemKey.timeline)
+        e.selectAllMediaPanelItems()
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        e.deleteMediaPanelItems()
+
+        #expect(e.timelines.count == 1)
+        #expect(e.selectedTimelineIds.count == 1)
+        #expect(e.mediaPanelToast?.message == "Can't delete every timeline — the project needs at least one.")
+        #expect(e.undo.undoLatest() == "Delete Media Items")
+        #expect(Set(e.timelines.map(\.id)) == Set(timelineIds))
+        #expect(e.selectedTimelineIds == Set(timelineIds))
+    }
+}
+
 // MARK: - handlePanelFinderDrop
 
 @Suite("MediaTab — handlePanelFinderDrop")

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -580,9 +580,9 @@ struct MoveMediaSelectionTests {
     }
 }
 
-@Suite("EditorViewModel — media panel selection")
+@Suite("Media panel interactions")
 @MainActor
-struct MediaPanelSelectionTests {
+struct MediaPanelInteractionTests {
     @Test func modifierFlagsUseMacSelectionConventions() {
         #expect(MediaPanelSelectionMode(modifierFlags: []) == .replacing)
         #expect(MediaPanelSelectionMode(modifierFlags: [.command]) == .toggling)
@@ -590,38 +590,22 @@ struct MediaPanelSelectionTests {
         #expect(MediaPanelSelectionMode(modifierFlags: [.command, .shift]) == .extendingRange)
     }
 
-    @Test func commandSelectionTogglesItemsAcrossKinds() {
-        let e = editor()
-        let folderId = e.createFolder(name: "Bin")
-        let clip = asset(name: "clip")
-        e.importMediaAsset(clip)
-        let folderKey = MediaPanelItemKey.folder(folderId)
-        e.mediaPanelOrderedItemIds = [folderKey, clip.id]
-
-        e.selectMediaPanelItem(folderKey, mode: .replacing)
-        e.selectMediaPanelItem(clip.id, mode: .toggling)
-
-        #expect(e.selectedFolderIds == [folderId])
-        #expect(e.selectedMediaAssetIds == [clip.id])
-        #expect(e.mediaPanelSelectionAnchor == clip.id)
-
-        e.selectMediaPanelItem(folderKey, mode: .toggling)
-
-        #expect(e.selectedFolderIds.isEmpty)
-        #expect(e.selectedMediaAssetIds == [clip.id])
-        #expect(e.mediaPanelSelectionAnchor == folderKey)
-    }
-
-    @Test func shiftSelectionUsesVisibleOrderAcrossKinds() {
+    @Test func commandAndShiftSelectionWorkAcrossKinds() {
         let e = editor()
         let folderId = e.createFolder(name: "Bin")
         let first = asset(name: "first")
         let second = asset(name: "second")
-        e.importMediaAsset(first)
-        e.importMediaAsset(second)
+        for clip in [first, second] { e.importMediaAsset(clip) }
         let folderKey = MediaPanelItemKey.folder(folderId)
         let timelineKey = MediaPanelItemKey.timeline(e.activeTimelineId)
         e.mediaPanelOrderedItemIds = [folderKey, timelineKey, first.id, second.id]
+
+        e.selectMediaPanelItem(folderKey, mode: .replacing)
+        e.selectMediaPanelItem(second.id, mode: .toggling)
+
+        #expect(e.selectedFolderIds == [folderId])
+        #expect(e.selectedMediaAssetIds == [second.id])
+        #expect(e.mediaPanelSelectionAnchor == second.id)
 
         e.selectMediaPanelItem(folderKey, mode: .replacing)
         e.selectMediaPanelItem(first.id, mode: .range)
@@ -630,36 +614,6 @@ struct MediaPanelSelectionTests {
         #expect(e.selectedTimelineIds == [e.activeTimelineId])
         #expect(e.selectedMediaAssetIds == [first.id])
         #expect(e.mediaPanelSelectionAnchor == folderKey)
-    }
-
-    @Test func shiftSelectionFallsBackToClickedItemWhenAnchorIsHidden() {
-        let e = editor()
-        let first = asset(name: "first")
-        let second = asset(name: "second")
-        e.importMediaAsset(first)
-        e.importMediaAsset(second)
-        e.mediaPanelOrderedItemIds = [first.id]
-
-        e.selectMediaPanelItem(first.id, mode: .replacing)
-        e.mediaPanelOrderedItemIds = [second.id]
-        e.selectMediaPanelItem(second.id, mode: .range)
-
-        #expect(e.selectedMediaAssetIds == [second.id])
-        #expect(e.mediaPanelSelectionAnchor == second.id)
-    }
-
-    @Test func commandShiftAddsRangeToExistingSelection() {
-        let e = editor()
-        let clips = (0..<4).map { asset(name: "clip-\($0)") }
-        for clip in clips { e.importMediaAsset(clip) }
-        e.mediaPanelOrderedItemIds = clips.map(\.id)
-
-        e.selectMediaPanelItem(clips[0].id, mode: .replacing)
-        e.selectMediaPanelItem(clips[3].id, mode: .toggling)
-        e.selectMediaPanelItem(clips[1].id, mode: .extendingRange)
-
-        #expect(e.selectedMediaAssetIds == [clips[0].id, clips[1].id, clips[2].id, clips[3].id])
-        #expect(e.mediaPanelSelectionAnchor == clips[3].id)
     }
 
     @Test func marqueeSelectionEstablishesAVisibleRangeAnchor() {
@@ -677,38 +631,6 @@ struct MediaPanelSelectionTests {
         #expect(e.mediaPanelSelectionAnchor == clips[0].id)
     }
 
-    @Test func selectAllUsesOnlyVisibleItems() {
-        let e = editor()
-        let visible = asset(name: "visible")
-        let hidden = asset(name: "hidden")
-        e.importMediaAsset(visible)
-        e.importMediaAsset(hidden)
-        e.mediaPanelOrderedItemIds = [visible.id]
-
-        e.selectAllMediaPanelItems()
-
-        #expect(e.selectedMediaAssetIds == [visible.id])
-        #expect(e.mediaPanelSelectionAnchor == visible.id)
-    }
-
-    @Test func selectAllClearsSelectionWhenNothingIsVisible() {
-        let e = editor()
-        let clip = asset(name: "clip")
-        e.importMediaAsset(clip)
-        e.mediaPanelOrderedItemIds = [clip.id]
-        e.selectMediaPanelItem(clip.id, mode: .replacing)
-        e.mediaPanelOrderedItemIds = []
-
-        e.selectAllMediaPanelItems()
-
-        #expect(e.selectedMediaAssetIds.isEmpty)
-        #expect(e.mediaPanelSelectionAnchor == nil)
-    }
-}
-
-@Suite("MediaTab — search selection order")
-@MainActor
-struct MediaTabSearchSelectionOrderTests {
     @Test func orderIncludesVisibleSectionsAndDeduplicatesAssets() {
         let ids = MediaTab.searchOrderedAssetIds(
             momentAssetIds: ["moment", "shared"],
@@ -719,11 +641,7 @@ struct MediaTabSearchSelectionOrderTests {
 
         #expect(ids == ["moment", "shared", "file"])
     }
-}
 
-@Suite("Media panel — folder creation")
-@MainActor
-struct MediaPanelFolderCreationTests {
     @Test func creationSelectsAndRevealsFolderAndRestoresSelectionOnUndo() {
         let e = editor()
         let parentId = e.createFolder(name: "Parent")
@@ -742,11 +660,6 @@ struct MediaPanelFolderCreationTests {
         #expect(e.undo.undoLatest() == "New Folder")
         #expect(e.folder(id: folderId) == nil)
         #expect(e.selectedMediaAssetIds == [clip.id])
-
-        undoManager.redo()
-
-        #expect(e.folder(id: folderId)?.parentFolderId == parentId)
-        #expect(e.selectedFolderIds == [folderId])
     }
 
     @Test func mainMenuUsesStandardNewFolderShortcut() throws {
@@ -759,57 +672,17 @@ struct MediaPanelFolderCreationTests {
         #expect(item.keyEquivalent == "n")
         #expect(item.keyEquivalentModifierMask == [.command, .shift])
     }
-}
-
-@Suite("EditorViewModel — media panel deletion")
-@MainActor
-struct MediaPanelDeletionTests {
-    @Test func contextDeleteRemovesEverySelectedAsset() {
-        let e = editor()
-        let first = asset(name: "first")
-        let second = asset(name: "second")
-        let keep = asset(name: "keep")
-        for clip in [first, second, keep] { e.importMediaAsset(clip) }
-        e.mediaPanelOrderedItemIds = [first.id, second.id, keep.id]
-        e.selectMediaPanelItem(first.id, mode: .replacing)
-        e.selectMediaPanelItem(second.id, mode: .toggling)
-        let undoManager = UndoManager()
-        e.undo.attach(undoManager)
-
-        e.deleteMediaPanelItems(targeting: first.id)
-
-        #expect(e.mediaAssets.map(\.id) == [keep.id])
-        #expect(e.undo.undoLatest() == "Delete Media Items")
-        #expect(Set(e.mediaAssets.map(\.id)) == [first.id, second.id, keep.id])
-        #expect(e.selectedMediaAssetIds == [first.id, second.id])
-    }
-
-    @Test func contextDeleteOnUnselectedItemTargetsOnlyThatItem() {
-        let e = editor()
-        let selected = asset(name: "selected")
-        let target = asset(name: "target")
-        e.importMediaAsset(selected)
-        e.importMediaAsset(target)
-        e.mediaPanelOrderedItemIds = [selected.id, target.id]
-        e.selectMediaPanelItem(selected.id, mode: .replacing)
-
-        e.deleteMediaPanelItems(targeting: target.id)
-
-        #expect(e.mediaAssets.map(\.id) == [selected.id])
-        #expect(e.selectedMediaAssetIds.isEmpty)
-    }
 
     @Test func mixedDeleteIsOneUndoableAction() {
         let e = editor()
         let folderId = e.createFolder(name: "Bin")
-        let selectedAsset = asset(name: "selected")
+        let selectedAssets = (0..<2).map { asset(name: "selected-\($0)") }
         let keep = asset(name: "keep")
-        e.importMediaAsset(selectedAsset)
-        e.importMediaAsset(keep)
+        for clip in selectedAssets + [keep] { e.importMediaAsset(clip) }
         let folderKey = MediaPanelItemKey.folder(folderId)
-        e.mediaPanelOrderedItemIds = [folderKey, selectedAsset.id, keep.id]
+        e.mediaPanelOrderedItemIds = [folderKey] + selectedAssets.map(\.id) + [keep.id]
         e.selectMediaPanelItem(folderKey, mode: .replacing)
-        e.selectMediaPanelItem(selectedAsset.id, mode: .toggling)
+        for clip in selectedAssets { e.selectMediaPanelItem(clip.id, mode: .toggling) }
         let undoManager = UndoManager()
         e.undo.attach(undoManager)
 
@@ -819,36 +692,10 @@ struct MediaPanelDeletionTests {
         #expect(e.mediaAssets.map(\.id) == [keep.id])
         #expect(e.undo.undoLatest() == "Delete Media Items")
         #expect(e.folder(id: folderId) != nil)
-        #expect(Set(e.mediaAssets.map(\.id)) == [selectedAsset.id, keep.id])
+        #expect(Set(e.mediaAssets.map(\.id)) == Set(selectedAssets.map(\.id) + [keep.id]))
         #expect(e.selectedFolderIds == [folderId])
-        #expect(e.selectedMediaAssetIds == [selectedAsset.id])
-        #expect(e.mediaPanelSelectionAnchor == selectedAsset.id)
-        #expect(e.undo.undoLatest() == nil)
-
-        undoManager.redo()
-
-        #expect(e.folder(id: folderId) == nil)
-        #expect(e.mediaAssets.map(\.id) == [keep.id])
-    }
-
-    @Test func deletingEverySelectedTimelinePreservesOne() {
-        let e = editor()
-        _ = e.createTimeline(activate: false)
-        _ = e.createTimeline(activate: false)
-        let timelineIds = e.timelines.map(\.id)
-        e.mediaPanelOrderedItemIds = timelineIds.map(MediaPanelItemKey.timeline)
-        e.selectAllMediaPanelItems()
-        let undoManager = UndoManager()
-        e.undo.attach(undoManager)
-
-        e.deleteMediaPanelItems()
-
-        #expect(e.timelines.count == 1)
-        #expect(e.selectedTimelineIds.count == 1)
-        #expect(e.mediaPanelToast?.message == "Can't delete every timeline — the project needs at least one.")
-        #expect(e.undo.undoLatest() == "Delete Media Items")
-        #expect(Set(e.timelines.map(\.id)) == Set(timelineIds))
-        #expect(e.selectedTimelineIds == Set(timelineIds))
+        #expect(e.selectedMediaAssetIds == Set(selectedAssets.map(\.id)))
+        #expect(e.mediaPanelSelectionAnchor == selectedAssets.last?.id)
     }
 }
 

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -662,6 +662,21 @@ struct MediaPanelSelectionTests {
         #expect(e.mediaPanelSelectionAnchor == clips[3].id)
     }
 
+    @Test func marqueeSelectionEstablishesAVisibleRangeAnchor() {
+        let e = editor()
+        let clips = (0..<3).map { asset(name: "clip-\($0)") }
+        for clip in clips { e.importMediaAsset(clip) }
+        e.mediaPanelOrderedItemIds = clips.map(\.id)
+        e.selectedMediaAssetIds = [clips[0].id, clips[1].id]
+        e.mediaPanelSelectionAnchor = nil
+
+        e.pruneMediaPanelSelectionAnchor()
+        e.selectMediaPanelItem(clips[2].id, mode: .range)
+
+        #expect(e.selectedMediaAssetIds == Set(clips.map(\.id)))
+        #expect(e.mediaPanelSelectionAnchor == clips[0].id)
+    }
+
     @Test func selectAllUsesOnlyVisibleItems() {
         let e = editor()
         let visible = asset(name: "visible")
@@ -688,6 +703,21 @@ struct MediaPanelSelectionTests {
 
         #expect(e.selectedMediaAssetIds.isEmpty)
         #expect(e.mediaPanelSelectionAnchor == nil)
+    }
+}
+
+@Suite("MediaTab — search selection order")
+@MainActor
+struct MediaTabSearchSelectionOrderTests {
+    @Test func orderIncludesVisibleSectionsAndDeduplicatesAssets() {
+        let ids = MediaTab.searchOrderedAssetIds(
+            momentAssetIds: ["moment", "shared"],
+            spokenAssetIds: ["spoken", "shared"],
+            fileAssetIds: ["file", "shared"],
+            collapsedSectionTitles: ["Spoken"]
+        )
+
+        #expect(ids == ["moment", "shared", "file"])
     }
 }
 


### PR DESCRIPTION
## Summary

Make the media browser follow standard macOS selection and folder-management conventions.

- Click replaces the selection; Command-click toggles individual clips, timelines, and folders.
- Shift-click selects a contiguous visible range; Command-Shift-click adds a range.
- Command-A selects all visible media-browser items.
- Search results use the same modifier behavior and visibly reflect selected assets.
- Delete and the item context menu remove the complete selection as one undoable action.
- Command-Shift-N creates a folder in the current location, selects it, reveals it, and begins renaming.
- Command-Up navigates to the parent folder.
- Right-clicking empty browser space exposes New Folder and Import Media.
- The shortcuts reference includes the new-folder shortcut.

Previously, Shift-click behaved like Command-click, range selection was unavailable, and context-menu deletion only removed the clicked item.

## Approach

- Centralize media-panel selection, navigation, folder creation, and bulk deletion in one view-model capability.
- Maintain one selection anchor and derive ranges from the visible item order across assets, folders, and timelines.
- Route mouse, keyboard, and context-menu intents through the same domain operations.
- Deduplicate folder descendants during bulk deletion, preserve at least one timeline, and restore selection through undo.
- Publish visible order and column count together when search or grid content appears so arrow navigation cannot use stale layout state.
- Clear selection and published navigation state when the browser becomes empty.
- Handle media commands only while the media panel is visible and focused.
- Reuse the existing folder-creation and media-import flows from the background context menu.

## Testing

- `swift test --filter MediaPanel` — passed: 67 tests in 12 suites.
- `swift build` — passed.
- `swift test --quiet` — passed: 1,235 tests in 192 suites.

Manual UI verification remains:

1. Select assets, folders, timelines, and search results with click, Command-click, Shift-click, Command-Shift-click, and Command-A; confirm each selected asset is highlighted.
2. Delete a mixed selection from the context menu, then undo once.
3. Create a folder with Command-Shift-N inside a nested folder and confirm rename begins.
4. Navigate to the parent folder with Command-Up.
5. Open the empty-space context menu and invoke New Folder and Import Media.
6. Select a moment search result and confirm its source frame opens, then clear search and immediately press Up or Down; navigation should use the restored grid columns.
7. Empty or hide the media panel and confirm Command-A, arrows, Delete, Command-Up, and Command-Shift-N do not act on hidden items.
