### PR TITLE
[perf] Batch bulk clip property mutations

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -328,8 +328,9 @@ extension EditorViewModel {
         actionName: String
     ) {
         registerTimelineUndo(actionName) { vm in
+            let locations = vm.clipLocations(for: undoTarget.map(\.id))
             for entry in undoTarget {
-                if let loc = vm.findClip(id: entry.id) {
+                if let loc = locations[entry.id] {
                     vm.timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = entry.clip
                 }
             }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -360,8 +360,9 @@ extension EditorViewModel {
     func applyClipProperties(clipIds: [String], rebuild: Bool = false, _ modify: (inout Clip) -> Void) {
         var touchedText = false
         var touchedVisual = false
+        let locations = clipLocations(for: clipIds)
         for clipId in clipIds {
-            guard let loc = findClip(id: clipId) else { continue }
+            guard let loc = locations[clipId] else { continue }
             var clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
             if dragBefore[clipId] == nil {
                 dragBefore[clipId] = clip
@@ -536,8 +537,9 @@ extension EditorViewModel {
         var touchedVisual = false
         var before: [(id: String, clip: Clip)] = []
         var after: [(id: String, clip: Clip)] = []
+        let locations = clipLocations(for: clipIds)
         for clipId in clipIds {
-            guard let loc = findClip(id: clipId) else { continue }
+            guard let loc = locations[clipId] else { continue }
             let current = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
             var clip = current
             let undoTarget = dragBefore.removeValue(forKey: clipId) ?? current
@@ -559,6 +561,25 @@ extension EditorViewModel {
         }
         if touchedText { videoEngine?.refreshVisuals() }
         if touchedVisual { notifyTimelineChanged() }
+    }
+
+    private func clipLocations(for clipIds: [String]) -> [String: ClipLocation] {
+        let requestedIds = Set(clipIds)
+        guard !requestedIds.isEmpty else { return [:] }
+
+        var locations: [String: ClipLocation] = [:]
+        locations.reserveCapacity(requestedIds.count)
+        for trackIndex in timeline.tracks.indices {
+            for clipIndex in timeline.tracks[trackIndex].clips.indices {
+                let clipId = timeline.tracks[trackIndex].clips[clipIndex].id
+                guard requestedIds.contains(clipId), locations[clipId] == nil else { continue }
+                locations[clipId] = ClipLocation(trackIndex: trackIndex, clipIndex: clipIndex)
+                if locations.count == requestedIds.count {
+                    return locations
+                }
+            }
+        }
+        return locations
     }
 
     /// Bidirectional undo/redo for a single clip's property change.

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -386,14 +386,25 @@ extension EditorViewModel {
     }
 
     func revertClipProperty(clipId: String) {
-        guard let original = dragBefore.removeValue(forKey: clipId),
-              let loc = findClip(id: clipId) else { return }
-        timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = original
-        if original.mediaType == .text {
-            videoEngine?.refreshVisuals()
-        } else {
-            notifyTimelineChanged()
+        revertClipProperties(clipIds: [clipId])
+    }
+
+    func revertClipProperties(clipIds: [String]) {
+        var touchedText = false
+        var touchedVisual = false
+        let locations = clipLocations(for: clipIds)
+        for clipId in clipIds {
+            guard let original = dragBefore.removeValue(forKey: clipId),
+                  let loc = locations[clipId] else { continue }
+            timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = original
+            if original.mediaType == .text {
+                touchedText = true
+            } else {
+                touchedVisual = true
+            }
         }
+        if touchedText { videoEngine?.refreshVisuals() }
+        if touchedVisual { notifyTimelineChanged() }
     }
 
     func debouncedCommitClipProperties(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -329,9 +329,11 @@ extension EditorViewModel {
     ) {
         registerTimelineUndo(actionName) { vm in
             let locations = vm.clipLocations(for: undoTarget.map(\.id))
-            for entry in undoTarget {
-                if let loc = locations[entry.id] {
-                    vm.timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = entry.clip
+            vm.mutateActiveTimeline { timeline in
+                for entry in undoTarget {
+                    if let loc = locations[entry.id] {
+                        timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = entry.clip
+                    }
                 }
             }
             vm.registerClipStateSwap(undoTarget: redoTarget, redoTarget: undoTarget, actionName: actionName)
@@ -362,18 +364,20 @@ extension EditorViewModel {
         var touchedText = false
         var touchedVisual = false
         let locations = clipLocations(for: clipIds)
-        for clipId in clipIds {
-            guard let loc = locations[clipId] else { continue }
-            var clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-            if dragBefore[clipId] == nil {
-                dragBefore[clipId] = clip
-            }
-            modify(&clip)
-            timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = clip
-            if clip.mediaType == .text {
-                touchedText = true
-            } else {
-                touchedVisual = true
+        mutateActiveTimeline { timeline in
+            for clipId in clipIds {
+                guard let loc = locations[clipId] else { continue }
+                var clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                if dragBefore[clipId] == nil {
+                    dragBefore[clipId] = clip
+                }
+                modify(&clip)
+                timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = clip
+                if clip.mediaType == .text {
+                    touchedText = true
+                } else {
+                    touchedVisual = true
+                }
             }
         }
         if touchedText { videoEngine?.refreshVisuals() }
@@ -394,14 +398,16 @@ extension EditorViewModel {
         var touchedText = false
         var touchedVisual = false
         let locations = clipLocations(for: clipIds)
-        for clipId in clipIds {
-            guard let original = dragBefore.removeValue(forKey: clipId),
-                  let loc = locations[clipId] else { continue }
-            timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = original
-            if original.mediaType == .text {
-                touchedText = true
-            } else {
-                touchedVisual = true
+        mutateActiveTimeline { timeline in
+            for clipId in clipIds {
+                guard let original = dragBefore.removeValue(forKey: clipId),
+                      let loc = locations[clipId] else { continue }
+                timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = original
+                if original.mediaType == .text {
+                    touchedText = true
+                } else {
+                    touchedVisual = true
+                }
             }
         }
         if touchedText { videoEngine?.refreshVisuals() }
@@ -550,22 +556,24 @@ extension EditorViewModel {
         var before: [(id: String, clip: Clip)] = []
         var after: [(id: String, clip: Clip)] = []
         let locations = clipLocations(for: clipIds)
-        for clipId in clipIds {
-            guard let loc = locations[clipId] else { continue }
-            let current = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-            var clip = current
-            let undoTarget = dragBefore.removeValue(forKey: clipId) ?? current
-            modify(&clip)
-            guard current != clip || undoTarget != clip else { continue }
-            timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = clip
-            if undoTarget != clip {
-                before.append((clipId, undoTarget))
-                after.append((clipId, clip))
-            }
-            if clip.mediaType == .text {
-                touchedText = true
-            } else {
-                touchedVisual = true
+        mutateActiveTimeline { timeline in
+            for clipId in clipIds {
+                guard let loc = locations[clipId] else { continue }
+                let current = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                var clip = current
+                let undoTarget = dragBefore.removeValue(forKey: clipId) ?? current
+                modify(&clip)
+                guard current != clip || undoTarget != clip else { continue }
+                timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = clip
+                if undoTarget != clip {
+                    before.append((clipId, undoTarget))
+                    after.append((clipId, clip))
+                }
+                if clip.mediaType == .text {
+                    touchedText = true
+                } else {
+                    touchedVisual = true
+                }
             }
         }
         if !before.isEmpty {
@@ -573,6 +581,10 @@ extension EditorViewModel {
         }
         if touchedText { videoEngine?.refreshVisuals() }
         if touchedVisual { notifyTimelineChanged() }
+    }
+
+    private func mutateActiveTimeline(_ mutation: (inout Timeline) -> Void) {
+        mutation(&timeline)
     }
 
     private func clipLocations(for clipIds: [String]) -> [String: ClipLocation] {

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -158,7 +158,7 @@ struct TextTab: View {
             },
             cancelPending: { editor.cancelDebouncedCommit(key: $0) },
             cancelFontPreview: { _ in
-                for id in clipIds { editor.revertClipProperty(clipId: id) }
+                editor.revertClipProperties(clipIds: clipIds)
             }
         )
     }

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -244,6 +244,12 @@ extension TextStyle.RGBA {
 }
 
 extension TextStyle {
+    nonisolated(unsafe) private static let resolvedFontCache: NSCache<NSString, NSFont> = {
+        let cache = NSCache<NSString, NSFont>()
+        cache.countLimit = 512
+        return cache
+    }()
+
     var scaledVisualStyle: TextStyle {
         guard fontScale != 1 else { return self }
         var style = self
@@ -265,14 +271,19 @@ extension TextStyle {
     }
 
     func resolvedFont(size: CGFloat) -> NSFont {
-        let base = NSFont(name: fontName, size: size) ?? NSFont.systemFont(ofSize: size)
-        let resolved = Self.font(base, size: size, bold: isBold, italic: isItalic)
-        guard widthScale != 1 || heightScale != 1 else { return resolved }
-        var transform = CGAffineTransform(
-            scaleX: CGFloat(widthScale),
-            y: CGFloat(heightScale)
-        )
-        return CTFontCreateCopyWithAttributes(resolved as CTFont, size, &transform, nil) as NSFont
+        let key = "\(fontName.utf8.count):\(fontName)|\(Double(size).bitPattern)|\(isBold)|\(isItalic)|\(widthScale.bitPattern)|\(heightScale.bitPattern)" as NSString
+        if let cached = Self.resolvedFontCache.object(forKey: key) { return cached }
+
+        let namedBase = NSFont(name: fontName, size: size)
+        let base = namedBase ?? NSFont.systemFont(ofSize: size)
+        var resolved = Self.font(base, size: size, bold: isBold, italic: isItalic)
+        if widthScale != 1 || heightScale != 1 {
+            var transform = CGAffineTransform(scaleX: CGFloat(widthScale), y: CGFloat(heightScale))
+            resolved = CTFontCreateCopyWithAttributes(resolved as CTFont, size, &transform, nil) as NSFont
+        }
+        // A bundled font may not be registered yet; do not cache its fallback.
+        if namedBase != nil { Self.resolvedFontCache.setObject(resolved, forKey: key) }
+        return resolved
     }
 
     var nsColor: NSColor { color.nsColor }

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -544,6 +544,9 @@ struct ClipPropertyCommitTests {
         undoManager.undo()
         #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation == nil })
         #expect(undoManager.canUndo == false)
+        undoManager.redo()
+        #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation?.preset == .wordPop })
+        #expect(undoManager.canRedo == false)
     }
 
     @Test func bulkClipPropertyPreviewCommitAndUndoResolveAcrossTracks() {

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -546,6 +546,31 @@ struct ClipPropertyCommitTests {
         #expect(undoManager.canUndo == false)
     }
 
+    @Test func bulkClipPropertyPreviewCommitAndUndoResolveAcrossTracks() {
+        let a = Fixtures.clip(id: "a", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        let b = Fixtures.clip(id: "b", mediaRef: "text", mediaType: .text, start: 30, duration: 30)
+        let c = Fixtures.clip(id: "c", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        let e = editor([
+            Fixtures.videoTrack(clips: [a, b]),
+            Fixtures.videoTrack(clips: [c]),
+        ])
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+
+        let selectedIds = ["c", "missing", "a"]
+        e.applyClipProperties(clipIds: selectedIds) { $0.opacity = 0.25 }
+        e.commitClipProperties(clipIds: selectedIds) { $0.opacity = 0.25 }
+
+        #expect(e.clipFor(id: "a")?.opacity == 0.25)
+        #expect(e.clipFor(id: "b")?.opacity == 1)
+        #expect(e.clipFor(id: "c")?.opacity == 0.25)
+        undoManager.undo()
+        #expect(e.clipFor(id: "a")?.opacity == 1)
+        #expect(e.clipFor(id: "b")?.opacity == 1)
+        #expect(e.clipFor(id: "c")?.opacity == 1)
+        #expect(undoManager.canUndo == false)
+    }
+
     @Test func cancelDebouncedCommitPreventsPendingHighlightWrite() async throws {
         var clip = Fixtures.clip(id: "caption", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
         clip.textAnimation = TextAnimation(preset: .highlightPop, highlight: .init(r: 1, g: 0, b: 0, a: 1))

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -571,6 +571,25 @@ struct ClipPropertyCommitTests {
         #expect(undoManager.canUndo == false)
     }
 
+    @Test func bulkClipPropertyRevertRestoresMixedTextStylesAcrossTracks() {
+        var a = Fixtures.clip(id: "a", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        var b = Fixtures.clip(id: "b", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
+        a.textStyle = TextStyle(fontName: "Helvetica", fontSize: 48)
+        b.textStyle = TextStyle(fontName: "Avenir", fontSize: 64)
+        let e = editor([
+            Fixtures.videoTrack(clips: [a]),
+            Fixtures.videoTrack(clips: [b]),
+        ])
+
+        e.applyTextStyles(clipIds: ["a", "b"], fitToContent: true) {
+            $0.fontName = "Courier"
+        }
+        e.revertClipProperties(clipIds: ["b", "missing", "a"])
+
+        #expect(e.clipFor(id: "a") == a)
+        #expect(e.clipFor(id: "b") == b)
+    }
+
     @Test func cancelDebouncedCommitPreventsPendingHighlightWrite() async throws {
         var clip = Fixtures.clip(id: "caption", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
         clip.textAnimation = TextAnimation(preset: .highlightPop, highlight: .init(r: 1, g: 0, b: 0, a: 1))


### PR DESCRIPTION
## Summary

Fix the main-thread hangs that occur while previewing, committing, or cancelling style changes across many selected text clips.

Successive samples exposed five separate costs in the bulk mutation flow:

- Color preview and commit scanned the entire timeline once per selected clip. With `K` selected clips and `N` timeline clips, each color event performed `O(K × N)` lookup work on the main actor.
- Closing the font menu without a committed pick reverted clips individually, and each individual revert rebuilt the complete visual composition. The sample spent 6,563 of 6,580 main-thread samples (99.7%) in `refreshVisuals`.
- Grouped Undo restored clips individually with the same full-timeline lookup per selected clip. The original sample spent 5,331 of 6,657 main-thread samples in `registerClipStateSwap`.
- After those costs were removed, font preview and numeric text-style scrubbing repeatedly rebuilt identical `NSFont` and CoreText trait descriptors while auto-fitting each clip. In the largest font-hover slice, font resolution occupied 372 of 396 text-layout samples.
- Each selected clip also opened a separate observable `timeline` mutation. After the earlier fixes made that overhead visible, Swift Observation publishing occupied about 75 samples during preview and 61 during commit.

## Approach

- Resolve all requested clip IDs with one indexed timeline scan per mutation pass.
- Reuse those locations in `applyClipProperties`, `commitClipProperties`, grouped Undo/Redo, and the new batched revert path.
- Restore every cancelled font preview before refreshing visuals once, instead of refreshing after every selected clip.
- Reuse immutable resolved fonts through a bounded, thread-safe cache keyed by font name, size, traits, and axis scales. Missing named fonts are not cached, so an early fallback cannot outlive bundled-font registration.
- Hold one active-timeline mutation across each bulk apply, commit, revert, or Undo/Redo pass so observers receive the same synchronous final state once instead of once per selected clip.
- Preserve selected-ID order, missing-ID behavior, mixed original fonts, fitted transforms, immediate preview, the 400 ms color debounce, and grouped undo behavior.
- Add regression coverage for preview/commit/undo and mixed-style font preview cancellation across multiple tracks.

No intended UI or debounce behavior changes. Bulk color and font editing should remain responsive.

## Testing

- `swift build`
- `swift test --filter bulkClipPropertyPreviewCommitAndUndoResolveAcrossTracks`
- `swift test --filter bulkClipPropertyRevertRestoresMixedTextStylesAcrossTracks`
- `swift test --filter commitClipPropertiesGroupsMultipleClipUndo`
- `swift test --filter TextFrameRenderer` — 14 tests passed
- `swift test` — 1,251 tests passed
- Synthetic preview/commit benchmark with 4,000 clips and 2,000 selected clips:
  - Before: 0.827041167 s
  - After: 0.005739583 s
  - About 144× faster
- Synthetic grouped-undo benchmark with 4,000 clips and 2,000 selected clips:
  - Before: 0.799370459 s
  - After: 0.005256459 s
  - About 152× faster
- Follow-up sample on the real project after the undo change: grouped Undo occupied 82 main-thread samples total, down from 5,331 in the original capture; only 1 sample was in the batched location lookup.
- Focused resolved-font benchmark, 2,000 identical resolutions:
  - Before: 0.026417584 s
  - After: 0.0037435 s
  - About 7× faster
- Follow-up real-project sample after the font cache: numeric text-style preview occupied 444 main-thread samples, down from 1,065; font resolution fell from hundreds of samples to low single digits.
- Manual multi-clip color/style sample after timeline batching: the prior repeated `timeline.modify → timelines.modify` observation stack fell from tens of samples to one sampled millisecond. Remaining time was in the expected single timeline mutation, text fitting, and visual refresh.

Manual verification plan: select many text clips across tracks; drag the system color wheel and verify one-step Undo; then open the font picker, hover fonts, cancel the menu and verify all original mixed styles return without a hang; finally select a font and verify it commits to every selected clip.

## Change statistics

- 4 files changed
- Production: +103 / -47
- Tests: +47 / -0
- Total: +150 / -47
