### PR TITLE
[ui] Add appearance settings

### DIFF
--- a/Sources/PalmierPro/Account/IdentityViews.swift
+++ b/Sources/PalmierPro/Account/IdentityViews.swift
@@ -29,7 +29,7 @@ struct UserAvatar: View {
         if account.isSignedIn {
             Circle().fill(AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium))
         } else if signedOutStyle == .filledCircle {
-            Circle().fill(Color.white.opacity(AppTheme.Opacity.soft))
+            Circle().fill(AppTheme.Interaction.fill(AppTheme.Opacity.soft))
         }
     }
 

--- a/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentInputBox.swift
@@ -74,7 +74,7 @@ struct AgentInputBox<LeadingTools: View>: View {
                 .strokeBorder(
                     isDropTargeted ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.strong)
                         : focused ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium)
-                        : Color.white.opacity(AppTheme.Opacity.hint),
+                        : AppTheme.Interaction.fill(AppTheme.Opacity.hint),
                     lineWidth: (focused || isDropTargeted) ? AppTheme.BorderWidth.thin : AppTheme.BorderWidth.hairline
                 )
                 .allowsHitTesting(false)

--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -55,7 +55,7 @@ struct AgentMessageView: View {
                     .padding(.vertical, AppTheme.Spacing.smMd)
                     .background(
                         RoundedRectangle(cornerRadius: AppTheme.Radius.lg, style: .continuous)
-                            .fill(Color.white.opacity(AppTheme.Opacity.faint))
+                            .fill(AppTheme.Interaction.fill(AppTheme.Opacity.faint))
                     )
                     .textSelection(.enabled)
             }
@@ -175,7 +175,7 @@ private struct ToolRunRow: View {
                 .padding(AppTheme.Spacing.md)
                 .background(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
-                        .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                        .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
                 )
                 .textSelection(.enabled)
                 .transition(.opacity.combined(with: .move(edge: .top)))

--- a/Sources/PalmierPro/Agent/Panel/MarkdownText.swift
+++ b/Sources/PalmierPro/Agent/Panel/MarkdownText.swift
@@ -36,7 +36,7 @@ struct MarkdownText: View {
                             .padding(AppTheme.Spacing.md)
                             .background(
                                 RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
-                                    .fill(Color.black.opacity(AppTheme.Opacity.moderate))
+                                    .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
                             )
                     }
 
@@ -66,7 +66,7 @@ struct MarkdownText: View {
                     .padding(AppTheme.Spacing.md)
                     .background(
                         RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous)
-                            .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                            .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
                     )
                 }
             }

