### PR TITLE
[telemetry] Add agent request correlation context

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -303,6 +303,10 @@ final class AgentService {
         }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        guard let conversationID = currentSessionId else {
+            streamError = .upstream("Chat session unavailable.")
+            return
+        }
         let referencedMentions = AgentMentionContext.referencedMentions(mentions, in: trimmed)
         let contextHint = referencedMentions.isEmpty
             ? nil
@@ -324,7 +328,7 @@ final class AgentService {
             mentions: referencedMentions, contextHint: contextHint
         ))
         streamError = nil
-        kickOffStream()
+        kickOffStream(conversationID: conversationID, traceID: UUID())
     }
 
     func postSystemNotice(_ text: String) {
@@ -339,7 +343,7 @@ final class AgentService {
         isStreaming = false
     }
 
-    private func kickOffStream() {
+    private func kickOffStream(conversationID: UUID, traceID: UUID) {
         currentTask?.cancel()
         isStreaming = true
         currentTask = Task { [weak self] in
@@ -348,11 +352,11 @@ final class AgentService {
                 self?.syncMessagesIntoCurrentSession()
                 self?.onSessionsChanged?()
             }
-            await self?.runLoop()
+            await self?.runLoop(conversationID: conversationID, traceID: traceID)
         }
     }
 
-    private func runLoop() async {
+    private func runLoop(conversationID: UUID, traceID: UUID) async {
         guard let client = selectClient() else {
             streamError = .upstream("No backend available.")
             return
@@ -365,6 +369,10 @@ final class AgentService {
         loop: while !Task.isCancelled {
             resolveOrphanToolUses()
             let apiMsgs = await apiMessages()
+            guard let inputMessageID = messages.last(where: { $0.role == .user })?.id else {
+                streamError = .upstream("The agent request has no user message.")
+                break loop
+            }
             let assistant = AgentMessage(role: .assistant, blocks: [])
             messages.append(assistant)
             let assistantID = assistant.id
@@ -373,7 +381,15 @@ final class AgentService {
                 let stream = client.stream(
                     system: AgentInstructions.serverInstructions + AgentInstructions.skillsSection(SkillStore.shared.skillIndex),
                     tools: tools,
-                    messages: apiMsgs
+                    messages: apiMsgs,
+                    context: AgentRequestContext(
+                        conversationID: conversationID,
+                        traceID: traceID,
+                        spanID: UUID(),
+                        inputMessageID: inputMessageID,
+                        outputMessageID: assistantID,
+                        projectID: editor?.projectId
+                    )
                 )
 
                 var stopReason: AnthropicStopReason = .endTurn

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -45,6 +45,27 @@ struct AnthropicToolSchema: @unchecked Sendable {
     let inputSchema: [String: Any]
 }
 
+struct AgentRequestContext: Equatable, Sendable {
+    let conversationID: UUID
+    let traceID: UUID
+    let spanID: UUID
+    let inputMessageID: UUID
+    let outputMessageID: UUID
+    let projectID: String?
+
+    func apply(to request: inout URLRequest, telemetryEnabled: Bool) {
+        request.setValue(conversationID.uuidString.lowercased(), forHTTPHeaderField: "X-Palmier-Conversation-Id")
+        request.setValue(traceID.uuidString.lowercased(), forHTTPHeaderField: "X-Palmier-Trace-Id")
+        request.setValue(spanID.uuidString.lowercased(), forHTTPHeaderField: "X-Palmier-Span-Id")
+        request.setValue(inputMessageID.uuidString.lowercased(), forHTTPHeaderField: "X-Palmier-Input-Message-Id")
+        request.setValue(outputMessageID.uuidString.lowercased(), forHTTPHeaderField: "X-Palmier-Output-Message-Id")
+        if let projectID, !projectID.isEmpty {
+            request.setValue(projectID, forHTTPHeaderField: "X-Palmier-Project-Id")
+        }
+        request.setValue(telemetryEnabled ? "1" : "0", forHTTPHeaderField: "X-Palmier-Agent-Telemetry")
+    }
+}
+
 enum AnthropicStreamEvent: Sendable {
     case textDelta(String)
     case toolUseComplete(id: String, name: String, inputJSON: String)
@@ -71,7 +92,8 @@ protocol AgentClient: Sendable {
     func stream(
         system: String,
         tools: [AnthropicToolSchema],
-        messages: [AnthropicMessage]
+        messages: [AnthropicMessage],
+        context: AgentRequestContext
     ) -> AsyncThrowingStream<AnthropicStreamEvent, Error>
 }
 

--- a/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
@@ -39,7 +39,8 @@ struct AnthropicClient: AgentClient {
     func stream(
         system: String,
         tools: [AnthropicToolSchema],
-        messages: [AnthropicMessage]
+        messages: [AnthropicMessage],
+        context: AgentRequestContext
     ) -> AsyncThrowingStream<AnthropicStreamEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {

--- a/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
@@ -8,12 +8,19 @@ struct PalmierClient: AgentClient {
     func stream(
         system: String,
         tools: [AnthropicToolSchema],
-        messages: [AnthropicMessage]
+        messages: [AnthropicMessage],
+        context: AgentRequestContext
     ) -> AsyncThrowingStream<AnthropicStreamEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    try await run(system: system, tools: tools, messages: messages, continuation: continuation)
+                    try await run(
+                        system: system,
+                        tools: tools,
+                        messages: messages,
+                        context: context,
+                        continuation: continuation
+                    )
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -27,6 +34,7 @@ struct PalmierClient: AgentClient {
         system: String,
         tools: [AnthropicToolSchema],
         messages: [AnthropicMessage],
+        context: AgentRequestContext,
         continuation: AsyncThrowingStream<AnthropicStreamEvent, Error>.Continuation
     ) async throws {
         guard let baseURL = BackendConfig.convexHttpURL else {
@@ -46,6 +54,7 @@ struct PalmierClient: AgentClient {
         request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
         request.setValue("text/event-stream", forHTTPHeaderField: "accept")
+        context.apply(to: &request, telemetryEnabled: Analytics.isEnabled)
         request.httpBody = try JSONSerialization.data(
             withJSONObject: AnthropicRequestBody.build(
                 model: model, maxTokens: maxTokens, system: system, tools: tools, messages: messages

--- a/Sources/PalmierPro/Settings/PrivacyPane.swift
+++ b/Sources/PalmierPro/Settings/PrivacyPane.swift
@@ -12,7 +12,7 @@ struct PrivacyPane: View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             SettingsToggleRow(
                 title: "Share usage data",
-                subtitle: "Send product usage data to help improve Palmier Pro. Media and project content are never included.",
+                subtitle: "Send usage data from your interactions with Palmier Pro to help improve the app.",
                 isOn: $analyticsEnabled
             )
             .onChange(of: analyticsEnabled) { _, newValue in


### PR DESCRIPTION
## Summary

- add a typed request context carrying conversation, trace, span, message, and project identifiers
- preserve one trace across an agent tool loop while assigning a unique span and output message ID to each streamed request
- attach the context as request headers in `PalmierClient`
- update the Share usage data description to accurately describe interaction data

## Why

Agent requests need stable client-generated identifiers so individual streamed calls can be correlated across a conversation and tool loop.

## Impact

The agent's visible behavior is unchanged. The app now generates stable correlation metadata for each conversation and tool-loop request, and direct Anthropic requests continue to use the same client interface.

## Validation

- `swift test` (1,242 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes on the agent request path; user-visible agent behavior is unchanged aside from clearer errors when the session or user message is missing.
> 
> **Overview**
> Adds **client-generated correlation metadata** for agent HTTP requests so the Palmier backend can tie streamed calls to a chat session and tool loop.
> 
> `AgentService` now requires an active chat session before sending, starts one **trace ID** per user message, and passes a new **span** and assistant **output message ID** on each iteration of the tool loop. It also fails fast if a stream would run without a user message.
> 
> A new `AgentRequestContext` type maps those IDs (plus optional project ID and an analytics opt-in flag) onto `X-Palmier-*` headers; **`PalmierClient`** applies them on `v1/agent/stream`. The shared `AgentClient` API takes `context` for all clients; direct **Anthropic** calls accept it but do not send the headers.
> 
> The **Share usage data** toggle copy is updated to describe interaction data rather than generic product usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095937273428df1b2f0d2732b8ec111d06ab8330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->