### PR TITLE
[ai model] support promptless lip sync generation

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -948,7 +948,7 @@ enum ToolDefinitions {
             description: "Starts an async AI video generation. Returns a placeholder asset ID immediately; generation runs in the background and the asset becomes usable in add_clips once ready. Costs real money and is not undoable.",
             inputSchema: objectSchema(
                 properties: [
-                    "prompt": ["type": "string", "description": "Text description of the video to generate"],
+                    "prompt": ["type": "string", "description": "Text description of the video to generate. Optional for transforms such as lip sync that do not use a prompt."],
                     "name": ["type": "string", "description": "Display name for the asset in the media library. Defaults to first 30 chars of prompt."],
                     "model": ["type": "string", "description": "Model ID (e.g. 'veo3.1-fast'). Use list_models to see options. Defaults to first available model."],
                     "duration": ["type": "integer", "description": "Duration in seconds. Valid values depend on model."],
@@ -960,10 +960,9 @@ enum ToolDefinitions {
                     "sourceClipId": ["type": "string", "description": "Optional. Clip id (from get_timeline) referencing sourceVideoMediaRef. When set and the clip is trimmed, only the clip's visible range is sent to the model, not the full source — matches the UI's 'Use trimmed portion only'."],
                     "referenceImageMediaRefs": ["type": "array", "items": ["type": "string"], "description": "Media asset IDs of image references. Covers both reference-to-video generation (Seedance, Kling V3/O3 elements, Grok — refer as @Image1/@Element1 in prompt) and the single-image ref used by video-to-video edit models (Kling V3 Motion Control). See list_models maxReferenceImages for per-model cap."],
                     "referenceVideoMediaRefs": ["type": "array", "items": ["type": "string"], "description": "Media asset IDs of video references (Seedance only). Refer to them as @Video1, @Video2. See maxReferenceVideos and maxCombinedVideoRefSeconds."],
-                    "referenceAudioMediaRefs": ["type": "array", "items": ["type": "string"], "description": "Media asset IDs of audio references (Seedance only). Refer to them as @Audio1, @Audio2. See maxReferenceAudios and maxCombinedAudioRefSeconds."],
+                    "referenceAudioMediaRefs": ["type": "array", "items": ["type": "string"], "description": "Media asset IDs of audio references. Lip-sync models use this as the replacement audio track; prompt-driven models refer to them as @Audio1, @Audio2. See maxReferenceAudios, requiresReferenceAudio, and maxCombinedAudioRefSeconds."],
                     "folder": ["type": "string", "description": "Optional destination folder path, e.g. 'Hero shots/Takes'. Created if missing. Omit for the project root."],
-                ],
-                required: ["prompt"]
+                ]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -86,12 +86,18 @@ extension ToolExecutor {
             throw ToolError(err)
         }
 
-        let sourceDuration = trimmed?.durationSeconds ?? sourceAsset.duration
-        guard sourceDuration.isFinite, sourceDuration > 0,
-              let roundedDuration = safeInt(sourceDuration.rounded()) else {
-            throw ToolError("Source video has an invalid duration.")
+        let sourceVideoDuration = trimmed?.durationSeconds ?? sourceAsset.resolvedDuration
+        if let error = model.validateSourceDuration(sourceVideoDuration) {
+            throw ToolError(error)
         }
-        let duration = max(1, roundedDuration)
+        guard let duration = model.billingDurationSeconds(
+            sourceVideoDuration: sourceVideoDuration,
+            sourceAudioDuration: audioRefs.first?.resolvedDuration
+        ) else {
+            throw ToolError(model.isLipSync
+                ? "Replacement audio has an invalid duration."
+                : "Source video has an invalid duration.")
+        }
         let genInput = GenerationInput(
             prompt: prompt, model: model.id,
             duration: duration,
@@ -101,7 +107,7 @@ extension ToolExecutor {
             genInput: genInput,
             model: model,
             inputAssets: inputAssets,
-            placeholderDuration: trimmed?.durationSeconds ?? (sourceAsset.duration > 0 ? sourceAsset.duration : 5),
+            placeholderDuration: sourceVideoDuration,
             trimmedSourceOverride: trimmed,
             name: args.string("name"),
             folderId: sourceAsset.folderId,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -87,9 +87,11 @@ extension ToolExecutor {
         }
 
         let sourceDuration = trimmed?.durationSeconds ?? sourceAsset.duration
-        guard let duration = safeInt(sourceDuration.rounded()), duration > 0 else {
+        guard sourceDuration.isFinite, sourceDuration > 0,
+              let roundedDuration = safeInt(sourceDuration.rounded()) else {
             throw ToolError("Source video has an invalid duration.")
         }
+        let duration = max(1, roundedDuration)
         let genInput = GenerationInput(
             prompt: prompt, model: model.id,
             duration: duration,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -25,7 +25,7 @@ extension ToolExecutor {
     }
 
     func generate(_ editor: EditorViewModel, _ args: [String: Any], type: ClipType) throws -> ToolResult {
-        let prompt = try args.requireString("prompt")
+        let prompt = args["prompt"] == nil ? "" : try args.requireString("prompt")
         guard AccountService.shared.isSignedIn else {
             throw ToolError("Generation requires signing in to Palmier. Tell the user to sign in.")
         }
@@ -66,21 +66,29 @@ extension ToolExecutor {
         let sourceAsset = try asset(sourceRef, editor: editor, label: "Source video")
         let trimmed = try trimmedSource(args, editor: editor, source: sourceAsset)
 
-        var imageRefs: [MediaAsset] = []
-        for id in args.stringArray("referenceImageMediaRefs") {
-            imageRefs.append(try asset(id, editor: editor, label: "Reference image"))
-        }
+        let imageRefs = try referenceAssets(
+            args, key: "referenceImageMediaRefs", label: "Reference image", editor: editor)
+        let videoRefs = try referenceAssets(
+            args, key: "referenceVideoMediaRefs", label: "Reference video", editor: editor)
+        let audioRefs = try referenceAssets(
+            args, key: "referenceAudioMediaRefs", label: "Reference audio", editor: editor)
 
         if let err = model.validate(duration: 0, aspectRatio: "", resolution: nil) {
             throw ToolError(err)
         }
-        let inputAssets = VideoGenerationSubmission.InputAssets(sourceVideo: sourceAsset, imageRefs: imageRefs)
+        let inputAssets = VideoGenerationSubmission.InputAssets(
+            sourceVideo: sourceAsset,
+            imageRefs: imageRefs,
+            videoRefs: videoRefs,
+            audioRefs: audioRefs
+        )
         if let err = inputAssets.validate(for: model) {
             throw ToolError(err)
         }
 
         let genInput = GenerationInput(
-            prompt: prompt, model: model.id, duration: Int(sourceAsset.duration.rounded()),
+            prompt: prompt, model: model.id,
+            duration: Int((trimmed?.durationSeconds ?? sourceAsset.duration).rounded()),
             aspectRatio: "", resolution: nil
         )
         let placeholderId = VideoGenerationSubmission.make(
@@ -122,14 +130,12 @@ extension ToolExecutor {
             frameSlots.append(try asset(endRef, editor: editor, label: "End frame"))
         }
 
-        func refs(_ argName: String, label: String) throws -> [MediaAsset] {
-            try args.stringArray(argName).map { id in
-                try asset(id, editor: editor, label: label)
-            }
-        }
-        let imageRefs = try refs("referenceImageMediaRefs", label: "Image reference")
-        let videoRefs = try refs("referenceVideoMediaRefs", label: "Video reference")
-        let audioRefs = try refs("referenceAudioMediaRefs", label: "Audio reference")
+        let imageRefs = try referenceAssets(
+            args, key: "referenceImageMediaRefs", label: "Image reference", editor: editor)
+        let videoRefs = try referenceAssets(
+            args, key: "referenceVideoMediaRefs", label: "Video reference", editor: editor)
+        let audioRefs = try referenceAssets(
+            args, key: "referenceAudioMediaRefs", label: "Audio reference", editor: editor)
         let inputAssets = VideoGenerationSubmission.InputAssets(
             frames: frameSlots,
             imageRefs: imageRefs,
@@ -170,6 +176,17 @@ extension ToolExecutor {
             ? ", refs: \(imageRefCount)img/\(videoRefCount)vid/\(audioRefCount)aud"
             : ""
         return .ok("Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), duration: \(duration)s, aspect: \(aspectRatio)\(refSummary)")
+    }
+
+    private func referenceAssets(
+        _ args: [String: Any],
+        key: String,
+        label: String,
+        editor: EditorViewModel
+    ) throws -> [MediaAsset] {
+        try args.stringArray(key).map { id in
+            try asset(id, editor: editor, label: label)
+        }
     }
 
     private func generateImage(
@@ -550,6 +567,7 @@ extension ToolExecutor {
             "supportsFirstFrame": m.supportsFirstFrame,
             "supportsLastFrame": m.supportsLastFrame,
             "supportsReferences": m.supportsReferences,
+            "supportsPrompt": m.supportsPrompt,
         ]
         if includeType { info["type"] = "video" }
         if let r = m.resolutions { info["resolutions"] = r }
@@ -563,6 +581,9 @@ extension ToolExecutor {
             if m.framesAndReferencesExclusive { info["framesAndReferencesExclusive"] = true }
             info["referenceTagNoun"] = m.referenceTagNoun
         }
+        if m.requiresSourceVideo { info["requiresSourceVideo"] = true }
+        if m.requiresReferenceImage { info["requiresReferenceImage"] = true }
+        if m.requiresReferenceAudio { info["requiresReferenceAudio"] = true }
         return info
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -86,9 +86,13 @@ extension ToolExecutor {
             throw ToolError(err)
         }
 
+        let sourceDuration = trimmed?.durationSeconds ?? sourceAsset.duration
+        guard let duration = safeInt(sourceDuration.rounded()), duration > 0 else {
+            throw ToolError("Source video has an invalid duration.")
+        }
         let genInput = GenerationInput(
             prompt: prompt, model: model.id,
-            duration: Int((trimmed?.durationSeconds ?? sourceAsset.duration).rounded()),
+            duration: duration,
             aspectRatio: "", resolution: nil
         )
         let placeholderId = VideoGenerationSubmission.make(

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -30,6 +30,7 @@ enum ModelRegistry {
 @MainActor
 final class ModelCatalog {
     static let shared = ModelCatalog()
+    private static let supportedCatalogVersion: Double = 2
 
     private(set) var video: [VideoModelConfig] = []
     private(set) var image: [ImageModelConfig] = []
@@ -56,7 +57,11 @@ final class ModelCatalog {
         guard let client = AccountService.shared.convex else { return }
 
         subscription = client
-            .subscribe(to: "models:list", yielding: [CatalogEntry].self)
+            .subscribe(
+                to: "models:list",
+                with: ["catalogVersion": Self.supportedCatalogVersion],
+                yielding: [CatalogEntry].self
+            )
             .receive(on: DispatchQueue.main)
             .sink(
                 receiveCompletion: { [weak self] completion in
@@ -227,6 +232,7 @@ struct CatalogEntry: Decodable, Sendable {
 }
 
 struct VideoCaps: Decodable, Sendable {
+    let supportsPrompt: Bool?
     let durations: [Int]
     let resolutions: [String]?
     let aspectRatios: [String]
@@ -243,6 +249,7 @@ struct VideoCaps: Decodable, Sendable {
     let requiresSourceVideo: Bool
     let maxSourceVideoResolution: SourceVideoResolution?
     let requiresReferenceImage: Bool
+    let requiresReferenceAudio: Bool?
 }
 
 enum SourceVideoResolution: String, Decodable, Sendable {

--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -247,6 +247,7 @@ struct VideoCaps: Decodable, Sendable {
     let framesAndReferencesExclusive: Bool
     let referenceTagNoun: String
     let requiresSourceVideo: Bool
+    let maxSourceVideoSeconds: Double?
     let maxSourceVideoResolution: SourceVideoResolution?
     let requiresReferenceImage: Bool
     let requiresReferenceAudio: Bool?

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -63,6 +63,16 @@ struct VideoModelConfig: Identifiable, Sendable {
         return "\(displayName) supports source videos up to \(limit). Trim the clip to continue."
     }
 
+    func billingDurationSeconds(
+        sourceVideoDuration: Double,
+        sourceAudioDuration: Double?
+    ) -> Int? {
+        let seconds = isLipSync ? sourceAudioDuration : sourceVideoDuration
+        guard let seconds, seconds.isFinite, seconds > 0,
+              let rounded = Int(exactly: seconds.rounded()) else { return nil }
+        return max(1, rounded)
+    }
+
     func audioDiscount(for resolution: String?) -> Double? {
         guard let dict = audioDiscountRate else { return nil }
         if let key = resolution, let v = dict[key] { return v }
@@ -89,6 +99,7 @@ struct VideoModelConfig: Identifiable, Sendable {
 struct VideoGenerationParams: Encodable, Sendable {
     let prompt: String
     let duration: Int
+    let sourceVideoDuration: Double?
     let aspectRatio: String
     let resolution: String?
     let sourceVideoURL: String?
@@ -101,6 +112,7 @@ struct VideoGenerationParams: Encodable, Sendable {
 
     init(
         prompt: String, duration: Int, aspectRatio: String, resolution: String?,
+        sourceVideoDuration: Double? = nil,
         sourceVideoURL: String? = nil,
         startFrameURL: String? = nil, endFrameURL: String? = nil,
         referenceImageURLs: [String] = [],
@@ -108,7 +120,7 @@ struct VideoGenerationParams: Encodable, Sendable {
         referenceAudioURLs: [String] = [],
         generateAudio: Bool = true
     ) {
-        self.prompt = prompt; self.duration = duration
+        self.prompt = prompt; self.duration = duration; self.sourceVideoDuration = sourceVideoDuration
         self.aspectRatio = aspectRatio; self.resolution = resolution
         self.sourceVideoURL = sourceVideoURL
         self.startFrameURL = startFrameURL; self.endFrameURL = endFrameURL
@@ -119,7 +131,7 @@ struct VideoGenerationParams: Encodable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case kind, prompt, duration, aspectRatio, resolution, sourceVideoURL
+        case kind, prompt, duration, sourceVideoDuration, aspectRatio, resolution, sourceVideoURL
         case startFrameURL, endFrameURL, referenceImageURLs, referenceVideoURLs
         case referenceAudioURLs, generateAudio
     }
@@ -129,6 +141,7 @@ struct VideoGenerationParams: Encodable, Sendable {
         try c.encode("video", forKey: .kind)
         try c.encode(prompt, forKey: .prompt)
         try c.encode(duration, forKey: .duration)
+        try c.encodeIfPresent(sourceVideoDuration, forKey: .sourceVideoDuration)
         try c.encode(aspectRatio, forKey: .aspectRatio)
         try c.encodeIfPresent(resolution, forKey: .resolution)
         try c.encodeIfPresent(sourceVideoURL, forKey: .sourceVideoURL)

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -17,6 +17,7 @@ struct VideoModelConfig: Identifiable, Sendable {
     var paidOnly: Bool { entry.paidOnly }
     var creditsPerSecond: [String: Double] { entry.creditsPerSecond ?? [:] }
     var audioDiscountRate: [String: Double]? { entry.audioDiscountRate }
+    var supportsPrompt: Bool { caps.supportsPrompt ?? true }
 
     var durations: [Int] { caps.durations }
     var resolutions: [String]? { caps.resolutions }
@@ -33,6 +34,7 @@ struct VideoModelConfig: Identifiable, Sendable {
     var referenceTagNoun: String { caps.referenceTagNoun }
     var requiresSourceVideo: Bool { caps.requiresSourceVideo }
     var requiresReferenceImage: Bool { caps.requiresReferenceImage }
+    var requiresReferenceAudio: Bool { caps.requiresReferenceAudio ?? false }
 
     var supportsReferences: Bool {
         maxReferenceImages > 0 || maxReferenceVideos > 0 || maxReferenceAudios > 0

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -35,6 +35,7 @@ struct VideoModelConfig: Identifiable, Sendable {
     var requiresSourceVideo: Bool { caps.requiresSourceVideo }
     var requiresReferenceImage: Bool { caps.requiresReferenceImage }
     var requiresReferenceAudio: Bool { caps.requiresReferenceAudio ?? false }
+    var isLipSync: Bool { !supportsPrompt && requiresSourceVideo && requiresReferenceAudio }
 
     var supportsReferences: Bool {
         maxReferenceImages > 0 || maxReferenceVideos > 0 || maxReferenceAudios > 0

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -33,12 +33,34 @@ struct VideoModelConfig: Identifiable, Sendable {
     var framesAndReferencesExclusive: Bool { caps.framesAndReferencesExclusive }
     var referenceTagNoun: String { caps.referenceTagNoun }
     var requiresSourceVideo: Bool { caps.requiresSourceVideo }
+    var maxSourceVideoSeconds: Double? { caps.maxSourceVideoSeconds }
     var requiresReferenceImage: Bool { caps.requiresReferenceImage }
     var requiresReferenceAudio: Bool { caps.requiresReferenceAudio ?? false }
     var isLipSync: Bool { !supportsPrompt && requiresSourceVideo && requiresReferenceAudio }
 
     var supportsReferences: Bool {
         maxReferenceImages > 0 || maxReferenceVideos > 0 || maxReferenceAudios > 0
+    }
+
+    var sourceDurationLimitLabel: String? {
+        guard let maximum = maxSourceVideoSeconds,
+              maximum.isFinite, maximum > 0,
+              let seconds = Int(exactly: maximum.rounded()) else { return nil }
+        if seconds.isMultiple(of: 60) {
+            let minutes = seconds / 60
+            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
+        }
+        return seconds == 1 ? "1 second" : "\(seconds) seconds"
+    }
+
+    func validateSourceDuration(_ duration: Double) -> String? {
+        guard duration.isFinite, duration > 0 else {
+            return "Loading video metadata…"
+        }
+        guard let maximum = maxSourceVideoSeconds,
+              duration > maximum,
+              let limit = sourceDurationLimitLabel else { return nil }
+        return "\(displayName) supports source videos up to \(limit). Trim the clip to continue."
     }
 
     func audioDiscount(for resolution: String?) -> Double? {

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -39,7 +39,7 @@ enum EditAction {
         case .edit:
             switch asset.type {
             case .video:
-                let duration = effectiveDurationOverride ?? Self.effectiveDuration(of: asset)
+                let duration = effectiveDurationOverride ?? asset.resolvedDuration
                 guard duration > 0 else {
                     return .disabled(reason: "Loading video metadata…")
                 }
@@ -99,14 +99,6 @@ enum EditAction {
         }
     }
 
-    /// Falls back to the recorded generation duration when AVAsset metadata hasn't loaded.
-    @MainActor
-    static func effectiveDuration(of asset: MediaAsset) -> Double {
-        if asset.duration > 0 { return asset.duration }
-        if let gd = asset.generationInput?.duration, gd > 0 { return Double(gd) }
-        return 0
-    }
-
     @MainActor
     private static func videoAudioAvailability(
         for asset: MediaAsset,
@@ -119,7 +111,7 @@ enum EditAction {
         if asset.isGenerating {
             return .disabled(reason: "Generation in progress")
         }
-        let duration = effectiveDurationOverride ?? effectiveDuration(of: asset)
+        let duration = effectiveDurationOverride ?? asset.resolvedDuration
         guard duration > 0 else {
             return .disabled(reason: "Loading video metadata…")
         }

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -101,7 +101,7 @@ enum EditAction {
 
     /// Falls back to the recorded generation duration when AVAsset metadata hasn't loaded.
     @MainActor
-    private static func effectiveDuration(of asset: MediaAsset) -> Double {
+    static func effectiveDuration(of asset: MediaAsset) -> Double {
         if asset.duration > 0 { return asset.duration }
         if let gd = asset.generationInput?.duration, gd > 0 { return Double(gd) }
         return 0

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
@@ -22,6 +22,18 @@ extension EditSubmitter {
         return stored
     }
 
+    static func lipSyncSeed(
+        for asset: MediaAsset,
+        model: VideoModelConfig
+    ) -> GenerationInput? {
+        guard asset.type == .video, model.isLipSync else { return nil }
+        var stored = GenerationInput(
+            prompt: "", model: model.id, duration: 0, aspectRatio: "", resolution: nil
+        )
+        stored.imageURLAssetIds = [asset.id]
+        return stored
+    }
+
     static func createVideoSeed(for asset: MediaAsset, asReference: Bool) -> GenerationInput? {
         guard let model = VideoModelConfig.allModels.first(where: {
             !$0.requiresSourceVideo && (asReference ? $0.supportsReferences : $0.supportsFirstFrame)

--- a/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
@@ -54,35 +54,58 @@ struct VideoGenerationSubmission {
         generateAudio: Bool
     ) -> VideoGenerationSubmission {
         var genInput = baseInput
+        let outputName = name ?? (model.supportsPrompt ? nil : model.displayName)
         if model.requiresSourceVideo {
+            let sourceCount = inputAssets.sourceVideo == nil ? 0 : 1
+            let imageRefCount = inputAssets.imageRefs.count
+            let videoRefCount = inputAssets.videoRefs.count
+            let audioRefCount = inputAssets.audioRefs.count
             let references = inputAssets.editReferences
-            genInput.imageURLAssetIds = assetIds(references)
+            genInput.imageURLAssetIds = assetIds(inputAssets.sourceVideo.map { [$0] } ?? [])
+            genInput.referenceImageAssetIds = assetIds(inputAssets.imageRefs)
+            genInput.referenceVideoAssetIds = assetIds(inputAssets.videoRefs)
+            genInput.referenceAudioAssetIds = assetIds(inputAssets.audioRefs)
             let preprocessSourceVideo = model.caps.maxSourceVideoResolution.map { resolution in
                 { @Sendable url in try await VideoCompressor.compressIfNeeded(
                     url: url, maxResolution: resolution) }
             }
+            let snapshotRefs = videoInputSnapshotter(
+                frameCount: sourceCount,
+                imageRefCount: imageRefCount,
+                videoRefCount: videoRefCount,
+                audioRefCount: audioRefCount
+            )
 
             return VideoGenerationSubmission(
                 genInput: genInput,
                 placeholderDuration: placeholderDuration,
                 references: references,
                 trimmedSourceOverride: trimmedSourceOverride,
-                name: name,
+                name: outputName,
                 folderId: folderId,
                 buildParams: { uploaded in
-                    .video(VideoGenerationParams(
+                    let urls = videoInputURLs(
+                        uploaded: uploaded,
+                        frameCount: sourceCount,
+                        imageRefCount: imageRefCount,
+                        videoRefCount: videoRefCount,
+                        audioRefCount: audioRefCount
+                    )
+                    return .video(VideoGenerationParams(
                         prompt: genInput.prompt,
                         duration: genInput.duration,
                         aspectRatio: genInput.aspectRatio,
                         resolution: genInput.resolution,
-                        sourceVideoURL: uploaded.first,
+                        sourceVideoURL: urls.frames.first,
                         startFrameURL: nil,
                         endFrameURL: nil,
-                        referenceImageURLs: Array(uploaded.dropFirst()),
+                        referenceImageURLs: urls.imageRefs,
+                        referenceVideoURLs: urls.videoRefs,
+                        referenceAudioURLs: urls.audioRefs,
                         generateAudio: generateAudio
                     ))
                 },
-                snapshotRefs: nil,
+                snapshotRefs: snapshotRefs,
                 preprocessRef: nil,
                 preprocessSourceVideo: preprocessSourceVideo
             )
@@ -119,7 +142,7 @@ struct VideoGenerationSubmission {
             placeholderDuration: placeholderDuration,
             references: references,
             trimmedSourceOverride: trimmedSourceOverride,
-            name: name,
+            name: outputName,
             folderId: folderId,
             buildParams: { uploaded in
                 let params = videoInputURLs(
@@ -162,7 +185,7 @@ struct VideoGenerationSubmission {
 
         @MainActor
         var editReferences: [MediaAsset] {
-            (sourceVideo.map { [$0] } ?? []) + imageRefs
+            (sourceVideo.map { [$0] } ?? []) + allRefs
         }
 
         @MainActor
@@ -186,18 +209,16 @@ struct VideoGenerationSubmission {
             guard sourceVideo.type == .video else {
                 return "sourceVideoMediaRef must reference a video asset"
             }
-            if !frames.isEmpty || !videoRefs.isEmpty || !audioRefs.isEmpty {
-                return "\(model.displayName) only accepts a source video and image references"
+            if !frames.isEmpty {
+                return "\(model.displayName) does not accept frame references"
             }
-            if !model.supportsReferences, !imageRefs.isEmpty {
-                return "\(model.displayName) does not accept image references"
+            if model.requiresReferenceImage && imageRefs.isEmpty {
+                return "\(model.displayName) requires an image reference"
             }
-            if imageRefs.count > model.maxReferenceImages {
-                return "\(model.displayName) accepts at most \(model.maxReferenceImages) image reference(s)"
+            if model.requiresReferenceAudio && audioRefs.isEmpty {
+                return "\(model.displayName) requires an audio reference"
             }
-            return validateTypes([
-                (imageRefs, .image, "referenceImageMediaRefs")
-            ])
+            return validateReferences(for: model, includingFrames: false)
         }
 
         @MainActor
@@ -217,14 +238,23 @@ struct VideoGenerationSubmission {
             if model.framesAndReferencesExclusive, !frames.isEmpty, !allRefs.isEmpty {
                 return "\(model.displayName) uses frames OR references, not both. Clear one side."
             }
+            return validateReferences(for: model, includingFrames: true)
+        }
+
+        @MainActor
+        private func validateReferences(
+            for model: VideoModelConfig,
+            includingFrames: Bool
+        ) -> String? {
+            let referenceLabel = model.requiresSourceVideo ? "reference(s)" : "references"
             if imageRefs.count > model.maxReferenceImages {
-                return "\(model.displayName) accepts at most \(model.maxReferenceImages) image references"
+                return "\(model.displayName) accepts at most \(model.maxReferenceImages) image \(referenceLabel)"
             }
             if videoRefs.count > model.maxReferenceVideos {
-                return "\(model.displayName) accepts at most \(model.maxReferenceVideos) video references"
+                return "\(model.displayName) accepts at most \(model.maxReferenceVideos) video \(referenceLabel)"
             }
             if audioRefs.count > model.maxReferenceAudios {
-                return "\(model.displayName) accepts at most \(model.maxReferenceAudios) audio references"
+                return "\(model.displayName) accepts at most \(model.maxReferenceAudios) audio \(referenceLabel)"
             }
             if let totalCap = model.maxTotalReferences, totalRefCount > totalCap {
                 return "\(model.displayName) accepts at most \(totalCap) references total"
@@ -237,12 +267,15 @@ struct VideoGenerationSubmission {
                audioRefs.reduce(0, { $0 + $1.duration }) > cap {
                 return "Combined audio reference duration exceeds \(Int(cap))s"
             }
-            return validateTypes([
-                (frames, .image, "frame references"),
+            var groups: [([MediaAsset], ClipType, String)] = [
                 (imageRefs, .image, "referenceImageMediaRefs"),
                 (videoRefs, .video, "referenceVideoMediaRefs"),
                 (audioRefs, .audio, "referenceAudioMediaRefs")
-            ])
+            ]
+            if includingFrames {
+                groups.insert((frames, .image, "frame references"), at: 0)
+            }
+            return validateTypes(groups)
         }
 
         @MainActor

--- a/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
@@ -61,6 +61,9 @@ struct VideoGenerationSubmission {
             let videoRefCount = inputAssets.videoRefs.count
             let audioRefCount = inputAssets.audioRefs.count
             let references = inputAssets.editReferences
+            let sourceVideoDuration = trimmedSourceOverride?.hasTrim == true
+                ? trimmedSourceOverride?.durationSeconds
+                : inputAssets.sourceVideo?.resolvedDuration
             genInput.imageURLAssetIds = assetIds(inputAssets.sourceVideo.map { [$0] } ?? [])
             genInput.referenceImageAssetIds = assetIds(inputAssets.imageRefs)
             genInput.referenceVideoAssetIds = assetIds(inputAssets.videoRefs)
@@ -96,6 +99,7 @@ struct VideoGenerationSubmission {
                         duration: genInput.duration,
                         aspectRatio: genInput.aspectRatio,
                         resolution: genInput.resolution,
+                        sourceVideoDuration: sourceVideoDuration,
                         sourceVideoURL: urls.frames.first,
                         startFrameURL: nil,
                         endFrameURL: nil,

--- a/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
@@ -130,7 +130,12 @@ extension GenerationView {
         return audioSource.type == .video ? .video : .audio
     }
     var showsPrompt: Bool {
-        selectedType != .upscale && (selectedType != .audio || audioModel.inputs.contains(.text))
+        switch selectedType {
+        case .video: videoModel.supportsPrompt
+        case .audio: audioModel.inputs.contains(.text)
+        case .image: true
+        case .upscale: false
+        }
     }
 
     var initialAudioTargetLanguage: String {

--- a/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
@@ -232,22 +232,22 @@ extension GenerationView {
         }
     }
 
-    var effectiveVideoSpanSeconds: Double {
+    var effectiveSourceVideoSeconds: Double {
         guard videoModel.requiresSourceVideo else { return Double(selectedDuration) }
         if let trim = editor.pendingEditTrimmedSource,
            let sv = sourceVideo,
            trim.sourceURL == sv.url, trim.hasTrim {
             return trim.durationSeconds
         }
-        return sourceVideo?.duration ?? 0
+        return sourceVideo?.resolvedDuration ?? 0
     }
 
     var effectiveVideoSeconds: Int {
         guard videoModel.requiresSourceVideo else { return selectedDuration }
-        let seconds = effectiveVideoSpanSeconds
-        guard seconds.isFinite, seconds > 0,
-              let rounded = Int(exactly: seconds.rounded()) else { return 0 }
-        return max(1, rounded)
+        return videoModel.billingDurationSeconds(
+            sourceVideoDuration: effectiveSourceVideoSeconds,
+            sourceAudioDuration: refAudios.first?.resolvedDuration
+        ) ?? 0
     }
 
     var effectiveAudioSourceSpanSeconds: Double {

--- a/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+ModelState.swift
@@ -232,14 +232,22 @@ extension GenerationView {
         }
     }
 
-    var effectiveVideoSeconds: Int {
-        guard videoModel.requiresSourceVideo else { return selectedDuration }
+    var effectiveVideoSpanSeconds: Double {
+        guard videoModel.requiresSourceVideo else { return Double(selectedDuration) }
         if let trim = editor.pendingEditTrimmedSource,
            let sv = sourceVideo,
            trim.sourceURL == sv.url, trim.hasTrim {
-            return max(1, Int(trim.durationSeconds.rounded()))
+            return trim.durationSeconds
         }
-        return max(0, Int((sourceVideo?.duration ?? 0).rounded()))
+        return sourceVideo?.duration ?? 0
+    }
+
+    var effectiveVideoSeconds: Int {
+        guard videoModel.requiresSourceVideo else { return selectedDuration }
+        let seconds = effectiveVideoSpanSeconds
+        guard seconds.isFinite, seconds > 0,
+              let rounded = Int(exactly: seconds.rounded()) else { return 0 }
+        return max(1, rounded)
     }
 
     var effectiveAudioSourceSpanSeconds: Double {

--- a/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
@@ -334,7 +334,7 @@ extension GenerationView {
                 onClear: { sourceVideo = nil },
                 onError: flashDropError
             )
-            if videoModel.supportsReferences {
+            if videoModel.maxReferenceImages > 0 {
                 FrameSlot(
                     label: "Reference Image",
                     asset: imageReferences.first,
@@ -343,6 +343,18 @@ extension GenerationView {
                     iconName: "photo.badge.plus",
                     onDrop: { imageReferences = [$0] },
                     onClear: { imageReferences.removeAll() },
+                    onError: flashDropError
+                )
+            }
+            if videoModel.maxReferenceAudios > 0 {
+                FrameSlot(
+                    label: "Replacement Audio",
+                    asset: refAudios.first,
+                    isTargeted: $refsTargeted,
+                    accepting: [.audio],
+                    iconName: "waveform",
+                    onDrop: { refAudios = [$0] },
+                    onClear: { refAudios.removeAll() },
                     onError: flashDropError
                 )
             }

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -148,6 +148,7 @@ extension GenerationView {
             return VideoGenerationSubmission.InputAssets(
                 sourceVideo: sourceVideo,
                 imageRefs: Array(imageReferences.prefix(model.maxReferenceImages)),
+                videoRefs: Array(refVideos.prefix(model.maxReferenceVideos)),
                 audioRefs: Array(refAudios.prefix(model.maxReferenceAudios))
             )
         }
@@ -526,6 +527,7 @@ extension GenerationView {
             if videoModel.requiresSourceVideo {
                 sourceVideo = primary.first
                 imageReferences = (stored.referenceImageAssetIds ?? []).compactMap(lookup)
+                refVideos = (stored.referenceVideoAssetIds ?? []).compactMap(lookup)
                 refAudios = (stored.referenceAudioAssetIds ?? []).compactMap(lookup)
                 if imageReferences.isEmpty, videoModel.maxReferenceImages > 0, primary.count > 1 {
                     imageReferences = [primary[1]]

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -18,6 +18,7 @@ extension GenerationView {
         if selectedType == .video && videoModel.requiresSourceVideo {
             guard sourceVideo != nil else { return false }
             if videoModel.requiresReferenceImage && imageReferences.isEmpty { return false }
+            if videoModel.requiresReferenceAudio && refAudios.isEmpty { return false }
             if !videoModel.supportsReferences && isPromptEmpty { return false }
             return true
         }
@@ -146,7 +147,8 @@ extension GenerationView {
         if model.requiresSourceVideo {
             return VideoGenerationSubmission.InputAssets(
                 sourceVideo: sourceVideo,
-                imageRefs: model.supportsReferences ? Array(imageReferences.prefix(1)) : []
+                imageRefs: Array(imageReferences.prefix(model.maxReferenceImages)),
+                audioRefs: Array(refAudios.prefix(model.maxReferenceAudios))
             )
         }
 
@@ -523,7 +525,9 @@ extension GenerationView {
         case .video:
             if videoModel.requiresSourceVideo {
                 sourceVideo = primary.first
-                if videoModel.supportsReferences, primary.count > 1 {
+                imageReferences = (stored.referenceImageAssetIds ?? []).compactMap(lookup)
+                refAudios = (stored.referenceAudioAssetIds ?? []).compactMap(lookup)
+                if imageReferences.isEmpty, videoModel.maxReferenceImages > 0, primary.count > 1 {
                     imageReferences = [primary[1]]
                 }
             } else {

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -19,6 +19,7 @@ extension GenerationView {
             guard sourceVideo != nil else { return false }
             if videoModel.requiresReferenceImage && imageReferences.isEmpty { return false }
             if videoModel.requiresReferenceAudio && refAudios.isEmpty { return false }
+            if videoModel.isLipSync && effectiveVideoSeconds == 0 { return false }
             if !videoModel.supportsReferences && isPromptEmpty { return false }
             return true
         }

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -177,7 +177,8 @@ extension GenerationView {
             let inputAssets = videoInputAssets(for: videoModel)
             let modelError: String?
             if videoModel.requiresSourceVideo {
-                modelError = videoModel.validate(duration: 0, aspectRatio: "", resolution: nil)
+                modelError = videoModel.validateSourceDuration(effectiveVideoSpanSeconds)
+                    ?? videoModel.validate(duration: 0, aspectRatio: "", resolution: nil)
             } else {
                 modelError = videoModel.validate(
                     duration: selectedDuration,

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -177,7 +177,7 @@ extension GenerationView {
             let inputAssets = videoInputAssets(for: videoModel)
             let modelError: String?
             if videoModel.requiresSourceVideo {
-                modelError = videoModel.validateSourceDuration(effectiveVideoSpanSeconds)
+                modelError = videoModel.validateSourceDuration(effectiveSourceVideoSeconds)
                     ?? videoModel.validate(duration: 0, aspectRatio: "", resolution: nil)
             } else {
                 modelError = videoModel.validate(

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -196,7 +196,7 @@ struct AIEditTab: View {
         if asset.isGenerating {
             return .disabled(reason: "Generation in progress")
         }
-        let duration = effectiveDurationForAvailability ?? asset.duration
+        let duration = effectiveDurationForAvailability ?? EditAction.effectiveDuration(of: asset)
         if let error = model.validateSourceDuration(duration) {
             return .disabled(reason: error)
         }

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -192,13 +192,13 @@ struct AIEditTab: View {
         VideoModelConfig.allModels.first(where: { $0.isLipSync })
     }
 
-    private var lipSyncAvailability: EditActionAvailability {
+    private func lipSyncAvailability(for model: VideoModelConfig) -> EditActionAvailability {
         if asset.isGenerating {
             return .disabled(reason: "Generation in progress")
         }
         let duration = effectiveDurationForAvailability ?? asset.duration
-        guard duration.isFinite, duration > 0 else {
-            return .disabled(reason: "Loading video metadata…")
+        if let error = model.validateSourceDuration(duration) {
+            return .disabled(reason: error)
         }
         return .available
     }
@@ -246,7 +246,7 @@ struct AIEditTab: View {
     }
 
     private func lipSyncActionRow(model: VideoModelConfig) -> some View {
-        let availability = lipSyncAvailability
+        let availability = lipSyncAvailability(for: model)
         let paidBlocked = model.paidOnly && !account.isPaid
         let isEnabled = availability.isAvailable && !paidBlocked && aiDisabledReason == nil
         let disabledReason = aiDisabledReason
@@ -256,6 +256,7 @@ struct AIEditTab: View {
             icon: "mouth",
             title: "Lip Sync",
             description: "Match mouth movement to replacement audio",
+            detail: model.sourceDurationLimitLabel.map { "Up to \($0)" },
             isEnabled: isEnabled,
             disabledReason: disabledReason
         ) {

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -196,7 +196,7 @@ struct AIEditTab: View {
         if asset.isGenerating {
             return .disabled(reason: "Generation in progress")
         }
-        let duration = effectiveDurationForAvailability ?? EditAction.effectiveDuration(of: asset)
+        let duration = effectiveDurationForAvailability ?? asset.resolvedDuration
         if let error = model.validateSourceDuration(duration) {
             return .disabled(reason: error)
         }

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -20,15 +20,21 @@ struct AIEditTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-                if hasScopeToggles {
-                    EditorPanelGroup("Scope", contentSpacing: AppTheme.Spacing.smMd) {
-                        if isVisualClipContext, clipId != nil { replaceToggle }
-                        if trimmedClipAvailable { trimmedClipToggle }
-                    }
+                if trimmedClipAvailable {
+                    trimmedClipToggle
+                        .padding(AppTheme.Spacing.smMd)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(AppTheme.Background.surfaceColor)
+                        .overlay(alignment: .bottom) {
+                            Rectangle()
+                                .fill(AppTheme.Border.primaryColor)
+                                .frame(height: AppTheme.BorderWidth.thin)
+                        }
                 }
 
                 if isVisualClipContext {
                     EditorPanelGroup("AI Enhance", isExpanded: $aiEnhanceExpanded, contentSpacing: AppTheme.Spacing.smMd) {
+                        if clipId != nil { replaceToggle }
                         actionRow(
                             action: .upscale,
                             icon: "sparkles.rectangle.stack",
@@ -41,6 +47,9 @@ struct AIEditTab: View {
                             title: "Edit",
                             description: "Transform with a prompt or motion reference"
                         )
+                        if asset.type == .video, let model = lipSyncModel {
+                            lipSyncActionRow(model: model)
+                        }
                         actionRow(
                             action: .rerun,
                             icon: "arrow.clockwise",
@@ -86,10 +95,6 @@ struct AIEditTab: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private var hasScopeToggles: Bool {
-        (isVisualClipContext && clipId != nil) || trimmedClipAvailable
     }
 
     private var showsAudioOutputOptions: Bool {
@@ -183,6 +188,21 @@ struct AIEditTab: View {
         trimmedSourceIfEnabled()?.durationSeconds
     }
 
+    private var lipSyncModel: VideoModelConfig? {
+        VideoModelConfig.allModels.first(where: { $0.isLipSync })
+    }
+
+    private var lipSyncAvailability: EditActionAvailability {
+        if asset.isGenerating {
+            return .disabled(reason: "Generation in progress")
+        }
+        let duration = effectiveDurationForAvailability ?? asset.duration
+        guard duration.isFinite, duration > 0 else {
+            return .disabled(reason: "Loading video metadata…")
+        }
+        return .available
+    }
+
     // MARK: - Action row
 
     @ViewBuilder
@@ -223,6 +243,29 @@ struct AIEditTab: View {
             description: kind.description,
             triggerTitle: "Generate"
         )
+    }
+
+    private func lipSyncActionRow(model: VideoModelConfig) -> some View {
+        let availability = lipSyncAvailability
+        let paidBlocked = model.paidOnly && !account.isPaid
+        let isEnabled = availability.isAvailable && !paidBlocked && aiDisabledReason == nil
+        let disabledReason = aiDisabledReason
+            ?? (paidBlocked ? "Requires a paid plan" : availability.reason)
+
+        return descriptiveActionRow(
+            icon: "mouth",
+            title: "Lip Sync",
+            description: "Match mouth movement to replacement audio",
+            isEnabled: isEnabled,
+            disabledReason: disabledReason
+        ) {
+            Button("Choose Audio") {
+                presentLipSync(model: model)
+            }
+            .buttonStyle(.capsule(.secondary))
+            .controlSize(.small)
+            .disabled(!isEnabled)
+        }
     }
 
     @ViewBuilder
@@ -299,6 +342,11 @@ struct AIEditTab: View {
             useTrimmedClip: useTrimmedClip,
             placeOnTimeline: placeAudioOnTimeline
         )
+    }
+
+    private func presentLipSync(model: VideoModelConfig) {
+        guard let stored = EditSubmitter.lipSyncSeed(for: asset, model: model) else { return }
+        seedPanel(stored: stored, trimmed: trimmedSourceIfEnabled())
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -81,6 +81,11 @@ final class MediaAsset: Identifiable {
     }
 
     var isGenerated: Bool { generationInput != nil }
+    var resolvedDuration: Double {
+        if duration.isFinite, duration > 0 { return duration }
+        if let generated = generationInput?.duration, generated > 0 { return Double(generated) }
+        return 0
+    }
     var canResumeGeneration: Bool {
         guard let generationInput else { return false }
         return generationInput.backendJobId?.isEmpty == false


### PR DESCRIPTION

<img width="948" height="926" alt="image" src="https://github.com/user-attachments/assets/2a2df577-4f03-4384-b3d4-9dfb238da38e" />

## Summary

- support promptless video transformations in the Mac generation flow
- show source-video and replacement-audio inputs when required by the selected model
- preserve each reference type through uploads, saved metadata, and restored generation state
- allow the agent generation tool to submit promptless jobs with audio references
- consolidate shared video-reference validation and asset resolution

## Impact

Users can select a lip-sync model, provide a video and replacement audio, and submit without entering a prompt. Existing prompt-driven video workflows retain their current defaults.

## Validation

- `swift build`
- `swift test` — 1,242 tests passed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paid generation submission, credit duration, and agent tool contracts; incorrect reference wiring or billing duration could charge wrong amounts or fail jobs.
> 
> **Overview**
> Adds **promptless lip sync** and broader **source-video transform** support driven by catalog capabilities (`supportsPrompt`, `requiresReferenceAudio`, `maxSourceVideoSeconds`).
> 
> The generation UI and **AI Edit** tab can require source video plus **replacement audio**, hide the prompt when the model does not support one, and expose a **Lip Sync** action that seeds the panel. **Billing and duration** for these jobs use replacement audio length for lip sync and enforce per-model source length limits via `MediaAsset.resolvedDuration`.
> 
> **Video-to-video submission** now keeps image, video, and audio references separate through validation, upload (`sourceVideoDuration` on params), and panel restore; edit-mode validation was unified and loosened so non–lip-sync edits can pass video/audio refs where the catalog allows.
> 
> The **agent** `generate_video` tool no longer requires `prompt`, documents audio refs for lip sync, and mirrors the same reference handling and duration logic. Model listing uses **catalog version 2** and exposes the new requirement flags to the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59601e928346686d242bbf0a14d6ac4c67344a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->