### PR TITLE
[fix/sentry] Guard live scopes without video tracks

### DIFF
--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -413,7 +413,8 @@ final class VideoEngine {
     /// Luma + per-channel histogram of the current composited frame (downsampled), normalized 0…1.
     func histogramYRGB(frame: Int? = nil, count: Int = 256) async
         -> (y: [Float], r: [Float], g: [Float], b: [Float])? {
-        guard let item = player.currentItem else { return nil }
+        guard let item = player.currentItem,
+              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
         let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
         let generator = AVAssetImageGenerator(asset: item.asset)
         generator.videoComposition = item.videoComposition
@@ -466,7 +467,8 @@ final class VideoEngine {
     /// Hue distribution of the current composited frame — pixel count per hue bucket, weighted by
     /// saturation so achromatic pixels don't show. Drives the silhouette behind the hue curves.
     func hueHistogram(frame: Int? = nil, count: Int = 96) async -> [Float]? {
-        guard let item = player.currentItem else { return nil }
+        guard let item = player.currentItem,
+              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
         let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
         let generator = AVAssetImageGenerator(asset: item.asset)
         generator.videoComposition = item.videoComposition
@@ -506,7 +508,8 @@ final class VideoEngine {
     }
 
     func sampleKeyHue(at normalizedPoint: CGPoint, frame: Int? = nil) async -> Double? {
-        guard let item = player.currentItem else { return nil }
+        guard let item = player.currentItem,
+              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
         let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
         let generator = AVAssetImageGenerator(asset: item.asset)
         generator.videoComposition = item.videoComposition

--- a/Tests/PalmierProTests/Rendering/HistogramTests.swift
+++ b/Tests/PalmierProTests/Rendering/HistogramTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import CoreGraphics
 import Testing
 @testable import PalmierPro
@@ -48,5 +49,24 @@ struct HistogramTests {
         let hue = try #require(VideoEngine.sampleKeyHue(from: solid(0, 1, 0), at: CGPoint(x: 0.5, y: 0.5)))
         #expect(abs(hue - 1.0 / 3.0) < 0.01)
         #expect(VideoEngine.sampleKeyHue(from: solid(0.5, 0.5, 0.5), at: CGPoint(x: 0.5, y: 0.5)) == nil)
+    }
+
+    @Test @MainActor func liveScopesSkipAssetsWithoutVideoTracks() async {
+        let editor = EditorViewModel()
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+        engine.player.replaceCurrentItem(with: AVPlayerItem(asset: AVMutableComposition()))
+
+        let histogram = await engine.histogramYRGB()
+        let hueHistogram = await engine.hueHistogram()
+        let sampledHue = await engine.sampleKeyHue(at: CGPoint(x: 0.5, y: 0.5))
+
+        #expect(histogram == nil)
+        #expect(hueHistogram == nil)
+        #expect(sampledHue == nil)
     }
 }


### PR DESCRIPTION
## What changed

- Check the current preview asset for a video track before live RGB, hue, or chroma-key scope frame generation.
- Return no scope sample for an empty or audio-only composition instead of constructing `AVAssetImageGenerator`.
- Add a regression test covering all three scope paths with an empty composition.

## Why

[PALMIER-PRO-1A](https://palmier.sentry.io/issues/7557710130/) is a fatal AVFoundation precondition failure: `AVAssetReaderVideoCompositionOutput` receives zero video tracks while servicing an asynchronous `AVAssetImageGenerator` request.

Sentry cannot retain the originating Swift caller because the exception is raised later on AVFoundation's queue. The post-June-17 occurrences began after live scopes were introduced, and affected events include empty/audio-only compositions around timeline replacement and track-removal workflows. This patch enforces the missing invariant at the live-scope generator boundary without changing task or inspector lifecycle behavior.

## Impact

Normal video scope timing, composition, and rendering are unchanged. When the preview has no video track, scopes and chroma-key sampling produce no frame rather than crashing.

## Validation

- `swift test --filter HistogramTests` — 6 passed
- `swift test` — 1,252 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive guards at the scope entry points; behavior for assets with video is unchanged, and failure mode is nil samples rather than a crash.
> 
> **Overview**
> Fixes a fatal AVFoundation crash when **live scopes** run against a preview item with **no video track** (empty or audio-only compositions during timeline swaps or track removal).
> 
> `histogramYRGB`, `hueHistogram`, and `sampleKeyHue` now **require a video track** on the current player asset before creating `AVAssetImageGenerator`; otherwise they return `nil` instead of triggering the zero-track video composition precondition. Normal video preview behavior is unchanged.
> 
> Adds a **regression test** that drives all three paths with an empty `AVMutableComposition` and expects no samples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2817e28a1a17bf3aded4c63a69873642a630a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->