### PR TITLE
[fix/sentry] Prevent AppKit save hangs without racing snapshots

### DIFF
--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -30,6 +30,13 @@ private typealias DocumentCloseCallback = @convention(c) (
 
 class VideoProject: NSDocument {
 
+    private struct SaveRequest {
+        let url: URL
+        let typeName: String
+        let operation: NSDocument.SaveOperationType
+        let completion: (Error?) -> Void
+    }
+
     static let typeIdentifier = Project.typeIdentifier
 
     let editorViewModel = EditorViewModel()
@@ -50,6 +57,9 @@ class VideoProject: NSDocument {
     private nonisolated(unsafe) var snapshotChatSessionFiles: [(name: String, data: Data)] = []
     private nonisolated(unsafe) var snapshotSourceProjectURL: URL?
     private nonisolated(unsafe) var snapshotPreparedForWrite = false
+    // AppKit saves asynchronously, but write() consumes one shared snapshot at a time.
+    // Keep the first request active and serialize any requests behind it.
+    private var saveQueue: [SaveRequest] = []
     private var projectCheckpointAutosaveScheduled = false
     private var isSavingBeforeClose = false
 
@@ -134,17 +144,32 @@ class VideoProject: NSDocument {
     }
 
     override func save(to url: URL, ofType typeName: String, for saveOperation: NSDocument.SaveOperationType, completionHandler: @escaping (Error?) -> Void) {
-        if let date = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate {
+        let request = SaveRequest(
+            url: url,
+            typeName: typeName,
+            operation: saveOperation,
+            completion: completionHandler
+        )
+        editorViewModel.projectPackageCoordinator.saveStarted()
+        saveQueue.append(request)
+        guard saveQueue.count == 1 else { return }
+        performNextSave()
+    }
+
+    private func performNextSave() {
+        guard let request = saveQueue.first else { return }
+        if let date = try? request.url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate {
             fileModificationDate = date
         }
 
         let coordinator = editorViewModel.projectPackageCoordinator
-        coordinator.saveStarted()
         captureSaveSnapshot()
         snapshotSourceProjectURL = fileURL
-        super.save(to: url, ofType: typeName, for: saveOperation) { error in
+        super.save(to: request.url, ofType: request.typeName, for: request.operation) { error in
             coordinator.saveFinished(success: error == nil)
-            completionHandler(error)
+            request.completion(error)
+            self.saveQueue.removeFirst()
+            self.performNextSave()
         }
     }
 
@@ -195,6 +220,16 @@ class VideoProject: NSDocument {
             coordinator.cancelClosing()
             throw error
         }
+    }
+
+    override func writeSafely(
+        to url: URL,
+        ofType typeName: String,
+        for saveOperation: NSDocument.SaveOperationType
+    ) throws {
+        // NSDocument otherwise blocks the main thread while super prepares a safe-save directory.
+        unblockUserInteraction()
+        try super.writeSafely(to: url, ofType: typeName, for: saveOperation)
     }
 
     override func write(to url: URL, ofType typeName: String) throws {

--- a/Tests/PalmierProTests/Project/VideoProjectWriteUnblockTests.swift
+++ b/Tests/PalmierProTests/Project/VideoProjectWriteUnblockTests.swift
@@ -1,16 +1,67 @@
+import AppKit
 import Foundation
 import Testing
 @testable import PalmierPro
 
-private final class UnblockCountingProject: VideoProject {
+private class UnblockCountingProject: VideoProject {
     nonisolated(unsafe) private(set) var unblockCount = 0
     override func unblockUserInteraction() { unblockCount += 1 }
+}
+
+private final class UnblockOrderingProject: UnblockCountingProject {
+    nonisolated(unsafe) private(set) var unblockCountAtWriteEntry: Int?
+
+    override func write(to url: URL, ofType typeName: String) throws {
+        unblockCountAtWriteEntry = unblockCount
+        try super.write(to: url, ofType: typeName)
+    }
+}
+
+private final class DelayedSafeWriteProject: VideoProject {
+    nonisolated(unsafe) var delaySafeWrites = false
+    let safeWriteEntered = DispatchSemaphore(value: 0)
+    let allowSafeWrite = DispatchSemaphore(value: 0)
+
+    override func writeSafely(
+        to url: URL,
+        ofType typeName: String,
+        for saveOperation: NSDocument.SaveOperationType
+    ) throws {
+        if delaySafeWrites {
+            unblockUserInteraction()
+            safeWriteEntered.signal()
+            allowSafeWrite.wait()
+        }
+        try super.writeSafely(to: url, ofType: typeName, for: saveOperation)
+    }
+}
+
+@MainActor
+private func save(_ document: VideoProject, to url: URL) async -> Error? {
+    await withCheckedContinuation { continuation in
+        document.save(
+            to: url,
+            ofType: VideoProject.typeIdentifier,
+            for: .saveOperation
+        ) { error in
+            continuation.resume(returning: error)
+        }
+    }
+}
+
+private func wait(for semaphore: DispatchSemaphore) async {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            semaphore.wait()
+            continuation.resume()
+        }
+    }
 }
 
 /// With `canAsynchronouslyWrite` enabled, AppKit parks the main thread in
 /// `_waitForUserInteractionUnblocking` until `write()` calls `unblockUserInteraction()`.
 /// A throw that skips the unblock freezes the app permanently (issue #402).
-@Suite("VideoProject write() main-thread unblocking")
+@Suite("VideoProject write() main-thread unblocking", .serialized)
 struct VideoProjectWriteUnblockTests {
 
     private func temporaryBundleURL() -> URL {
@@ -48,5 +99,67 @@ struct VideoProjectWriteUnblockTests {
         }
 
         #expect(doc.unblockCount == 1)
+    }
+
+    @Test func safeWriteUnblocksBeforeEnteringWrite() async throws {
+        let doc = await MainActor.run {
+            let doc = UnblockOrderingProject()
+            doc.editorViewModel.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+            return doc
+        }
+        let url = temporaryBundleURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await MainActor.run {
+            try doc.writeSafely(
+                to: url,
+                ofType: VideoProject.typeIdentifier,
+                for: .saveOperation
+            )
+        }
+
+        #expect(doc.unblockCountAtWriteEntry == 1)
+    }
+
+    @Test func overlappingSavesPreserveLatestSnapshot() async throws {
+        let url = temporaryBundleURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let doc = await MainActor.run {
+            let doc = DelayedSafeWriteProject()
+            doc.fileURL = url
+            doc.fileType = VideoProject.typeIdentifier
+            doc.editorViewModel.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack()])
+            return doc
+        }
+        #expect(await save(doc, to: url) == nil)
+
+        await MainActor.run {
+            doc.editorViewModel.timeline.name = "First save"
+            doc.updateChangeCount(.changeDone)
+            doc.delaySafeWrites = true
+        }
+        let firstSave = Task { @MainActor in await save(doc, to: url) }
+        await wait(for: doc.safeWriteEntered)
+
+        await MainActor.run {
+            doc.editorViewModel.timeline.name = "Second save"
+            doc.updateChangeCount(.changeDone)
+        }
+        let release = doc.allowSafeWrite
+        let releaseWrites = Task.detached {
+            try? await Task.sleep(for: .milliseconds(100))
+            release.signal()
+            release.signal()
+        }
+        let secondSave = Task { @MainActor in await save(doc, to: url) }
+
+        let firstError = await firstSave.value
+        let secondError = await secondSave.value
+        await releaseWrites.value
+        #expect(firstError == nil)
+        #expect(secondError == nil)
+
+        let saved = try VideoProject.readProjectPackage(at: url)
+        #expect(saved.projectFile.timelines.first?.name == "Second save")
     }
 }


### PR DESCRIPTION
## Summary

- unblock `NSDocument` user interaction before AppKit prepares its safe-save directory
- serialize document save requests so the earlier unblock cannot race the shared write snapshot
- add deterministic coverage for the unblock ordering and overlapping saves

## Root cause

For asynchronous `NSDocument` saves, AppKit parks the main thread until the document calls `unblockUserInteraction()`. Palmier called it from `write(to:)`, but AppKit's default `writeSafely(...)` first prepares a temporary replacement directory. Sentry samples show that preparation stalled in `_URLForReplacingItemAtURL` / `mkdir`, leaving the main thread parked in `_waitForUserInteractionUnblocking` long enough to register as an app hang.

Moving the unblock before `super.writeSafely(...)` makes that filesystem work genuinely asynchronous. That also allows another save to begin before the first save consumes Palmier's shared snapshot, so saves are now processed FIFO and each captures its snapshot only when it becomes active.

## Impact

The editor remains interactive while AppKit performs safe-save preparation. Overlapping manual saves and autosaves complete in order, and the latest project state is persisted. There is no intended visible UX change beyond a later save waiting for the active save to finish.

## Validation

- `swift test --filter VideoProjectWriteUnblockTests`
- focused package coordination, close persistence, and package load suites
- `swift test` — 1,254 tests passed
- manual save and close/reopen smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core project persistence and save ordering; behavior is constrained by existing coordinator hooks and new regression tests, but incorrect queueing could still affect what gets written on disk.
> 
> **Overview**
> Fixes **main-thread hangs** during asynchronous `NSDocument` saves by calling **`unblockUserInteraction()`** at the start of **`writeSafely`**—before AppKit prepares the safe-save replacement directory—instead of only unblocking inside **`write(to:)`**, which left the UI parked while filesystem work ran.
> 
> Because that unblock allows overlapping save requests, saves are now **queued FIFO**: each active save captures its snapshot when it starts, and the next save runs only after the previous one finishes, so the shared write snapshot is not consumed by concurrent writes.
> 
> Adds **serialized tests** for safe-write unblock ordering and for overlapping saves persisting the **latest** timeline state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c7ea4b84762a96e174e967036b9c23db58aad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->