### PR TITLE
[fix/sentry] disable automatic scrub-audio fill

### DIFF
--- a/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
+++ b/Sources/PalmierPro/Preview/ScrubAudioEngine.swift
@@ -91,30 +91,27 @@ final class ScrubAudioEngine {
 
     func configure(asset: AVAsset?, audioMix: AVAudioMix?, resetMeter: Bool = true) {
         let mixOnlyChange = asset != nil && asset === source?.asset
-        let anchor = lastRequestedSample ?? 0
         stopScrubbing()
         cancelFill()
         sourceGeneration &+= 1
         source = asset.map { Source(asset: $0, audioMix: audioMix, generation: sourceGeneration) }
         if mixOnlyChange {
-            scheduleMixInvalidation(anchor: anchor)
+            scheduleMixInvalidation()
         } else {
             mixInvalidationTask?.cancel()
             mixInvalidationTask = nil
             windows.removeAll()
-            if let source { startFill(from: anchor, source: source) }
         }
         if resetMeter { meter.reset() }
     }
 
-    private func scheduleMixInvalidation(anchor: Int64) {
+    private func scheduleMixInvalidation() {
         mixInvalidationTask?.cancel()
         mixInvalidationTask = Task { [weak self] in
             try? await Task.sleep(for: Self.mixInvalidationDebounce)
             guard !Task.isCancelled, let self else { return }
             self.mixInvalidationTask = nil
             self.windows.removeAll()
-            if let source = self.source { self.startFill(from: self.lastRequestedSample ?? anchor, source: source) }
         }
     }
 


### PR DESCRIPTION
## Summary

- stop starting the automatic whole-timeline scrub-audio cache fill
- keep on-demand decoding, LRU caching, directional prefetch, reader teardown, AVPlayer replacement, and visual refresh unchanged
- one file, five touched lines, **net -3 LOC**

## Root cause

This PR targets the `ScrubAudioEngine.streamWindows` crash family in Sentry, including the 0.6.15 crash where `update_text` finished roughly one second before the crash.

`update_text` calls `refreshVisuals()`. That updates the live `AVPlayerItem.audioMix`, then calls `ScrubAudioEngine.configure()`. `configure()` cancels the automatic fill task, but cancellation is cooperative and not awaited. The fill's `AVAssetReaderAudioMixOutput` can therefore still be inside `copyNextSampleBuffer()` while AVPlayer creates or updates its AudioQueue pipeline.

The crashing stack is in Apple's AudioQueue XPC path at `__DISPATCH_WAIT_FOR_QUEUE__`. libdispatch traps there when `dispatch_sync` targets a queue already owned by the current thread. Our overlapping long-lived reader/player AudioQueue lifecycles are the trigger; this is not a cache-array corruption.

```mermaid
flowchart TD
  A[Timeline/source installed] --> B[Start whole-timeline AVAssetReader fill]
  B --> C[streamWindows copyNextSampleBuffer]
  D[Text or visual update] --> E[Mutate live AVPlayerItem audioMix]
  E --> F[Cancel fill task without awaiting reader exit]
  C --> G[Reader AudioQueue lifecycle still active]
  E --> H[AVPlayer updates AudioQueue pipeline]
  F --> G
  G --> I[Overlapping AudioQueue XPC work]
  H --> I
  I --> J[dispatch_sync self-deadlock trap]
```

## Fix

Do not launch the background fill on source installation or after audio-mix invalidation. Cache misses continue through the existing bounded on-demand decoder, and nearby windows continue to prefetch in the user's scrub direction.

```mermaid
flowchart TD
  A[Timeline/source installed] --> B[No background reader]
  C[Text or visual update] --> D[Existing AVPlayer visual refresh]
  D --> E[Invalidate cached mixed audio]
  E --> B
  F[User scrubs] --> G{Cached window?}
  G -->|yes| H[Play cached PCM]
  G -->|no| I[Decode requested window]
  I --> H
  H --> J[Prefetch nearby window]
```

## Why the previous implementation existed

The automatic fill was introduced for scrub responsiveness: repeated cold `AVAssetReader` startup was dominated by synchronous XPC overhead and could create audible gaps. It filled up to 256 two-second stereo PCM windows in two passes, starting near the playhead, with an approximately 96 MiB budget.

That optimization is valuable, but keeping a reader alive across normal editing and AVPlayer pipeline changes is the unsafe part. This patch preserves the smaller on-demand cache/prefetch path and removes only the automatic entry points.

## UX / regression surface

- Possible change: the first scrub into a cold, uncached region can take longer to produce audio.
- Preserved: subsequent/nearby scrubs remain cached or prefetched.
- Preserved: live visual refresh, paused/scrubbed playhead position, playback, source preview, meter behavior, and the dedicated reader teardown queue.

This intentionally does **not** claim to fix every issue grouped under `__DISPATCH_WAIT_FOR_QUEUE__`; Sentry also contains separate `AudioTrackReader.read` and on-demand-reader stacks that should be handled independently.

## Verification

- `swift build`
- `swift test` — 1,242 tests across 195 suites passed
- synthetic AVFoundation stress harness: two concurrent audio-mix readers plus 2,554 player item replacement/play/seek cycles; no deterministic reproduction, consistent with a media/timing-specific framework race
