### PR TITLE
[fix] Prevent recursive editor layout

### DIFF
--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -57,7 +57,6 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
     private var currentPreset: LayoutPreset?
     private var currentMaximized: EditorViewModel.FocusedPanel?
     private var pendingPositioning: (() -> Void)?
-    private var isPositioning = false
     private weak var agentSplitItem: NSSplitViewItem?
     private weak var mediaSplitItem: NSSplitViewItem?
     private weak var previewSplitItem: NSSplitViewItem?
@@ -386,7 +385,9 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        runPendingPositioning()
+        if pendingPositioning != nil {
+            DispatchQueue.main.async { [weak self] in self?.runPendingPositioning() }
+        }
         updateTourFrame()   // see EditorSplitViewController+Tour.swift
     }
 
@@ -397,20 +398,13 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
             self.mediaSplitItem?.isCollapsed = !self.editor.mediaPanelVisible
             self.inspectorSplitItem?.isCollapsed = !self.editor.inspectorPanelVisible
         }
-        if view.bounds.width > 0 {
-            view.layoutSubtreeIfNeeded()
-            runPendingPositioning()
-        } else {
-            view.needsLayout = true
-        }
+        view.needsLayout = true
     }
 
     private func runPendingPositioning() {
-        guard !isPositioning, view.bounds.width > 0, let work = pendingPositioning else { return }
+        guard view.bounds.width > 0, let work = pendingPositioning else { return }
         pendingPositioning = nil
-        isPositioning = true
         work()
-        isPositioning = false
     }
 }
 

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -405,6 +405,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         guard view.bounds.width > 0, let work = pendingPositioning else { return }
         pendingPositioning = nil
         work()
+        updateTourFrame()
     }
 }
 


### PR DESCRIPTION
## Summary

Prevent the editor split view from recursively entering AppKit layout while seeding divider positions. This addresses the stack-overflow crash reported in [PALMIER-PRO-1CB](https://palmier.sentry.io/issues/7637091531/) and the matching historical signature in [PALMIER-PRO-DC](https://palmier.sentry.io/issues/7567739182/).

## Approach

`applyAfterLayout` previously forced `layoutSubtreeIfNeeded()` synchronously. That entered `viewDidLayout`, which ran pending divider positioning; `NSSplitView.setPosition` could then trigger another layout while the first layout stack was still active. The re-entry flag prevented the positioning closure from executing twice, but it did not prevent AppKit and hosted SwiftUI views from recursively laying themselves out.

The editor now:

- marks the split view as needing layout;
- waits for `viewDidLayout` to establish valid child bounds;
- schedules divider positioning on the next main-loop turn, after the current layout stack unwinds;
- clears the pending closure before changing divider positions.

Default positions, autosaved divider positions, panel visibility, and layout presets are unchanged. The only timing difference is that initial divider seeding happens one main-loop turn later.

## Testing

- `swift build` — passed.
- Manual editor smoke test — passed per user verification.
- No focused unit test: the failure depends on re-entrant AppKit/SwiftUI layout and is not exposed through a deterministic unit seam.

## Change statistics

- Production logic: +5 / -11
- Tests: +0 / -0
- Total: +5 / -11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor AppKit layout timing for all presets; behavior is intended to be equivalent with a one-frame delay on initial divider seeding, but layout edge cases could surface.
> 
> **Overview**
> Fixes a **stack-overflow crash** when the editor seeds `NSSplitView` divider positions during layout by avoiding synchronous re-entrant AppKit/SwiftUI layout.
> 
> **`applyAfterLayout`** no longer calls `layoutSubtreeIfNeeded()` (or runs positioning immediately when width &gt; 0). It only stores the pending closure and sets `view.needsLayout = true`.
> 
> **`viewDidLayout`** defers `runPendingPositioning()` to the **next main run-loop turn** via `DispatchQueue.main.async`, so divider `setPosition` runs after the current layout pass unwinds.
> 
> The **`isPositioning`** guard is removed; pending work is still cleared before applying positions, and **`updateTourFrame()`** runs after positioning completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45165f16855af2cabe8735cf5819a1038f16649c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->