### PR TITLE
[fix] Pre-warm the open/save panel service at launch

### DIFF
--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -20,6 +20,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppNotifications.configure()
 
         AppState.shared.startMCPService()
+
+        // Pre-warm NSOpenPanel to avoid main thread blocking during cold start.
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            _ = NSOpenPanel()
+        }
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -22,8 +22,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppState.shared.startMCPService()
 
         // Pre-warm NSOpenPanel to avoid main thread blocking during cold start.
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(3))
+            guard let self, !self.isTerminating else { return }
             _ = NSOpenPanel()
         }
     }


### PR DESCRIPTION
## Summary

Sentry shows an app-hang class (12 issues, ~280 events over five weeks, e.g. PALMIER-PRO-4A, PALMIER-PRO-1F, PALMIER-PRO-D0) where the main thread blocks 8+ seconds inside `-[NSSavePanel _initBridgeAndStuff]` the moment an `NSOpenPanel`/`NSSavePanel` is constructed — export destination, import media, new project, open project, relink, and LUT pickers are all affected.

Root cause: since macOS 10.15 the open/save panel is drawn by a separate XPC service (`com.apple.appkit.xpc.openAndSavePanelService`). Panel `init` synchronously waits for that service to spawn and handshake, on the main thread, with no off-main or async alternative (`NSSavePanel` is main-actor via `NSResponder`). The spawn is once per app session — the service persists until quit — so the first panel of a session pays the full cost. Slow spawns correlate with iCloud Drive / file-provider state (a known macOS 26.1 regression).

This change constructs a throwaway `NSOpenPanel` 3 seconds after launch, forcing the service spawn at idle so every user-initiated panel afterward skips the cold handshake.

## Approach

- One site in `applicationDidFinishLaunching`; no call-site changes needed since all panels share the one per-app service.
- The panel is never presented — construction alone triggers the handshake; nothing renders and focus is unaffected.
- For pathological service stalls this relocates the wait to launch idle rather than eliminating it (init must run on the main thread); those events will re-attribute in Sentry from user flows to the pre-warm site. True elimination would require panel-free flows, deliberately out of scope here.
- Rejected alternatives: off-main construction (main-actor API, undefined behavior), timeout/cancellation (wait is inside AppKit before init returns), SwiftUI `fileImporter` (same XPC service).

## Testing

- `swift build` passes.
- Ran the built binary: `openAndSavePanelService` process count went 1 → 2 within 8s of launch (new instance parented to the app), confirming the service spawns from the pre-warm and persists.
- Manual verification pending: launch packaged app, confirm no visual artifact around t+3s, then confirm Open/Export panels behave normally.

## Change statistics

- Code: +6 lines (1 file), no deletions, no tests (behavior is a timing optimization over an OS service; no stable seam to assert).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small launch-timing tweak with no API or user-flow changes; worst case is a brief main-thread stall at idle if the OS service is slow, which the PR intentionally moves off interactive paths.
> 
> **Overview**
> Addresses **main-thread hangs** when users first open an `NSOpenPanel`/`NSSavePanel` by forcing macOS’s `openAndSavePanelService` to spawn during idle launch instead of on the first real picker (open project, export, import, etc.).
> 
> In `applicationDidFinishLaunching`, a **main-actor `Task`** waits **3 seconds**, skips work if the app is already terminating, then allocates a throwaway **`NSOpenPanel`** (never shown). That one-time construction pays the synchronous XPC handshake so later panels across the app reuse the warm service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a1ba56923471952e1a6e627f14103554540b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->