### PR TITLE
[feat] Add configurable silence removal controls

### DIFF
--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -212,7 +212,10 @@ private struct ToolRunRow: View {
     private func prettyPrinted(_ json: String) -> String {
         guard let data = json.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data),
-              let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted]),
+              let pretty = try? JSONSerialization.data(
+                  withJSONObject: roundJSONFloatingPointNumbers(obj, toPlaces: 3),
+                  options: [.prettyPrinted]
+              ),
               let s = String(data: pretty, encoding: .utf8),
               !s.isEmpty, s != "{}" else {
             return "(no args)"

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -715,14 +715,14 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .removeSilence,
-            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nOmit clipIds to process the whole timeline, or pass clip IDs from get_timeline to process only those clips. Scoped clips must share one track or be members of one linked A/V unit. By default, this uses the current Minimum Pause and Speech Padding controls. Pass either optional value as a one-shot override without changing those controls. Use this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry.",
+            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nOmit clipIds to process the whole timeline, or pass clip IDs from get_timeline to process only those clips. A scoped selection must include audio from exactly one track, and all selected clips must share one track or belong to one linked A/V unit. By default, this uses the current Minimum Pause and Speech Padding controls. Pass either optional value as a one-shot override without changing those controls. Use this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry.",
             inputSchema: objectSchema(
                 properties: [
                     "clipIds": [
                         "type": "array",
                         "items": ["type": "string"],
                         "minItems": 1,
-                        "description": "Optional timeline clip IDs from get_timeline. Restricts removal to these clips; linked A/V partners are cut with them. Clips must share one track or one link group. Omit to process the whole timeline.",
+                        "description": "Optional timeline clip IDs from get_timeline. Restricts removal to these clips; linked A/V partners are cut with them. Include audio clips from exactly one track, and select clips from one track or one link group. Omit to process the whole timeline.",
                     ],
                     "minimumPauseSeconds": [
                         "type": "number",

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -715,8 +715,24 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .removeSilence,
-            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut, and speech-boundary slop keeps the cuts from feeling clipped. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nUse this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry. Takes no arguments.",
-            inputSchema: objectSchema(properties: [:], required: [])
+            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nBy default, this uses the current Minimum Pause and Speech Padding controls. Pass either optional value as a one-shot override without changing those controls. Use this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry.",
+            inputSchema: objectSchema(
+                properties: [
+                    "minimumPauseSeconds": [
+                        "type": "number",
+                        "minimum": SilenceRemovalSettings.minimumPauseRange.lowerBound,
+                        "maximum": SilenceRemovalSettings.minimumPauseRange.upperBound,
+                        "description": "Minimum quiet, speech-free pause to remove. Omit to use the current Minimum Pause control.",
+                    ],
+                    "speechPaddingSeconds": [
+                        "type": "number",
+                        "minimum": SilenceRemovalSettings.speechPaddingRange.lowerBound,
+                        "maximum": SilenceRemovalSettings.speechPaddingRange.upperBound,
+                        "description": "Audio to keep before and after detected speech. Omit to use the current Speech Padding control.",
+                    ],
+                ],
+                required: []
+            )
         ),
         AgentTool(
             name: .detectBeats,

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -715,9 +715,15 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .removeSilence,
-            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nBy default, this uses the current Minimum Pause and Speech Padding controls. Pass either optional value as a one-shot override without changing those controls. Use this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry.",
+            description: "Remove dead air — quiet, speech-free sections — from the timeline's audio, ripple-closing the gaps. Sections come from on-device speech detection (the same spans marked red on waveforms): non-speech runs whose level sits well below the recording's own speech level, so music beds and loud ambience are never cut. Cuts linked A/V partners and honors sync lock; the whole pass is one undoable action.\n\nOmit clipIds to process the whole timeline, or pass clip IDs from get_timeline to process only those clips. Scoped clips must share one track or be members of one linked A/V unit. By default, this uses the current Minimum Pause and Speech Padding controls. Pass either optional value as a one-shot override without changing those controls. Use this to tighten pacing (long pauses, dead space between takes) before or instead of word-level edits: remove_silence handles pauses, remove_words handles fillers and flubbed lines. No transcript needed. If it reports no dead air, speech analysis may still be running in the background — wait a moment and retry.",
             inputSchema: objectSchema(
                 properties: [
+                    "clipIds": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "minItems": 1,
+                        "description": "Optional timeline clip IDs from get_timeline. Restricts removal to these clips; linked A/V partners are cut with them. Clips must share one track or one link group. Omit to process the whole timeline.",
+                    ],
                     "minimumPauseSeconds": [
                         "type": "number",
                         "minimum": SilenceRemovalSettings.minimumPauseRange.lowerBound,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -3,7 +3,7 @@ import Foundation
 extension ToolExecutor {
 
     private static let removeWordsAllowedKeys: Set<String> = ["words", "matches", "cutAggressiveness", "language"]
-    private static let removeSilenceAllowedKeys: Set<String> = ["minimumPauseSeconds", "speechPaddingSeconds"]
+    private static let removeSilenceAllowedKeys: Set<String> = ["clipIds", "minimumPauseSeconds", "speechPaddingSeconds"]
 
     func removeWords(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.removeWordsAllowedKeys, path: "remove_words")
@@ -130,12 +130,36 @@ extension ToolExecutor {
             args,
             defaults: editor.silenceRemovalSettings
         )
+        let clipIds: [String]?
+        if let rawClipIds = args["clipIds"] {
+            guard let values = rawClipIds as? [Any], !values.isEmpty else {
+                throw ToolError("remove_silence: clipIds must be a non-empty array of clip IDs.")
+            }
+            var seen = Set<String>()
+            clipIds = try values.enumerated().compactMap { index, raw in
+                guard let value = raw as? String,
+                      !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw ToolError("remove_silence: clipIds[\(index)] must be a non-empty string.")
+                }
+                guard editor.findClip(id: value) != nil else {
+                    throw ToolError("Clip not found: \(value)")
+                }
+                return seen.insert(value).inserted ? value : nil
+            }
+        } else {
+            clipIds = nil
+        }
         let snapshot = timelineSnapshot(editor)
         let result = editor.undo.perform("Remove Silence (Agent)") {
-            editor.removeAllDeadAir(settings: settings)
+            if let clipIds {
+                editor.removeDeadAir(clipIds: clipIds, settings: settings)
+            } else {
+                editor.removeAllDeadAir(settings: settings)
+            }
         }
         guard let result else {
-            throw ToolError("No dead air on the timeline. Speech analysis may still be running, or the audio has no quiet non-speech sections.")
+            let scope = clipIds == nil ? "on the timeline" : "in the selected clips"
+            throw ToolError("No dead air \(scope). Speech analysis may still be running, or the audio has no quiet non-speech sections.")
         }
         if let refusal = result.refusal, result.sections == 0 {
             throw ToolError("Ripple delete refused: \(refusal)")
@@ -144,12 +168,13 @@ extension ToolExecutor {
         if let refusal = result.refusal {
             notes.append("A later track refused: \(refusal). Earlier tracks were already edited.")
         }
-        let extra: [String: Any] = [
+        var extra: [String: Any] = [
             "sectionsRemoved": result.sections,
             "removedFrames": result.removedFrames,
             "minimumPauseSeconds": settings.minimumPauseSeconds,
             "speechPaddingSeconds": settings.speechPaddingSeconds,
         ]
+        if let clipIds { extra["clipIds"] = clipIds }
         return mutationResult(
             editor, since: snapshot,
             extra: extra,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -150,12 +150,17 @@ extension ToolExecutor {
             clipIds = nil
         }
         let snapshot = timelineSnapshot(editor)
-        let result = editor.undo.perform("Remove Silence (Agent)") {
-            if let clipIds {
-                editor.removeDeadAir(clipIds: clipIds, settings: settings)
-            } else {
-                editor.removeAllDeadAir(settings: settings)
+        let result: (sections: Int, removedFrames: Int, refusal: String?)?
+        do {
+            result = try editor.undo.perform("Remove Silence (Agent)") {
+                if let clipIds {
+                    try editor.removeDeadAir(clipIds: clipIds, settings: settings)
+                } else {
+                    editor.removeAllDeadAir(settings: settings)
+                }
             }
+        } catch let error as DeadAirSelectionError {
+            throw ToolError("remove_silence: \(error.message)")
         }
         guard let result else {
             let scope = clipIds == nil ? "on the timeline" : "in the selected clips"

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Words.swift
@@ -3,6 +3,7 @@ import Foundation
 extension ToolExecutor {
 
     private static let removeWordsAllowedKeys: Set<String> = ["words", "matches", "cutAggressiveness", "language"]
+    private static let removeSilenceAllowedKeys: Set<String> = ["minimumPauseSeconds", "speechPaddingSeconds"]
 
     func removeWords(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
         try validateUnknownKeys(args, allowed: Self.removeWordsAllowedKeys, path: "remove_words")
@@ -125,10 +126,13 @@ extension ToolExecutor {
     }
 
     func removeSilence(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
-        try validateUnknownKeys(args, allowed: [], path: "remove_silence")
+        let settings = try Self.parseSilenceRemovalSettings(
+            args,
+            defaults: editor.silenceRemovalSettings
+        )
         let snapshot = timelineSnapshot(editor)
         let result = editor.undo.perform("Remove Silence (Agent)") {
-            editor.removeAllDeadAir()
+            editor.removeAllDeadAir(settings: settings)
         }
         guard let result else {
             throw ToolError("No dead air on the timeline. Speech analysis may still be running, or the audio has no quiet non-speech sections.")
@@ -140,11 +144,57 @@ extension ToolExecutor {
         if let refusal = result.refusal {
             notes.append("A later track refused: \(refusal). Earlier tracks were already edited.")
         }
+        let extra: [String: Any] = [
+            "sectionsRemoved": result.sections,
+            "removedFrames": result.removedFrames,
+            "minimumPauseSeconds": settings.minimumPauseSeconds,
+            "speechPaddingSeconds": settings.speechPaddingSeconds,
+        ]
         return mutationResult(
             editor, since: snapshot,
-            extra: ["sectionsRemoved": result.sections, "removedFrames": result.removedFrames],
+            extra: extra,
             notes: notes
         )
+    }
+
+    static func parseSilenceRemovalSettings(
+        _ args: [String: Any],
+        defaults: SilenceRemovalSettings
+    ) throws -> SilenceRemovalSettings {
+        try validateUnknownKeys(args, allowed: removeSilenceAllowedKeys, path: "remove_silence")
+
+        func value(
+            _ key: String,
+            fallback: Double,
+            range: ClosedRange<Double>
+        ) throws -> Double {
+            guard args[key] != nil else { return fallback }
+            guard let value = args.double(key), value.isFinite, range.contains(value) else {
+                throw ToolError(
+                    "remove_silence: \(key) must be a finite number from "
+                    + "\(range.lowerBound) through \(range.upperBound)."
+                )
+            }
+            return value
+        }
+
+        let minimumPause = try value(
+            "minimumPauseSeconds",
+            fallback: defaults.minimumPauseSeconds,
+            range: SilenceRemovalSettings.minimumPauseRange
+        )
+        let speechPadding = try value(
+            "speechPaddingSeconds",
+            fallback: defaults.speechPaddingSeconds,
+            range: SilenceRemovalSettings.speechPaddingRange
+        )
+        guard let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: minimumPause,
+            speechPaddingSeconds: speechPadding
+        ) else {
+            throw ToolError("remove_silence: invalid silence-removal settings.")
+        }
+        return settings
     }
 
     static func parseWordSpans(_ raw: [Any]) throws -> [(Int, Int)] {

--- a/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
@@ -34,13 +34,10 @@ enum SilenceRemovalPlanner {
         cellDuration: Double = VoiceActivity.chunkDuration
     ) -> [Bool] {
         guard !quietNonSpeechMask.isEmpty, cellDuration.isFinite, cellDuration > 0 else { return [] }
-        let maximumMinimumCells = quietNonSpeechMask.count == Int.max
-            ? Int.max
-            : quietNonSpeechMask.count + 1
         let minimumCells = cellCount(
             for: settings.minimumPauseSeconds,
             cellDuration: cellDuration,
-            maximum: maximumMinimumCells
+            maximum: quietNonSpeechMask.count + 1
         )
         let paddingCells = cellCount(
             for: settings.speechPaddingSeconds,
@@ -79,7 +76,9 @@ enum SilenceRemovalPlanner {
         cellDuration: Double = VoiceActivity.chunkDuration
     ) -> [Range<Double>] {
         let cellFrames = cellDuration * Double(max(1, framesPerSecond))
-        guard cellFrames.isFinite, cellFrames > 0 else { return [] }
+        guard cellFrames.isFinite, cellFrames > 0,
+              visibleSourceRange.lowerBound.isFinite,
+              visibleSourceRange.upperBound.isFinite else { return [] }
         let visibleCells = (visibleSourceRange.lowerBound / cellFrames)..<(visibleSourceRange.upperBound / cellFrames)
         return visibleRemovableCellRanges(
             from: removableMask,

--- a/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
@@ -1,0 +1,77 @@
+struct SilenceRemovalSettings: Equatable, Sendable {
+    static let minimumPauseRange = 0.25...3.0
+    static let speechPaddingRange = 0.0...0.5
+
+    static let `default` = SilenceRemovalSettings(
+        uncheckedMinimumPauseSeconds: 0.5,
+        uncheckedSpeechPaddingSeconds: 0.15
+    )
+
+    let minimumPauseSeconds: Double
+    let speechPaddingSeconds: Double
+
+    init?(minimumPauseSeconds: Double, speechPaddingSeconds: Double) {
+        guard minimumPauseSeconds.isFinite,
+              speechPaddingSeconds.isFinite,
+              Self.minimumPauseRange.contains(minimumPauseSeconds),
+              Self.speechPaddingRange.contains(speechPaddingSeconds) else { return nil }
+        self.init(
+            uncheckedMinimumPauseSeconds: minimumPauseSeconds,
+            uncheckedSpeechPaddingSeconds: speechPaddingSeconds
+        )
+    }
+
+    private init(uncheckedMinimumPauseSeconds: Double, uncheckedSpeechPaddingSeconds: Double) {
+        self.minimumPauseSeconds = uncheckedMinimumPauseSeconds
+        self.speechPaddingSeconds = uncheckedSpeechPaddingSeconds
+    }
+}
+
+enum SilenceRemovalPlanner {
+    static func removableMask(
+        from quietNonSpeechMask: [Bool],
+        settings: SilenceRemovalSettings,
+        cellDuration: Double = VoiceActivity.chunkDuration
+    ) -> [Bool] {
+        guard !quietNonSpeechMask.isEmpty, cellDuration.isFinite, cellDuration > 0 else { return [] }
+        let maximumMinimumCells = quietNonSpeechMask.count == Int.max
+            ? Int.max
+            : quietNonSpeechMask.count + 1
+        let minimumCells = cellCount(
+            for: settings.minimumPauseSeconds,
+            cellDuration: cellDuration,
+            maximum: maximumMinimumCells
+        )
+        let paddingCells = cellCount(
+            for: settings.speechPaddingSeconds,
+            cellDuration: cellDuration,
+            maximum: quietNonSpeechMask.count
+        )
+        var removable = [Bool](repeating: false, count: quietNonSpeechMask.count)
+        var i = 0
+
+        while i < quietNonSpeechMask.count {
+            guard quietNonSpeechMask[i] else {
+                i += 1
+                continue
+            }
+            var j = i + 1
+            while j < quietNonSpeechMask.count, quietNonSpeechMask[j] { j += 1 }
+            if j - i >= minimumCells {
+                let start = i + (i > 0 ? paddingCells : 0)
+                let end = j - (j < quietNonSpeechMask.count ? paddingCells : 0)
+                if start < end {
+                    for cell in start..<end { removable[cell] = true }
+                }
+            }
+            i = j
+        }
+        return removable
+    }
+
+    private static func cellCount(for seconds: Double, cellDuration: Double, maximum: Int) -> Int {
+        let count = (seconds / cellDuration).rounded(.up)
+        guard count.isFinite, count < Double(maximum) else { return maximum }
+        return max(0, Int(count))
+    }
+}

--- a/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SilenceRemovalSettings.swift
@@ -69,6 +69,87 @@ enum SilenceRemovalPlanner {
         return removable
     }
 
+    /// Clip-visible removable ranges in source-frame coordinates. These are the source of truth
+    /// for both timeline shading and removal, including unpadded exposed clip edges.
+    static func visibleRemovableRanges(
+        from removableMask: [Bool],
+        visibleSourceRange: Range<Double>,
+        framesPerSecond: Int,
+        settings: SilenceRemovalSettings,
+        cellDuration: Double = VoiceActivity.chunkDuration
+    ) -> [Range<Double>] {
+        let cellFrames = cellDuration * Double(max(1, framesPerSecond))
+        guard cellFrames.isFinite, cellFrames > 0 else { return [] }
+        let visibleCells = (visibleSourceRange.lowerBound / cellFrames)..<(visibleSourceRange.upperBound / cellFrames)
+        return visibleRemovableCellRanges(
+            from: removableMask,
+            visibleRange: visibleCells,
+            settings: settings,
+            cellDuration: cellDuration
+        ).map { ($0.lowerBound * cellFrames)..<($0.upperBound * cellFrames) }
+    }
+
+    private static func visibleRemovableCellRanges(
+        from removableMask: [Bool],
+        visibleRange: Range<Double>,
+        settings: SilenceRemovalSettings,
+        cellDuration: Double
+    ) -> [Range<Double>] {
+        guard !removableMask.isEmpty, !visibleRange.isEmpty,
+              visibleRange.lowerBound.isFinite, visibleRange.upperBound.isFinite,
+              cellDuration.isFinite, cellDuration > 0 else { return [] }
+        let edgePadding = Double(cellCount(
+            for: settings.speechPaddingSeconds,
+            cellDuration: cellDuration,
+            maximum: removableMask.count
+        ))
+        let scanStart = Int(max(
+            0,
+            min(Double(removableMask.count), (visibleRange.lowerBound - edgePadding).rounded(.down))
+        ))
+        let scanEnd = Int(max(
+            Double(scanStart),
+            min(Double(removableMask.count), (visibleRange.upperBound + edgePadding).rounded(.up))
+        ))
+        var ranges: [Range<Double>] = []
+        var i = scanStart
+        while i < scanEnd {
+            guard removableMask[i] else { i += 1; continue }
+            var j = i + 1
+            while j < scanEnd, removableMask[j] { j += 1 }
+            let sourceRange = Double(i)..<Double(j)
+            let expanded = expandingToVisibleEdges(
+                sourceRange,
+                within: visibleRange,
+                edgePadding: edgePadding
+            )
+            if expanded.overlaps(visibleRange) {
+                let start = max(expanded.lowerBound, visibleRange.lowerBound)
+                let end = min(expanded.upperBound, visibleRange.upperBound)
+                if start < end { ranges.append(start..<end) }
+            }
+            i = j
+        }
+        return ranges
+    }
+
+    private static func expandingToVisibleEdges(
+        _ removableRange: Range<Double>,
+        within visibleRange: Range<Double>,
+        edgePadding: Double
+    ) -> Range<Double> {
+        guard edgePadding >= 0 else { return removableRange }
+        let start = removableRange.upperBound > visibleRange.lowerBound
+            && removableRange.lowerBound <= visibleRange.lowerBound + edgePadding
+            ? visibleRange.lowerBound
+            : removableRange.lowerBound
+        let end = removableRange.lowerBound < visibleRange.upperBound
+            && removableRange.upperBound >= visibleRange.upperBound - edgePadding
+            ? visibleRange.upperBound
+            : removableRange.upperBound
+        return start..<end
+    }
+
     private static func cellCount(for seconds: Double, cellDuration: Double, maximum: Int) -> Int {
         let count = (seconds / cellDuration).rounded(.up)
         guard count.isFinite, count < Double(maximum) else { return maximum }

--- a/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
@@ -4,7 +4,8 @@ import Foundation
 @MainActor
 final class SpeechMaskStore {
     private var speechMasks: [String: [Bool]] = [:]
-    private var deadAirMasks: [String: [Bool]] = [:]
+    private var quietNonSpeechMasks: [String: [Bool]] = [:]
+    private var deadAirMasks: [String: (settings: SilenceRemovalSettings, mask: [Bool])] = [:]
     private var failed: Set<String> = []
     private var epoch: [String: Int] = [:]
     private var inFlight: Set<String> = [] {
@@ -44,6 +45,7 @@ final class SpeechMaskStore {
                 self.inFlight.remove(key)
                 if let mask {
                     self.speechMasks[key] = mask
+                    self.quietNonSpeechMasks.removeValue(forKey: key)
                     self.deadAirMasks.removeValue(forKey: key)
                     if !mask.isEmpty { self.onMaskReady?() }
                 } else {
@@ -58,6 +60,7 @@ final class SpeechMaskStore {
         for key in inFlight { epoch[key, default: 0] += 1 }
         inFlight.removeAll()
         speechMasks.removeAll()
+        quietNonSpeechMasks.removeAll()
         deadAirMasks.removeAll()
         failed.removeAll()
     }
@@ -66,6 +69,7 @@ final class SpeechMaskStore {
         epoch[mediaRef, default: 0] += 1
         inFlight.remove(mediaRef)
         speechMasks.removeValue(forKey: mediaRef)
+        quietNonSpeechMasks.removeValue(forKey: mediaRef)
         deadAirMasks.removeValue(forKey: mediaRef)
         failed.remove(mediaRef)
     }
@@ -75,21 +79,28 @@ final class SpeechMaskStore {
     // Marks a span as dead air if its median level is `speechGap` below the file's speech level, using normalized waveform values.
     private nonisolated static let speechGap: Float = 0.24      // 12 dB
     private nonisolated static let noSpeechFloor: Float = 0.56  // absolute fallback ≈ -28 dB
-    private nonisolated static let minCells = 8                 // ≈ 0.26 s
-
     /// Derived lazily once the speech mask and waveform samples both exist.
-    nonisolated func deadAirMask(for mediaRef: String, samples: [Float]?) -> [Bool]? {
+    nonisolated func deadAirMask(
+        for mediaRef: String,
+        samples: [Float]?,
+        settings: SilenceRemovalSettings
+    ) -> [Bool]? {
         MainActor.assumeIsolated {
-            if let cached = deadAirMasks[mediaRef] { return cached }
+            if let cached = deadAirMasks[mediaRef], cached.settings == settings { return cached.mask }
             guard let speech = speechMasks[mediaRef], !speech.isEmpty,
                   let samples, !samples.isEmpty else { return nil }
-            let mask = Self.buildDeadAirMask(speech: speech, samples: samples)
-            deadAirMasks[mediaRef] = mask
+            let quietNonSpeech = quietNonSpeechMasks[mediaRef] ?? Self.buildQuietNonSpeechMask(
+                speech: speech,
+                samples: samples
+            )
+            quietNonSpeechMasks[mediaRef] = quietNonSpeech
+            let mask = SilenceRemovalPlanner.removableMask(from: quietNonSpeech, settings: settings)
+            deadAirMasks[mediaRef] = (settings, mask)
             return mask
         }
     }
 
-    private nonisolated static func buildDeadAirMask(speech: [Bool], samples: [Float]) -> [Bool] {
+    private nonisolated static func buildQuietNonSpeechMask(speech: [Bool], samples: [Float]) -> [Bool] {
         let n = speech.count
         func cellPeak(_ c: Int) -> Float {
             let s0 = c * samples.count / n
@@ -111,7 +122,7 @@ final class SpeechMaskStore {
             guard !speech[i] else { i += 1; continue }
             var j = i
             while j < n && !speech[j] { j += 1 }
-            if j - i >= Self.minCells, median((i..<j).map(cellPeak)) >= quietFloor {
+            if median((i..<j).map(cellPeak)) >= quietFloor {
                 for c in i..<j { dead[c] = true }
             }
             i = j

--- a/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
@@ -79,6 +79,16 @@ final class SpeechMaskStore {
     // Marks a span as dead air if its median level is `speechGap` below the file's speech level, using normalized waveform values.
     private nonisolated static let speechGap: Float = 0.24      // 12 dB
     private nonisolated static let noSpeechFloor: Float = 0.56  // absolute fallback ≈ -28 dB
+    /// Quiet, non-speech cells before minimum-pause and speech-padding policy is applied.
+    nonisolated func quietNonSpeechMask(
+        for mediaRef: String,
+        samples: [Float]?
+    ) -> [Bool]? {
+        MainActor.assumeIsolated {
+            quietNonSpeechMaskIsolated(for: mediaRef, samples: samples)
+        }
+    }
+
     /// Derived lazily once the speech mask and waveform samples both exist.
     nonisolated func deadAirMask(
         for mediaRef: String,
@@ -87,17 +97,26 @@ final class SpeechMaskStore {
     ) -> [Bool]? {
         MainActor.assumeIsolated {
             if let cached = deadAirMasks[mediaRef], cached.settings == settings { return cached.mask }
-            guard let speech = speechMasks[mediaRef], !speech.isEmpty,
-                  let samples, !samples.isEmpty else { return nil }
-            let quietNonSpeech = quietNonSpeechMasks[mediaRef] ?? Self.buildQuietNonSpeechMask(
-                speech: speech,
+            guard let quietNonSpeech = quietNonSpeechMaskIsolated(
+                for: mediaRef,
                 samples: samples
-            )
-            quietNonSpeechMasks[mediaRef] = quietNonSpeech
+            ) else { return nil }
             let mask = SilenceRemovalPlanner.removableMask(from: quietNonSpeech, settings: settings)
             deadAirMasks[mediaRef] = (settings, mask)
             return mask
         }
+    }
+
+    private func quietNonSpeechMaskIsolated(
+        for mediaRef: String,
+        samples: [Float]?
+    ) -> [Bool]? {
+        if let cached = quietNonSpeechMasks[mediaRef] { return cached }
+        guard let speech = speechMasks[mediaRef], !speech.isEmpty,
+              let samples, !samples.isEmpty else { return nil }
+        let mask = Self.buildQuietNonSpeechMask(speech: speech, samples: samples)
+        quietNonSpeechMasks[mediaRef] = mask
+        return mask
     }
 
     private nonisolated static func buildQuietNonSpeechMask(speech: [Bool], samples: [Float]) -> [Bool] {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -19,11 +19,11 @@ extension EditorViewModel {
         silenceRemovalSettings = settings
     }
 
-    private func deadAirMask(for clip: Clip) -> [Bool]? {
+    private func deadAirMask(for clip: Clip, settings: SilenceRemovalSettings) -> [Bool]? {
         guard let member = multicamGroup(of: clip)?.member(mediaRef: clip.mediaRef) else {
-            return mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: silenceRemovalSettings)
+            return mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: settings)
         }
-        guard let groupMask = multicamDeadAirMask(for: clip) else { return nil }
+        guard let groupMask = multicamDeadAirMask(for: clip, settings: settings) else { return nil }
         let shift = Int((member.sync.offsetSeconds / VoiceActivity.chunkDuration).rounded())
         if shift > 0 { return Array(groupMask.dropFirst(shift)) }
         if shift < 0 { return [Bool](repeating: false, count: -shift) + groupMask }
@@ -32,7 +32,7 @@ extension EditorViewModel {
 
     /// The dead-air span under `timelineFrame` in `clip`, as a timeline range. Nil when the frame isn't dead air.
     func deadAirSpanRange(clip: Clip, atTimelineFrame frame: Int) -> FrameRange? {
-        guard let mask = deadAirMask(for: clip), !mask.isEmpty else { return nil }
+        guard let mask = deadAirMask(for: clip, settings: silenceRemovalSettings), !mask.isEmpty else { return nil }
         let cellFrames = VoiceActivity.chunkDuration * Double(max(1, timeline.fps))
         let sourceFrame = Double(clip.trimStartFrame) + Double(frame - clip.startFrame) * clip.speed
         let cell = Int(sourceFrame / cellFrames)
@@ -45,8 +45,12 @@ extension EditorViewModel {
     }
 
     /// Every dead-air span visible within `clip`, as timeline ranges.
-    func deadAirRanges(for clip: Clip) -> [FrameRange] {
-        guard let mask = deadAirMask(for: clip), !mask.isEmpty else { return [] }
+    func deadAirRanges(
+        for clip: Clip,
+        settings: SilenceRemovalSettings? = nil
+    ) -> [FrameRange] {
+        let effectiveSettings = settings ?? silenceRemovalSettings
+        guard let mask = deadAirMask(for: clip, settings: effectiveSettings), !mask.isEmpty else { return [] }
         let cellFrames = VoiceActivity.chunkDuration * Double(max(1, timeline.fps))
         var ranges: [FrameRange] = []
         var i = 0
@@ -63,10 +67,13 @@ extension EditorViewModel {
     }
 
     /// Dead-air ranges grouped by track; each track ripples its own spans.
-    func allDeadAir() -> [(trackIndex: Int, ranges: [FrameRange])] {
+    func allDeadAir(
+        settings: SilenceRemovalSettings? = nil
+    ) -> [(trackIndex: Int, ranges: [FrameRange])] {
+        let effectiveSettings = settings ?? silenceRemovalSettings
         var out: [(Int, [FrameRange])] = []
         for (ti, track) in timeline.tracks.enumerated() where track.type == .audio {
-            let ranges = track.clips.flatMap { deadAirRanges(for: $0) }
+            let ranges = track.clips.flatMap { deadAirRanges(for: $0, settings: effectiveSettings) }
             if !ranges.isEmpty { out.append((ti, ranges)) }
         }
         return out
@@ -84,13 +91,16 @@ extension EditorViewModel {
 
     /// Ripples dead air per-track, updating ranges between passes. Stops if a track refuses.
     @discardableResult
-    func removeAllDeadAir() -> (sections: Int, removedFrames: Int, refusal: String?)? {
-        undo.perform("Remove Dead Air") {
+    func removeAllDeadAir(
+        settings: SilenceRemovalSettings? = nil
+    ) -> (sections: Int, removedFrames: Int, refusal: String?)? {
+        let effectiveSettings = settings ?? silenceRemovalSettings
+        return undo.perform("Remove Dead Air") { () -> (sections: Int, removedFrames: Int, refusal: String?)? in
             var sections = 0
             var removedFrames = 0
             var refusal: String?
             for _ in timeline.tracks.indices {
-                guard let next = allDeadAir().first else { break }
+                guard let next = allDeadAir(settings: effectiveSettings).first else { break }
                 switch rippleDeleteRangesOnTrack(trackIndex: next.trackIndex, ranges: next.ranges) {
                 case .ok(let report):
                     sections += next.ranges.count

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -32,16 +32,10 @@ extension EditorViewModel {
 
     /// The dead-air span under `timelineFrame` in `clip`, as a timeline range. Nil when the frame isn't dead air.
     func deadAirSpanRange(clip: Clip, atTimelineFrame frame: Int) -> FrameRange? {
-        guard let mask = deadAirMask(for: clip, settings: silenceRemovalSettings), !mask.isEmpty else { return nil }
-        let cellFrames = VoiceActivity.chunkDuration * Double(max(1, timeline.fps))
         let sourceFrame = Double(clip.trimStartFrame) + Double(frame - clip.startFrame) * clip.speed
-        let cell = Int(sourceFrame / cellFrames)
-        guard mask.indices.contains(cell), mask[cell] else { return nil }
-        var lo = cell
-        while lo > 0 && mask[lo - 1] { lo -= 1 }
-        var hi = cell + 1
-        while hi < mask.count && mask[hi] { hi += 1 }
-        return timelineRange(clip: clip, sourceStart: Double(lo) * cellFrames, sourceEnd: Double(hi) * cellFrames)
+        guard let sourceRange = deadAirSourceRanges(for: clip, settings: silenceRemovalSettings)
+            .first(where: { $0.contains(sourceFrame) }) else { return nil }
+        return timelineRange(clip: clip, sourceStart: sourceRange.lowerBound, sourceEnd: sourceRange.upperBound)
     }
 
     /// Every dead-air span visible within `clip`, as timeline ranges.
@@ -50,20 +44,9 @@ extension EditorViewModel {
         settings: SilenceRemovalSettings? = nil
     ) -> [FrameRange] {
         let effectiveSettings = settings ?? silenceRemovalSettings
-        guard let mask = deadAirMask(for: clip, settings: effectiveSettings), !mask.isEmpty else { return [] }
-        let cellFrames = VoiceActivity.chunkDuration * Double(max(1, timeline.fps))
-        var ranges: [FrameRange] = []
-        var i = 0
-        while i < mask.count {
-            guard mask[i] else { i += 1; continue }
-            var j = i
-            while j < mask.count && mask[j] { j += 1 }
-            if let r = timelineRange(clip: clip, sourceStart: Double(i) * cellFrames, sourceEnd: Double(j) * cellFrames) {
-                ranges.append(r)
-            }
-            i = j
+        return deadAirSourceRanges(for: clip, settings: effectiveSettings).compactMap {
+            timelineRange(clip: clip, sourceStart: $0.lowerBound, sourceEnd: $0.upperBound)
         }
-        return ranges
     }
 
     /// Dead-air ranges grouped by track; each track ripples its own spans.
@@ -158,6 +141,21 @@ extension EditorViewModel {
             guard sections > 0 || refusal != nil else { return nil }
             return (sections, removedFrames, refusal)
         }
+    }
+
+    private func deadAirSourceRanges(
+        for clip: Clip,
+        settings: SilenceRemovalSettings
+    ) -> [Range<Double>] {
+        guard let mask = deadAirMask(for: clip, settings: settings), !mask.isEmpty else { return [] }
+        let visibleStart = Double(clip.trimStartFrame)
+        let visibleEnd = Double(clip.trimStartFrame + clip.sourceFramesConsumed)
+        return SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: visibleStart..<visibleEnd,
+            framesPerSecond: timeline.fps,
+            settings: settings
+        )
     }
 
     private func timelineRange(clip: Clip, sourceStart: Double, sourceEnd: Double) -> FrameRange? {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -89,6 +89,49 @@ extension EditorViewModel {
         }
     }
 
+    /// Ripples every dead-air span within selected clips on one track or in one linked A/V unit.
+    @discardableResult
+    func removeDeadAir(
+        clipIds: [String],
+        settings: SilenceRemovalSettings
+    ) -> (sections: Int, removedFrames: Int, refusal: String?)? {
+        let targets = clipIds.compactMap { id -> (trackIndex: Int, clip: Clip)? in
+            guard let loc = findClip(id: id) else { return nil }
+            return (loc.trackIndex, timeline.tracks[loc.trackIndex].clips[loc.clipIndex])
+        }
+        guard targets.count == clipIds.count, !targets.isEmpty else { return nil }
+
+        let trackIndices = Set(targets.map(\.trackIndex))
+        let anchorTrackIndex: Int
+        let anchorClips: [Clip]
+        if trackIndices.count == 1, let onlyTrack = trackIndices.first {
+            anchorTrackIndex = onlyTrack
+            anchorClips = targets.map(\.clip)
+        } else {
+            let linkGroups = targets.compactMap { $0.clip.linkGroupId }
+            guard linkGroups.count == targets.count, Set(linkGroups).count == 1 else {
+                return (0, 0, "Selected clips must share one track or belong to one linked A/V unit.")
+            }
+            anchorTrackIndex = trackIndices
+                .filter { timeline.tracks[$0].type == .audio }
+                .min() ?? trackIndices.min()!
+            anchorClips = targets.filter { $0.trackIndex == anchorTrackIndex }.map(\.clip)
+        }
+
+        let ranges = RippleEngine.mergeRanges(
+            anchorClips.flatMap { deadAirRanges(for: $0, settings: settings) }
+        )
+        guard !ranges.isEmpty else { return nil }
+        switch rippleDeleteRangesOnTrack(trackIndex: anchorTrackIndex, ranges: ranges) {
+        case .ok(let report):
+            return (ranges.count, report.removedFrames, nil)
+        case .refused(let reason):
+            NSSound.beep()
+            Log.editor.notice("remove dead air blocked: \(reason)")
+            return (0, 0, reason)
+        }
+    }
+
     /// Ripples dead air per-track, updating ranges between passes. Stops if a track refuses.
     @discardableResult
     func removeAllDeadAir(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -3,19 +3,17 @@ import AppKit
 enum DeadAirMaskResolver {
     static func mask(
         for clip: Clip,
-        in group: MulticamSource?,
-        maskForMedia: (String) -> [Bool]?
+        in group: MulticamSource,
+        settings: SilenceRemovalSettings,
+        quietMaskForMedia: (String) -> [Bool]?
     ) -> [Bool]? {
-        guard let group,
-              let member = group.member(mediaRef: clip.mediaRef) else {
-            return maskForMedia(clip.mediaRef)
-        }
-        guard clip.mediaType == .audio, !group.mics.isEmpty else { return nil }
+        guard let member = group.member(mediaRef: clip.mediaRef),
+              clip.mediaType == .audio, !group.mics.isEmpty else { return nil }
 
         let cellSeconds = VoiceActivity.chunkDuration
         var masks: [[Bool]] = []
         for mic in group.mics {
-            guard let mask = maskForMedia(mic.mediaRef), !mask.isEmpty else { return nil }
+            guard let mask = quietMaskForMedia(mic.mediaRef), !mask.isEmpty else { return nil }
             let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
             var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))
             for (i, dead) in mask.enumerated() where i + shift >= 0 && i + shift < shifted.count {
@@ -28,10 +26,20 @@ enum DeadAirMaskResolver {
             masks.allSatisfy { i >= $0.count || $0[i] }
         }
         let shift = Int((member.sync.offsetSeconds / cellSeconds).rounded())
-        if shift > 0 { return Array(groupMask.dropFirst(shift)) }
-        if shift < 0 { return [Bool](repeating: false, count: -shift) + groupMask }
-        return groupMask
+        let memberMask: [Bool]
+        if shift > 0 {
+            memberMask = Array(groupMask.dropFirst(shift))
+        } else if shift < 0 {
+            memberMask = [Bool](repeating: false, count: -shift) + groupMask
+        } else {
+            memberMask = groupMask
+        }
+        return SilenceRemovalPlanner.removableMask(from: memberMask, settings: settings)
     }
+}
+
+struct DeadAirSelectionError: Error, Equatable, Sendable {
+    let message: String
 }
 
 /// Dead-air removal: maps SpeechMaskStore spans onto timeline ranges and ripple-deletes them.
@@ -76,7 +84,9 @@ extension EditorViewModel {
         let effectiveSettings = settings ?? silenceRemovalSettings
         var out: [(Int, [FrameRange])] = []
         for (ti, track) in timeline.tracks.enumerated() where track.type == .audio {
-            let ranges = track.clips.flatMap { deadAirRanges(for: $0, settings: effectiveSettings) }
+            let ranges = RippleEngine.mergeRanges(
+                track.clips.flatMap { deadAirRanges(for: $0, settings: effectiveSettings) }
+            )
             if !ranges.isEmpty { out.append((ti, ranges)) }
         }
         return out
@@ -97,41 +107,46 @@ extension EditorViewModel {
     func removeDeadAir(
         clipIds: [String],
         settings: SilenceRemovalSettings
-    ) -> (sections: Int, removedFrames: Int, refusal: String?)? {
+    ) throws -> (sections: Int, removedFrames: Int, refusal: String?)? {
         let targets = clipIds.compactMap { id -> (trackIndex: Int, clip: Clip)? in
             guard let loc = findClip(id: id) else { return nil }
             return (loc.trackIndex, timeline.tracks[loc.trackIndex].clips[loc.clipIndex])
         }
-        guard targets.count == clipIds.count, !targets.isEmpty else { return nil }
+        guard targets.count == clipIds.count, !targets.isEmpty else {
+            throw DeadAirSelectionError(message: "Selected clips could not be resolved.")
+        }
+        let audioTargets = targets.filter { $0.clip.mediaType == .audio }
+        guard !audioTargets.isEmpty else {
+            throw DeadAirSelectionError(message: "Selected clips must include at least one audio clip.")
+        }
 
         let trackIndices = Set(targets.map(\.trackIndex))
-        let anchorTrackIndex: Int
-        let anchorClips: [Clip]
-        if trackIndices.count == 1, let onlyTrack = trackIndices.first {
-            anchorTrackIndex = onlyTrack
-            anchorClips = targets.map(\.clip)
-        } else {
+        if trackIndices.count > 1 {
             let linkGroups = targets.compactMap { $0.clip.linkGroupId }
             guard linkGroups.count == targets.count, Set(linkGroups).count == 1 else {
-                return (0, 0, "Selected clips must share one track or belong to one linked A/V unit.")
+                throw DeadAirSelectionError(
+                    message: "Selected clips must share one track or belong to one linked A/V unit."
+                )
             }
-            anchorTrackIndex = trackIndices
-                .filter { timeline.tracks[$0].type == .audio }
-                .min() ?? trackIndices.min()!
-            anchorClips = targets.filter { $0.trackIndex == anchorTrackIndex }.map(\.clip)
+        }
+        let audioTrackIndices = Set(audioTargets.map(\.trackIndex))
+        guard audioTrackIndices.count == 1, let anchorTrackIndex = audioTrackIndices.first else {
+            throw DeadAirSelectionError(message: "Selected audio clips must come from one track.")
         }
 
         let ranges = RippleEngine.mergeRanges(
-            anchorClips.flatMap { deadAirRanges(for: $0, settings: settings) }
+            audioTargets.flatMap { deadAirRanges(for: $0.clip, settings: settings) }
         )
         guard !ranges.isEmpty else { return nil }
-        switch rippleDeleteRangesOnTrack(trackIndex: anchorTrackIndex, ranges: ranges) {
-        case .ok(let report):
-            return (ranges.count, report.removedFrames, nil)
-        case .refused(let reason):
-            NSSound.beep()
-            Log.editor.notice("remove dead air blocked: \(reason)")
-            return (0, 0, reason)
+        return undo.perform("Remove Dead Air") {
+            switch rippleDeleteRangesOnTrack(trackIndex: anchorTrackIndex, ranges: ranges) {
+            case .ok(let report):
+                return (ranges.count, report.removedFrames, nil)
+            case .refused(let reason):
+                NSSound.beep()
+                Log.editor.notice("remove dead air blocked: \(reason)")
+                return (0, 0, reason)
+            }
         }
     }
 
@@ -167,11 +182,18 @@ extension EditorViewModel {
         for clip: Clip,
         settings: SilenceRemovalSettings
     ) -> [Range<Double>] {
-        guard let mask = DeadAirMaskResolver.mask(
-            for: clip,
-            in: multicamGroup(of: clip),
-            maskForMedia: { mediaVisualCache.deadAirMask(for: $0, settings: settings) }
-        ), !mask.isEmpty else { return [] }
+        let mask: [Bool]?
+        if let group = multicamGroup(of: clip) {
+            mask = DeadAirMaskResolver.mask(
+                for: clip,
+                in: group,
+                settings: settings,
+                quietMaskForMedia: { mediaVisualCache.quietNonSpeechMask(for: $0) }
+            )
+        } else {
+            mask = mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: settings)
+        }
+        guard let mask, !mask.isEmpty else { return [] }
         let visibleStart = Double(clip.trimStartFrame)
         let visibleEnd = Double(clip.trimStartFrame + clip.sourceFramesConsumed)
         return SilenceRemovalPlanner.visibleRemovableRanges(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -1,5 +1,39 @@
 import AppKit
 
+enum DeadAirMaskResolver {
+    static func mask(
+        for clip: Clip,
+        in group: MulticamSource?,
+        maskForMedia: (String) -> [Bool]?
+    ) -> [Bool]? {
+        guard let group,
+              let member = group.member(mediaRef: clip.mediaRef) else {
+            return maskForMedia(clip.mediaRef)
+        }
+        guard clip.mediaType == .audio, !group.mics.isEmpty else { return nil }
+
+        let cellSeconds = VoiceActivity.chunkDuration
+        var masks: [[Bool]] = []
+        for mic in group.mics {
+            guard let mask = maskForMedia(mic.mediaRef), !mask.isEmpty else { return nil }
+            let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
+            var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))
+            for (i, dead) in mask.enumerated() where i + shift >= 0 && i + shift < shifted.count {
+                shifted[i + shift] = dead
+            }
+            masks.append(shifted)
+        }
+
+        let groupMask = (0..<(masks.map(\.count).max() ?? 0)).map { i in
+            masks.allSatisfy { i >= $0.count || $0[i] }
+        }
+        let shift = Int((member.sync.offsetSeconds / cellSeconds).rounded())
+        if shift > 0 { return Array(groupMask.dropFirst(shift)) }
+        if shift < 0 { return [Bool](repeating: false, count: -shift) + groupMask }
+        return groupMask
+    }
+}
+
 /// Dead-air removal: maps SpeechMaskStore spans onto timeline ranges and ripple-deletes them.
 extension EditorViewModel {
 
@@ -19,23 +53,9 @@ extension EditorViewModel {
         silenceRemovalSettings = settings
     }
 
-    private func deadAirMask(for clip: Clip, settings: SilenceRemovalSettings) -> [Bool]? {
-        guard let member = multicamGroup(of: clip)?.member(mediaRef: clip.mediaRef) else {
-            return mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: settings)
-        }
-        guard let groupMask = multicamDeadAirMask(for: clip, settings: settings) else { return nil }
-        let shift = Int((member.sync.offsetSeconds / VoiceActivity.chunkDuration).rounded())
-        if shift > 0 { return Array(groupMask.dropFirst(shift)) }
-        if shift < 0 { return [Bool](repeating: false, count: -shift) + groupMask }
-        return groupMask
-    }
-
     /// The dead-air span under `timelineFrame` in `clip`, as a timeline range. Nil when the frame isn't dead air.
     func deadAirSpanRange(clip: Clip, atTimelineFrame frame: Int) -> FrameRange? {
-        let sourceFrame = Double(clip.trimStartFrame) + Double(frame - clip.startFrame) * clip.speed
-        guard let sourceRange = deadAirSourceRanges(for: clip, settings: silenceRemovalSettings)
-            .first(where: { $0.contains(sourceFrame) }) else { return nil }
-        return timelineRange(clip: clip, sourceStart: sourceRange.lowerBound, sourceEnd: sourceRange.upperBound)
+        deadAirRanges(for: clip).first { $0.start <= frame && frame < $0.end }
     }
 
     /// Every dead-air span visible within `clip`, as timeline ranges.
@@ -143,11 +163,15 @@ extension EditorViewModel {
         }
     }
 
-    private func deadAirSourceRanges(
+    func deadAirSourceRanges(
         for clip: Clip,
         settings: SilenceRemovalSettings
     ) -> [Range<Double>] {
-        guard let mask = deadAirMask(for: clip, settings: settings), !mask.isEmpty else { return [] }
+        guard let mask = DeadAirMaskResolver.mask(
+            for: clip,
+            in: multicamGroup(of: clip),
+            maskForMedia: { mediaVisualCache.deadAirMask(for: $0, settings: settings) }
+        ), !mask.isEmpty else { return [] }
         let visibleStart = Double(clip.trimStartFrame)
         let visibleEnd = Double(clip.trimStartFrame + clip.sourceFramesConsumed)
         return SilenceRemovalPlanner.visibleRemovableRanges(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -3,9 +3,25 @@ import AppKit
 /// Dead-air removal: maps SpeechMaskStore spans onto timeline ranges and ripple-deletes them.
 extension EditorViewModel {
 
+    func setMinimumSilenceDuration(_ seconds: Double) {
+        guard let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: seconds,
+            speechPaddingSeconds: silenceRemovalSettings.speechPaddingSeconds
+        ) else { return }
+        silenceRemovalSettings = settings
+    }
+
+    func setSpeechPaddingDuration(_ seconds: Double) {
+        guard let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: silenceRemovalSettings.minimumPauseSeconds,
+            speechPaddingSeconds: seconds
+        ) else { return }
+        silenceRemovalSettings = settings
+    }
+
     private func deadAirMask(for clip: Clip) -> [Bool]? {
         guard let member = multicamGroup(of: clip)?.member(mediaRef: clip.mediaRef) else {
-            return mediaVisualCache.deadAirMask(for: clip.mediaRef)
+            return mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: silenceRemovalSettings)
         }
         guard let groupMask = multicamDeadAirMask(for: clip) else { return nil }
         let shift = Int((member.sync.offsetSeconds / VoiceActivity.chunkDuration).rounded())

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -562,7 +562,10 @@ extension EditorViewModel {
 
     // MARK: - Dead air (remove_silence)
 
-    func multicamDeadAirMask(for clip: Clip) -> [Bool]? {
+    func multicamDeadAirMask(
+        for clip: Clip,
+        settings: SilenceRemovalSettings
+    ) -> [Bool]? {
         guard clip.mediaType == .audio, let group = multicamGroup(of: clip) else { return nil }
         let mics = group.mics
         guard !mics.isEmpty else { return nil }
@@ -571,7 +574,7 @@ extension EditorViewModel {
         for mic in mics {
             guard let mask = mediaVisualCache.deadAirMask(
                 for: mic.mediaRef,
-                settings: silenceRemovalSettings
+                settings: settings
             ), !mask.isEmpty else { return nil }
             let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
             var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -560,29 +560,4 @@ extension EditorViewModel {
             AngleSwitchRequest(range: range, angle: angle))
     }
 
-    // MARK: - Dead air (remove_silence)
-
-    func multicamDeadAirMask(
-        for clip: Clip,
-        settings: SilenceRemovalSettings
-    ) -> [Bool]? {
-        guard clip.mediaType == .audio, let group = multicamGroup(of: clip) else { return nil }
-        let mics = group.mics
-        guard !mics.isEmpty else { return nil }
-        let cellSeconds = VoiceActivity.chunkDuration
-        var masks: [[Bool]] = []
-        for mic in mics {
-            guard let mask = mediaVisualCache.deadAirMask(
-                for: mic.mediaRef,
-                settings: settings
-            ), !mask.isEmpty else { return nil }
-            let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
-            var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))
-            for (i, dead) in mask.enumerated() where i + shift >= 0 && i + shift < shifted.count {
-                shifted[i + shift] = dead
-            }
-            masks.append(shifted)
-        }
-        return (0..<(masks.map(\.count).max() ?? 0)).map { i in masks.allSatisfy { i >= $0.count || $0[i] } }
-    }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Multicam.swift
@@ -569,7 +569,10 @@ extension EditorViewModel {
         let cellSeconds = VoiceActivity.chunkDuration
         var masks: [[Bool]] = []
         for mic in mics {
-            guard let mask = mediaVisualCache.deadAirMask(for: mic.mediaRef), !mask.isEmpty else { return nil }
+            guard let mask = mediaVisualCache.deadAirMask(
+                for: mic.mediaRef,
+                settings: silenceRemovalSettings
+            ), !mask.isEmpty else { return nil }
             let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
             var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))
             for (i, dead) in mask.enumerated() where i + shift >= 0 && i + shift < shifted.count {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -227,6 +227,12 @@ final class EditorViewModel {
         }
     }
 
+    var silenceRemovalSettings = SilenceRemovalSettings.default {
+        didSet {
+            mediaVisualCache.timelineView?.needsDisplay = true
+        }
+    }
+
     var markBeats: Bool = {
         UserDefaults.standard.object(forKey: "markBeats") as? Bool ?? true
     }() {

--- a/Sources/PalmierPro/Inspector/Components/InspectorRow.swift
+++ b/Sources/PalmierPro/Inspector/Components/InspectorRow.swift
@@ -4,17 +4,20 @@ import SwiftUI
 struct InspectorRow<Trailing: View>: View {
     let label: String
     let labelHelp: String?
+    let labelAlignment: Alignment
     let onReset: (() -> Void)?
     @ViewBuilder let trailing: () -> Trailing
 
     init(
         label: String,
         labelHelp: String? = nil,
+        labelAlignment: Alignment = .trailing,
         onReset: (() -> Void)? = nil,
         @ViewBuilder trailing: @escaping () -> Trailing
     ) {
         self.label = label
         self.labelHelp = labelHelp
+        self.labelAlignment = labelAlignment
         self.onReset = onReset
         self.trailing = trailing
     }
@@ -34,7 +37,7 @@ struct InspectorRow<Trailing: View>: View {
                 .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.regular))
                 .foregroundStyle(AppTheme.Text.secondaryColor)
                 .lineLimit(1)
-                .frame(width: AppTheme.EditorPanel.labelColumnWidth, alignment: .trailing)
+                .frame(width: AppTheme.EditorPanel.labelColumnWidth, alignment: labelAlignment)
 
             trailing()
                 .frame(maxWidth: .infinity, alignment: .trailing)

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
@@ -3,11 +3,6 @@ import SwiftUI
 struct SpeechTab: View {
     @Environment(EditorViewModel.self) private var editor
 
-    private enum SilenceDurationControl {
-        case minimumPause
-        case speechPadding
-    }
-
     var body: some View {
         ZStack {
             ScrollView {
@@ -131,7 +126,13 @@ struct SpeechTab: View {
                     editor.setMinimumSilenceDuration(SilenceRemovalSettings.default.minimumPauseSeconds)
                 }
             ) {
-                durationControl(.minimumPause)
+                durationField(
+                    label: "Minimum Pause",
+                    value: editor.silenceRemovalSettings.minimumPauseSeconds,
+                    range: SilenceRemovalSettings.minimumPauseRange,
+                    step: 0.05,
+                    set: editor.setMinimumSilenceDuration
+                )
             }
             InspectorRow(
                 label: "Speech Padding",
@@ -141,43 +142,36 @@ struct SpeechTab: View {
                     editor.setSpeechPaddingDuration(SilenceRemovalSettings.default.speechPaddingSeconds)
                 }
             ) {
-                durationControl(.speechPadding)
+                durationField(
+                    label: "Speech Padding",
+                    value: editor.silenceRemovalSettings.speechPaddingSeconds,
+                    range: SilenceRemovalSettings.speechPaddingRange,
+                    step: 0.025,
+                    set: editor.setSpeechPaddingDuration
+                )
             }
         }
     }
 
-    private func durationControl(_ control: SilenceDurationControl) -> some View {
-        let label = control == .minimumPause ? "Minimum Pause" : "Speech Padding"
-        let value = control == .minimumPause
-            ? editor.silenceRemovalSettings.minimumPauseSeconds
-            : editor.silenceRemovalSettings.speechPaddingSeconds
-        let range = control == .minimumPause
-            ? SilenceRemovalSettings.minimumPauseRange
-            : SilenceRemovalSettings.speechPaddingRange
-        let step = control == .minimumPause ? 0.05 : 0.025
-        return ScrubbableNumberField(
+    private func durationField(
+        label: String,
+        value: Double,
+        range: ClosedRange<Double>,
+        step: Double,
+        set: @escaping (Double) -> Void
+    ) -> some View {
+        ScrubbableNumberField(
             value: value,
             range: range,
             displayMultiplier: 1_000,
             format: "%.0f",
             valueSuffix: " ms",
             dragSensitivity: 10,
-            dragValueAdjustment: { candidate in
-                min(range.upperBound, max(range.lowerBound, (candidate / step).rounded() * step))
-            },
-            onChanged: { setDuration($0, for: control) },
-            onCommit: { setDuration($0, for: control) }
+            dragValueAdjustment: { ($0 / step).rounded() * step },
+            onChanged: set,
+            onCommit: set
         )
         .accessibilityLabel(label)
-    }
-
-    private func setDuration(_ seconds: Double, for control: SilenceDurationControl) {
-        switch control {
-        case .minimumPause:
-            editor.setMinimumSilenceDuration(seconds)
-        case .speechPadding:
-            editor.setSpeechPaddingDuration(seconds)
-        }
     }
 
     private var removeSilenceRow: some View {

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
@@ -3,6 +3,11 @@ import SwiftUI
 struct SpeechTab: View {
     @Environment(EditorViewModel.self) private var editor
 
+    private enum SilenceDurationControl {
+        case minimumPause
+        case speechPadding
+    }
+
     var body: some View {
         ZStack {
             ScrollView {
@@ -21,10 +26,11 @@ struct SpeechTab: View {
     }
 
     private var speakersSection: some View {
-        EditorPanelGroup("Speakers") {
+        EditorPanelGroup("Speakers", contentInsets: sectionContentInsets) {
             InspectorRow(
                 label: "Mark Speakers",
                 labelHelp: "Tints waveforms by speaker. Voices are matched across clips using cloud transcripts.",
+                labelAlignment: .leading,
                 onReset: { editor.markSpeakers = false }
             ) {
                 Toggle("", isOn: Binding(
@@ -36,12 +42,12 @@ struct SpeechTab: View {
                 .labelsHidden()
                 .accessibilityLabel("Mark Speakers")
             }
-            HStack(spacing: AppTheme.Spacing.sm) {
-                Button(editor.projectSpeakers.isEmpty ? "Identify Speakers" : "Refresh") { editor.identifySpeakers(transcribeMissing: true) }
-                    .controlSize(.small)
-                    .disabled(editor.speakerIdentifyInFlight)
-                    .help("Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast.")
+            Button(editor.projectSpeakers.isEmpty ? "Identify Speakers" : "Refresh") {
+                editor.identifySpeakers(transcribeMissing: true)
             }
+            .buttonStyle(.capsule(.secondary))
+            .disabled(editor.speakerIdentifyInFlight)
+            .help("Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast.")
             if let error = editor.speakerIdentifyError {
                 Text(error)
                     .font(.system(size: AppTheme.FontSize.xs))
@@ -83,10 +89,11 @@ struct SpeechTab: View {
     }
 
     private var silenceSection: some View {
-        EditorPanelGroup("Silence Detection") {
+        EditorPanelGroup("Silence Detection", contentInsets: sectionContentInsets) {
             InspectorRow(
                 label: "Mark Silence",
                 labelHelp: "Speech is detected on-device in the background. Dims quiet, speech-free spans on timeline waveforms.",
+                labelAlignment: .leading,
                 onReset: { editor.markDeadAir = false }
             ) {
                 Toggle("", isOn: Binding(
@@ -109,15 +116,75 @@ struct SpeechTab: View {
                         .foregroundStyle(AppTheme.Text.mutedColor)
                 }
             }
+            silenceTimingControls
             removeSilenceRow
+        }
+    }
+
+    private var silenceTimingControls: some View {
+        Group {
+            InspectorRow(
+                label: "Minimum Pause",
+                labelHelp: "Ignores speech-free pauses shorter than this.",
+                labelAlignment: .leading,
+                onReset: {
+                    editor.setMinimumSilenceDuration(SilenceRemovalSettings.default.minimumPauseSeconds)
+                }
+            ) {
+                durationControl(.minimumPause)
+            }
+            InspectorRow(
+                label: "Speech Padding",
+                labelHelp: "Keeps this much audio before and after detected speech.",
+                labelAlignment: .leading,
+                onReset: {
+                    editor.setSpeechPaddingDuration(SilenceRemovalSettings.default.speechPaddingSeconds)
+                }
+            ) {
+                durationControl(.speechPadding)
+            }
+        }
+    }
+
+    private func durationControl(_ control: SilenceDurationControl) -> some View {
+        let label = control == .minimumPause ? "Minimum Pause" : "Speech Padding"
+        let value = control == .minimumPause
+            ? editor.silenceRemovalSettings.minimumPauseSeconds
+            : editor.silenceRemovalSettings.speechPaddingSeconds
+        let range = control == .minimumPause
+            ? SilenceRemovalSettings.minimumPauseRange
+            : SilenceRemovalSettings.speechPaddingRange
+        let step = control == .minimumPause ? 0.05 : 0.025
+        return ScrubbableNumberField(
+            value: value,
+            range: range,
+            displayMultiplier: 1_000,
+            format: "%.0f",
+            valueSuffix: " ms",
+            dragSensitivity: 10,
+            dragValueAdjustment: { candidate in
+                min(range.upperBound, max(range.lowerBound, (candidate / step).rounded() * step))
+            },
+            onChanged: { setDuration($0, for: control) },
+            onCommit: { setDuration($0, for: control) }
+        )
+        .accessibilityLabel(label)
+    }
+
+    private func setDuration(_ seconds: Double, for control: SilenceDurationControl) {
+        switch control {
+        case .minimumPause:
+            editor.setMinimumSilenceDuration(seconds)
+        case .speechPadding:
+            editor.setSpeechPaddingDuration(seconds)
         }
     }
 
     private var removeSilenceRow: some View {
         let count = editor.allDeadAir().reduce(0) { $0 + $1.ranges.count }
         return HStack(spacing: AppTheme.Spacing.sm) {
-            Button("Remove Silence") { editor.removeAllDeadAir() }
-                .controlSize(.small)
+            Button("Remove") { editor.removeAllDeadAir() }
+                .buttonStyle(.capsule(.secondary))
                 .disabled(count == 0)
                 .help("Ripple-deletes every silent section; downstream clips close the gaps.")
             if count > 0 {
@@ -126,5 +193,14 @@ struct SpeechTab: View {
                     .foregroundStyle(AppTheme.Text.mutedColor)
             }
         }
+    }
+
+    private var sectionContentInsets: EdgeInsets {
+        EdgeInsets(
+            top: AppTheme.Spacing.smMd,
+            leading: AppTheme.Spacing.mdLg,
+            bottom: AppTheme.Spacing.smMd,
+            trailing: AppTheme.Spacing.mdLg
+        )
     }
 }

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -74,7 +74,7 @@ enum ClipRenderer {
         opacity: CGFloat = 1.0,
         context: CGContext,
         cache: MediaVisualCache? = nil,
-        silenceRemovalSettings: SilenceRemovalSettings? = nil,
+        deadAirRanges: @autoclosure () -> [Range<Double>] = [],
         displayName: String? = nil,
         linkOffset: Int? = nil,
         multicamAngleLabel: String? = nil,
@@ -125,13 +125,9 @@ enum ClipRenderer {
             drawTiledImage(image: image, in: thumbRect, clipRect: rect, cornerRadius: cornerRadius, context: context)
         } else if type == .audio, let samples = cache?.samples(for: clip.mediaRef), !samples.isEmpty {
             let audioRect = CGRect(x: contentX, y: contentY, width: contentWidth, height: mainHeight)
-            let mask = silenceRemovalSettings.flatMap {
-                cache?.deadAirMask(for: clip.mediaRef, settings: $0)
-            }
-            drawWaveform(samples: samples, deadAirMask: mask,
-                         silenceRemovalSettings: silenceRemovalSettings,
+            drawWaveform(samples: samples, deadAirRanges: deadAirRanges(),
                          speakerMask: speakerColors.isEmpty ? nil : cache?.speakerMask(for: clip.mediaRef),
-                         clip: clip, type: colorType, fps: fps, in: audioRect, context: context)
+                         clip: clip, type: colorType, in: audioRect, context: context)
         }
 
         let showsFadeControls = showsFadeControls(isSelected: isSelected, isHovered: isHovered, in: rect)
@@ -310,12 +306,10 @@ enum ClipRenderer {
 
     private static func drawWaveform(
         samples: [Float],
-        deadAirMask: [Bool]?,
-        silenceRemovalSettings: SilenceRemovalSettings?,
+        deadAirRanges: [Range<Double>],
         speakerMask: [Int]? = nil,
         clip: Clip,
         type: ClipType,
-        fps: Int,
         in drawRect: NSRect,
         context: CGContext
     ) {
@@ -354,20 +348,8 @@ enum ClipRenderer {
         let needsPerBarVolume = (clip.volumeTrack?.isActive ?? false) || clip.fadeInFrames > 0 || clip.fadeOutFrames > 0
         let staticShift = CGFloat(VolumeScale.dbFromLinear(clip.volume)) / dbRange
 
-        // Dead-air shading uses the same clip-visible ranges as removal.
         let visibleSourceStart = Double(clip.trimStartFrame)
         let visibleSourceEnd = Double(clip.trimStartFrame + clip.sourceFramesConsumed)
-        let deadAirRanges: [Range<Double>]
-        if let deadAirMask, let silenceRemovalSettings, visibleSourceStart < visibleSourceEnd {
-            deadAirRanges = SilenceRemovalPlanner.visibleRemovableRanges(
-                from: deadAirMask,
-                visibleSourceRange: visibleSourceStart..<visibleSourceEnd,
-                framesPerSecond: fps,
-                settings: silenceRemovalSettings
-            )
-        } else {
-            deadAirRanges = []
-        }
         var washes: [CGRect] = []
         let spkCount = speakerMask?.count ?? 0
         let spkStart = max(0, min(spkCount, Int(startFrac * Double(spkCount))))

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -74,6 +74,7 @@ enum ClipRenderer {
         opacity: CGFloat = 1.0,
         context: CGContext,
         cache: MediaVisualCache? = nil,
+        silenceRemovalSettings: SilenceRemovalSettings? = nil,
         displayName: String? = nil,
         linkOffset: Int? = nil,
         multicamAngleLabel: String? = nil,
@@ -124,7 +125,9 @@ enum ClipRenderer {
             drawTiledImage(image: image, in: thumbRect, clipRect: rect, cornerRadius: cornerRadius, context: context)
         } else if type == .audio, let samples = cache?.samples(for: clip.mediaRef), !samples.isEmpty {
             let audioRect = CGRect(x: contentX, y: contentY, width: contentWidth, height: mainHeight)
-            let mask = markDeadAir ? cache?.deadAirMask(for: clip.mediaRef) : nil
+            let mask = silenceRemovalSettings.flatMap {
+                cache?.deadAirMask(for: clip.mediaRef, settings: $0)
+            }
             drawWaveform(samples: samples, deadAirMask: mask,
                          speakerMask: speakerColors.isEmpty ? nil : cache?.speakerMask(for: clip.mediaRef),
                          clip: clip, type: colorType, in: audioRect, context: context)
@@ -302,7 +305,6 @@ enum ClipRenderer {
 
     private static let washColor = AppTheme.Status.error.withAlphaComponent(AppTheme.Opacity.medium).cgColor
     nonisolated(unsafe) static var speakerColors: [Int: CGColor] = [:]
-    private static var markDeadAir: Bool { UserDefaults.standard.object(forKey: "markDeadAir") as? Bool ?? true }
     private static var markBeats: Bool { UserDefaults.standard.object(forKey: "markBeats") as? Bool ?? true }
 
     private static func drawWaveform(

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -359,6 +359,7 @@ enum ClipRenderer {
 
         var bars: [CGRect] = []
         bars.reserveCapacity(lastBar - firstBar)
+        var deadAirRangeIndex = 0
         for i in firstBar..<lastBar {
             // Peak-detect (min, since 0=loud) over the bar's range so zero crossings don't flatten loud audio.
             let sStart = sampleStart + i * visCount / barCount
@@ -394,7 +395,12 @@ enum ClipRenderer {
             if !deadAirRanges.isEmpty {
                 let m0 = visibleSourceStart + Double(i) * (visibleSourceEnd - visibleSourceStart) / Double(barCount)
                 let m1 = visibleSourceStart + Double(i + 1) * (visibleSourceEnd - visibleSourceStart) / Double(barCount)
-                if deadAirRanges.contains(where: { $0.overlaps(m0..<m1) }) {
+                while deadAirRangeIndex < deadAirRanges.count,
+                      deadAirRanges[deadAirRangeIndex].upperBound <= m0 {
+                    deadAirRangeIndex += 1
+                }
+                if deadAirRangeIndex < deadAirRanges.count,
+                   deadAirRanges[deadAirRangeIndex].lowerBound < m1 {
                     washes.append(CGRect(x: drawRect.minX + CGFloat(i), y: drawRect.minY, width: 1, height: drawRect.height))
                 }
             }

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -129,8 +129,9 @@ enum ClipRenderer {
                 cache?.deadAirMask(for: clip.mediaRef, settings: $0)
             }
             drawWaveform(samples: samples, deadAirMask: mask,
+                         silenceRemovalSettings: silenceRemovalSettings,
                          speakerMask: speakerColors.isEmpty ? nil : cache?.speakerMask(for: clip.mediaRef),
-                         clip: clip, type: colorType, in: audioRect, context: context)
+                         clip: clip, type: colorType, fps: fps, in: audioRect, context: context)
         }
 
         let showsFadeControls = showsFadeControls(isSelected: isSelected, isHovered: isHovered, in: rect)
@@ -310,9 +311,11 @@ enum ClipRenderer {
     private static func drawWaveform(
         samples: [Float],
         deadAirMask: [Bool]?,
+        silenceRemovalSettings: SilenceRemovalSettings?,
         speakerMask: [Int]? = nil,
         clip: Clip,
         type: ClipType,
+        fps: Int,
         in drawRect: NSRect,
         context: CGContext
     ) {
@@ -351,11 +354,20 @@ enum ClipRenderer {
         let needsPerBarVolume = (clip.volumeTrack?.isActive ?? false) || clip.fadeInFrames > 0 || clip.fadeOutFrames > 0
         let staticShift = CGFloat(VolumeScale.dbFromLinear(clip.volume)) / dbRange
 
-        // Dead-air shading maps the mask through the same source fractions as samples.
-        let maskCount = deadAirMask?.count ?? 0
-        let maskStart = max(0, min(maskCount, Int(startFrac * Double(maskCount))))
-        let maskEnd = max(maskStart, min(maskCount, Int(endFrac * Double(maskCount))))
-        let maskVisCount = maskEnd - maskStart
+        // Dead-air shading uses the same clip-visible ranges as removal.
+        let visibleSourceStart = Double(clip.trimStartFrame)
+        let visibleSourceEnd = Double(clip.trimStartFrame + clip.sourceFramesConsumed)
+        let deadAirRanges: [Range<Double>]
+        if let deadAirMask, let silenceRemovalSettings, visibleSourceStart < visibleSourceEnd {
+            deadAirRanges = SilenceRemovalPlanner.visibleRemovableRanges(
+                from: deadAirMask,
+                visibleSourceRange: visibleSourceStart..<visibleSourceEnd,
+                framesPerSecond: fps,
+                settings: silenceRemovalSettings
+            )
+        } else {
+            deadAirRanges = []
+        }
         var washes: [CGRect] = []
         let spkCount = speakerMask?.count ?? 0
         let spkStart = max(0, min(spkCount, Int(startFrac * Double(spkCount))))
@@ -397,10 +409,10 @@ enum ClipRenderer {
                 bars.append(bar)
             }
 
-            if let deadAirMask, maskVisCount > 0 {
-                let m0 = maskStart + i * maskVisCount / barCount
-                let m1 = min(maskEnd, max(m0 + 1, maskStart + (i + 1) * maskVisCount / barCount))
-                if deadAirMask[m0..<m1].contains(true) {
+            if !deadAirRanges.isEmpty {
+                let m0 = visibleSourceStart + Double(i) * (visibleSourceEnd - visibleSourceStart) / Double(barCount)
+                let m1 = visibleSourceStart + Double(i + 1) * (visibleSourceEnd - visibleSourceStart) / Double(barCount)
+                if deadAirRanges.contains(where: { $0.overlaps(m0..<m1) }) {
                     washes.append(CGRect(x: drawRect.minX + CGFloat(i), y: drawRect.minY, width: 1, height: drawRect.height))
                 }
             }

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -57,8 +57,11 @@ final class MediaVisualCache {
         MainActor.assumeIsolated { waveformSamples[mediaRef] }
     }
 
-    nonisolated func deadAirMask(for mediaRef: String) -> [Bool]? {
-        speech.deadAirMask(for: mediaRef, samples: samples(for: mediaRef))
+    nonisolated func deadAirMask(
+        for mediaRef: String,
+        settings: SilenceRemovalSettings
+    ) -> [Bool]? {
+        speech.deadAirMask(for: mediaRef, samples: samples(for: mediaRef), settings: settings)
     }
 
     nonisolated func thumbnails(for mediaRef: String) -> [(time: Double, image: CGImage)]? {

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -64,6 +64,10 @@ final class MediaVisualCache {
         speech.deadAirMask(for: mediaRef, samples: samples(for: mediaRef), settings: settings)
     }
 
+    nonisolated func quietNonSpeechMask(for mediaRef: String) -> [Bool]? {
+        speech.quietNonSpeechMask(for: mediaRef, samples: samples(for: mediaRef))
+    }
+
     nonisolated func thumbnails(for mediaRef: String) -> [(time: Double, image: CGImage)]? {
         MainActor.assumeIsolated { videoThumbnails[mediaRef] }
     }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -86,6 +86,10 @@ final class TimelineView: NSView {
         TimelineGeometry(editor: editor, bounds: bounds)
     }
 
+    private var displayedSilenceRemovalSettings: SilenceRemovalSettings? {
+        editor.markDeadAir ? editor.silenceRemovalSettings : nil
+    }
+
     private var isUpdatingContentSize = false
 
     // Nil until first layout; used to detect playhead-anchored zoom changes.
@@ -378,6 +382,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
                                           isSelected: isSelected, opacity: CGFloat(AppTheme.Opacity.prominent), context: ctx,
                                           cache: editor.mediaVisualCache,
+                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
                                           displayName: displayName(clip, in: previewRect, isSelected: isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -393,6 +398,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(clip, type: clip.mediaType, in: originalRect,
                                           isSelected: drag.isDuplicate && isSelected, opacity: originalOpacity, context: ctx,
                                           cache: editor.mediaVisualCache,
+                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
                                           displayName: displayName(clip, in: originalRect, isSelected: drag.isDuplicate && isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -419,6 +425,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(ghostClip, type: clip.mediaType, in: ghostRect,
                                           isSelected: true, opacity: 0.7, context: ctx,
                                           cache: editor.mediaVisualCache,
+                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
                                           displayName: displayName(clip, in: ghostRect, isSelected: true),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -457,7 +464,9 @@ final class TimelineView: NSView {
                         deferredDraws.append {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
                                               isSelected: isSelected, context: ctx,
-                                              cache: cache, displayName: name,
+                                              cache: cache,
+                                              silenceRemovalSettings: self.displayedSilenceRemovalSettings,
+                                              displayName: name,
                                               multicamAngleLabel: chip,
                                               fps: fps, isMissing: clipMissing, isGenerating: clipGenerating)
                         }
@@ -495,7 +504,9 @@ final class TimelineView: NSView {
                         deferredDraws.append {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: rect,
                                               isSelected: isSelected, context: ctx,
-                                              cache: cache, displayName: name,
+                                              cache: cache,
+                                              silenceRemovalSettings: self.displayedSilenceRemovalSettings,
+                                              displayName: name,
                                               multicamAngleLabel: chip,
                                               fps: fps, isMissing: clipMissing, isGenerating: clipGenerating)
                         }
@@ -512,6 +523,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(shiftedClip, type: clip.mediaType, in: shiftedRect,
                                           isSelected: isSelected, context: ctx,
                                           cache: editor.mediaVisualCache,
+                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
                                           displayName: displayName(clip, in: shiftedRect, isSelected: isSelected),
                                           linkOffset: linkOffsets[clip.id],
                                           multicamAngleLabel: angleLabel(clip),
@@ -526,6 +538,7 @@ final class TimelineView: NSView {
                 ClipRenderer.draw(clip, type: clip.mediaType, in: rect,
                                   isSelected: isSelected, isHovered: hoveredClipId == clip.id, context: ctx,
                                   cache: editor.mediaVisualCache,
+                                  silenceRemovalSettings: displayedSilenceRemovalSettings,
                                   displayName: displayName(clip, in: rect, isSelected: isSelected),
                                   linkOffset: linkOffsets[clip.id],
                                   multicamAngleLabel: angleLabel(clip),
@@ -584,6 +597,7 @@ final class TimelineView: NSView {
             opacity: CGFloat(AppTheme.Opacity.medium),
             context: ctx,
             cache: editor.mediaVisualCache,
+            silenceRemovalSettings: displayedSilenceRemovalSettings,
             displayName: editor.clipDisplayLabel(for: clip),
             multicamAngleLabel: angleLabel,
             fps: editor.timeline.fps,
@@ -778,6 +792,7 @@ final class TimelineView: NSView {
             ClipRenderer.draw(ghost.clip, type: ghost.clip.mediaType, in: ghost.rect,
                               isSelected: true, opacity: 0.5, context: ctx,
                               cache: editor.mediaVisualCache,
+                              silenceRemovalSettings: displayedSilenceRemovalSettings,
                               fps: editor.timeline.fps,
                               isMissing: editor.isClipMediaOffline(ghost.clip),
                               isGenerating: editor.isClipMediaGenerating(ghost.clip))

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -90,6 +90,12 @@ final class TimelineView: NSView {
         editor.markDeadAir ? editor.silenceRemovalSettings : nil
     }
 
+    private func displayedDeadAirRanges(for clip: Clip) -> [Range<Double>] {
+        guard clip.mediaType == .audio,
+              let settings = displayedSilenceRemovalSettings else { return [] }
+        return editor.deadAirSourceRanges(for: clip, settings: settings)
+    }
+
     private var isUpdatingContentSize = false
 
     // Nil until first layout; used to detect playhead-anchored zoom changes.
@@ -382,7 +388,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
                                           isSelected: isSelected, opacity: CGFloat(AppTheme.Opacity.prominent), context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
+                                          deadAirRanges: displayedDeadAirRanges(for: previewClip),
                                           displayName: displayName(clip, in: previewRect, isSelected: isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -398,7 +404,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(clip, type: clip.mediaType, in: originalRect,
                                           isSelected: drag.isDuplicate && isSelected, opacity: originalOpacity, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
+                                          deadAirRanges: displayedDeadAirRanges(for: clip),
                                           displayName: displayName(clip, in: originalRect, isSelected: drag.isDuplicate && isSelected),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -425,7 +431,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(ghostClip, type: clip.mediaType, in: ghostRect,
                                           isSelected: true, opacity: 0.7, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
+                                          deadAirRanges: displayedDeadAirRanges(for: ghostClip),
                                           displayName: displayName(clip, in: ghostRect, isSelected: true),
                                           multicamAngleLabel: angleLabel(clip),
                                           fps: editor.timeline.fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -465,7 +471,7 @@ final class TimelineView: NSView {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: previewRect,
                                               isSelected: isSelected, context: ctx,
                                               cache: cache,
-                                              silenceRemovalSettings: self.displayedSilenceRemovalSettings,
+                                              deadAirRanges: self.displayedDeadAirRanges(for: previewClip),
                                               displayName: name,
                                               multicamAngleLabel: chip,
                                               fps: fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -505,7 +511,7 @@ final class TimelineView: NSView {
                             ClipRenderer.draw(previewClip, type: clip.mediaType, in: rect,
                                               isSelected: isSelected, context: ctx,
                                               cache: cache,
-                                              silenceRemovalSettings: self.displayedSilenceRemovalSettings,
+                                              deadAirRanges: self.displayedDeadAirRanges(for: previewClip),
                                               displayName: name,
                                               multicamAngleLabel: chip,
                                               fps: fps, isMissing: clipMissing, isGenerating: clipGenerating)
@@ -523,7 +529,7 @@ final class TimelineView: NSView {
                         ClipRenderer.draw(shiftedClip, type: clip.mediaType, in: shiftedRect,
                                           isSelected: isSelected, context: ctx,
                                           cache: editor.mediaVisualCache,
-                                          silenceRemovalSettings: displayedSilenceRemovalSettings,
+                                          deadAirRanges: displayedDeadAirRanges(for: shiftedClip),
                                           displayName: displayName(clip, in: shiftedRect, isSelected: isSelected),
                                           linkOffset: linkOffsets[clip.id],
                                           multicamAngleLabel: angleLabel(clip),
@@ -538,7 +544,7 @@ final class TimelineView: NSView {
                 ClipRenderer.draw(clip, type: clip.mediaType, in: rect,
                                   isSelected: isSelected, isHovered: hoveredClipId == clip.id, context: ctx,
                                   cache: editor.mediaVisualCache,
-                                  silenceRemovalSettings: displayedSilenceRemovalSettings,
+                                  deadAirRanges: displayedDeadAirRanges(for: clip),
                                   displayName: displayName(clip, in: rect, isSelected: isSelected),
                                   linkOffset: linkOffsets[clip.id],
                                   multicamAngleLabel: angleLabel(clip),
@@ -597,7 +603,7 @@ final class TimelineView: NSView {
             opacity: CGFloat(AppTheme.Opacity.medium),
             context: ctx,
             cache: editor.mediaVisualCache,
-            silenceRemovalSettings: displayedSilenceRemovalSettings,
+            deadAirRanges: displayedDeadAirRanges(for: sourceClip),
             displayName: editor.clipDisplayLabel(for: clip),
             multicamAngleLabel: angleLabel,
             fps: editor.timeline.fps,
@@ -792,7 +798,7 @@ final class TimelineView: NSView {
             ClipRenderer.draw(ghost.clip, type: ghost.clip.mediaType, in: ghost.rect,
                               isSelected: true, opacity: 0.5, context: ctx,
                               cache: editor.mediaVisualCache,
-                              silenceRemovalSettings: displayedSilenceRemovalSettings,
+                              deadAirRanges: displayedDeadAirRanges(for: ghost.clip),
                               fps: editor.timeline.fps,
                               isMissing: editor.isClipMediaOffline(ghost.clip),
                               isGenerating: editor.isClipMediaGenerating(ghost.clip))

--- a/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
+++ b/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
@@ -94,6 +94,15 @@ struct RemoveSilenceParamTests {
         #expect(parsed.speechPaddingSeconds == 0.15)
     }
 
+    @Test func acceptsClipScopeWithoutChangingSettings() throws {
+        let parsed = try ToolExecutor.parseSilenceRemovalSettings(
+            ["clipIds": ["clip-1"]],
+            defaults: .default
+        )
+
+        #expect(parsed == .default)
+    }
+
     @Test func rejectsInvalidValuesAndUnknownKeys() {
         #expect(throws: ToolError.self) {
             _ = try ToolExecutor.parseSilenceRemovalSettings(
@@ -125,5 +134,51 @@ struct RemoveSilenceParamTests {
         )
 
         #expect(harness.editor.silenceRemovalSettings == before)
+    }
+
+    @Test func rejectsInvalidOrMissingClipScope() async {
+        let harness = ToolHarness()
+
+        #expect((await harness.runRaw("remove_silence", args: ["clipIds": []])).isError)
+        #expect((await harness.runRaw("remove_silence", args: ["clipIds": [42]])).isError)
+        #expect((await harness.runRaw("remove_silence", args: ["clipIds": ["missing-clip"]])).isError)
+    }
+
+    @Test func resolvesShortClipIdAndUsesClipScope() async {
+        let clipId = "AAAAAAAA-1111-2222-3333-444444444444"
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: clipId, mediaType: .audio, start: 0, duration: 100),
+            ]),
+        ])
+        let harness = ToolHarness(timeline: timeline)
+
+        let result = await harness.runRaw(
+            "remove_silence",
+            args: ["clipIds": [String(clipId.prefix(8))]]
+        )
+
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("No dead air in the selected clips"))
+    }
+
+    @Test func rejectsUnlinkedClipsAcrossTracks() async {
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100),
+            ]),
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "a2", mediaType: .audio, start: 0, duration: 100),
+            ]),
+        ])
+        let harness = ToolHarness(timeline: timeline)
+
+        let result = await harness.runRaw(
+            "remove_silence",
+            args: ["clipIds": ["a1", "a2"]]
+        )
+
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("must share one track"))
     }
 }

--- a/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
+++ b/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
@@ -180,5 +180,54 @@ struct RemoveSilenceParamTests {
 
         #expect(result.isError)
         #expect(ToolHarness.textOf(result).contains("must share one track"))
+        #expect(!ToolHarness.textOf(result).contains("Ripple delete refused"))
+    }
+
+    @Test func rejectsScopeWithoutAnAudioClip() async {
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "v1", mediaType: .video, start: 0, duration: 100),
+            ]),
+        ])
+        let harness = ToolHarness(timeline: timeline)
+
+        let result = await harness.runRaw(
+            "remove_silence",
+            args: ["clipIds": ["v1"]]
+        )
+        let message = ToolHarness.textOf(result)
+
+        #expect(result.isError)
+        #expect(message.contains("must include at least one audio clip"))
+        #expect(!message.contains("No dead air"))
+        #expect(!message.contains("Ripple delete refused"))
+    }
+
+    @Test func rejectsLinkedAudioClipsAcrossTracks() async {
+        var first = Fixtures.clip(
+            id: "a1", mediaType: .audio, start: 0, duration: 100
+        )
+        var second = Fixtures.clip(
+            id: "a2", mediaType: .audio, start: 0, duration: 100
+        )
+        first.linkGroupId = "linked"
+        second.linkGroupId = "linked"
+        let timeline = Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [first]),
+            Fixtures.audioTrack(clips: [second]),
+        ])
+        let harness = ToolHarness(timeline: timeline)
+
+        let result = await harness.runRaw(
+            "remove_silence",
+            args: ["clipIds": ["a1", "a2"]]
+        )
+        let message = ToolHarness.textOf(result)
+
+        #expect(result.isError)
+        #expect(message.contains("audio clips must come from one track"))
+        #expect(!message.contains("Ripple delete refused"))
+        #expect(harness.editor.timeline.tracks[0].clips == [first])
+        #expect(harness.editor.timeline.tracks[1].clips == [second])
     }
 }

--- a/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
+++ b/Tests/PalmierProTests/Agent/RemoveWordsTests.swift
@@ -64,3 +64,66 @@ struct RemoveWordsParamTests {
         }
     }
 }
+
+@Suite("remove_silence — param validation")
+@MainActor
+struct RemoveSilenceParamTests {
+    @Test func omittedValuesUseCurrentSettings() throws {
+        let current = try #require(SilenceRemovalSettings(
+            minimumPauseSeconds: 1.25,
+            speechPaddingSeconds: 0.2
+        ))
+
+        let parsed = try ToolExecutor.parseSilenceRemovalSettings([:], defaults: current)
+
+        #expect(parsed == current)
+    }
+
+    @Test func acceptsPartialOneShotOverride() throws {
+        let current = try #require(SilenceRemovalSettings(
+            minimumPauseSeconds: 0.5,
+            speechPaddingSeconds: 0.15
+        ))
+
+        let parsed = try ToolExecutor.parseSilenceRemovalSettings(
+            ["minimumPauseSeconds": 1.0],
+            defaults: current
+        )
+
+        #expect(parsed.minimumPauseSeconds == 1.0)
+        #expect(parsed.speechPaddingSeconds == 0.15)
+    }
+
+    @Test func rejectsInvalidValuesAndUnknownKeys() {
+        #expect(throws: ToolError.self) {
+            _ = try ToolExecutor.parseSilenceRemovalSettings(
+                ["minimumPauseSeconds": 0.1],
+                defaults: .default
+            )
+        }
+        #expect(throws: ToolError.self) {
+            _ = try ToolExecutor.parseSilenceRemovalSettings(
+                ["speechPaddingSeconds": "lots"],
+                defaults: .default
+            )
+        }
+        #expect(throws: ToolError.self) {
+            _ = try ToolExecutor.parseSilenceRemovalSettings(
+                ["persist": true],
+                defaults: .default
+            )
+        }
+    }
+
+    @Test func overrideDoesNotChangeEditorSettings() async {
+        let harness = ToolHarness()
+        let before = harness.editor.silenceRemovalSettings
+
+        _ = await harness.runRaw(
+            "remove_silence",
+            args: ["minimumPauseSeconds": 1.0, "speechPaddingSeconds": 0.25]
+        )
+
+        #expect(harness.editor.silenceRemovalSettings == before)
+    }
+}

--- a/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
+++ b/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
@@ -48,6 +48,50 @@ struct SilenceRemovalPlannerTests {
         #expect(mask == [true, true, true, false, false, false, false, false, true, true, true])
     }
 
+    @Test func removesPaddingAtTrimmedClipEdgesOnly() {
+        let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: 0.5,
+            speechPaddingSeconds: 0.2
+        )!
+        let mask = [false, false, true, true, true, true, false, false]
+
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: 0.0..<9.0,
+            framesPerSecond: 10,
+            settings: settings,
+            cellDuration: 0.1
+        ) == [0.0..<6.0])
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: -1.0..<8.0,
+            framesPerSecond: 10,
+            settings: settings,
+            cellDuration: 0.1
+        ) == [2.0..<8.0])
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: -1.0..<9.0,
+            framesPerSecond: 10,
+            settings: settings,
+            cellDuration: 0.1
+        ) == [2.0..<6.0])
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: 0.0..<1.0,
+            framesPerSecond: 10,
+            settings: settings,
+            cellDuration: 0.1
+        ) == [0.0..<1.0])
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: mask,
+            visibleSourceRange: 7.0..<8.0,
+            framesPerSecond: 10,
+            settings: settings,
+            cellDuration: 0.1
+        ) == [7.0..<8.0])
+    }
+
     @Test func rejectsInvalidSettings() {
         #expect(SilenceRemovalSettings(minimumPauseSeconds: .nan, speechPaddingSeconds: 0.15) == nil)
         #expect(SilenceRemovalSettings(minimumPauseSeconds: 0.1, speechPaddingSeconds: 0.15) == nil)

--- a/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
+++ b/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Silence removal planner")
+struct SilenceRemovalPlannerTests {
+    @Test func filtersPausesShorterThanMinimum() throws {
+        let settings = try #require(SilenceRemovalSettings(
+            minimumPauseSeconds: 0.5,
+            speechPaddingSeconds: 0
+        ))
+
+        let mask = SilenceRemovalPlanner.removableMask(
+            from: [false, true, true, true, true, false],
+            settings: settings,
+            cellDuration: 0.1
+        )
+
+        #expect(!mask.contains(true))
+    }
+
+    @Test func padsBothSpeechBoundaries() throws {
+        let settings = try #require(SilenceRemovalSettings(
+            minimumPauseSeconds: 0.5,
+            speechPaddingSeconds: 0.2
+        ))
+
+        let mask = SilenceRemovalPlanner.removableMask(
+            from: [false] + [Bool](repeating: true, count: 10) + [false],
+            settings: settings,
+            cellDuration: 0.1
+        )
+
+        #expect(mask == [false, false, false] + [Bool](repeating: true, count: 6) + [false, false, false])
+    }
+
+    @Test func doesNotPadSourceEdges() throws {
+        let settings = try #require(SilenceRemovalSettings(
+            minimumPauseSeconds: 0.3,
+            speechPaddingSeconds: 0.2
+        ))
+
+        let mask = SilenceRemovalPlanner.removableMask(
+            from: [Bool](repeating: true, count: 5) + [false] + [Bool](repeating: true, count: 5),
+            settings: settings,
+            cellDuration: 0.1
+        )
+
+        #expect(mask == [true, true, true, false, false, false, false, false, true, true, true])
+    }
+
+    @Test func rejectsInvalidSettings() {
+        #expect(SilenceRemovalSettings(minimumPauseSeconds: .nan, speechPaddingSeconds: 0.15) == nil)
+        #expect(SilenceRemovalSettings(minimumPauseSeconds: 0.1, speechPaddingSeconds: 0.15) == nil)
+        #expect(SilenceRemovalSettings(minimumPauseSeconds: 0.5, speechPaddingSeconds: 0.75) == nil)
+    }
+
+    @Test func extremeCellResolutionDoesNotOverflow() {
+        let mask = SilenceRemovalPlanner.removableMask(
+            from: [true, true],
+            settings: .default,
+            cellDuration: .leastNonzeroMagnitude
+        )
+
+        #expect(mask == [false, false])
+    }
+}

--- a/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
+++ b/Tests/PalmierProTests/Audio/SilenceRemovalPlannerTests.swift
@@ -107,4 +107,13 @@ struct SilenceRemovalPlannerTests {
 
         #expect(mask == [false, false])
     }
+
+    @Test func rejectsNonFiniteVisibleSourceBounds() {
+        #expect(SilenceRemovalPlanner.visibleRemovableRanges(
+            from: [true],
+            visibleSourceRange: 0..<Double.infinity,
+            framesPerSecond: 30,
+            settings: .default
+        ).isEmpty)
+    }
 }

--- a/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
@@ -51,4 +51,34 @@ import Testing
 
         #expect(duration < .seconds(2))
     }
+
+    @Test func compactClipsDoNotResolveSilenceRanges() throws {
+        let context = try #require(CGContext(
+            data: nil,
+            width: 1,
+            height: 64,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        let clip = Fixtures.clip(mediaRef: "audio", mediaType: .audio, start: 0, duration: 30)
+        var didResolve = false
+        func ranges() -> [Range<Double>] {
+            didResolve = true
+            return []
+        }
+
+        ClipRenderer.draw(
+            clip,
+            type: .audio,
+            in: CGRect(x: 0, y: 0, width: 0.5, height: 64),
+            isSelected: false,
+            context: context,
+            deadAirRanges: ranges(),
+            fps: 30
+        )
+
+        #expect(!didResolve)
+    }
 }

--- a/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
@@ -104,6 +104,33 @@ struct MulticamTests {
         #expect(clip.linkGroupId != "L1")
     }
 
+    @Test func silenceMaskRequiresEveryMicToBeSilent() {
+        var group = MulticamSource(name: "Podcast", members: [
+            .init(mediaRef: "host", kind: .mic, angleLabel: "host",
+                  sync: .init(offsetSeconds: VoiceActivity.chunkDuration, confidence: 1)),
+            .init(mediaRef: "guest", kind: .mic, angleLabel: "guest",
+                  sync: .init(offsetSeconds: 0, confidence: 1)),
+        ])
+        group.masterMemberId = group.members[0].id
+
+        var clip = Fixtures.clip(
+            mediaRef: "host", mediaType: .audio, start: 0, duration: 10
+        )
+        clip.multicamGroupId = group.id
+        let masks = [
+            "host": [Bool](repeating: true, count: 40),
+            "guest": [Bool](repeating: false, count: 10)
+                + [Bool](repeating: true, count: 30),
+        ]
+        let mask = DeadAirMaskResolver.mask(
+            for: clip,
+            in: group,
+            maskForMedia: { masks[$0] }
+        )
+
+        #expect(mask == [Bool](repeating: false, count: 9) + [Bool](repeating: true, count: 31))
+    }
+
     @Test func lagSearchKeepsHalfOverlap() {
         // 3:35 files (~21500 hops) with a 240s window: without the clamp, ±220s lags
         // with seconds of overlap were legal — the false-peak that doubled a group's length.

--- a/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
@@ -105,6 +105,10 @@ struct MulticamTests {
     }
 
     @Test func silenceMaskRequiresEveryMicToBeSilent() {
+        let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: 0.25,
+            speechPaddingSeconds: 0
+        )!
         var group = MulticamSource(name: "Podcast", members: [
             .init(mediaRef: "host", kind: .mic, angleLabel: "host",
                   sync: .init(offsetSeconds: VoiceActivity.chunkDuration, confidence: 1)),
@@ -125,10 +129,53 @@ struct MulticamTests {
         let mask = DeadAirMaskResolver.mask(
             for: clip,
             in: group,
-            maskForMedia: { masks[$0] }
+            settings: settings,
+            quietMaskForMedia: { masks[$0] }
         )
 
         #expect(mask == [Bool](repeating: false, count: 9) + [Bool](repeating: true, count: 31))
+    }
+
+    @Test func silenceMaskAppliesMinimumPauseAfterMicIntersection() {
+        let settings = SilenceRemovalSettings(
+            minimumPauseSeconds: 1,
+            speechPaddingSeconds: 0
+        )!
+        var group = MulticamSource(name: "Podcast", members: [
+            .init(mediaRef: "host", kind: .mic, angleLabel: "host",
+                  sync: .init(offsetSeconds: 0, confidence: 1)),
+            .init(mediaRef: "guest", kind: .mic, angleLabel: "guest",
+                  sync: .init(offsetSeconds: 0, confidence: 1)),
+        ])
+        group.masterMemberId = group.members[0].id
+
+        var clip = Fixtures.clip(
+            mediaRef: "host", mediaType: .audio, start: 0, duration: 10
+        )
+        clip.multicamGroupId = group.id
+        let masks = [
+            "host": [Bool](repeating: true, count: 41)
+                + [Bool](repeating: false, count: 39),
+            "guest": [Bool](repeating: false, count: 30)
+                + [Bool](repeating: true, count: 41)
+                + [Bool](repeating: false, count: 9),
+        ]
+
+        #expect(SilenceRemovalPlanner.removableMask(
+            from: masks["host"]!, settings: settings
+        ).contains(true))
+        #expect(SilenceRemovalPlanner.removableMask(
+            from: masks["guest"]!, settings: settings
+        ).contains(true))
+
+        let mask = DeadAirMaskResolver.mask(
+            for: clip,
+            in: group,
+            settings: settings,
+            quietMaskForMedia: { masks[$0] }
+        )
+
+        #expect(mask?.contains(true) == false)
     }
 
     @Test func lagSearchKeepsHalfOverlap() {


### PR DESCRIPTION
Code: +597 - 102
Test: +390
<img width="596" height="162" alt="Screenshot 2026-07-29 at 6 41 34 PM" src="https://github.com/user-attachments/assets/a0d3bd28-195d-4b8c-b360-1423bcc9a6e2" />


## Summary

This PR is a mix of 3 features related to `remove_silence`
1.  silence tuning controls - Minimum Pause and Speech Padding, exposed in the Speech tab and threaded through the mask pipeline
2. `remove_silence` can now specify padding, clipIds, and minimum pause
3. multicam silence fix - the minimum-pause guarantee now survives the per-mic intersection 

## Why

Silence removal previously used fixed boundaries, and the multicam preview and removal paths could disagree. Applying the minimum-pause policy to each microphone before intersecting them could also produce cuts shorter than the selected minimum.

## Impact

Editors can tune pause length and speech padding, preview the exact cuts, remove silence globally or from selected clips, and undo agent removal as one `Remove Silence (Agent)` action. The controls remain session-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ripple-delete dead-air behavior, multicam mask intersection, and agent tool contracts; risk is mitigated by broad new tests but edits still affect core timeline audio editing.
> 
> **Overview**
> Adds **Minimum Pause** and **Speech Padding** session controls in Silence Detection, wired so waveform shading, manual **Remove**, and the agent’s `remove_silence` tool all use the same `SilenceRemovalSettings` and `SilenceRemovalPlanner`.
> 
> Dead-air detection is split into a cached **quiet non-speech** mask (VAD + level) and a settings-dependent **removable** mask. Timeline waveforms now shade from clip-visible source ranges instead of a raw per-cell mask, and multicam removal goes through `DeadAirMaskResolver` so every mic must be quiet before intersection, then minimum pause/padding apply once.
> 
> `remove_silence` gains optional `clipIds` (whole timeline vs selected clips with validation), plus one-shot `minimumPauseSeconds` / `speechPaddingSeconds` overrides that do not change the UI controls. Agent tool-arg JSON pretty-printing rounds floats to three decimal places.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7e611ce4366682ce4574a00ec8a2da5f6aa086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->