--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -150,15 +150,15 @@ enum MainMenuBuilder {
         let item = NSMenuItem(title: "Layout", action: nil, keyEquivalent: "")
         let submenu = NSMenu(title: "Layout")
 
-        let defaultItem = NSMenuItem(title: LayoutPreset.default.label, action: #selector(EditorActions.setLayoutDefault(_:)), keyEquivalent: "1")
+        let defaultItem = NSMenuItem(title: LayoutPreset.default.label, action: #selector(EditorActions.setLayoutDefault(_:)), keyEquivalent: String(LayoutPreset.default.shortcutKey))
         defaultItem.keyEquivalentModifierMask = [.command]
         submenu.addItem(defaultItem)
 
-        let mediaItem = NSMenuItem(title: LayoutPreset.media.label, action: #selector(EditorActions.setLayoutMedia(_:)), keyEquivalent: "2")
+        let mediaItem = NSMenuItem(title: LayoutPreset.media.label, action: #selector(EditorActions.setLayoutMedia(_:)), keyEquivalent: String(LayoutPreset.media.shortcutKey))
         mediaItem.keyEquivalentModifierMask = [.command]
         submenu.addItem(mediaItem)
 
-        let verticalItem = NSMenuItem(title: LayoutPreset.vertical.label, action: #selector(EditorActions.setLayoutVertical(_:)), keyEquivalent: "3")
+        let verticalItem = NSMenuItem(title: LayoutPreset.vertical.label, action: #selector(EditorActions.setLayoutVertical(_:)), keyEquivalent: String(LayoutPreset.vertical.shortcutKey))
         verticalItem.keyEquivalentModifierMask = [.command]
         submenu.addItem(verticalItem)
 

--- a/Sources/PalmierPro/App/main.swift
+++ b/Sources/PalmierPro/App/main.swift
@@ -12,6 +12,7 @@ ModelCatalog.shared.configure()
 UserDefaults.standard.set(10, forKey: "NSInitialToolTipDelay")
 
 let app = NSApplication.shared
+AppAppearanceStore.shared.apply()
 let delegate = AppDelegate()
 app.delegate = delegate
 app.mainMenu = MainMenuBuilder.buildMenu()

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -3,13 +3,14 @@ import SwiftUI
 
 struct EditorView: NSViewControllerRepresentable {
     @Environment(EditorViewModel.self) var editor
+    @Bindable private var workspaceLayout = WorkspaceLayoutStore.shared
 
     func makeNSViewController(context: Context) -> EditorSplitViewController {
         EditorSplitViewController(editor: editor)
     }
 
     func updateNSViewController(_ controller: EditorSplitViewController, context: Context) {
-        controller.applyLayoutIfNeeded(editor.layoutPreset)
+        controller.applyLayoutIfNeeded(workspaceLayout.selection)
         controller.applyAgentVisibility(editor.agentPanelVisible)
         controller.applyMediaVisibility(editor.mediaPanelVisible)
         controller.applyInspectorVisibility(editor.inspectorPanelVisible)
@@ -95,7 +96,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         super.viewDidLoad()
         splitView.dividerStyle = .thin
         splitView.autosaveName = SplitAutosave.root
-        buildLayout(editor.layoutPreset)
+        buildLayout(WorkspaceLayoutStore.shared.selection)
     }
 
     // MARK: - Layout switching

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -313,9 +313,9 @@ extension EditorWindowController: EditorActions {
     @objc func toggleInspectorPanel(_ sender: Any?) { editorViewModel.inspectorPanelVisible.toggle() }
     @objc func toggleAgentPanel(_ sender: Any?) { editorViewModel.agentPanelVisible.toggle() }
     @objc func toggleMaximizePanel(_ sender: Any?) { toggleMaximizePanelAction() }
-    @objc func setLayoutDefault(_ sender: Any?) { editorViewModel.layoutPreset = .default }
-    @objc func setLayoutMedia(_ sender: Any?) { editorViewModel.layoutPreset = .media }
-    @objc func setLayoutVertical(_ sender: Any?) { editorViewModel.layoutPreset = .vertical }
+    @objc func setLayoutDefault(_ sender: Any?) { WorkspaceLayoutStore.shared.selection = .default }
+    @objc func setLayoutMedia(_ sender: Any?) { WorkspaceLayoutStore.shared.selection = .media }
+    @objc func setLayoutVertical(_ sender: Any?) { WorkspaceLayoutStore.shared.selection = .vertical }
 
     private func toggleMaximizePanelAction() {
         if editorViewModel.maximizedPanel != nil {
@@ -340,13 +340,13 @@ extension EditorWindowController: EditorActions {
             menuItem.state = editorViewModel.maximizedPanel != nil ? .on : .off
             return editorViewModel.maximizedPanel != nil || editorViewModel.focusedPanel != nil
         case #selector(setLayoutDefault(_:)):
-            menuItem.state = editorViewModel.layoutPreset == .default ? .on : .off
+            menuItem.state = WorkspaceLayoutStore.shared.selection == .default ? .on : .off
             return true
         case #selector(setLayoutMedia(_:)):
-            menuItem.state = editorViewModel.layoutPreset == .media ? .on : .off
+            menuItem.state = WorkspaceLayoutStore.shared.selection == .media ? .on : .off
             return true
         case #selector(setLayoutVertical(_:)):
-            menuItem.state = editorViewModel.layoutPreset == .vertical ? .on : .off
+            menuItem.state = WorkspaceLayoutStore.shared.selection == .vertical ? .on : .off
             return true
         case #selector(copy(_:)), #selector(cut(_:)):
             return canHandleClipboardShortcut() && !editorViewModel.selectedClipIds.isEmpty

--- a/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourOverlay.swift
@@ -56,7 +56,7 @@ struct TourOverlay: View {
     }
 
     private func scrim(cutout: CGRect?) -> some View {
-        Color.black.opacity(AppTheme.Opacity.strong)
+        AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
             .reverseMask {
                 if let cutout {
                     RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -151,15 +151,6 @@ final class EditorViewModel {
     var sourcePlayheadFrame: Int = 0 {
         didSet { playheadState.sourceFrame = sourcePlayheadFrame }
     }
-    var layoutPreset: LayoutPreset = {
-        if let raw = UserDefaults.standard.string(forKey: "layoutPreset"),
-           let preset = LayoutPreset(rawValue: raw) {
-            return preset
-        }
-        return .default
-    }() {
-        didSet { UserDefaults.standard.set(layoutPreset.rawValue, forKey: "layoutPreset") }
-    }
     // MARK: - Media library (in-memory, rebuilt on project open)
 
     var mediaAssets: [MediaAsset] = [] {

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Settings.swift
@@ -38,7 +38,7 @@ extension GenerationView {
                             outer: AppTheme.Radius.sm,
                             padding: AppTheme.Spacing.xxs
                         ))
-                            .fill(selectedType == type ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                            .fill(selectedType == type ? AppTheme.Interaction.fill(AppTheme.Opacity.faint) : .clear)
                     )
                     .hoverHighlight(cornerRadius: AppTheme.Radius.concentric(
                         outer: AppTheme.Radius.sm,
@@ -53,7 +53,7 @@ extension GenerationView {
         .padding(AppTheme.Spacing.xxs)
         .background(
             RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
         )
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
@@ -431,7 +431,9 @@ extension GenerationView {
                                 .padding(.vertical, 4)
                                 .background(
                                     RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                                        .fill(selection.wrappedValue == option ? Color.white.opacity(AppTheme.Opacity.soft) : Color.white.opacity(AppTheme.Opacity.subtle))
+                                        .fill(selection.wrappedValue == option
+                                            ? AppTheme.Interaction.fill(AppTheme.Opacity.soft)
+                                            : AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
                                 )
                         }
                         .buttonStyle(.plain)

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -165,7 +165,7 @@ struct GenerationView: View {
         .overlay {
             RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
                 .strokeBorder(
-                    Color.white.opacity(AppTheme.Opacity.hint),
+                    AppTheme.Interaction.fill(AppTheme.Opacity.hint),
                     lineWidth: AppTheme.BorderWidth.hairline
                 )
                 .allowsHitTesting(false)
@@ -251,7 +251,7 @@ struct GenerationView: View {
                 .strokeBorder(
                     isPromptFocused
                         ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium)
-                        : Color.white.opacity(AppTheme.Opacity.hint),
+                        : AppTheme.Interaction.fill(AppTheme.Opacity.hint),
                     lineWidth: isPromptFocused ? AppTheme.BorderWidth.thin : AppTheme.BorderWidth.hairline
                 )
                 .allowsHitTesting(false)
@@ -343,7 +343,7 @@ struct GenerationView: View {
 
     private var resizeHandle: some View {
         Capsule()
-            .fill(Color.white.opacity(AppTheme.Opacity.soft))
+            .fill(AppTheme.Interaction.fill(AppTheme.Opacity.soft))
             .frame(width: 24, height: 2)
             .frame(maxWidth: .infinity, minHeight: AppTheme.Spacing.md)
             .contentShape(Rectangle())
@@ -401,7 +401,7 @@ struct GenerationView: View {
     // MARK: - Secondary fields (lyrics / style instructions)
 
     private var inputDivider: some View {
-        Rectangle().fill(Color.white.opacity(AppTheme.Opacity.hint)).frame(height: AppTheme.BorderWidth.hairline)
+        Rectangle().fill(AppTheme.Interaction.fill(AppTheme.Opacity.hint)).frame(height: AppTheme.BorderWidth.hairline)
     }
 
     private func secondaryField(

--- a/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
+++ b/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
@@ -5,7 +5,7 @@ private struct ReferenceAssetPreview: View {
 
     var body: some View {
         ZStack {
-            Color.black
+            AppTheme.MediaOverlay.backgroundColor
             if let thumbnail = asset.thumbnail {
                 Image(nsImage: thumbnail)
                     .resizable()
@@ -13,7 +13,7 @@ private struct ReferenceAssetPreview: View {
             } else {
                 Image(systemName: asset.type.sfSymbolName)
                     .font(.system(size: AppTheme.FontSize.xl))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
             }
         }
         .accessibilityElement(children: .ignore)
@@ -42,10 +42,10 @@ struct RefCard: View {
                     Text(tag)
                         .font(.system(size: AppTheme.FontSize.xxs, weight: .medium))
                         .monospacedDigit()
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                         .padding(.horizontal, AppTheme.Spacing.xs)
                         .padding(.vertical, AppTheme.Spacing.xxs)
-                        .background(Color.black.opacity(AppTheme.Opacity.strong), in: Capsule())
+                        .background(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong), in: Capsule())
                         .padding(AppTheme.Spacing.xs)
                 }
             }
@@ -53,7 +53,7 @@ struct RefCard: View {
                 Button { onRemove() } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: AppTheme.FontSize.smMd))
-                        .foregroundStyle(.white.opacity(AppTheme.Opacity.prominent))
+                        .foregroundStyle(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.prominent))
                         .shadow(radius: 2)
                         .frame(width: AppTheme.IconSize.smMd, height: AppTheme.IconSize.smMd)
                         .contentShape(Rectangle())
@@ -79,7 +79,9 @@ struct RefDropZone: View {
             .frame(width: AppTheme.GenerationPanel.referenceTileWidth, height: AppTheme.GenerationPanel.referenceTileHeight)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(isTargeted ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.faint) : Color.white.opacity(AppTheme.Opacity.subtle))
+                    .fill(isTargeted
+                        ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.faint)
+                        : AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
@@ -127,7 +129,7 @@ struct FrameSlot: View {
                         Button { onClear() } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .font(.system(size: AppTheme.FontSize.smMd))
-                                .foregroundStyle(.white.opacity(AppTheme.Opacity.prominent))
+                                .foregroundStyle(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.prominent))
                                 .shadow(radius: 2)
                                 .frame(width: AppTheme.IconSize.smMd, height: AppTheme.IconSize.smMd)
                                 .contentShape(Rectangle())

--- a/Sources/PalmierPro/Help/FeedbackView.swift
+++ b/Sources/PalmierPro/Help/FeedbackView.swift
@@ -303,7 +303,6 @@ final class FeedbackWindowController: NSWindowController {
         window.setContentSize(NSSize(width: 480, height: 480))
         window.minSize = NSSize(width: 480, height: 420)
         window.title = "Send feedback"
-        window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false
         window.titleVisibility = .hidden

--- a/Sources/PalmierPro/Help/HelpView.swift
+++ b/Sources/PalmierPro/Help/HelpView.swift
@@ -28,7 +28,7 @@ struct HelpView: View {
 
             detail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black.opacity(AppTheme.Opacity.medium))
+                .background(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
         }
         .frame(minWidth: 820, idealWidth: 900, minHeight: 520, idealHeight: 560)
         .background(.ultraThinMaterial)
@@ -103,7 +103,6 @@ final class HelpWindowController: NSWindowController {
         window.minSize = NSSize(width: 820, height: 520)
         window.title = "Help"
         window.setFrameAutosaveName("PalmierProHelp-v1")
-        window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false
         window.titleVisibility = .hidden

--- a/Sources/PalmierPro/Home/HomeView.swift
+++ b/Sources/PalmierPro/Home/HomeView.swift
@@ -11,7 +11,7 @@ struct HomeView: View {
 
             content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black.opacity(AppTheme.Opacity.medium))
+                .background(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
         }
         .frame(
             minWidth: AppTheme.Window.homeMin.width,
@@ -139,7 +139,6 @@ final class HomeWindowController: NSWindowController {
         window.setContentSize(AppTheme.Window.homeDefault)
         window.minSize = AppTheme.Window.homeMin
         window.title = "Palmier Pro"
-        window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false
         window.titleVisibility = .hidden

--- a/Sources/PalmierPro/Home/MyProjectsSection.swift
+++ b/Sources/PalmierPro/Home/MyProjectsSection.swift
@@ -120,12 +120,12 @@ struct MyProjectsSection: View {
         .padding(.vertical, AppTheme.Spacing.xs)
         .background(
             Capsule(style: .continuous)
-                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
         )
         .overlay(
             Capsule(style: .continuous)
                 .strokeBorder(
-                    Color.white.opacity(AppTheme.Opacity.faint),
+                    AppTheme.Interaction.fill(AppTheme.Opacity.faint),
                     lineWidth: AppTheme.BorderWidth.thin
                 )
         )
@@ -256,7 +256,7 @@ private struct NewProjectCard: View {
                 .clipped()
 
             LinearGradient(
-                colors: [.clear, .black.opacity(AppTheme.Opacity.high)],
+                colors: [.clear, AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.high)],
                 startPoint: .top,
                 endPoint: .bottom
             )
@@ -265,7 +265,7 @@ private struct NewProjectCard: View {
 
             Text("Untitled")
                 .font(.system(size: AppTheme.FontSize.smMd, weight: .regular))
-                .foregroundStyle(.white)
+                .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                 .lineLimit(1)
                 .padding(.horizontal, AppTheme.Spacing.md)
                 .padding(.bottom, AppTheme.Spacing.smMd)
@@ -276,11 +276,11 @@ private struct NewProjectCard: View {
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.Radius.mdLg, style: .continuous)
                 .strokeBorder(
-                    Color.white.opacity(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
+                    AppTheme.Interaction.fill(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
                     lineWidth: AppTheme.BorderWidth.hairline
                 )
         )
-        .shadow(color: .black.opacity(isHovered ? 0.4 : 0.2), radius: isHovered ? 12 : 4, y: isHovered ? 4 : 2)
+        .shadow(color: AppTheme.MediaOverlay.backgroundColor.opacity(isHovered ? 0.4 : 0.2), radius: isHovered ? 12 : 4, y: isHovered ? 4 : 2)
         .scaleEffect(isHovered ? 1.03 : 1.0)
         .padding(AppTheme.Spacing.xs)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isHovered)

--- a/Sources/PalmierPro/Home/ProjectCard.swift
+++ b/Sources/PalmierPro/Home/ProjectCard.swift
@@ -32,7 +32,7 @@ struct ProjectCard: View {
                 }
                 .overlay {
                     if !entry.isAccessible {
-                        Color.black.opacity(0.6)
+                        AppTheme.MediaOverlay.backgroundColor.opacity(0.6)
 
                         VStack(spacing: AppTheme.Spacing.xs) {
                             Image(systemName: "questionmark.folder")
@@ -40,7 +40,7 @@ struct ProjectCard: View {
                             Text("File missing")
                                 .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
                         }
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
                     }
                 }
                 .clipped()
@@ -49,7 +49,7 @@ struct ProjectCard: View {
             LinearGradient(
                 stops: [
                     .init(color: .clear, location: 0),
-                    .init(color: .black.opacity(0.7), location: 1),
+                    .init(color: AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.high), location: 1),
                 ],
                 startPoint: .top,
                 endPoint: .bottom
@@ -60,12 +60,14 @@ struct ProjectCard: View {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
                 Text(entry.name)
                     .font(.system(size: AppTheme.FontSize.smMd, weight: .regular))
-                    .foregroundStyle(entry.isAccessible ? .white : AppTheme.Text.mutedColor)
+                    .foregroundStyle(entry.isAccessible
+                        ? AppTheme.MediaOverlay.primaryColor
+                        : AppTheme.MediaOverlay.mutedColor)
                     .lineLimit(1)
 
                 Text(Self.relativeString(for: entry.createdDate))
                     .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(.white.opacity(AppTheme.Opacity.medium))
+                    .foregroundStyle(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.medium))
             }
             .padding(.horizontal, AppTheme.Spacing.md)
             .padding(.bottom, AppTheme.Spacing.smMd)
@@ -83,7 +85,9 @@ struct ProjectCard: View {
             if isSelecting {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: AppTheme.FontSize.xl, weight: .semibold))
-                    .foregroundStyle(isSelected ? AppTheme.Accent.primary : AppTheme.Text.tertiaryColor)
+                    .foregroundStyle(isSelected
+                        ? AppTheme.MediaOverlay.primaryColor
+                        : AppTheme.MediaOverlay.tertiaryColor)
                     .padding(AppTheme.Spacing.smMd)
                     .allowsHitTesting(false)
             } else if isHovered {
@@ -105,11 +109,11 @@ struct ProjectCard: View {
                 .strokeBorder(
                     isSelected
                         ? AppTheme.Accent.primary
-                        : Color.white.opacity(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
+                        : AppTheme.Interaction.fill(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
                     lineWidth: isSelected ? AppTheme.BorderWidth.thick : AppTheme.BorderWidth.hairline
                 )
         )
-        .shadow(color: .black.opacity(isHovered ? 0.4 : 0.2), radius: isHovered ? 12 : 4, y: isHovered ? 4 : 2)
+        .shadow(color: AppTheme.MediaOverlay.backgroundColor.opacity(isHovered ? 0.4 : 0.2), radius: isHovered ? 12 : 4, y: isHovered ? 4 : 2)
         .scaleEffect(isHovered ? 1.03 : 1.0)
         .padding(AppTheme.Spacing.xs)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isHovered)

--- a/Sources/PalmierPro/Home/SampleProjectsStrip.swift
+++ b/Sources/PalmierPro/Home/SampleProjectsStrip.swift
@@ -95,7 +95,7 @@ private struct SampleCard: View {
             LinearGradient(
                 stops: [
                     .init(color: .clear, location: 0),
-                    .init(color: .black.opacity(0.7), location: 1),
+                    .init(color: AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.high), location: 1),
                 ],
                 startPoint: .top,
                 endPoint: .bottom
@@ -105,7 +105,7 @@ private struct SampleCard: View {
 
             Text(sample.title)
                 .font(.system(size: AppTheme.FontSize.smMd, weight: .regular))
-                .foregroundStyle(.white)
+                .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                 .lineLimit(1)
                 .padding(.horizontal, AppTheme.Spacing.md)
                 .padding(.bottom, AppTheme.Spacing.smMd)
@@ -123,7 +123,7 @@ private struct SampleCard: View {
         .overlay(
             RoundedRectangle(cornerRadius: cardRadius, style: .continuous)
                 .strokeBorder(
-                    Color.white.opacity(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
+                    AppTheme.Interaction.fill(isHovered ? AppTheme.Opacity.muted : AppTheme.Opacity.hint),
                     lineWidth: AppTheme.BorderWidth.hairline
                 )
         )
@@ -137,7 +137,7 @@ private struct SampleCard: View {
     @ViewBuilder
     private func downloadOverlay(_ download: SampleDownload) -> some View {
         ZStack {
-            Color.black.opacity(AppTheme.Opacity.faint)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.faint)
             if download.failed {
                 VStack(spacing: AppTheme.Spacing.xs) {
                     Image(systemName: "arrow.clockwise")
@@ -145,11 +145,11 @@ private struct SampleCard: View {
                     Text("Retry")
                         .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
                 }
-                .foregroundStyle(AppTheme.Text.primaryColor)
+                .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
             } else {
                 ProgressView(value: download.progress)
                     .progressViewStyle(.linear)
-                    .tint(AppTheme.Accent.primary)
+                    .tint(AppTheme.MediaOverlay.primaryColor)
                     .padding(.horizontal, AppTheme.Spacing.lg)
             }
         }

--- a/Sources/PalmierPro/Home/UpdateOverlay.swift
+++ b/Sources/PalmierPro/Home/UpdateOverlay.swift
@@ -9,7 +9,7 @@ struct UpdateOverlay: View {
     var body: some View {
         GeometryReader { proxy in
             ZStack {
-                Color.black.opacity(AppTheme.Opacity.strong)
+                AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
                     .ignoresSafeArea()
                 card
                     .frame(width: AppTheme.ComponentSize.updateOverlayWidth)

--- a/Sources/PalmierPro/Home/WelcomeOverlay.swift
+++ b/Sources/PalmierPro/Home/WelcomeOverlay.swift
@@ -11,7 +11,7 @@ struct WelcomeOverlay: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(AppTheme.Opacity.strong)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
                 .ignoresSafeArea()
             card
                 .frame(width: 520)

--- a/Sources/PalmierPro/Inspector/Components/Adjust/ColorWheelPad.swift
+++ b/Sources/PalmierPro/Inspector/Components/Adjust/ColorWheelPad.swift
@@ -36,7 +36,7 @@ struct ColorWheelPad: View {
 
     private var puck: some View {
         Circle()
-            .fill(.white)
+            .fill(AppTheme.MediaOverlay.primaryColor)
             .frame(width: AppTheme.Wheels.puckSize, height: AppTheme.Wheels.puckSize)
             .overlay(Circle().strokeBorder(AppTheme.Background.baseColor, lineWidth: AppTheme.BorderWidth.thin))
             .shadow(AppTheme.Shadow.sm)

--- a/Sources/PalmierPro/Inspector/Components/Adjust/HueCurveEditorView.swift
+++ b/Sources/PalmierPro/Inspector/Components/Adjust/HueCurveEditorView.swift
@@ -37,9 +37,9 @@ struct HueCurveEditorView: View {
                     Canvas { ctx, _ in
                         if hueHist.count > 1 {
                             ctx.fill(histogramPath(hueHist, size),
-                                     with: .color(.white.opacity(AppTheme.Opacity.muted)))
+                                     with: .color(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.muted)))
                             ctx.stroke(histogramLine(hueHist, size),
-                                       with: .color(.white.opacity(AppTheme.Opacity.prominent)),
+                                       with: .color(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.prominent)),
                                        lineWidth: AppTheme.BorderWidth.thin)
                         }
                         var grid = Path()

--- a/Sources/PalmierPro/Inspector/Components/ColorField.swift
+++ b/Sources/PalmierPro/Inspector/Components/ColorField.swift
@@ -16,7 +16,7 @@ struct ColorField: View {
                 .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.xs)
                 .overlay(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                        .stroke(Color.white.opacity(AppTheme.Opacity.medium), lineWidth: AppTheme.BorderWidth.thin)
+                        .stroke(AppTheme.Border.dividerColor, lineWidth: AppTheme.BorderWidth.thin)
                 )
         }
         .buttonStyle(.plain)

--- a/Sources/PalmierPro/Inspector/Components/ColorField.swift
+++ b/Sources/PalmierPro/Inspector/Components/ColorField.swift
@@ -8,12 +8,13 @@ struct ColorField: View {
     let onUserChange: (Color) -> Void
     var supportsOpacity: Bool = true
     var accessibilityLabel: String = "Choose color"
+    var swatchSize = CGSize(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.xs)
 
     var body: some View {
         Button(action: open) {
             RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
                 .fill(displayColor)
-                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.xs)
+                .frame(width: swatchSize.width, height: swatchSize.height)
                 .overlay(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
                         .stroke(AppTheme.Border.dividerColor, lineWidth: AppTheme.BorderWidth.thin)

--- a/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
+++ b/Sources/PalmierPro/Inspector/Components/GenerationReferencesStrip.swift
@@ -65,19 +65,19 @@ struct GenerationReferencesStrip: View {
     private func thumbnail(label: String, asset: MediaAsset) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
             ZStack {
-                Rectangle().fill(Color.black)
+                Rectangle().fill(AppTheme.MediaOverlay.backgroundColor)
                 if let thumb = asset.thumbnail {
                     Image(nsImage: thumb).resizable().aspectRatio(contentMode: .fit)
                 } else {
                     Image(systemName: asset.type.sfSymbolName)
                         .font(.system(size: AppTheme.FontSize.mdLg))
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
                 }
             }
             .frame(width: 72, height: 41)
             .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
             .overlay(RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                .strokeBorder(Color.white.opacity(AppTheme.Opacity.faint), lineWidth: AppTheme.BorderWidth.hairline))
+                .strokeBorder(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.faint), lineWidth: AppTheme.BorderWidth.hairline))
             Text(label)
                 .font(.system(size: AppTheme.FontSize.xxs, weight: .medium))
                 .foregroundStyle(AppTheme.Text.mutedColor)

--- a/Sources/PalmierPro/Inspector/Components/TextStyleControls.swift
+++ b/Sources/PalmierPro/Inspector/Components/TextStyleControls.swift
@@ -229,7 +229,7 @@ struct TextStyleControls<AfterAlignment: View, AfterColor: View>: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-            .tint(Color.white.opacity(AppTheme.Opacity.strong))
+            .tint(AppTheme.Accent.primary.opacity(AppTheme.Opacity.strong))
             .fixedSize()
         }
     }

--- a/Sources/PalmierPro/Inspector/Components/TextStyleTraitButtons.swift
+++ b/Sources/PalmierPro/Inspector/Components/TextStyleTraitButtons.swift
@@ -59,7 +59,7 @@ struct TextStyleTraitButtons: View {
                 .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.md)
                 .background(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.xsSm)
-                        .fill(isActive ? AppTheme.Accent.primary : Color.white.opacity(AppTheme.Opacity.hint))
+                        .fill(isActive ? AppTheme.Accent.primary : AppTheme.Interaction.fill(AppTheme.Opacity.hint))
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.xsSm)

--- a/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
+++ b/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
@@ -50,7 +50,7 @@ struct TitleTabBar: View {
 
     private func tabBackground(active: Bool, hovered: Bool) -> Color {
         if active { return AppTheme.Background.surfaceColor }
-        if hovered { return Color.white.opacity(AppTheme.Opacity.faint) }
+        if hovered { return AppTheme.Interaction.fill(AppTheme.Opacity.faint) }
         return Color.clear
     }
 }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -906,7 +906,7 @@ struct InspectorView: View {
                 .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
                 .background(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                        .fill(Color.white.opacity(isOn ? AppTheme.Opacity.subtle : 0))
+                        .fill(AppTheme.Interaction.fill(isOn ? AppTheme.Opacity.subtle : 0))
                 )
                 .hoverHighlight()
         }
@@ -1115,7 +1115,7 @@ struct InspectorView: View {
             .padding(.vertical, AppTheme.Spacing.xxs)
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(Color.white.opacity(AppTheme.Opacity.muted), lineWidth: AppTheme.BorderWidth.hairline)
+                    .strokeBorder(AppTheme.Interaction.fill(AppTheme.Opacity.muted), lineWidth: AppTheme.BorderWidth.hairline)
             )
     }
 

--- a/Sources/PalmierPro/Inspector/Keyframes/KeyframesLane.swift
+++ b/Sources/PalmierPro/Inspector/Keyframes/KeyframesLane.swift
@@ -44,7 +44,7 @@ struct ClipRulerBlock: View {
                     .overlay(alignment: .leading) {
                         Text(editor.clipDisplayLabel(for: clip))
                             .font(.system(size: AppTheme.FontSize.xxs, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.95))
+                            .foregroundStyle(AppTheme.MediaOverlay.primaryColor.opacity(0.95))
                             .padding(.horizontal, AppTheme.Spacing.sm)
                             .lineLimit(1)
                     }
@@ -89,7 +89,7 @@ struct KeyframesLaneRow: View {
     var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: .leading) {
-                Rectangle().fill(.white.opacity(AppTheme.Opacity.subtle))
+                Rectangle().fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
                 Canvas { ctx, size in
                     let half = KeyframesMetrics.diamondSize / 2
                     let y = size.height / 2
@@ -102,7 +102,11 @@ struct KeyframesLaneRow: View {
                         d.addLine(to: CGPoint(x: x - half, y: y))
                         d.closeSubpath()
                         ctx.fill(d, with: .color(tint))
-                        ctx.stroke(d, with: .color(.black.opacity(0.4)), lineWidth: AppTheme.BorderWidth.hairline)
+                        ctx.stroke(
+                            d,
+                            with: .color(AppTheme.MediaOverlay.backgroundColor.opacity(0.4)),
+                            lineWidth: AppTheme.BorderWidth.hairline
+                        )
                     }
                 }
 

--- a/Sources/PalmierPro/Inspector/Keyframes/KeyframesLane.swift
+++ b/Sources/PalmierPro/Inspector/Keyframes/KeyframesLane.swift
@@ -262,6 +262,7 @@ struct KeyframesLaneRow: View {
 struct KeyframesPanel: View {
     let clip: Clip
     @Environment(EditorViewModel.self) private var editor
+    private let timelineColors = TimelineClipColorStore.shared
     @State private var snapX: CGFloat?
 
     private static let videoRows: [(AnimatableProperty, String)] = [
@@ -279,7 +280,10 @@ struct KeyframesPanel: View {
         clip.mediaType == .audio ? Self.audioRows : Self.videoRows
     }
 
-    private var tint: Color { Color(nsColor: clip.sourceClipType.themeColor) }
+    private var tint: Color {
+        _ = timelineColors.revision
+        return Color(nsColor: clip.sourceClipType.themeColor)
+    }
     private var span: Int { max(1, clip.endFrame - clip.startFrame) }
 
     var body: some View {

--- a/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AdjustTab.swift
@@ -496,7 +496,7 @@ extension InspectorView {
                 .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                        .fill(Color.white.opacity(AppTheme.Opacity.hint))
+                        .fill(AppTheme.Interaction.fill(AppTheme.Opacity.hint))
                 )
             }
             .buttonStyle(.plain)

--- a/Sources/PalmierPro/Inspector/Tabs/MulticamTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/MulticamTab.swift
@@ -18,7 +18,7 @@ struct MulticamTab: View {
         HStack(spacing: AppTheme.Spacing.sm) {
             Text(member.kind.rawValue.capitalized)
                 .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
-                .foregroundStyle(.black.opacity(AppTheme.Opacity.prominent))
+                .foregroundStyle(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.prominent))
                 .padding(.horizontal, AppTheme.Spacing.xs)
                 .padding(.vertical, AppTheme.Spacing.xxs)
                 .background(Color(kindColor(member.kind)), in: RoundedRectangle(cornerRadius: AppTheme.Radius.xs))

--- a/Sources/PalmierPro/Inspector/Tabs/MulticamTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/MulticamTab.swift
@@ -3,8 +3,11 @@ import SwiftUI
 struct MulticamTab: View {
     @Environment(EditorViewModel.self) var editor
     let groupId: String
+    @Bindable private var timelineColors = TimelineClipColorStore.shared
 
     var body: some View {
+        let _ = timelineColors.revision
+
         if let group = editor.multicamGroup(id: groupId) {
             EditorPanelGroup(group.name.isEmpty ? "Multicam" : group.name) {
                 ForEach(group.members) { member in
@@ -18,7 +21,7 @@ struct MulticamTab: View {
         HStack(spacing: AppTheme.Spacing.sm) {
             Text(member.kind.rawValue.capitalized)
                 .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
-                .foregroundStyle(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.prominent))
+                .foregroundStyle(Color(AppTheme.TrackColor.readableForeground(on: kindColor(member.kind))).opacity(AppTheme.Opacity.prominent))
                 .padding(.horizontal, AppTheme.Spacing.xs)
                 .padding(.vertical, AppTheme.Spacing.xxs)
                 .background(Color(kindColor(member.kind)), in: RoundedRectangle(cornerRadius: AppTheme.Radius.xs))

--- a/Sources/PalmierPro/MediaPanel/MatteSheet.swift
+++ b/Sources/PalmierPro/MediaPanel/MatteSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct MatteSheet: View {
     @Environment(EditorViewModel.self) private var editor
     @Binding var isPresented: Bool
-    @State private var color = Color.black
+    @State private var color = AppTheme.MediaOverlay.backgroundColor
     @State private var aspect = MatteAspect.project
     @State private var isCreating = false
     @State private var error: String?

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -11,7 +11,7 @@ struct AssetThumbnailView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
             ZStack {
-                Rectangle().fill(Color.black)
+                Rectangle().fill(AppTheme.MediaOverlay.backgroundColor)
                 thumbnailContent
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
@@ -58,7 +58,7 @@ struct AssetThumbnailView: View {
             .padding(.vertical, AppTheme.Spacing.xxs)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                    .fill(isRenaming ? AppTheme.Interaction.fill(AppTheme.Opacity.faint) : .clear)
             )
         }
         .frame(maxWidth: .infinity)
@@ -146,7 +146,7 @@ struct AssetThumbnailView: View {
                         Color.clear
                             .overlay { Image(nsImage: image).resizable().scaledToFill().blur(radius: 12) }
                             .clipped()
-                        Color.black.opacity(AppTheme.Opacity.strong)
+                        AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
                     }
                     GeneratingOverlay(label: asset.generatingLabel)
                 }
@@ -162,7 +162,7 @@ struct AssetThumbnailView: View {
             } else {
                 Image(systemName: asset.type.sfSymbolName)
                     .font(.system(size: AppTheme.FontSize.xl))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
             }
         }
     }
@@ -202,12 +202,15 @@ struct AssetThumbnailView: View {
             Button { editor.agentService.attachMention(for: asset) } label: {
                 Image(systemName: "bubble.left")
                     .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                     .frame(width: AppTheme.IconSize.smMd, height: AppTheme.IconSize.smMd)
             }
             .buttonStyle(.plain)
-            .background(.black.opacity(AppTheme.Opacity.strong), in: .circle)
-            .overlay(Circle().strokeBorder(Color.white.opacity(AppTheme.Opacity.muted), lineWidth: AppTheme.BorderWidth.hairline))
+            .background(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong), in: .circle)
+            .overlay(Circle().strokeBorder(
+                AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.muted),
+                lineWidth: AppTheme.BorderWidth.hairline
+            ))
             .padding(AppTheme.Spacing.xs)
             .transition(.opacity)
             .help("Add to chat")
@@ -217,10 +220,10 @@ struct AssetThumbnailView: View {
     private var sourceBadge: some View {
         Text("AI")
             .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
-            .foregroundStyle(AppTheme.aiGradient)
+            .foregroundStyle(AppTheme.MediaOverlay.aiGradient)
             .padding(.horizontal, AppTheme.Spacing.sm)
             .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(Color.black.opacity(AppTheme.Opacity.prominent), in: .capsule)
+            .background(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.prominent), in: .capsule)
     }
 
     private var durationBadge: some View {
@@ -237,10 +240,10 @@ struct AssetThumbnailView: View {
                 .foregroundStyle(.red.opacity(AppTheme.Opacity.prominent))
             Text("Failed")
                 .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
             Text(error)
                 .font(.system(size: AppTheme.FontSize.xxs))
-                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
                 .truncationMode(.tail)
@@ -253,10 +256,10 @@ struct AssetThumbnailView: View {
         VStack(spacing: AppTheme.Spacing.xxs) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: AppTheme.FontSize.mdLg))
-                .foregroundStyle(AppTheme.Status.errorColor)
+                .foregroundStyle(AppTheme.MediaOverlay.errorColor)
             Text("Media Offline")
                 .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
-                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
         }
         .help("Palmier couldn't load this source file. It may be missing, on an ejected drive, or unreadable.")
     }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/FolderTileView.swift
@@ -24,7 +24,7 @@ struct FolderTileView: View {
             onCancelRename: onCancelRename
         ) {
             RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
             Image(systemName: "folder.fill")
                 .font(.system(size: AppTheme.FontSize.display, weight: AppTheme.FontWeight.light))
                 .foregroundStyle(AppTheme.Accent.primary.opacity(AppTheme.Opacity.prominent))

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Drag.swift
@@ -85,12 +85,12 @@ extension MediaTab {
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
                     .strokeBorder(AppTheme.Accent.primary, lineWidth: AppTheme.BorderWidth.medium)
             )
-            .shadow(color: .black.opacity(AppTheme.Opacity.medium), radius: 4, y: 2)
+            .shadow(color: AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.medium), radius: 4, y: 2)
 
             if count > 1 {
                 Text("\(count)")
                     .font(.system(size: AppTheme.FontSize.sm, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(AppTheme.Background.baseColor)
                     .padding(.horizontal, AppTheme.Spacing.sm)
                     .padding(.vertical, AppTheme.Spacing.xxs)
                     .background(Capsule().fill(AppTheme.Accent.primary))

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -551,6 +551,6 @@ private struct TileDragPreview: View {
         .padding(.horizontal, AppTheme.Spacing.smMd)
         .padding(.vertical, AppTheme.Spacing.sm)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: AppTheme.Radius.sm))
-        .shadow(color: .black.opacity(AppTheme.Opacity.medium), radius: 4, y: 2)
+        .shadow(color: AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.medium), radius: 4, y: 2)
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -147,12 +147,12 @@ extension MediaTab {
     private func momentThumb(_ asset: MediaAsset?, time: Double) -> some View {
         if let asset, asset.type == .image {
             ZStack {
-                Rectangle().fill(Color.black)
+                Rectangle().fill(AppTheme.MediaOverlay.backgroundColor)
                 if let thumb = asset.thumbnail {
                     Image(nsImage: thumb).resizable().aspectRatio(contentMode: .fit)
                 } else {
                     Image(systemName: "photo")
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
                 }
             }
             .task(id: searchThumbnailTaskID(for: asset)) {
@@ -197,12 +197,12 @@ extension MediaTab {
     private func fileCard(_ asset: MediaAsset) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
             ZStack {
-                Rectangle().fill(Color.black)
+                Rectangle().fill(AppTheme.MediaOverlay.backgroundColor)
                 if let thumb = asset.thumbnail {
                     Image(nsImage: thumb).resizable().aspectRatio(contentMode: .fit)
                 } else {
                     Image(systemName: asset.type.sfSymbolName)
-                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.tertiaryColor)
                 }
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
@@ -286,7 +286,7 @@ private struct MomentThumbnail: View {
 
     var body: some View {
         ZStack {
-            Rectangle().fill(Color.black)
+            Rectangle().fill(AppTheme.MediaOverlay.backgroundColor)
             if let image {
                 Image(decorative: image, scale: 1)
                     .resizable()

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -579,11 +579,11 @@ struct MediaTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             Capsule(style: .continuous)
-                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
         )
         .overlay(
             Capsule(style: .continuous)
-                .strokeBorder(Color.white.opacity(AppTheme.Opacity.faint), lineWidth: AppTheme.BorderWidth.thin)
+                .strokeBorder(AppTheme.Interaction.fill(AppTheme.Opacity.faint), lineWidth: AppTheme.BorderWidth.thin)
         )
     }
 
@@ -755,8 +755,8 @@ struct MediaTab: View {
     var marqueeOverlay: some View {
         if let rect = marqueeSelection.rect {
             Rectangle()
-                .stroke(Color.white.opacity(AppTheme.Opacity.strong), style: StrokeStyle(lineWidth: AppTheme.BorderWidth.thin, dash: [3, 3]))
-                .background(Rectangle().fill(Color.white.opacity(AppTheme.Opacity.soft)))
+                .stroke(AppTheme.Interaction.fill(AppTheme.Opacity.strong), style: StrokeStyle(lineWidth: AppTheme.BorderWidth.thin, dash: [3, 3]))
+                .background(Rectangle().fill(AppTheme.Interaction.fill(AppTheme.Opacity.soft)))
                 .frame(width: rect.width, height: rect.height)
                 .position(x: rect.midX, y: rect.midY)
                 .allowsHitTesting(false)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
@@ -31,7 +31,7 @@ struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
                 .padding(.vertical, AppTheme.Spacing.xxs)
                 .background(
                     RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                        .fill(isRenaming ? Color.white.opacity(AppTheme.Opacity.faint) : .clear)
+                        .fill(isRenaming ? AppTheme.Interaction.fill(AppTheme.Opacity.faint) : .clear)
                 )
         }
         .frame(maxWidth: .infinity)
@@ -88,10 +88,10 @@ struct MediaTileScaffold<Artwork: View, MenuItems: View>: View {
 
 extension View {
     func tileBadge() -> some View {
-        foregroundStyle(.white)
+        foregroundStyle(AppTheme.MediaOverlay.primaryColor)
             .padding(.horizontal, AppTheme.Spacing.sm)
             .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(.ultraThinMaterial, in: .capsule)
+            .background(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong), in: .capsule)
             .padding(AppTheme.Spacing.xs)
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
@@ -26,7 +26,7 @@ struct TimelineTileView: View {
             onCancelRename: onCancelRename
         ) {
             RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                .fill(Color(white: 1.0, opacity: AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
             if let posterImage {
                 GeometryReader { geo in
                     Image(nsImage: posterImage)
@@ -64,7 +64,9 @@ struct TimelineTileView: View {
                 Image(systemName: "film.stack")
                     .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
                     .tileBadge()
-                    .foregroundStyle(isActive ? AppTheme.Accent.primary : .white)
+                    .foregroundStyle(isActive
+                        ? AppTheme.MediaOverlay.primaryColor
+                        : AppTheme.MediaOverlay.secondaryColor)
                 Spacer()
             }
             Spacer()

--- a/Sources/PalmierPro/Preview/CropOverlayView.swift
+++ b/Sources/PalmierPro/Preview/CropOverlayView.swift
@@ -5,7 +5,7 @@ struct CropOverlayView: View {
 
     private let handleSize: CGFloat = AppTheme.Spacing.smMd
     private let borderColor = AppTheme.Accent.timecodeColor
-    private let dimColor = Color.black.opacity(AppTheme.Opacity.strong)
+    private let dimColor = AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
     private let guideColor = AppTheme.Accent.timecodeColor.opacity(AppTheme.Opacity.medium)
 
     var body: some View {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -66,7 +66,10 @@ struct PreviewContainerView: View {
                 )
                 .overlay(
                     Rectangle()
-                        .stroke(Color.white.opacity(editor.canvasZoom < 1.0 ? AppTheme.Opacity.moderate : 0), lineWidth: AppTheme.BorderWidth.thin)
+                        .stroke(
+                            AppTheme.MediaOverlay.primaryColor.opacity(editor.canvasZoom < 1.0 ? AppTheme.Opacity.moderate : 0),
+                            lineWidth: AppTheme.BorderWidth.thin
+                        )
                 )
                 .position(x: geo.size.width / 2, y: geo.size.height / 2)
                 .offset(x: editor.canvasOffset.width, y: editor.canvasOffset.height)
@@ -277,7 +280,7 @@ struct PreviewContainerView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.black)
+        .background(AppTheme.Background.previewCanvasColor)
         .allowsHitTesting(false)
         .task(id: assetKey) {
             failedImagePreviewKey = nil
@@ -405,7 +408,7 @@ struct PreviewContainerView: View {
                     .overlay { Image(nsImage: image).resizable().scaledToFill().blur(radius: 24) }
                     .clipped()
             }
-            Color.black.opacity(AppTheme.Opacity.strong)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
             GeneratingOverlay(label: label, size: .preview)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -438,26 +441,26 @@ struct PreviewContainerView: View {
 
     private func offlinePreview(assetId: String?, path: String?, isUnprocessable: Bool) -> some View {
         ZStack {
-            Color.black.opacity(AppTheme.Opacity.strong)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
             VStack(spacing: AppTheme.Spacing.md) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: AppTheme.FontSize.display))
                     .foregroundStyle(AppTheme.Status.errorColor)
                 Text(isUnprocessable ? "Couldn't Prepare Media" : "Media Offline")
                     .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
-                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                 Text(isUnprocessable
                     ? "Palmier loaded this clip's source file but couldn't prepare it for playback. The file may be corrupt or in an unsupported format."
                     : "Palmier couldn't load this clip's source file. It may be missing, on an ejected drive, or unreadable.")
                     .font(.system(size: AppTheme.FontSize.sm))
-                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, AppTheme.Spacing.lg)
                 if let path {
                     Text(path)
                         .font(.system(size: AppTheme.FontSize.sm))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
                         .multilineTextAlignment(.center)
                         .textSelection(.enabled)
                         .lineLimit(3)
@@ -490,18 +493,18 @@ struct PreviewContainerView: View {
 
     private func failedPreview(error: String) -> some View {
         ZStack {
-            Color.black.opacity(AppTheme.Opacity.strong)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
             VStack(spacing: AppTheme.Spacing.md) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: AppTheme.FontSize.display))
                     .foregroundStyle(.red.opacity(AppTheme.Opacity.prominent))
                 Text("Generation Failed")
                     .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
-                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                 ScrollView {
                     Text(error)
                         .font(.system(size: AppTheme.FontSize.md))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
                         .multilineTextAlignment(.center)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity)
@@ -518,13 +521,16 @@ struct PreviewContainerView: View {
                             Text("Retry Download")
                         }
                         .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
-                        .foregroundStyle(AppTheme.Text.primaryColor)
+                        .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                         .padding(.horizontal, AppTheme.Spacing.md)
                         .padding(.vertical, AppTheme.Spacing.sm)
                     }
                     .buttonStyle(.plain)
-                    .background(.white.opacity(AppTheme.Opacity.soft), in: .capsule)
-                    .overlay(Capsule().strokeBorder(.white.opacity(AppTheme.Opacity.muted), lineWidth: AppTheme.BorderWidth.hairline))
+                    .background(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.soft), in: .capsule)
+                    .overlay(Capsule().strokeBorder(
+                        AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.muted),
+                        lineWidth: AppTheme.BorderWidth.hairline
+                    ))
                 }
             }
             .padding(AppTheme.Spacing.xl)
@@ -642,7 +648,7 @@ struct PreviewContainerView: View {
             let barHeight: CGFloat = active ? 4 : 3
             ZStack(alignment: .leading) {
                 Capsule()
-                    .fill(Color.white.opacity(AppTheme.Opacity.soft))
+                    .fill(AppTheme.Interaction.fill(AppTheme.Opacity.soft))
                     .frame(height: barHeight)
                 PreviewScrubProgress(
                     isTimeline: isTimeline,
@@ -830,9 +836,9 @@ private struct PreviewScrubProgress: View {
                 .fill(AppTheme.Accent.primary)
                 .frame(width: max(0, g.size.width * progress), height: g.barHeight)
             Circle()
-                .fill(Color.white)
+                .fill(AppTheme.Text.primaryColor)
                 .frame(width: g.thumbSize, height: g.thumbSize)
-                .shadow(color: .black.opacity(0.3), radius: 1, y: 1)
+                .shadow(AppTheme.Shadow.sm)
                 .position(x: g.size.width * progress, y: g.size.height / 2)
         }
     }

--- a/Sources/PalmierPro/Preview/PreviewView.swift
+++ b/Sources/PalmierPro/Preview/PreviewView.swift
@@ -67,13 +67,18 @@ final class PreviewNSView: NSView {
     override init(frame: NSRect) {
         super.init(frame: frame)
         wantsLayer = true
-        layer?.backgroundColor = AppTheme.Background.surface.cgColor
+        updateAppearanceColors()
         playerLayer.videoGravity = .resizeAspect
         layer?.addSublayer(playerLayer)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearanceColors()
+    }
 
     override func layout() {
         super.layout()
@@ -94,5 +99,11 @@ final class PreviewNSView: NSView {
         let delta = event.scrollingDeltaY * sensitivity
         if delta == 0 { return }
         onCmdScroll(delta, topDown, bounds.size)
+    }
+
+    private func updateAppearanceColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = AppTheme.Background.surface.cgColor
+        }
     }
 }

--- a/Sources/PalmierPro/Preview/SlipTwoUpView.swift
+++ b/Sources/PalmierPro/Preview/SlipTwoUpView.swift
@@ -20,7 +20,7 @@ struct SlipTwoUpView: View {
 
     var body: some View {
         ZStack {
-            Color.black
+            AppTheme.MediaOverlay.backgroundColor
             HStack(spacing: AppTheme.Spacing.xxs) {
                 pane(image: inImage, label: "Start", frame: state.inSourceFrame)
                 pane(image: outImage, label: "End", frame: state.outSourceFrame)
@@ -68,7 +68,7 @@ struct SlipTwoUpView: View {
 
     private func pane(image: CGImage?, label: String, frame: Int) -> some View {
         ZStack(alignment: .topLeading) {
-            Color.black
+            AppTheme.MediaOverlay.backgroundColor
             if let image {
                 Image(decorative: image, scale: 1)
                     .resizable()
@@ -78,14 +78,14 @@ struct SlipTwoUpView: View {
             HStack(spacing: AppTheme.Spacing.xs) {
                 Text(label)
                     .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.semibold))
-                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.primaryColor)
                 Text(formatTimecode(frame: frame, fps: state.fps))
                     .font(.system(size: AppTheme.FontSize.xs).monospacedDigit())
-                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
             }
             .padding(.horizontal, AppTheme.Spacing.sm)
             .padding(.vertical, AppTheme.Spacing.xxs)
-            .background(Color.black.opacity(AppTheme.Opacity.strong), in: RoundedRectangle(cornerRadius: AppTheme.Radius.xs))
+            .background(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong), in: RoundedRectangle(cornerRadius: AppTheme.Radius.xs))
             .padding(AppTheme.Spacing.sm)
         }
         .clipped()

--- a/Sources/PalmierPro/Preview/TransformOverlayView.swift
+++ b/Sources/PalmierPro/Preview/TransformOverlayView.swift
@@ -4,7 +4,7 @@ struct TransformOverlayView: View {
     @Environment(EditorViewModel.self) var editor
 
     private let handleSize: CGFloat = AppTheme.Spacing.smMd
-    private let borderColor = Color.white.opacity(AppTheme.Opacity.strong)
+    private let borderColor = AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.strong)
 
     var body: some View {
         GeometryReader { geo in
@@ -20,7 +20,7 @@ struct TransformOverlayView: View {
 
                 let hit = rotatedHitTarget(clipRect.size, degrees: rotation)
                 Rectangle()
-                    .fill(Color.white.opacity(0.001))
+                    .fill(AppTheme.MediaOverlay.primaryColor.opacity(0.001))
                     .frame(width: hit.frame.width, height: hit.frame.height)
                     .contentShape(hit.shape)
                     .position(x: clipRect.midX, y: clipRect.midY)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -469,10 +469,9 @@ class VideoProject: NSDocument {
 
         let window = NSWindow(contentViewController: hostingController)
         window.minSize = AppTheme.Window.projectMin
-        window.appearance = NSAppearance(named: .darkAqua)
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = true
-        window.backgroundColor = NSColor(AppTheme.Background.surfaceColor)
+        window.backgroundColor = AppTheme.Background.surface
         window.fillVisibleScreen()
 
         window.addTitlebarSwiftUI(TitleBarLeadingView().environment(editorViewModel), side: .leading, width: AppTheme.IconSize.lg + AppTheme.Spacing.sm)

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -75,7 +75,7 @@ struct AgentPane: View {
             .padding(.vertical, AppTheme.Spacing.smMd)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .fill(Color.black.opacity(AppTheme.Opacity.muted))
+                    .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm)

--- a/Sources/PalmierPro/Settings/AppearancePane.swift
+++ b/Sources/PalmierPro/Settings/AppearancePane.swift
@@ -2,17 +2,40 @@ import SwiftUI
 
 struct AppearancePane: View {
     @Bindable private var appearance = AppAppearanceStore.shared
+    @Bindable private var workspaceLayout = WorkspaceLayoutStore.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xxl) {
             SettingsGroup(title: "Theme") {
                 HStack(alignment: .top, spacing: AppTheme.Spacing.mdLg) {
                     ForEach(AppAppearance.allCases) { option in
-                        AppearanceOptionCard(
-                            option: option,
+                        SettingsPreviewCard(
+                            label: option.label,
+                            shortcutLabel: nil,
                             isSelected: appearance.selection == option,
+                            accessibilityLabel: "\(option.label) appearance",
                             action: { appearance.selection = option }
-                        )
+                        ) {
+                            AppearancePreview(option: option)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            SettingsGroup(title: "Workspace layout") {
+                HStack(alignment: .top, spacing: AppTheme.Spacing.mdLg) {
+                    ForEach(LayoutPreset.allCases) { preset in
+                        SettingsPreviewCard(
+                            label: preset.label,
+                            shortcutLabel: preset.shortcutLabel,
+                            isSelected: workspaceLayout.selection == preset,
+                            accessibilityLabel: "\(preset.label) workspace layout",
+                            action: { workspaceLayout.selection = preset }
+                        ) {
+                            WorkspaceLayoutPreview(preset: preset)
+                        }
+                        .keyboardShortcut(KeyEquivalent(preset.shortcutKey), modifiers: .command)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -25,17 +48,20 @@ struct AppearancePane: View {
     }
 }
 
-private struct AppearanceOptionCard: View {
-    let option: AppAppearance
+private struct SettingsPreviewCard<Preview: View>: View {
+    let label: String
+    let shortcutLabel: String?
     let isSelected: Bool
+    let accessibilityLabel: String
     let action: () -> Void
+    @ViewBuilder let preview: () -> Preview
 
     @State private var isHovering = false
 
     var body: some View {
         Button(action: action) {
             VStack(spacing: AppTheme.Spacing.smMd) {
-                AppearancePreview(option: option)
+                preview()
                     .aspectRatio(1.5, contentMode: .fit)
                     .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
                     .overlay {
@@ -46,21 +72,174 @@ private struct AppearanceOptionCard: View {
                             )
                     }
 
-                Text(option.label)
-                    .font(.system(size: AppTheme.FontSize.mdLg, weight: AppTheme.FontWeight.regular))
-                    .foregroundStyle(isSelected ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
+                HStack(spacing: AppTheme.Spacing.xs) {
+                    Text(label)
+                        .foregroundStyle(isSelected ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
+
+                    if let shortcutLabel {
+                        Text(shortcutLabel)
+                            .foregroundStyle(AppTheme.Text.mutedColor)
+                    }
+                }
+                .font(.system(size: AppTheme.FontSize.mdLg, weight: AppTheme.FontWeight.regular))
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
-        .accessibilityLabel("\(option.label) appearance")
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
     }
 
     private var borderColor: Color {
         if isSelected { return AppTheme.Accent.primary }
         return isHovering ? AppTheme.Border.dividerColor : AppTheme.Border.subtleColor
+    }
+}
+
+private struct WorkspaceLayoutPreview: View {
+    let preset: LayoutPreset
+
+    var body: some View {
+        GeometryReader { geometry in
+            let gap = max(geometry.size.width * 0.012, AppTheme.BorderWidth.thin)
+
+            ZStack {
+                AppTheme.Background.surfaceColor
+
+                Group {
+                    switch preset {
+                    case .default:
+                        VStack(spacing: gap) {
+                            HStack(spacing: gap) {
+                                LayoutPanelPreview(kind: .media)
+                                    .frame(width: geometry.size.width * 0.24)
+                                LayoutPanelPreview(kind: .preview)
+                                LayoutPanelPreview(kind: .inspector)
+                                    .frame(width: geometry.size.width * 0.22)
+                            }
+                            LayoutPanelPreview(kind: .timeline)
+                                .frame(height: geometry.size.height * 0.29)
+                        }
+                    case .media:
+                        HStack(spacing: gap) {
+                            LayoutPanelPreview(kind: .media)
+                                .frame(width: geometry.size.width * 0.28)
+                            VStack(spacing: gap) {
+                                HStack(spacing: gap) {
+                                    LayoutPanelPreview(kind: .preview)
+                                    LayoutPanelPreview(kind: .inspector)
+                                        .frame(width: geometry.size.width * 0.20)
+                                }
+                                LayoutPanelPreview(kind: .timeline)
+                                    .frame(height: geometry.size.height * 0.39)
+                            }
+                        }
+                    case .vertical:
+                        HStack(spacing: gap) {
+                            VStack(spacing: gap) {
+                                HStack(spacing: gap) {
+                                    LayoutPanelPreview(kind: .media)
+                                    LayoutPanelPreview(kind: .inspector)
+                                }
+                                LayoutPanelPreview(kind: .timeline)
+                                    .frame(height: geometry.size.height * 0.39)
+                            }
+                            LayoutPanelPreview(kind: .preview)
+                        }
+                    }
+                }
+                .padding(geometry.size.width * 0.04)
+            }
+        }
+    }
+}
+
+private struct LayoutPanelPreview: View {
+    private enum Metrics {
+        static let inspectorLineHeight: CGFloat = 2
+        static let minimumTrackSpacing: CGFloat = 1
+    }
+
+    enum Kind {
+        case media
+        case preview
+        case inspector
+        case timeline
+    }
+
+    let kind: Kind
+    @Bindable private var timelineColors = TimelineClipColorStore.shared
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                panelBackground
+
+                switch kind {
+                case .media:
+                    LazyVGrid(
+                        columns: Array(repeating: GridItem(.flexible(), spacing: AppTheme.Spacing.xxs), count: 2),
+                        spacing: AppTheme.Spacing.xxs
+                    ) {
+                        ForEach(0..<6, id: \.self) { _ in
+                            RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                                .fill(AppTheme.Text.mutedColor.opacity(AppTheme.Opacity.moderate))
+                                .aspectRatio(1.25, contentMode: .fit)
+                        }
+                    }
+                    .padding(max(geometry.size.width * 0.10, AppTheme.Spacing.xs))
+                case .preview:
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                        .fill(AppTheme.Background.previewCanvasColor.opacity(AppTheme.Opacity.prominent))
+                        .aspectRatio(16 / 9, contentMode: .fit)
+                        .padding(max(geometry.size.width * 0.08, AppTheme.Spacing.xs))
+                case .inspector:
+                    VStack(alignment: .leading, spacing: max(geometry.size.height * 0.10, AppTheme.Spacing.xxs)) {
+                        ForEach(0..<4, id: \.self) { row in
+                            Capsule()
+                                .fill(row == 0 ? AppTheme.Text.mutedColor : AppTheme.Border.dividerColor)
+                                .frame(
+                                    width: geometry.size.width * (row == 0 ? 0.58 : 0.78),
+                                    height: Metrics.inspectorLineHeight
+                                )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(max(geometry.size.width * 0.12, AppTheme.Spacing.xs))
+                case .timeline:
+                    ZStack {
+                        VStack(spacing: max(geometry.size.height * 0.08, Metrics.minimumTrackSpacing)) {
+                            ForEach([TimelineClipColor.text, .video, .audio]) { clipKind in
+                                Capsule()
+                                    .fill(timelineColors.color(for: clipKind).opacity(AppTheme.Opacity.high))
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                        .padding(.horizontal, max(geometry.size.width * 0.05, AppTheme.Spacing.xs))
+                        .padding(.vertical, max(geometry.size.height * 0.16, AppTheme.Spacing.xxs))
+
+                        Rectangle()
+                            .fill(Color(nsColor: Playhead.color))
+                            .frame(width: AppTheme.BorderWidth.thin)
+                            .padding(.vertical, AppTheme.Spacing.xxs)
+                    }
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.xs))
+            .overlay {
+                RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                    .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.hairline)
+            }
+        }
+    }
+
+    private var panelBackground: Color {
+        switch kind {
+        case .preview: AppTheme.Background.baseColor
+        case .media, .inspector: AppTheme.Background.prominentColor
+        case .timeline: AppTheme.Background.raisedColor
+        }
     }
 }
 

--- a/Sources/PalmierPro/Settings/AppearancePane.swift
+++ b/Sources/PalmierPro/Settings/AppearancePane.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+struct AppearancePane: View {
+    @Bindable private var appearance = AppAppearanceStore.shared
+
+    var body: some View {
+        HStack(alignment: .top, spacing: AppTheme.Spacing.mdLg) {
+            ForEach(AppAppearance.allCases) { option in
+                AppearanceOptionCard(
+                    option: option,
+                    isSelected: appearance.selection == option,
+                    action: { appearance.selection = option }
+                )
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct AppearanceOptionCard: View {
+    let option: AppAppearance
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: AppTheme.Spacing.smMd) {
+                AppearancePreview(option: option)
+                    .aspectRatio(1.5, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                            .strokeBorder(
+                                borderColor,
+                                lineWidth: isSelected ? AppTheme.BorderWidth.thick : AppTheme.BorderWidth.thin
+                            )
+                    }
+
+                Text(option.label)
+                    .font(.system(size: AppTheme.FontSize.mdLg, weight: AppTheme.FontWeight.regular))
+                    .foregroundStyle(isSelected ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .accessibilityLabel("\(option.label) appearance")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+
+    private var borderColor: Color {
+        if isSelected { return AppTheme.Accent.primary }
+        return isHovering ? AppTheme.Border.dividerColor : AppTheme.Border.subtleColor
+    }
+}
+
+private struct AppearancePreview: View {
+    let option: AppAppearance
+
+    var body: some View {
+        ZStack {
+            switch option {
+            case .system:
+                AppearancePreviewScene(palette: .light)
+                AppearancePreviewScene(palette: .dark)
+                    .mask {
+                        HStack(spacing: 0) {
+                            Color.clear
+                            Color.white
+                        }
+                    }
+            case .light:
+                AppearancePreviewScene(palette: .light)
+            case .dark:
+                AppearancePreviewScene(palette: .dark)
+            }
+        }
+    }
+}
+
+private struct AppearancePreviewScene: View {
+    let palette: AppearancePreviewPalette
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let height = geometry.size.height
+
+            ZStack(alignment: .bottom) {
+                palette.canvas
+
+                VStack(spacing: height * 0.045) {
+                    Capsule()
+                        .fill(palette.strongLine)
+                        .frame(width: width * 0.28, height: max(height * 0.045, 3))
+                    Capsule()
+                        .fill(palette.line)
+                        .frame(width: width * 0.48, height: max(height * 0.025, 2))
+                    Spacer(minLength: 0)
+                }
+                .padding(.top, height * 0.18)
+
+                VStack(spacing: 0) {
+                    ForEach(0..<3, id: \.self) { row in
+                        VStack(alignment: .leading, spacing: height * 0.035) {
+                            Capsule()
+                                .fill(palette.strongLine)
+                                .frame(width: width * 0.28, height: max(height * 0.045, 3))
+                            Capsule()
+                                .fill(palette.line)
+                                .frame(width: width * 0.45, height: max(height * 0.025, 2))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, width * 0.08)
+                        .frame(maxHeight: .infinity)
+
+                        if row < 2 {
+                            Rectangle()
+                                .fill(palette.divider)
+                                .frame(height: AppTheme.BorderWidth.hairline)
+                        }
+                    }
+                }
+                .frame(width: width * 0.78, height: height * 0.62)
+                .background(palette.panel)
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: AppTheme.Radius.md,
+                        topTrailingRadius: AppTheme.Radius.md
+                    )
+                )
+            }
+        }
+    }
+}
+
+private struct AppearancePreviewPalette {
+    let canvas: Color
+    let panel: Color
+    let line: Color
+    let strongLine: Color
+    let divider: Color
+
+    static let light = AppearancePreviewPalette(
+        canvas: Color(white: 0.92),
+        panel: Color(white: 0.99),
+        line: Color.black.opacity(0.08),
+        strongLine: Color.black.opacity(0.15),
+        divider: Color.black.opacity(0.08)
+    )
+
+    static let dark = AppearancePreviewPalette(
+        canvas: Color(white: 0.25),
+        panel: Color(white: 0.13),
+        line: Color.white.opacity(0.17),
+        strongLine: Color.white.opacity(0.30),
+        divider: Color.white.opacity(0.10)
+    )
+}

--- a/Sources/PalmierPro/Settings/AppearancePane.swift
+++ b/Sources/PalmierPro/Settings/AppearancePane.swift
@@ -4,16 +4,24 @@ struct AppearancePane: View {
     @Bindable private var appearance = AppAppearanceStore.shared
 
     var body: some View {
-        HStack(alignment: .top, spacing: AppTheme.Spacing.mdLg) {
-            ForEach(AppAppearance.allCases) { option in
-                AppearanceOptionCard(
-                    option: option,
-                    isSelected: appearance.selection == option,
-                    action: { appearance.selection = option }
-                )
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxl) {
+            SettingsGroup(title: "Theme") {
+                HStack(alignment: .top, spacing: AppTheme.Spacing.mdLg) {
+                    ForEach(AppAppearance.allCases) { option in
+                        AppearanceOptionCard(
+                            option: option,
+                            isSelected: appearance.selection == option,
+                            action: { appearance.selection = option }
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            SettingsSection(title: "Timeline colors") {
+                TimelineColorsPane()
             }
         }
-        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Sources/PalmierPro/Settings/ModelsPane.swift
+++ b/Sources/PalmierPro/Settings/ModelsPane.swift
@@ -79,7 +79,7 @@ struct ModelsPane: View {
         .padding(.vertical, AppTheme.Spacing.smMd)
         .background(
             RoundedRectangle(cornerRadius: AppTheme.Radius.md)
-                .fill(Color.white.opacity(AppTheme.Opacity.subtle))
+                .fill(AppTheme.Interaction.fill(AppTheme.Opacity.subtle))
         )
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.Radius.md)

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SettingsTab: String, CaseIterable, Identifiable {
     case account
     case general
+    case appearance
     case models
     case agent
     case skills
@@ -14,6 +15,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         switch self {
         case .account: return "Account"
         case .general: return "General"
+        case .appearance: return "Appearance"
         case .models: return "Models"
         case .agent: return "Agent"
         case .skills: return "Skills"
@@ -25,6 +27,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         switch self {
         case .account: return "person.circle"
         case .general: return "gearshape"
+        case .appearance: return "sun.max"
         case .models: return "square.stack.3d.up"
         case .agent: return "paperplane"
         case .skills: return "book.closed"
@@ -54,7 +57,7 @@ struct SettingsView: View {
 
             SettingsDetail(tab: selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black.opacity(AppTheme.Opacity.medium))
+                .background(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
         }
         .frame(
             minWidth: AppTheme.Window.settingsMin.width,
@@ -136,6 +139,10 @@ private struct SettingsDetail: View {
                                 }
                                 SettingsSection(title: "Privacy & Diagnostics") {
                                     PrivacyPane()
+                                }
+                            case .appearance:
+                                SettingsGroup(title: "Theme") {
+                                    AppearancePane()
                                 }
                             case .models:
                                 ModelsPane()
@@ -240,7 +247,6 @@ final class SettingsWindowController: NSWindowController {
         window.setContentSize(AppTheme.Window.settingsDefault)
         window.minSize = AppTheme.Window.settingsMin
         window.title = "Settings"
-        window.appearance = NSAppearance(named: .darkAqua)
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false
         window.titleVisibility = .hidden

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -141,9 +141,7 @@ private struct SettingsDetail: View {
                                     PrivacyPane()
                                 }
                             case .appearance:
-                                SettingsGroup(title: "Theme") {
-                                    AppearancePane()
-                                }
+                                AppearancePane()
                             case .models:
                                 ModelsPane()
                             case .agent:

--- a/Sources/PalmierPro/Settings/TimelineColorsPane.swift
+++ b/Sources/PalmierPro/Settings/TimelineColorsPane.swift
@@ -4,8 +4,6 @@ struct TimelineColorsPane: View {
     @Bindable private var colors = TimelineClipColorStore.shared
 
     var body: some View {
-        let _ = colors.revision
-
         VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             VStack(spacing: 0) {
                 ForEach(Array(TimelineClipColor.allCases.enumerated()), id: \.element) { index, kind in

--- a/Sources/PalmierPro/Settings/TimelineColorsPane.swift
+++ b/Sources/PalmierPro/Settings/TimelineColorsPane.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct TimelineColorsPane: View {
+    @Bindable private var colors = TimelineClipColorStore.shared
+
+    var body: some View {
+        let _ = colors.revision
+
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            VStack(spacing: 0) {
+                ForEach(Array(TimelineClipColor.allCases.enumerated()), id: \.element) { index, kind in
+                    colorRow(kind)
+
+                    if index < TimelineClipColor.allCases.count - 1 {
+                        Rectangle()
+                            .fill(AppTheme.Border.subtleColor)
+                            .frame(height: AppTheme.BorderWidth.hairline)
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Reset All") {
+                    colors.resetAll()
+                }
+                .buttonStyle(.capsule(.secondary, fill: AnyShapeStyle(AppTheme.Background.raisedColor)))
+                .disabled(!colors.hasOverrides)
+            }
+        }
+    }
+
+    private func colorRow(_ kind: TimelineClipColor) -> some View {
+        HStack(spacing: AppTheme.Spacing.md) {
+            Text(kind.label)
+                .font(.system(size: AppTheme.FontSize.md))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+
+            Spacer(minLength: AppTheme.Spacing.md)
+
+            Text(colors.hex(for: kind))
+                .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+
+            ColorField(
+                displayColor: colors.color(for: kind),
+                onUserChange: { colors.set($0, for: kind) },
+                supportsOpacity: false,
+                accessibilityLabel: "Choose \(kind.label.lowercased()) clip color",
+                swatchSize: CGSize(width: 64, height: AppTheme.IconSize.mdLg)
+            )
+        }
+        .frame(minHeight: 36)
+    }
+}

--- a/Sources/PalmierPro/Timeline/ClipGeneratingOverlay.swift
+++ b/Sources/PalmierPro/Timeline/ClipGeneratingOverlay.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ClipGeneratingOverlay: View {
     var body: some View {
         ZStack {
-            Color.black.opacity(0.55)
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
             GeneratingOverlay()
         }
         .clipShape(RoundedRectangle(cornerRadius: Trim.clipCornerRadius))

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -338,7 +338,7 @@ enum ClipRenderer {
         let lastBar = min(barCount, Int(ceil(visible.maxX - drawRect.minX)))
         guard firstBar < lastBar else { return }
 
-        context.setFillColor(AppTheme.MediaOverlay.primary.withAlphaComponent(AppTheme.Opacity.high).cgColor)
+        context.setFillColor(type.themeForegroundColor.withAlphaComponent(AppTheme.Opacity.high).cgColor)
 
         let dur = CGFloat(max(1, clip.durationFrames))
         let frameStep = dur / CGFloat(barCount)
@@ -436,8 +436,9 @@ enum ClipRenderer {
 
         let body = clipBodyRect(in: rect)
         let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
-        let lineColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha).cgColor
-        let fadeColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha * 0.7).cgColor
+        let foreground = clip.sourceClipType.themeForegroundColor
+        let lineColor = foreground.withAlphaComponent(alpha).cgColor
+        let fadeColor = foreground.withAlphaComponent(alpha * 0.7).cgColor
 
         // 1) Volume line — through kfs, or flat at static volume when no kfs.
         context.setStrokeColor(lineColor)
@@ -553,8 +554,9 @@ enum ClipRenderer {
 
         let body = clipBodyRect(in: rect)
         let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
-        let lineColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha).cgColor
-        let fadeColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha * 0.7).cgColor
+        let foreground = clip.sourceClipType.themeForegroundColor
+        let lineColor = foreground.withAlphaComponent(alpha).cgColor
+        let fadeColor = foreground.withAlphaComponent(alpha * 0.7).cgColor
 
         let leftOffset = min(clip.fadeInFrames, clip.durationFrames)
         let rightOffset = max(0, clip.durationFrames - clip.fadeOutFrames)
@@ -828,13 +830,21 @@ enum ClipRenderer {
 
     private static func drawLabelBar(clip: Clip, type: ClipType, in labelRect: NSRect, clipRect: NSRect, context: CGContext, displayName: String? = nil, badge: String? = nil, fps: Int) {
         var labelRect = labelRect
-        if let badge,
-           let chipRect = drawPill(badge, textColor: AppTheme.MediaOverlay.background.withAlphaComponent(AppTheme.Opacity.prominent),
-                                   fill: AppTheme.TrackColor.multicam, fontSize: AppTheme.FontSize.xxs,
-                                   at: NSPoint(x: labelRect.minX + AppTheme.Spacing.xs, y: labelRect.minY + AppTheme.Spacing.xxs),
-                                   maxWidth: labelRect.width - AppTheme.Spacing.smMd, context: context) {
-            labelRect.origin.x = chipRect.maxX + AppTheme.Spacing.xxs
-            labelRect.size.width -= chipRect.width + AppTheme.Spacing.sm
+        if let badge {
+            let fill = AppTheme.TrackColor.multicam
+            let textColor = AppTheme.TrackColor.readableForeground(on: fill)
+            if let chipRect = drawPill(
+                badge,
+                textColor: textColor.withAlphaComponent(AppTheme.Opacity.prominent),
+                fill: fill,
+                fontSize: AppTheme.FontSize.xxs,
+                at: NSPoint(x: labelRect.minX + AppTheme.Spacing.xs, y: labelRect.minY + AppTheme.Spacing.xxs),
+                maxWidth: labelRect.width - AppTheme.Spacing.smMd,
+                context: context
+            ) {
+                labelRect.origin.x = chipRect.maxX + AppTheme.Spacing.xxs
+                labelRect.size.width -= chipRect.width + AppTheme.Spacing.sm
+            }
         }
 
         let timecode = formatClipDuration(frame: clip.durationFrames, fps: fps)
@@ -844,7 +854,7 @@ enum ClipRenderer {
 
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs, weight: .medium),
-            .foregroundColor: AppTheme.MediaOverlay.primary,
+            .foregroundColor: clip.sourceClipType.themeForegroundColor,
         ]
         let attributed = NSMutableAttributedString(string: text, attributes: baseAttrs)
         if clip.linkGroupId != nil {

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -91,7 +91,7 @@ enum ClipRenderer {
         if usesCompactRendering(in: rect) {
             let color = isMissing && !isGenerating
                 ? AppTheme.Status.error
-                : (isSelected ? AppTheme.Text.primary : colorType.themeColor)
+                : (isSelected ? AppTheme.MediaOverlay.primary : colorType.themeColor)
             context.setFillColor(color.cgColor)
             context.fill(rect)
             if opacity < 1.0 { context.restoreGState() }
@@ -157,7 +157,7 @@ enum ClipRenderer {
         }
 
         if isSelected {
-            context.setStrokeColor(AppTheme.Text.primary.cgColor)
+            context.setStrokeColor(AppTheme.MediaOverlay.primary.cgColor)
             context.setLineWidth(AppTheme.BorderWidth.medium)
             context.addPath(path)
             context.strokePath()
@@ -165,7 +165,7 @@ enum ClipRenderer {
 
         // Subtle wash while the clip's media is being rendered/generated.
         if isGenerating {
-            context.setFillColor(NSColor.white.withAlphaComponent(AppTheme.Opacity.faint).cgColor)
+            context.setFillColor(AppTheme.MediaOverlay.primary.withAlphaComponent(AppTheme.Opacity.faint).cgColor)
             context.addPath(path)
             context.fillPath()
         }
@@ -229,7 +229,7 @@ enum ClipRenderer {
         let y = rect.maxY - 5
         let half: CGFloat = 3
         context.setFillColor(NSColor.systemYellow.withAlphaComponent(0.95).cgColor)
-        context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
+        context.setStrokeColor(AppTheme.MediaOverlay.background.withAlphaComponent(0.5).cgColor)
         context.setLineWidth(0.5)
         for f in frames where clip.contains(timelineFrame: f) {
             let x = baseX + CGFloat(f - clip.startFrame) * pxPerFrame
@@ -246,7 +246,7 @@ enum ClipRenderer {
 
     private static let beatTickColor = NSColor.systemOrange.withAlphaComponent(0.7).cgColor
     private static let downbeatTickColor = NSColor.systemOrange.cgColor
-    private static let beatTickBackingColor = NSColor.black.withAlphaComponent(0.55).cgColor
+    private static let beatTickBackingColor = AppTheme.MediaOverlay.background.withAlphaComponent(0.55).cgColor
     private static let beatTickWidth: CGFloat = 1
     private static let beatTickHeight: CGFloat = 7
     private static let downbeatTickHeight: CGFloat = 14
@@ -300,7 +300,9 @@ enum ClipRenderer {
 
     // MARK: - Waveform
 
-    private static let washColor = AppTheme.Status.error.withAlphaComponent(AppTheme.Opacity.medium).cgColor
+    private static var washColor: CGColor {
+        AppTheme.Status.error.withAlphaComponent(AppTheme.Opacity.medium).cgColor
+    }
     nonisolated(unsafe) static var speakerColors: [Int: CGColor] = [:]
     private static var markBeats: Bool { UserDefaults.standard.object(forKey: "markBeats") as? Bool ?? true }
 
@@ -336,7 +338,7 @@ enum ClipRenderer {
         let lastBar = min(barCount, Int(ceil(visible.maxX - drawRect.minX)))
         guard firstBar < lastBar else { return }
 
-        context.setFillColor(AppTheme.Text.primary.withAlphaComponent(AppTheme.Opacity.high).cgColor)
+        context.setFillColor(AppTheme.MediaOverlay.primary.withAlphaComponent(AppTheme.Opacity.high).cgColor)
 
         let dur = CGFloat(max(1, clip.durationFrames))
         let frameStep = dur / CGFloat(barCount)
@@ -434,8 +436,8 @@ enum ClipRenderer {
 
         let body = clipBodyRect(in: rect)
         let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
-        let lineColor = NSColor.white.withAlphaComponent(alpha).cgColor
-        let fadeColor = NSColor.white.withAlphaComponent(alpha * 0.7).cgColor
+        let lineColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha).cgColor
+        let fadeColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha * 0.7).cgColor
 
         // 1) Volume line — through kfs, or flat at static volume when no kfs.
         context.setStrokeColor(lineColor)
@@ -517,7 +519,7 @@ enum ClipRenderer {
 
         if showsVolumeKeyframes {
             context.setFillColor(lineColor)
-            context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
+            context.setStrokeColor(AppTheme.MediaOverlay.background.withAlphaComponent(0.5).cgColor)
             context.setLineWidth(0.5)
 
             // 4) Keyframe diamonds — independent of the fade knees.
@@ -551,8 +553,8 @@ enum ClipRenderer {
 
         let body = clipBodyRect(in: rect)
         let alpha: CGFloat = showsFadeControls ? 0.95 : 0.75
-        let lineColor = NSColor.white.withAlphaComponent(alpha).cgColor
-        let fadeColor = NSColor.white.withAlphaComponent(alpha * 0.7).cgColor
+        let lineColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha).cgColor
+        let fadeColor = AppTheme.MediaOverlay.primary.withAlphaComponent(alpha * 0.7).cgColor
 
         let leftOffset = min(clip.fadeInFrames, clip.durationFrames)
         let rightOffset = max(0, clip.durationFrames - clip.fadeOutFrames)
@@ -604,7 +606,7 @@ enum ClipRenderer {
         defer { context.restoreGState() }
 
         context.setFillColor(fillColor)
-        context.setStrokeColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
+        context.setStrokeColor(AppTheme.MediaOverlay.background.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
         context.setLineWidth(AppTheme.BorderWidth.hairline)
         context.fill(rect)
         context.stroke(rect)
@@ -632,13 +634,13 @@ enum ClipRenderer {
         fill.addLine(to: end)
         fill.closeSubpath()
         context.addPath(fill)
-        context.setFillColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
+        context.setFillColor(AppTheme.MediaOverlay.background.withAlphaComponent(CGFloat(AppTheme.Opacity.strong)).cgColor)
         context.fillPath()
 
         context.beginPath()
         context.move(to: start)
         context.addLine(to: end)
-        context.setStrokeColor(AppTheme.Background.base.withAlphaComponent(CGFloat(AppTheme.Opacity.prominent)).cgColor)
+        context.setStrokeColor(AppTheme.MediaOverlay.background.withAlphaComponent(CGFloat(AppTheme.Opacity.prominent)).cgColor)
         context.setLineWidth(AppTheme.BorderWidth.thin)
         context.setLineCap(.round)
         context.setLineJoin(.round)
@@ -667,7 +669,7 @@ enum ClipRenderer {
         fill.closeSubpath()
         context.saveGState()
         context.addPath(fill)
-        context.setFillColor(NSColor.black.withAlphaComponent(fillAlpha).cgColor)
+        context.setFillColor(AppTheme.MediaOverlay.background.withAlphaComponent(fillAlpha).cgColor)
         context.fillPath()
         context.restoreGState()
 
@@ -827,7 +829,7 @@ enum ClipRenderer {
     private static func drawLabelBar(clip: Clip, type: ClipType, in labelRect: NSRect, clipRect: NSRect, context: CGContext, displayName: String? = nil, badge: String? = nil, fps: Int) {
         var labelRect = labelRect
         if let badge,
-           let chipRect = drawPill(badge, textColor: NSColor.black.withAlphaComponent(AppTheme.Opacity.prominent),
+           let chipRect = drawPill(badge, textColor: AppTheme.MediaOverlay.background.withAlphaComponent(AppTheme.Opacity.prominent),
                                    fill: AppTheme.TrackColor.multicam, fontSize: AppTheme.FontSize.xxs,
                                    at: NSPoint(x: labelRect.minX + AppTheme.Spacing.xs, y: labelRect.minY + AppTheme.Spacing.xxs),
                                    maxWidth: labelRect.width - AppTheme.Spacing.smMd, context: context) {
@@ -842,7 +844,7 @@ enum ClipRenderer {
 
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs, weight: .medium),
-            .foregroundColor: AppTheme.Text.primary,
+            .foregroundColor: AppTheme.MediaOverlay.primary,
         ]
         let attributed = NSMutableAttributedString(string: text, attributes: baseAttrs)
         if clip.linkGroupId != nil {
@@ -871,7 +873,7 @@ enum ClipRenderer {
 
     // MARK: - Out-of-sync offset badge
 
-    private static let offsetBadgeColor = NSColor(red: 1.0, green: 0.28, blue: 0.28, alpha: 1.0)
+    private static let offsetBadgeColor = AppTheme.MediaOverlay.error
 
     private static func drawOffsetBadge(frames: Int, in rect: NSRect, context: CGContext) {
         let text = frames > 0 ? "+\(frames)" : "\(frames)"
@@ -881,7 +883,7 @@ enum ClipRenderer {
         ]).size().width + padH * 2
         let x = rect.maxX - Trim.handleWidth - width - AppTheme.Spacing.xxs
         guard x > rect.minX + AppTheme.Spacing.sm else { return }
-        drawPill(text, textColor: .white, fill: offsetBadgeColor, fontSize: AppTheme.FontSize.xs,
+        drawPill(text, textColor: AppTheme.MediaOverlay.primary, fill: offsetBadgeColor, fontSize: AppTheme.FontSize.xs,
                  at: NSPoint(x: x, y: rect.minY + AppTheme.Spacing.xxs), maxWidth: width, context: context)
     }
 

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -157,7 +157,7 @@ enum ClipRenderer {
         }
 
         if isSelected {
-            context.setStrokeColor(AppTheme.MediaOverlay.primary.cgColor)
+            context.setStrokeColor(AppTheme.Border.timelineClipSelected.cgColor)
             context.setLineWidth(AppTheme.BorderWidth.medium)
             context.addPath(path)
             context.strokePath()
@@ -244,8 +244,8 @@ enum ClipRenderer {
         }
     }
 
-    private static let beatTickColor = NSColor.systemOrange.withAlphaComponent(0.7).cgColor
-    private static let downbeatTickColor = NSColor.systemOrange.cgColor
+    private static var beatTickColor: CGColor { NSColor.systemOrange.withAlphaComponent(0.7).cgColor }
+    private static var downbeatTickColor: CGColor { NSColor.systemOrange.cgColor }
     private static let beatTickBackingColor = AppTheme.MediaOverlay.background.withAlphaComponent(0.55).cgColor
     private static let beatTickWidth: CGFloat = 1
     private static let beatTickHeight: CGFloat = 7

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -28,9 +28,7 @@ struct TimelineContainerView: NSViewRepresentable {
         scrollView.autoresizingMask = [.width, .height]
         container.addSubview(scrollView)
 
-        let border = NSView()
-        border.wantsLayer = true
-        border.layer?.backgroundColor = AppTheme.Border.primary.cgColor
+        let border = TimelineDividerView()
         border.frame = NSRect(x: Layout.trackHeaderWidth - 1, y: 0, width: 1, height: 0)
         border.autoresizingMask = [.height]
         container.addSubview(border)
@@ -141,6 +139,28 @@ struct TimelineContainerView: NSViewRepresentable {
 
         deinit {
             NotificationCenter.default.removeObserver(self)
+        }
+    }
+}
+
+private final class TimelineDividerView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        updateAppearanceColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearanceColors()
+    }
+
+    private func updateAppearanceColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = AppTheme.Border.primary.cgColor
         }
     }
 }

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -52,6 +52,12 @@ struct TimelineContainerView: NSViewRepresentable {
             name: NSView.frameDidChangeNotification,
             object: scrollView.contentView
         )
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.timelineClipColorsDidChange),
+            name: .timelineClipColorsDidChange,
+            object: nil
+        )
 
         return container
     }
@@ -135,6 +141,15 @@ struct TimelineContainerView: NSViewRepresentable {
         @MainActor @objc func clipViewFrameChanged(_ notification: Notification) {
             timelineView?.updateContentSize()
             timelineView?.updatePlayheadLayer()
+        }
+
+        @MainActor @objc func timelineClipColorsDidChange(_ notification: Notification) {
+            if let timelineView {
+                timelineView.setNeedsDisplay(timelineView.visibleRect)
+            }
+            if let headerView {
+                headerView.setNeedsDisplay(headerView.visibleRect)
+            }
         }
 
         deinit {

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -6,11 +6,11 @@ final class TimelineHeaderView: NSView {
 
     var requestCanvasRedraw: (() -> Void)?
 
-    private static let headerBg = AppTheme.Background.surface.cgColor
-    private static let labelAttrs: [NSAttributedString.Key: Any] = [
+    private static var headerBg: CGColor { AppTheme.Background.surface.cgColor }
+    private static var labelAttrs: [NSAttributedString.Key: Any] { [
         .font: NSFont.systemFont(ofSize: AppTheme.FontSize.sm, weight: .medium),
         .foregroundColor: AppTheme.Text.secondary,
-    ]
+    ] }
 
     /// Rects for mute/hide/sync-lock buttons, indexed by track. Used for hit testing.
     var muteButtonRects: [Int: NSRect] = [:]
@@ -22,13 +22,19 @@ final class TimelineHeaderView: NSView {
         self.editor = editor
         super.init(frame: .zero)
         wantsLayer = true
-        layer?.backgroundColor = Self.headerBg
+        updateAppearanceColors()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
     override var isFlipped: Bool { true }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearanceColors()
+        needsDisplay = true
+    }
 
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
@@ -146,6 +152,12 @@ final class TimelineHeaderView: NSView {
             return true
         }
         tinted.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+    }
+
+    private func updateAppearanceColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = Self.headerBg
+        }
     }
 
     // MARK: - Input handling (mute/hide/resize)

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -7,10 +7,8 @@ final class TimelineHeaderView: NSView {
     var requestCanvasRedraw: (() -> Void)?
 
     private static var headerBg: CGColor { AppTheme.Background.surface.cgColor }
-    private static var labelAttrs: [NSAttributedString.Key: Any] { [
-        .font: NSFont.systemFont(ofSize: AppTheme.FontSize.sm, weight: .medium),
-        .foregroundColor: AppTheme.Text.secondary,
-    ] }
+    private static let labelFont = NSFont.systemFont(ofSize: AppTheme.FontSize.sm, weight: .medium)
+    private var labelAttrs: [NSAttributedString.Key: Any] = [:]
 
     /// Rects for mute/hide/sync-lock buttons, indexed by track. Used for hit testing.
     var muteButtonRects: [Int: NSRect] = [:]
@@ -83,11 +81,10 @@ final class TimelineHeaderView: NSView {
             dragHandleRects[i] = gripRect.insetBy(dx: -4, dy: -4)
 
             // Track label
-            let str = NSAttributedString(string: editor.timelineTrackDisplayLabel(at: i), attributes: Self.labelAttrs)
+            let str = NSAttributedString(string: editor.timelineTrackDisplayLabel(at: i), attributes: labelAttrs)
             let labelSize = str.size()
             let labelY = y + (h - labelSize.height) / 2
             str.draw(at: NSPoint(x: gripX + iconSize + 6, y: labelY))
-
 
             let iconY = y + (h - iconSize) / 2
             let rightmostX = headerWidth - iconSize - 6
@@ -157,6 +154,10 @@ final class TimelineHeaderView: NSView {
     private func updateAppearanceColors() {
         effectiveAppearance.performAsCurrentDrawingAppearance {
             layer?.backgroundColor = Self.headerBg
+            labelAttrs = [
+                .font: Self.labelFont,
+                .foregroundColor: AppTheme.Text.secondary.usingColorSpace(.sRGB) ?? AppTheme.Text.secondary,
+            ]
         }
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -801,10 +801,10 @@ final class TimelineInputController {
             bracket.line(to: NSPoint(x: capX, y: bracketBottom))
             bracket.lineCapStyle = .square
 
-            AppTheme.Background.base.setStroke()
+            AppTheme.MediaOverlay.background.setStroke()
             bracket.lineWidth = AppTheme.BorderWidth.thick + AppTheme.BorderWidth.thin
             bracket.stroke()
-            AppTheme.Status.error.setStroke()
+            AppTheme.MediaOverlay.error.setStroke()
             bracket.lineWidth = AppTheme.BorderWidth.thick
             bracket.stroke()
 
@@ -817,9 +817,9 @@ final class TimelineInputController {
             arrow.close()
             arrow.lineJoinStyle = .round
             arrow.lineWidth = AppTheme.BorderWidth.thick
-            AppTheme.Text.primary.setStroke()
+            AppTheme.MediaOverlay.primary.setStroke()
             arrow.stroke()
-            AppTheme.Status.error.setFill()
+            AppTheme.MediaOverlay.error.setFill()
             arrow.fill()
             return true
         }
@@ -841,10 +841,10 @@ final class TimelineInputController {
             }
             ticks.lineCapStyle = .square
 
-            AppTheme.Background.base.setStroke()
+            AppTheme.MediaOverlay.background.setStroke()
             ticks.lineWidth = AppTheme.BorderWidth.thick + AppTheme.BorderWidth.thin
             ticks.stroke()
-            AppTheme.Status.error.setStroke()
+            AppTheme.MediaOverlay.error.setStroke()
             ticks.lineWidth = AppTheme.BorderWidth.thick
             ticks.stroke()
 
@@ -859,9 +859,9 @@ final class TimelineInputController {
             arrow.close()
             arrow.lineJoinStyle = .round
             arrow.lineWidth = AppTheme.BorderWidth.thick
-            AppTheme.Text.primary.setStroke()
+            AppTheme.MediaOverlay.primary.setStroke()
             arrow.stroke()
-            AppTheme.Status.error.setFill()
+            AppTheme.MediaOverlay.error.setFill()
             arrow.fill()
             return true
         }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -24,7 +24,7 @@ final class TimelineView: NSView {
         editor.mediaVisualCache.timelineView = self
         editor.onCancelTimelineDrag = { [weak self] in self?.inputController.cancelActiveDrag() }
         wantsLayer = true
-        layer?.backgroundColor = AppTheme.Background.surface.cgColor
+        updateAppearanceColors()
         canvas.wantsLayer = true
         canvas.layerContentsRedrawPolicy = .onSetNeedsDisplay
         addSubview(canvas)
@@ -37,6 +37,12 @@ final class TimelineView: NSView {
     required init?(coder: NSCoder) { fatalError() }
 
     override var isFlipped: Bool { true }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearanceColors()
+        needsDisplay = true
+    }
 
     // MARK: - Viewport canvas
 
@@ -70,8 +76,13 @@ final class TimelineView: NSView {
         canvas.needsDisplay = true
     }
 
-    // Cached for draw performance — avoid per-frame allocations.
-    private static let trackBg = AppTheme.Background.surface.cgColor
+    private static var trackBg: CGColor { AppTheme.Background.surface.cgColor }
+
+    private func updateAppearanceColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = AppTheme.Background.surface.cgColor
+        }
+    }
 
     var externalDropTarget: TrackDropTarget?
     var externalDragAssets: [MediaAsset]?
@@ -244,8 +255,8 @@ final class TimelineView: NSView {
 
         if case .marquee(let marq) = inputController.dragState,
            marq.current.width > 0 || marq.current.height > 0 {
-            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.6).cgColor)
-            ctx.setFillColor(NSColor.white.withAlphaComponent(0.1).cgColor)
+            ctx.setStrokeColor(AppTheme.Text.primary.withAlphaComponent(0.6).cgColor)
+            ctx.setFillColor(AppTheme.Text.primary.withAlphaComponent(0.1).cgColor)
             ctx.setLineWidth(1)
             ctx.setLineDash(phase: 0, lengths: [3, 3])
             ctx.addRect(marq.current)
@@ -708,8 +719,8 @@ final class TimelineView: NSView {
         let maxX = geo.xForFrame(gap.range.end)
         let rect = NSRect(x: minX, y: y + 2, width: maxX - minX, height: height - 4)
 
-        ctx.setFillColor(NSColor.white.withAlphaComponent(0.12).cgColor)
-        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.9).cgColor)
+        ctx.setFillColor(AppTheme.Text.primary.withAlphaComponent(0.12).cgColor)
+        ctx.setStrokeColor(AppTheme.Text.primary.withAlphaComponent(0.9).cgColor)
         ctx.setLineWidth(1)
         ctx.setLineDash(phase: 0, lengths: [3, 3])
         ctx.addRect(rect.insetBy(dx: 0.5, dy: 0.5))

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -80,7 +80,7 @@ final class TimelineView: NSView {
 
     private func updateAppearanceColors() {
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.backgroundColor = AppTheme.Background.surface.cgColor
+            layer?.backgroundColor = Self.trackBg
         }
     }
 

--- a/Sources/PalmierPro/UI/AppAppearance.swift
+++ b/Sources/PalmierPro/UI/AppAppearance.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Foundation
+import Observation
+
+enum AppAppearance: String, CaseIterable, Identifiable, Sendable {
+    case system
+    case light
+    case dark
+
+    static let defaultsKey = "appAppearance"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .system: nil
+        case .light: NSAppearance(named: .aqua)
+        case .dark: NSAppearance(named: .darkAqua)
+        }
+    }
+
+    static func stored(in defaults: UserDefaults) -> AppAppearance {
+        defaults.string(forKey: defaultsKey).flatMap(AppAppearance.init(rawValue:)) ?? .system
+    }
+}
+
+@MainActor @Observable
+final class AppAppearanceStore {
+    static let shared = AppAppearanceStore()
+
+    var selection: AppAppearance {
+        didSet {
+            guard selection != oldValue else { return }
+            defaults.set(selection.rawValue, forKey: AppAppearance.defaultsKey)
+            apply()
+        }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        selection = AppAppearance.stored(in: defaults)
+    }
+
+    func apply() {
+        NSApp.appearance = selection.nsAppearance
+    }
+}

--- a/Sources/PalmierPro/UI/AppAppearance.swift
+++ b/Sources/PalmierPro/UI/AppAppearance.swift
@@ -28,7 +28,7 @@ enum AppAppearance: String, CaseIterable, Identifiable, Sendable {
     }
 
     static func stored(in defaults: UserDefaults) -> AppAppearance {
-        defaults.string(forKey: defaultsKey).flatMap(AppAppearance.init(rawValue:)) ?? .system
+        defaults.string(forKey: defaultsKey).flatMap(AppAppearance.init(rawValue:)) ?? .dark
     }
 }
 

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -272,13 +272,34 @@ enum AppTheme {
     // MARK: - Track type colors
 
     enum TrackColor {
-        static let video = NSColor(red: 0x1D/255.0, green: 0x58/255.0, blue: 0x78/255.0, alpha: 1)
-        static let audio = NSColor(red: 0x2E/255.0, green: 0x77/255.0, blue: 0x65/255.0, alpha: 1)
-        static let image = NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
-        static let text = NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
-        static let lottie = NSColor(red: 0xA0/255.0, green: 0x78/255.0, blue: 0x22/255.0, alpha: 1)
-        static let sequence = NSColor(red: 0xB9/255.0, green: 0xB2/255.0, blue: 0x9A/255.0, alpha: 1)
+        static var video: NSColor { TimelineClipColorPalette.shared.color(for: .video) }
+        static var audio: NSColor { TimelineClipColorPalette.shared.color(for: .audio) }
+        static var image: NSColor { TimelineClipColorPalette.shared.color(for: .image) }
+        static var text: NSColor { TimelineClipColorPalette.shared.color(for: .text) }
+        static var lottie: NSColor { TimelineClipColorPalette.shared.color(for: .animation) }
+        static var sequence: NSColor { TimelineClipColorPalette.shared.color(for: .sequence) }
         static let multicam = NSColor.systemRed
+
+        static func readableForeground(on background: NSColor) -> NSColor {
+            guard let background = background.usingColorSpace(.sRGB) else { return .white }
+            let luminance = relativeLuminance(
+                red: background.redComponent,
+                green: background.greenComponent,
+                blue: background.blueComponent
+            )
+            let blackContrast = (luminance + 0.05) / 0.05
+            let whiteContrast = 1.05 / (luminance + 0.05)
+            return blackContrast >= whiteContrast ? .black : .white
+        }
+
+        private static func relativeLuminance(red: CGFloat, green: CGFloat, blue: CGFloat) -> CGFloat {
+            func linear(_ component: CGFloat) -> CGFloat {
+                component <= 0.04045
+                    ? component / 12.92
+                    : pow((component + 0.055) / 1.055, 2.4)
+            }
+            return linear(red) * 0.2126 + linear(green) * 0.7152 + linear(blue) * 0.0722
+        }
     }
 
     // MARK: - Corner radii
@@ -518,5 +539,9 @@ extension ClipType {
         case .lottie: AppTheme.TrackColor.lottie
         case .sequence: AppTheme.TrackColor.sequence
         }
+    }
+
+    var themeForegroundColor: NSColor {
+        AppTheme.TrackColor.readableForeground(on: themeColor)
     }
 }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -56,7 +56,8 @@ enum AppTheme {
             light: NSColor.black.withAlphaComponent(0.44),
             dark: NSColor.white.withAlphaComponent(0.44)
         )
-        static let timelineClip = NSColor.black
+        static let timelineClip = AppTheme.adaptive(light: .white, dark: .black)
+        static let timelineClipSelected = AppTheme.adaptive(light: .black, dark: .white)
 
         static var primaryColor: Color { Color(primary) }
         static var subtleColor: Color { Color(subtle) }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -3,13 +3,31 @@ import SwiftUI
 
 enum AppTheme {
 
+    private static func adaptive(light: NSColor, dark: NSColor) -> NSColor {
+        NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+        }
+    }
+
     // MARK: - Backgrounds
 
     enum Background {
-        static let base = NSColor(red: 10/255, green: 10/255, blue: 10/255, alpha: 1)
-        static let surface = NSColor(red: 22/255, green: 22/255, blue: 22/255, alpha: 1)
-        static let raised = NSColor(red: 30/255, green: 30/255, blue: 30/255, alpha: 1)
-        static let prominent = NSColor(red: 44/255, green: 44/255, blue: 44/255, alpha: 1)
+        static let base = AppTheme.adaptive(
+            light: NSColor(red: 0.88, green: 0.88, blue: 0.88, alpha: 1),
+            dark: NSColor(red: 10/255, green: 10/255, blue: 10/255, alpha: 1)
+        )
+        static let surface = AppTheme.adaptive(
+            light: NSColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1),
+            dark: NSColor(red: 22/255, green: 22/255, blue: 22/255, alpha: 1)
+        )
+        static let raised = AppTheme.adaptive(
+            light: NSColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1),
+            dark: NSColor(red: 30/255, green: 30/255, blue: 30/255, alpha: 1)
+        )
+        static let prominent = AppTheme.adaptive(
+            light: NSColor(red: 0.975, green: 0.975, blue: 0.975, alpha: 1),
+            dark: NSColor(red: 44/255, green: 44/255, blue: 44/255, alpha: 1)
+        )
 
         /// Alias — empty media slot is a raised plate.
         static let placeholder = raised
@@ -26,13 +44,23 @@ enum AppTheme {
     // MARK: - Borders
 
     enum Border {
-        static let primary = NSColor.white.withAlphaComponent(0.16)
-        static let subtle = NSColor.white.withAlphaComponent(0.12)
-        static let divider = NSColor.white.withAlphaComponent(0.44)
+        static let primary = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.24),
+            dark: NSColor.white.withAlphaComponent(0.16)
+        )
+        static let subtle = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.18),
+            dark: NSColor.white.withAlphaComponent(0.12)
+        )
+        static let divider = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.44),
+            dark: NSColor.white.withAlphaComponent(0.44)
+        )
         static let timelineClip = NSColor.black
 
         static var primaryColor: Color { Color(primary) }
         static var subtleColor: Color { Color(subtle) }
+        static var dividerColor: Color { Color(divider) }
     }
 
     // MARK: - Border widths
@@ -47,11 +75,17 @@ enum AppTheme {
     // MARK: - Accent
 
     enum Accent {
-        static let timecodeNSColor = NSColor(red: 0.95, green: 0.6, blue: 0.2, alpha: 1)
+        static let timecodeNSColor = AppTheme.adaptive(
+            light: NSColor(red: 0.58, green: 0.29, blue: 0.02, alpha: 1),
+            dark: NSColor(red: 0.95, green: 0.6, blue: 0.2, alpha: 1)
+        )
         static let timecodeColor = Color(timecodeNSColor)
 
-        /// Warm off-white
-        static let primary = Color(red: 0.961, green: 0.937, blue: 0.894)
+        static let primaryNSColor = AppTheme.adaptive(
+            light: NSColor(red: 0.18, green: 0.16, blue: 0.13, alpha: 1),
+            dark: NSColor(red: 0.961, green: 0.937, blue: 0.894, alpha: 1)
+        )
+        static let primary = Color(primaryNSColor)
 
         static let link = Color(nsColor: .linkColor)
 
@@ -115,32 +149,39 @@ enum AppTheme {
         static let pointDiameter: CGFloat = 9
         /// Invisible grab target around each point — much larger than the dot so it's easy to hit.
         static let pointHitDiameter: CGFloat = 30
-        static let lumaColor = Color(red: 1, green: 1, blue: 1)
+        static var lumaColor: Color { AppTheme.Text.primaryColor }
         static let redColor = Color(red: 1, green: 0.22, blue: 0.18)
         static let greenColor = Color(red: 0.32, green: 0.82, blue: 0.36)
         static let blueColor = Color(red: 0.32, green: 0.56, blue: 1)
     }
 
-    /// Monochrome silver shimmer
-    static let aiGradient = LinearGradient(
-        stops: [
-            .init(color: Color(white: 1.00), location: 0.00),
-            .init(color: Color(white: 0.78), location: 0.45),
-            .init(color: Color(white: 0.60), location: 0.55),
-            .init(color: Color(white: 1.00), location: 1.00),
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
+    static var aiGradient: LinearGradient {
+        LinearGradient(
+            stops: [
+                .init(color: Text.primaryColor, location: 0.00),
+                .init(color: Text.secondaryColor, location: 0.45),
+                .init(color: Text.tertiaryColor, location: 0.55),
+                .init(color: Text.primaryColor, location: 1.00),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
 
     // MARK: - Status
 
     enum Status {
-        static let error = NSColor(red: 0xE5/255.0, green: 0x4F/255.0, blue: 0x4F/255.0, alpha: 1)
+        static let error = AppTheme.adaptive(
+            light: NSColor(red: 0.70, green: 0.14, blue: 0.09, alpha: 1),
+            dark: NSColor(red: 0xE5/255.0, green: 0x4F/255.0, blue: 0x4F/255.0, alpha: 1)
+        )
 
         static var errorColor: Color { Color(error) }
 
-        static let success = NSColor(red: 0x4F/255.0, green: 0xB8/255.0, blue: 0x5F/255.0, alpha: 1)
+        static let success = AppTheme.adaptive(
+            light: NSColor(red: 0.09, green: 0.45, blue: 0.28, alpha: 1),
+            dark: NSColor(red: 0x4F/255.0, green: 0xB8/255.0, blue: 0x5F/255.0, alpha: 1)
+        )
 
         static var successColor: Color { Color(success) }
 
@@ -152,15 +193,64 @@ enum AppTheme {
     // MARK: - Text
 
     enum Text {
-        static let primary = NSColor.white.withAlphaComponent(1.0)
-        static let secondary = NSColor.white.withAlphaComponent(0.80)
-        static let tertiary = NSColor.white.withAlphaComponent(0.62)
-        static let muted = NSColor.white.withAlphaComponent(0.34)
+        static let primary = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.94),
+            dark: NSColor.white
+        )
+        static let secondary = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.78),
+            dark: NSColor.white.withAlphaComponent(0.80)
+        )
+        static let tertiary = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.64),
+            dark: NSColor.white.withAlphaComponent(0.62)
+        )
+        static let muted = AppTheme.adaptive(
+            light: NSColor.black.withAlphaComponent(0.44),
+            dark: NSColor.white.withAlphaComponent(0.34)
+        )
 
         static var primaryColor: Color { Color(primary) }
         static var secondaryColor: Color { Color(secondary) }
         static var tertiaryColor: Color { Color(tertiary) }
         static var mutedColor: Color { Color(muted) }
+    }
+
+    // MARK: - Interaction fills
+
+    enum Interaction {
+        static func fill(_ opacity: Double) -> Color {
+            AppTheme.Text.primaryColor.opacity(opacity)
+        }
+    }
+
+    // MARK: - Media overlays
+
+    enum MediaOverlay {
+        static let background = NSColor.black
+        static let primary = NSColor.white
+        static let secondary = NSColor.white.withAlphaComponent(0.80)
+        static let tertiary = NSColor.white.withAlphaComponent(0.62)
+        static let muted = NSColor.white.withAlphaComponent(0.34)
+        static let error = NSColor(red: 0xE5/255.0, green: 0x4F/255.0, blue: 0x4F/255.0, alpha: 1)
+
+        static var backgroundColor: Color { Color(background) }
+        static var primaryColor: Color { Color(primary) }
+        static var secondaryColor: Color { Color(secondary) }
+        static var tertiaryColor: Color { Color(tertiary) }
+        static var mutedColor: Color { Color(muted) }
+        static var errorColor: Color { Color(error) }
+
+        static let aiGradient = LinearGradient(
+            stops: [
+                .init(color: Color(white: 1.00), location: 0.00),
+                .init(color: Color(white: 0.78), location: 0.45),
+                .init(color: Color(white: 0.60), location: 0.55),
+                .init(color: Color(white: 1.00), location: 1.00),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
 
     // MARK: - Opacity

--- a/Sources/PalmierPro/UI/CapsuleButton.swift
+++ b/Sources/PalmierPro/UI/CapsuleButton.swift
@@ -46,7 +46,7 @@ struct CapsuleButtonStyle: ButtonStyle {
                 .padding(.vertical, vPadding)
                 .background(Capsule(style: .continuous).fill(background))
                 .overlay(Capsule(style: .continuous).fill(
-                    AppTheme.Background.baseColor.opacity(isEnabled && hovered ? AppTheme.Opacity.faint : 0)
+                    AppTheme.Interaction.fill(isEnabled && hovered ? AppTheme.Opacity.faint : 0)
                 ))
                 .opacity(isEnabled
                     ? (configuration.isPressed ? AppTheme.Opacity.strong : AppTheme.Opacity.opaque)

--- a/Sources/PalmierPro/UI/CapsuleButton.swift
+++ b/Sources/PalmierPro/UI/CapsuleButton.swift
@@ -45,7 +45,9 @@ struct CapsuleButtonStyle: ButtonStyle {
                 .padding(.horizontal, hPadding)
                 .padding(.vertical, vPadding)
                 .background(Capsule(style: .continuous).fill(background))
-                .overlay(Capsule(style: .continuous).fill(.white.opacity(isEnabled && hovered ? AppTheme.Opacity.faint : 0)))
+                .overlay(Capsule(style: .continuous).fill(
+                    AppTheme.Background.baseColor.opacity(isEnabled && hovered ? AppTheme.Opacity.faint : 0)
+                ))
                 .opacity(isEnabled
                     ? (configuration.isPressed ? AppTheme.Opacity.strong : AppTheme.Opacity.opaque)
                     : AppTheme.Opacity.strong)

--- a/Sources/PalmierPro/UI/GeneratingOverlay.swift
+++ b/Sources/PalmierPro/UI/GeneratingOverlay.swift
@@ -38,7 +38,7 @@ struct GeneratingOverlay: View {
         VStack(spacing: size.spacing) {
             Text(label)
                 .font(.system(size: size.fontSize, weight: .semibold))
-                .foregroundStyle(AppTheme.aiGradient)
+                .foregroundStyle(AppTheme.MediaOverlay.aiGradient)
             progressBar
         }
     }
@@ -47,9 +47,9 @@ struct GeneratingOverlay: View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
                 Capsule()
-                    .fill(Color.white.opacity(AppTheme.Opacity.muted))
+                    .fill(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.muted))
                 Capsule()
-                    .fill(Color.white.opacity(AppTheme.Opacity.strong))
+                    .fill(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.strong))
                     .frame(width: geo.size.width * progress)
             }
         }
@@ -72,7 +72,7 @@ private struct ShimmerModifier: ViewModifier {
                         LinearGradient(
                             stops: [
                                 .init(color: .clear, location: 0),
-                                .init(color: .white.opacity(0.42), location: 0.48),
+                                .init(color: AppTheme.MediaOverlay.primaryColor.opacity(0.42), location: 0.48),
                                 .init(color: .clear, location: 1),
                             ],
                             startPoint: .top,

--- a/Sources/PalmierPro/UI/HoverHighlight.swift
+++ b/Sources/PalmierPro/UI/HoverHighlight.swift
@@ -24,9 +24,9 @@ struct HoverHighlight: ViewModifier {
         guard isEnabled else { return .clear }
         if isActive, let activeFill { return activeFill }
         return switch (isActive, isHovered) {
-        case (true, true): Color.white.opacity(AppTheme.Opacity.muted)
-        case (true, false): Color.white.opacity(AppTheme.Opacity.soft)
-        case (false, true): Color.white.opacity(AppTheme.Opacity.faint)
+        case (true, true): AppTheme.Interaction.fill(AppTheme.Opacity.muted)
+        case (true, false): AppTheme.Interaction.fill(AppTheme.Opacity.soft)
+        case (false, true): AppTheme.Interaction.fill(AppTheme.Opacity.faint)
         case (false, false): .clear
         }
     }

--- a/Sources/PalmierPro/UI/TimelineClipColors.swift
+++ b/Sources/PalmierPro/UI/TimelineClipColors.swift
@@ -128,10 +128,12 @@ final class TimelineClipColorStore {
     }
 
     func color(for kind: TimelineClipColor) -> Color {
-        Color(palette.color(for: kind))
+        _ = revision
+        return Color(palette.color(for: kind))
     }
 
     func hex(for kind: TimelineClipColor) -> String {
+        _ = revision
         guard let color = palette.color(for: kind).usingColorSpace(.sRGB) else { return "" }
         return String(
             format: "#%02X%02X%02X",

--- a/Sources/PalmierPro/UI/TimelineClipColors.swift
+++ b/Sources/PalmierPro/UI/TimelineClipColors.swift
@@ -1,0 +1,167 @@
+import AppKit
+import Foundation
+import Observation
+import SwiftUI
+
+enum TimelineClipColor: String, CaseIterable, Identifiable, Sendable {
+    case video
+    case audio
+    case image
+    case text
+    case animation
+    case sequence
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .video: "Video"
+        case .audio: "Audio"
+        case .image: "Image"
+        case .text: "Text"
+        case .animation: "Animation"
+        case .sequence: "Sequence"
+        }
+    }
+
+    var defaultColor: NSColor {
+        switch self {
+        case .video: NSColor(red: 0x1D/255.0, green: 0x58/255.0, blue: 0x78/255.0, alpha: 1)
+        case .audio: NSColor(red: 0x2E/255.0, green: 0x77/255.0, blue: 0x65/255.0, alpha: 1)
+        case .image: NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
+        case .text: NSColor(red: 0x71/255.0, green: 0x54/255.0, blue: 0x86/255.0, alpha: 1)
+        case .animation: NSColor(red: 0xA0/255.0, green: 0x78/255.0, blue: 0x22/255.0, alpha: 1)
+        case .sequence: NSColor(red: 0xB9/255.0, green: 0xB2/255.0, blue: 0x9A/255.0, alpha: 1)
+        }
+    }
+
+    var defaultsKey: String { "timelineClipColor.\(rawValue)" }
+
+    func storedColor(in defaults: UserDefaults) -> NSColor {
+        guard let components = defaults.array(forKey: defaultsKey) as? [NSNumber],
+              components.count == 3 else { return defaultColor }
+        let values = components.map(\.doubleValue)
+        guard values.allSatisfy({ $0.isFinite && (0...1).contains($0) }) else { return defaultColor }
+        return NSColor(
+            srgbRed: CGFloat(values[0]),
+            green: CGFloat(values[1]),
+            blue: CGFloat(values[2]),
+            alpha: 1
+        )
+    }
+}
+
+final class TimelineClipColorPalette: @unchecked Sendable {
+    static let shared = TimelineClipColorPalette()
+
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private var colors: [TimelineClipColor: NSColor]
+    private var overrides: Set<TimelineClipColor>
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        colors = Dictionary(uniqueKeysWithValues: TimelineClipColor.allCases.map {
+            ($0, $0.storedColor(in: defaults))
+        })
+        overrides = Set(TimelineClipColor.allCases.filter {
+            defaults.array(forKey: $0.defaultsKey) != nil
+        })
+    }
+
+    func color(for kind: TimelineClipColor) -> NSColor {
+        lock.lock()
+        defer { lock.unlock() }
+        return colors[kind] ?? kind.defaultColor
+    }
+
+    func set(_ color: NSColor, for kind: TimelineClipColor) {
+        guard let color = color.usingColorSpace(.sRGB) else { return }
+        let components = [
+            Double(color.redComponent),
+            Double(color.greenComponent),
+            Double(color.blueComponent),
+        ]
+
+        lock.lock()
+        colors[kind] = NSColor(
+            srgbRed: CGFloat(components[0]),
+            green: CGFloat(components[1]),
+            blue: CGFloat(components[2]),
+            alpha: 1
+        )
+        overrides.insert(kind)
+        lock.unlock()
+
+        defaults.set(components, forKey: kind.defaultsKey)
+    }
+
+    func resetAll() {
+        lock.lock()
+        colors = Dictionary(uniqueKeysWithValues: TimelineClipColor.allCases.map {
+            ($0, $0.defaultColor)
+        })
+        overrides.removeAll()
+        lock.unlock()
+
+        for kind in TimelineClipColor.allCases {
+            defaults.removeObject(forKey: kind.defaultsKey)
+        }
+    }
+
+    var hasOverrides: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !overrides.isEmpty
+    }
+}
+
+@MainActor @Observable
+final class TimelineClipColorStore {
+    static let shared = TimelineClipColorStore()
+
+    private(set) var revision = 0
+    private let palette: TimelineClipColorPalette
+
+    init(palette: TimelineClipColorPalette = .shared) {
+        self.palette = palette
+    }
+
+    func color(for kind: TimelineClipColor) -> Color {
+        Color(palette.color(for: kind))
+    }
+
+    func hex(for kind: TimelineClipColor) -> String {
+        guard let color = palette.color(for: kind).usingColorSpace(.sRGB) else { return "" }
+        return String(
+            format: "#%02X%02X%02X",
+            Int(round(color.redComponent * 255)),
+            Int(round(color.greenComponent * 255)),
+            Int(round(color.blueComponent * 255))
+        )
+    }
+
+    func set(_ color: Color, for kind: TimelineClipColor) {
+        palette.set(NSColor(color), for: kind)
+        didChange()
+    }
+
+    func resetAll() {
+        palette.resetAll()
+        didChange()
+    }
+
+    var hasOverrides: Bool {
+        _ = revision
+        return palette.hasOverrides
+    }
+
+    private func didChange() {
+        revision &+= 1
+        NotificationCenter.default.post(name: .timelineClipColorsDidChange, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let timelineClipColorsDidChange = Notification.Name("timelineClipColorsDidChange")
+}

--- a/Sources/PalmierPro/UI/WorkspaceLayout.swift
+++ b/Sources/PalmierPro/UI/WorkspaceLayout.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Observation
+
+enum LayoutPreset: String, CaseIterable, Identifiable, Sendable {
+    case `default`
+    case media
+    case vertical
+
+    static let defaultsKey = "layoutPreset"
+
+    var id: String { rawValue }
+
+    var shortcutKey: Character {
+        switch self {
+        case .default: "1"
+        case .media: "2"
+        case .vertical: "3"
+        }
+    }
+
+    var shortcutLabel: String { "⌘\(shortcutKey)" }
+
+    var label: String {
+        switch self {
+        case .default: "Default"
+        case .media: "Media"
+        case .vertical: "Vertical"
+        }
+    }
+
+    static func stored(in defaults: UserDefaults) -> LayoutPreset {
+        defaults.string(forKey: defaultsKey).flatMap(LayoutPreset.init(rawValue:)) ?? .default
+    }
+}
+
+@MainActor @Observable
+final class WorkspaceLayoutStore {
+    static let shared = WorkspaceLayoutStore()
+
+    var selection: LayoutPreset {
+        didSet {
+            guard selection != oldValue else { return }
+            defaults.set(selection.rawValue, forKey: LayoutPreset.defaultsKey)
+        }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        selection = LayoutPreset.stored(in: defaults)
+    }
+}

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -1,27 +1,5 @@
 import Foundation
 
-enum LayoutPreset: String, CaseIterable {
-    case `default`
-    case media
-    case vertical
-
-    var label: String {
-        switch self {
-        case .default: "Default"
-        case .media: "Media"
-        case .vertical: "Vertical"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .default: "rectangle.split.3x1"
-        case .media: "sidebar.left"
-        case .vertical: "sidebar.right"
-        }
-    }
-}
-
 enum Layout {
     // Media panel
     static let mediaPanelDefault: CGFloat = 500

--- a/Tests/PalmierProTests/UI/AppAppearanceTests.swift
+++ b/Tests/PalmierProTests/UI/AppAppearanceTests.swift
@@ -1,0 +1,95 @@
+import AppKit
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("App appearance")
+@MainActor
+struct AppAppearanceTests {
+    @Test func missingOrInvalidPreferenceUsesSystemAppearance() throws {
+        let suiteName = "AppAppearanceTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(AppAppearance.stored(in: defaults) == .system)
+
+        defaults.set("sepia", forKey: AppAppearance.defaultsKey)
+        #expect(AppAppearance.stored(in: defaults) == .system)
+    }
+
+    @Test func storedPreferenceRoundTrips() throws {
+        let suiteName = "AppAppearanceTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(AppAppearance.light.rawValue, forKey: AppAppearance.defaultsKey)
+        #expect(AppAppearance.stored(in: defaults) == .light)
+
+        defaults.set(AppAppearance.dark.rawValue, forKey: AppAppearance.defaultsKey)
+        #expect(AppAppearance.stored(in: defaults) == .dark)
+    }
+
+    @Test func semanticPaletteInvertsBetweenAppearances() throws {
+        let light = try #require(NSAppearance(named: .aqua))
+        let dark = try #require(NSAppearance(named: .darkAqua))
+
+        #expect(brightness(AppTheme.Background.surface, in: light) > brightness(AppTheme.Background.surface, in: dark))
+        #expect(brightness(AppTheme.Text.primary, in: light) < brightness(AppTheme.Text.primary, in: dark))
+        #expect(brightness(AppTheme.Accent.primaryNSColor, in: light) < brightness(AppTheme.Accent.primaryNSColor, in: dark))
+    }
+
+    @Test func lightPaletteMaintainsReadableContrast() throws {
+        let light = try #require(NSAppearance(named: .aqua))
+
+        #expect(brightness(AppTheme.Background.surface, in: light) < brightness(AppTheme.Background.raised, in: light))
+        #expect(brightness(AppTheme.Background.raised, in: light) < brightness(AppTheme.Background.prominent, in: light))
+        #expect(brightness(AppTheme.Background.prominent, in: light) < 1)
+        #expect(contrastRatio(AppTheme.Text.tertiary, over: AppTheme.Background.surface, in: light) >= 4.5)
+        #expect(contrastRatio(AppTheme.Text.muted, over: AppTheme.Background.surface, in: light) >= 3)
+        #expect(contrastRatio(AppTheme.Border.divider, over: AppTheme.Background.surface, in: light) >= 3)
+    }
+
+    private func brightness(_ color: NSColor, in appearance: NSAppearance) -> CGFloat {
+        let resolved = resolved(color, in: appearance)
+        return resolved.redComponent * 0.2126
+            + resolved.greenComponent * 0.7152
+            + resolved.blueComponent * 0.0722
+    }
+
+    private func resolved(_ color: NSColor, in appearance: NSAppearance) -> NSColor {
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB) ?? color
+        }
+        return resolved
+    }
+
+    private func contrastRatio(_ foreground: NSColor, over background: NSColor, in appearance: NSAppearance) -> CGFloat {
+        let foreground = resolved(foreground, in: appearance)
+        let background = resolved(background, in: appearance)
+        let alpha = foreground.alphaComponent
+        let blended = [
+            foreground.redComponent * alpha + background.redComponent * (1 - alpha),
+            foreground.greenComponent * alpha + background.greenComponent * (1 - alpha),
+            foreground.blueComponent * alpha + background.blueComponent * (1 - alpha),
+        ]
+        let foregroundLuminance = relativeLuminance(blended)
+        let backgroundLuminance = relativeLuminance([
+            background.redComponent,
+            background.greenComponent,
+            background.blueComponent,
+        ])
+        let lighter = max(foregroundLuminance, backgroundLuminance)
+        let darker = min(foregroundLuminance, backgroundLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ components: [CGFloat]) -> CGFloat {
+        let linear = components.map { component in
+            component <= 0.04045
+                ? component / 12.92
+                : pow((component + 0.055) / 1.055, 2.4)
+        }
+        return linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722
+    }
+}

--- a/Tests/PalmierProTests/UI/AppAppearanceTests.swift
+++ b/Tests/PalmierProTests/UI/AppAppearanceTests.swift
@@ -38,6 +38,33 @@ struct AppAppearanceTests {
         #expect(brightness(AppTheme.Accent.primaryNSColor, in: light) < brightness(AppTheme.Accent.primaryNSColor, in: dark))
     }
 
+    @Test func mediaOverlayPaletteIsAppearanceInvariant() throws {
+        let light = try #require(NSAppearance(named: .aqua))
+        let dark = try #require(NSAppearance(named: .darkAqua))
+        let colors = [
+            AppTheme.MediaOverlay.background,
+            AppTheme.MediaOverlay.primary,
+            AppTheme.MediaOverlay.secondary,
+            AppTheme.MediaOverlay.tertiary,
+            AppTheme.MediaOverlay.muted,
+            AppTheme.MediaOverlay.error,
+        ]
+
+        for color in colors {
+            expectSameColor(resolved(color, in: light), resolved(color, in: dark))
+        }
+    }
+
+    @Test func clipSelectionBorderInvertsBetweenAppearances() throws {
+        let light = try #require(NSAppearance(named: .aqua))
+        let dark = try #require(NSAppearance(named: .darkAqua))
+
+        expectSameColor(resolved(AppTheme.Border.timelineClip, in: light), resolved(.white, in: light))
+        expectSameColor(resolved(AppTheme.Border.timelineClipSelected, in: light), resolved(.black, in: light))
+        expectSameColor(resolved(AppTheme.Border.timelineClip, in: dark), resolved(.black, in: dark))
+        expectSameColor(resolved(AppTheme.Border.timelineClipSelected, in: dark), resolved(.white, in: dark))
+    }
+
     @Test func lightPaletteMaintainsReadableContrast() throws {
         let light = try #require(NSAppearance(named: .aqua))
 
@@ -62,6 +89,17 @@ struct AppAppearanceTests {
             resolved = color.usingColorSpace(.sRGB) ?? color
         }
         return resolved
+    }
+
+    private func expectSameColor(
+        _ lhs: NSColor,
+        _ rhs: NSColor,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(abs(lhs.redComponent - rhs.redComponent) < 0.001, sourceLocation: sourceLocation)
+        #expect(abs(lhs.greenComponent - rhs.greenComponent) < 0.001, sourceLocation: sourceLocation)
+        #expect(abs(lhs.blueComponent - rhs.blueComponent) < 0.001, sourceLocation: sourceLocation)
+        #expect(abs(lhs.alphaComponent - rhs.alphaComponent) < 0.001, sourceLocation: sourceLocation)
     }
 
     private func contrastRatio(_ foreground: NSColor, over background: NSColor, in appearance: NSAppearance) -> CGFloat {

--- a/Tests/PalmierProTests/UI/AppAppearanceTests.swift
+++ b/Tests/PalmierProTests/UI/AppAppearanceTests.swift
@@ -6,15 +6,15 @@ import Testing
 @Suite("App appearance")
 @MainActor
 struct AppAppearanceTests {
-    @Test func missingOrInvalidPreferenceUsesSystemAppearance() throws {
+    @Test func missingOrInvalidPreferenceUsesDarkAppearance() throws {
         let suiteName = "AppAppearanceTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        #expect(AppAppearance.stored(in: defaults) == .system)
+        #expect(AppAppearance.stored(in: defaults) == .dark)
 
         defaults.set("sepia", forKey: AppAppearance.defaultsKey)
-        #expect(AppAppearance.stored(in: defaults) == .system)
+        #expect(AppAppearance.stored(in: defaults) == .dark)
     }
 
     @Test func storedPreferenceRoundTrips() throws {

--- a/Tests/PalmierProTests/UI/AppAppearanceTests.swift
+++ b/Tests/PalmierProTests/UI/AppAppearanceTests.swift
@@ -17,16 +17,14 @@ struct AppAppearanceTests {
         #expect(AppAppearance.stored(in: defaults) == .dark)
     }
 
-    @Test func storedPreferenceRoundTrips() throws {
+    @Test(arguments: AppAppearance.allCases)
+    func storedPreferenceRoundTrips(_ appearance: AppAppearance) throws {
         let suiteName = "AppAppearanceTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        defaults.set(AppAppearance.light.rawValue, forKey: AppAppearance.defaultsKey)
-        #expect(AppAppearance.stored(in: defaults) == .light)
-
-        defaults.set(AppAppearance.dark.rawValue, forKey: AppAppearance.defaultsKey)
-        #expect(AppAppearance.stored(in: defaults) == .dark)
+        defaults.set(appearance.rawValue, forKey: AppAppearance.defaultsKey)
+        #expect(AppAppearance.stored(in: defaults) == appearance)
     }
 
     @Test func semanticPaletteInvertsBetweenAppearances() throws {

--- a/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
+++ b/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Observation
 import SwiftUI
 import Testing
 @testable import PalmierPro
@@ -48,6 +49,22 @@ struct TimelineClipColorTests {
         store.resetAll()
         #expect(store.revision == 2)
         #expect(!store.hasOverrides)
+    }
+
+    @Test func colorAccessTracksPaletteChanges() async throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = TimelineClipColorStore(palette: TimelineClipColorPalette(defaults: defaults))
+
+        await confirmation("Color access is invalidated") { invalidated in
+            withObservationTracking {
+                _ = store.color(for: .text)
+            } onChange: {
+                invalidated()
+            }
+
+            store.set(Color(red: 0.8, green: 0.7, blue: 0.6), for: .text)
+        }
     }
 
     @Test func foregroundChoosesTheHigherContrastColor() {

--- a/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
+++ b/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import PalmierPro
+
+@Suite("Timeline clip colors")
+@MainActor
+struct TimelineClipColorTests {
+    @Test func missingOrInvalidPreferenceUsesDefaultColor() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        expectSameColor(TimelineClipColor.video.storedColor(in: defaults), TimelineClipColor.video.defaultColor)
+
+        defaults.set([2, -1, 0.5], forKey: TimelineClipColor.video.defaultsKey)
+        expectSameColor(TimelineClipColor.video.storedColor(in: defaults), TimelineClipColor.video.defaultColor)
+    }
+
+    @Test func customColorPersistsAndResetRestoresDefaults() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let palette = TimelineClipColorPalette(defaults: defaults)
+        let custom = NSColor(srgbRed: 0.12, green: 0.34, blue: 0.56, alpha: 1)
+
+        palette.set(custom, for: .audio)
+
+        expectSameColor(palette.color(for: .audio), custom)
+        expectSameColor(TimelineClipColor.audio.storedColor(in: defaults), custom)
+        #expect(palette.hasOverrides)
+
+        palette.resetAll()
+
+        expectSameColor(palette.color(for: .audio), TimelineClipColor.audio.defaultColor)
+        #expect(defaults.object(forKey: TimelineClipColor.audio.defaultsKey) == nil)
+        #expect(!palette.hasOverrides)
+    }
+
+    @Test func storePublishesChanges() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = TimelineClipColorStore(palette: TimelineClipColorPalette(defaults: defaults))
+
+        store.set(Color(red: 0.8, green: 0.7, blue: 0.6), for: .text)
+        #expect(store.revision == 1)
+        #expect(store.hasOverrides)
+
+        store.resetAll()
+        #expect(store.revision == 2)
+        #expect(!store.hasOverrides)
+    }
+
+    @Test func foregroundChoosesTheHigherContrastColor() {
+        let onDark = AppTheme.TrackColor.readableForeground(on: .black)
+        let onLight = AppTheme.TrackColor.readableForeground(on: .white)
+
+        expectSameColor(onDark, .white)
+        expectSameColor(onLight, .black)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "TimelineClipColorTests-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: suiteName)), suiteName)
+    }
+
+    private func expectSameColor(_ lhs: NSColor, _ rhs: NSColor, sourceLocation: SourceLocation = #_sourceLocation) {
+        let lhs = lhs.usingColorSpace(.sRGB) ?? lhs
+        let rhs = rhs.usingColorSpace(.sRGB) ?? rhs
+        #expect(abs(lhs.redComponent - rhs.redComponent) < 0.001, sourceLocation: sourceLocation)
+        #expect(abs(lhs.greenComponent - rhs.greenComponent) < 0.001, sourceLocation: sourceLocation)
+        #expect(abs(lhs.blueComponent - rhs.blueComponent) < 0.001, sourceLocation: sourceLocation)
+    }
+}

--- a/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
+++ b/Tests/PalmierProTests/UI/TimelineClipColorTests.swift
@@ -37,18 +37,24 @@ struct TimelineClipColorTests {
         #expect(!palette.hasOverrides)
     }
 
-    @Test func storePublishesChanges() throws {
+    @Test func storeNotifiesTimelineAfterChanges() async throws {
         let (defaults, suiteName) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = TimelineClipColorStore(palette: TimelineClipColorPalette(defaults: defaults))
 
-        store.set(Color(red: 0.8, green: 0.7, blue: 0.6), for: .text)
-        #expect(store.revision == 1)
-        #expect(store.hasOverrides)
+        await confirmation("Timeline redraw is requested", expectedCount: 2) { notified in
+            let observer = NotificationCenter.default.addObserver(
+                forName: .timelineClipColorsDidChange,
+                object: nil,
+                queue: nil
+            ) { _ in
+                notified()
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
 
-        store.resetAll()
-        #expect(store.revision == 2)
-        #expect(!store.hasOverrides)
+            store.set(Color(red: 0.8, green: 0.7, blue: 0.6), for: .text)
+            store.resetAll()
+        }
     }
 
     @Test func colorAccessTracksPaletteChanges() async throws {

--- a/Tests/PalmierProTests/UI/WorkspaceLayoutStoreTests.swift
+++ b/Tests/PalmierProTests/UI/WorkspaceLayoutStoreTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Workspace layout preference")
+@MainActor
+struct WorkspaceLayoutStoreTests {
+    @Test func presetsHaveUniqueShortcuts() {
+        let presets = LayoutPreset.allCases
+
+        #expect(Set(presets.map(\.shortcutKey)).count == presets.count)
+        #expect(presets.allSatisfy { $0.shortcutLabel == "⌘\($0.shortcutKey)" })
+    }
+
+    @Test func missingOrInvalidPreferenceUsesDefaultLayout() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(makeStore(defaults).selection == .default)
+
+        defaults.set("cinema", forKey: LayoutPreset.defaultsKey)
+        #expect(makeStore(defaults).selection == .default)
+    }
+
+    @Test func selectedLayoutPersists() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeStore(defaults)
+
+        store.selection = .media
+        #expect(makeStore(defaults).selection == .media)
+
+        store.selection = .vertical
+        #expect(makeStore(defaults).selection == .vertical)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "WorkspaceLayoutStoreTests-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: suiteName)), suiteName)
+    }
+
+    private func makeStore(_ defaults: UserDefaults) -> WorkspaceLayoutStore {
+        WorkspaceLayoutStore(defaults: defaults)
+    }
+}


### PR DESCRIPTION

<img width="1188" height="789" alt="Screenshot 2026-07-30 at 1 18 05 PM" src="https://github.com/user-attachments/assets/e6b35b18-9491-48be-a9fa-9b2f04a25555" />

## Summary
- add System, Light, and Dark appearance choices with an adaptive app-wide palette and Dark as the default
- add configurable timeline clip colors, including matching track accents and live layout-preview updates
- add configurable workspace layouts with visual previews, persistence, and Command-1/2/3 shortcuts
- keep timeline cursors, labels, backgrounds, and selection outlines correct during live appearance changes

## Why

The app previously assumed a fixed dark palette. This gives users a readable light appearance and a focused set of useful appearance and layout controls while preserving the existing dark experience.

## User impact

Appearance settings now live in a dedicated Settings pane and apply without relaunching. Workspace layout is a shared app preference, so changing it updates all open editor windows.

## Validation

- `swift test --filter 'AppAppearanceTests|TimelineClipColorTests|WorkspaceLayoutStoreTests'`
- 14 focused tests pass across appearance persistence and contrast, clip-color persistence and propagation, and workspace layout persistence and shortcuts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting UI/theming refactor touching timeline rendering, windows, and many views; behavior should be validated in both appearances and with custom clip colors.
> 
> **Overview**
> Adds **System / Light / Dark** appearance with an adaptive `AppTheme`, applied at launch via `AppAppearanceStore` and a new **Appearance** settings pane. Windows no longer force dark Aqua; AppKit timeline/preview views refresh colors on effective-appearance changes.
> 
> **Workspace layout** moves from per-editor `EditorViewModel` state to shared `WorkspaceLayoutStore` (persisted, menu shortcuts from preset metadata, visual previews in settings).
> 
> **Timeline clip colors** are user-configurable (`TimelineClipColorStore`), drive track/clip rendering with contrast-aware labels, and trigger timeline redraws on change.
> 
> UI-wide: hardcoded white/black fills become `AppTheme.Interaction`, `MediaOverlay`, and semantic text/background tokens so light mode stays readable on thumbnails and overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb18668a1a2f948ddd4e1e7a81e1bd040f93d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->