### PR TITLE
[feat] Add localization foundation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "906de2ff6042edd4caa9d953acc6eff7bf1ef215616e7d13442c518018634c50",
+  "originHash" : "c80b49489eef7850fa92dd9d2f64d0fe49f300786831e32d9439f9efb1ef17ab",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "PalmierPro",
+    defaultLocalization: "en",
     platforms: [.macOS(.v26)],
     products: [
         .executable(name: "PalmierPro", targets: ["PalmierPro"]),
@@ -74,7 +75,7 @@ let package = Package(
                 .copy("Resources/MCPB/palmier-pro.mcpb"),
                 .copy("Resources/Images"),
                 .copy("Resources/Changelog"),
-                .copy("Resources/Localization"),
+                .process("Resources/Localization"),
                 .copy("Resources/Models"),
             ],
             swiftSettings: [

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -59,14 +59,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 for project in projects {
                     try await project.saveBeforeClosing()
                 }
-                if !MLXRuntime.beginTermination() {
-                    await MLXRuntime.waitUntilIdle()
-                }
                 if shouldRestart {
                     try await Self.scheduleRelaunch(
                         applicationURL: Bundle.main.bundleURL,
                         processID: ProcessInfo.processInfo.processIdentifier
                     )
+                }
+                if !MLXRuntime.beginTermination() {
+                    await MLXRuntime.waitUntilIdle()
                 }
                 sender.reply(toApplicationShouldTerminate: true)
             } catch {

--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -1,8 +1,16 @@
 import AppKit
 import ClerkKit
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    static let shared = AppDelegate()
+
     private var isTerminating = false
+    private var restartRequested = false
+
+    private override init() {
+        super.init()
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Activate the app (required when launched from CLI, not a .app bundle)
@@ -44,6 +52,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if isTerminating { return .terminateLater }
         isTerminating = true
         let projects = AppState.shared.openProjects
+        let shouldRestart = restartRequested
 
         Task { @MainActor in
             do {
@@ -53,15 +62,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if !MLXRuntime.beginTermination() {
                     await MLXRuntime.waitUntilIdle()
                 }
+                if shouldRestart {
+                    try await Self.scheduleRelaunch(
+                        applicationURL: Bundle.main.bundleURL,
+                        processID: ProcessInfo.processInfo.processIdentifier
+                    )
+                }
                 sender.reply(toApplicationShouldTerminate: true)
             } catch {
                 projects.forEach { $0.editorViewModel.projectPackageCoordinator.cancelClosing() }
+                restartRequested = false
                 isTerminating = false
                 sender.presentError(error)
                 sender.reply(toApplicationShouldTerminate: false)
             }
         }
         return .terminateLater
+    }
+
+    func restart() {
+        guard !isTerminating else { return }
+        restartRequested = true
+        NSApp.terminate(nil)
+    }
+
+    @concurrent
+    private static func scheduleRelaunch(applicationURL: URL, processID: Int32) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "while kill -0 \"$1\" 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n \"$2\"",
+            "palmier-restart",
+            String(processID),
+            applicationURL.path,
+        ]
+        try process.run()
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {

--- a/Sources/PalmierPro/App/main.swift
+++ b/Sources/PalmierPro/App/main.swift
@@ -14,7 +14,7 @@ UserDefaults.standard.set(10, forKey: "NSInitialToolTipDelay")
 let app = NSApplication.shared
 AppAppearanceStore.shared.apply()
 _ = AppLocalization.shared
-let delegate = AppDelegate()
+let delegate = AppDelegate.shared
 app.delegate = delegate
 app.mainMenu = MainMenuBuilder.buildMenu()
 app.run()

--- a/Sources/PalmierPro/App/main.swift
+++ b/Sources/PalmierPro/App/main.swift
@@ -13,6 +13,7 @@ UserDefaults.standard.set(10, forKey: "NSInitialToolTipDelay")
 
 let app = NSApplication.shared
 AppAppearanceStore.shared.apply()
+_ = AppLocalization.shared
 let delegate = AppDelegate()
 app.delegate = delegate
 app.mainMenu = MainMenuBuilder.buildMenu()

--- a/Sources/PalmierPro/App/main.swift
+++ b/Sources/PalmierPro/App/main.swift
@@ -13,7 +13,6 @@ UserDefaults.standard.set(10, forKey: "NSInitialToolTipDelay")
 
 let app = NSApplication.shared
 AppAppearanceStore.shared.apply()
-_ = AppLocalization.shared
 let delegate = AppDelegate.shared
 app.delegate = delegate
 app.mainMenu = MainMenuBuilder.buildMenu()

--- a/Sources/PalmierPro/Editor/EditorView.swift
+++ b/Sources/PalmierPro/Editor/EditorView.swift
@@ -368,6 +368,7 @@ final class EditorSplitViewController: PaddedDividerSplitViewController {
         let hc = NSHostingController(
             rootView: content
                 .environment(editor)
+                .appLocalization()
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .background(AppTheme.Background.surfaceColor)
                 .clipShape(panelShell)

--- a/Sources/PalmierPro/Help/FeedbackView.swift
+++ b/Sources/PalmierPro/Help/FeedbackView.swift
@@ -298,7 +298,7 @@ final class FeedbackWindowController: NSWindowController {
 
     private init() {
         let initialView = FeedbackView(screenshot: nil).tint(AppTheme.Accent.primary)
-        let hosting = NSHostingController(rootView: AnyView(initialView))
+        let hosting = NSHostingController(rootView: AnyView(initialView.appLocalization()))
         let window = NSWindow(contentViewController: hosting)
         window.setContentSize(NSSize(width: 480, height: 480))
         window.minSize = NSSize(width: 480, height: 420)
@@ -324,6 +324,7 @@ final class FeedbackWindowController: NSWindowController {
         hosting?.rootView = AnyView(
             FeedbackView(screenshot: screenshot, prefill: prefill)
                 .id(UUID())
+                .appLocalization()
                 .tint(AppTheme.Accent.primary)
         )
         showWindow(nil)

--- a/Sources/PalmierPro/Help/HelpView.swift
+++ b/Sources/PalmierPro/Help/HelpView.swift
@@ -97,7 +97,7 @@ final class HelpWindowController: NSWindowController {
 
     private init() {
         let initialView = HelpView().tint(AppTheme.Accent.primary)
-        let hosting = NSHostingController(rootView: AnyView(initialView))
+        let hosting = NSHostingController(rootView: AnyView(initialView.appLocalization()))
         let window = NSWindow(contentViewController: hosting)
         window.setContentSize(NSSize(width: 900, height: 560))
         window.minSize = NSSize(width: 820, height: 520)
@@ -121,6 +121,7 @@ final class HelpWindowController: NSWindowController {
         hosting?.rootView = AnyView(
             HelpView(initialTab: tab)
                 .id(UUID())
+                .appLocalization()
                 .tint(AppTheme.Accent.primary)
         )
         showWindow(nil)

--- a/Sources/PalmierPro/Home/HomeView.swift
+++ b/Sources/PalmierPro/Home/HomeView.swift
@@ -133,7 +133,7 @@ final class HomeWindowController: NSWindowController {
     static let shared = HomeWindowController()
 
     private init() {
-        let hostingController = NSHostingController(rootView: HomeView().tint(AppTheme.Accent.primary))
+        let hostingController = NSHostingController(rootView: HomeView().appLocalization().tint(AppTheme.Accent.primary))
         hostingController.sizingOptions = .minSize
         let window = NSWindow(contentViewController: hostingController)
         window.setContentSize(AppTheme.Window.homeDefault)

--- a/Sources/PalmierPro/Localization/AppLanguage.swift
+++ b/Sources/PalmierPro/Localization/AppLanguage.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum AppLanguage: Hashable, Identifiable, Sendable {
+    case system
+    case language(String)
+
+    static let defaultsKey = "appLanguage"
+
+    var id: String {
+        switch self {
+        case .system: "system"
+        case .language(let identifier): identifier
+        }
+    }
+
+    var identifier: String? {
+        switch self {
+        case .system: nil
+        case .language(let identifier): identifier
+        }
+    }
+
+    static func stored(in defaults: UserDefaults) -> AppLanguage {
+        guard let identifier = defaults.string(forKey: defaultsKey), identifier != "system" else {
+            return .system
+        }
+        return .language(identifier)
+    }
+}

--- a/Sources/PalmierPro/Localization/AppLanguage.swift
+++ b/Sources/PalmierPro/Localization/AppLanguage.swift
@@ -9,14 +9,14 @@ enum AppLanguage: Hashable, Identifiable, Sendable {
     var id: String {
         switch self {
         case .system: "system"
-        case .language(let identifier): identifier
+        case .language(let identifier): Locale(identifier: identifier).identifier
         }
     }
 
     var identifier: String? {
         switch self {
         case .system: nil
-        case .language(let identifier): identifier
+        case .language: id
         }
     }
 
@@ -24,6 +24,6 @@ enum AppLanguage: Hashable, Identifiable, Sendable {
         guard let identifier = defaults.string(forKey: defaultsKey), identifier != "system" else {
             return .system
         }
-        return .language(identifier)
+        return .language(Locale(identifier: identifier).identifier)
     }
 }

--- a/Sources/PalmierPro/Localization/AppLocalization.swift
+++ b/Sources/PalmierPro/Localization/AppLocalization.swift
@@ -19,32 +19,49 @@ final class AppLocalization {
     }
 
     var requiresRestart: Bool {
-        selection != activeLanguage
+        (selection.identifier ?? systemIdentifier) != activeIdentifier
     }
 
     private let defaults: UserDefaults
     private let localizedBundle: Bundle
+    private let systemIdentifier: String
 
-    init(defaults: UserDefaults = .standard, resourceBundle: Bundle = BundledResource.bundle) {
+    init(
+        defaults: UserDefaults = .standard,
+        resourceBundle: Bundle = BundledResource.bundle,
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) {
         self.defaults = defaults
 
-        let identifiers = Self.localizationIdentifiers(in: resourceBundle)
+        let resources = Self.localizationResources(in: resourceBundle)
+        let identifiers = resources.map(\.identifier)
         availableLanguages = identifiers.map(AppLanguage.language)
+        let resolvedSystemIdentifier = Self.preferredIdentifier(
+            in: resources,
+            preferredLanguages: preferredLanguages
+        )
+        systemIdentifier = resolvedSystemIdentifier
 
         let storedLanguage = AppLanguage.stored(in: defaults)
         let validLanguage: AppLanguage
         if let identifier = storedLanguage.identifier, identifiers.contains(identifier) {
-            validLanguage = storedLanguage
+            validLanguage = .language(identifier)
         } else {
             validLanguage = .system
+        }
+        if defaults.string(forKey: AppLanguage.defaultsKey).map({ $0 != validLanguage.id }) == true {
+            defaults.set(validLanguage.id, forKey: AppLanguage.defaultsKey)
         }
 
         activeLanguage = validLanguage
         selection = validLanguage
-        activeIdentifier = Self.resolveIdentifier(for: validLanguage, available: identifiers)
-        activeLocale = Locale(identifier: activeIdentifier)
+        let resolvedActiveIdentifier = validLanguage.identifier ?? resolvedSystemIdentifier
+        activeIdentifier = resolvedActiveIdentifier
+        activeLocale = Locale(identifier: resolvedActiveIdentifier)
+        let resourceIdentifier = resources.first { $0.identifier == resolvedActiveIdentifier }?.resourceIdentifier
+            ?? resolvedActiveIdentifier
         localizedBundle = Self.localizedBundle(
-            for: activeIdentifier,
+            for: resourceIdentifier,
             resourceBundle: resourceBundle
         )
     }
@@ -69,24 +86,41 @@ final class AppLocalization {
         return locale.localizedString(forIdentifier: identifier) ?? identifier
     }
 
-    private static func localizationIdentifiers(in bundle: Bundle) -> [String] {
+    private struct LocalizationResource {
+        let identifier: String
+        let resourceIdentifier: String
+    }
+
+    private static func localizationResources(in bundle: Bundle) -> [LocalizationResource] {
         bundle.localizations
             .filter { $0 != "Base" }
+            .map {
+                LocalizationResource(
+                    identifier: Locale(identifier: $0).identifier,
+                    resourceIdentifier: $0
+                )
+            }
             .sorted { lhs, rhs in
-                let lhsName = Locale(identifier: lhs).localizedString(forIdentifier: lhs) ?? lhs
-                let rhsName = Locale(identifier: rhs).localizedString(forIdentifier: rhs) ?? rhs
+                let lhsName = Locale(identifier: lhs.identifier)
+                    .localizedString(forIdentifier: lhs.identifier) ?? lhs.identifier
+                let rhsName = Locale(identifier: rhs.identifier)
+                    .localizedString(forIdentifier: rhs.identifier) ?? rhs.identifier
                 return lhsName.localizedStandardCompare(rhsName) == .orderedAscending
             }
     }
 
-    private static func resolveIdentifier(for language: AppLanguage, available: [String]) -> String {
-        if let identifier = language.identifier {
-            return identifier
-        }
-        return Bundle.preferredLocalizations(
-            from: available,
-            forPreferences: Locale.preferredLanguages
-        ).first ?? "en"
+    private static func preferredIdentifier(
+        in resources: [LocalizationResource],
+        preferredLanguages: [String]
+    ) -> String {
+        let preferredIdentifier = Bundle.preferredLocalizations(
+            from: resources.map(\.resourceIdentifier),
+            forPreferences: preferredLanguages
+        ).first.map { Locale(identifier: $0).identifier }
+        return resources.first { $0.identifier == preferredIdentifier }?.identifier
+            ?? resources.first { $0.identifier == "en" }?.identifier
+            ?? resources.first?.identifier
+            ?? "en"
     }
 
     private static func localizedBundle(for identifier: String, resourceBundle: Bundle) -> Bundle {

--- a/Sources/PalmierPro/Localization/AppLocalization.swift
+++ b/Sources/PalmierPro/Localization/AppLocalization.swift
@@ -6,7 +6,6 @@ import SwiftUI
 final class AppLocalization {
     static let shared = AppLocalization()
 
-    let activeLanguage: AppLanguage
     let activeIdentifier: String
     let activeLocale: Locale
     let availableLanguages: [AppLanguage]
@@ -53,7 +52,6 @@ final class AppLocalization {
             defaults.set(validLanguage.id, forKey: AppLanguage.defaultsKey)
         }
 
-        activeLanguage = validLanguage
         selection = validLanguage
         let resolvedActiveIdentifier = validLanguage.identifier ?? resolvedSystemIdentifier
         activeIdentifier = resolvedActiveIdentifier
@@ -74,13 +72,13 @@ final class AppLocalization {
         )
     }
 
-    func string(key: String, defaultValue: String? = nil) -> String {
-        localizedBundle.localizedString(forKey: key, value: defaultValue, table: nil)
+    func string(key: String) -> String {
+        localizedBundle.localizedString(forKey: key, value: nil, table: nil)
     }
 
     func displayName(for language: AppLanguage) -> String {
         guard let identifier = language.identifier else {
-            return string("System Language")
+            return string(key: L10n.key("System Language"))
         }
         let locale = Locale(identifier: identifier)
         return locale.localizedString(forIdentifier: identifier) ?? identifier
@@ -113,14 +111,10 @@ final class AppLocalization {
         in resources: [LocalizationResource],
         preferredLanguages: [String]
     ) -> String {
-        let preferredIdentifier = Bundle.preferredLocalizations(
+        return Bundle.preferredLocalizations(
             from: resources.map(\.resourceIdentifier),
             forPreferences: preferredLanguages
-        ).first.map { Locale(identifier: $0).identifier }
-        return resources.first { $0.identifier == preferredIdentifier }?.identifier
-            ?? resources.first { $0.identifier == "en" }?.identifier
-            ?? resources.first?.identifier
-            ?? "en"
+        ).first.map { Locale(identifier: $0).identifier } ?? "en"
     }
 
     private static func localizedBundle(for identifier: String, resourceBundle: Bundle) -> Bundle {
@@ -148,7 +142,7 @@ enum L10n {
         AppLocalization.shared.string(keyAndValue)
     }
 
-    static func string(key: String, defaultValue: String? = nil) -> String {
-        AppLocalization.shared.string(key: key, defaultValue: defaultValue)
+    static func string(key: String) -> String {
+        AppLocalization.shared.string(key: key)
     }
 }

--- a/Sources/PalmierPro/Localization/AppLocalization.swift
+++ b/Sources/PalmierPro/Localization/AppLocalization.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Observation
+import SwiftUI
+
+@MainActor @Observable
+final class AppLocalization {
+    static let shared = AppLocalization()
+
+    let activeLanguage: AppLanguage
+    let activeIdentifier: String
+    let activeLocale: Locale
+    let availableLanguages: [AppLanguage]
+
+    var selection: AppLanguage {
+        didSet {
+            guard selection != oldValue else { return }
+            defaults.set(selection.id, forKey: AppLanguage.defaultsKey)
+        }
+    }
+
+    var requiresRestart: Bool {
+        selection != activeLanguage
+    }
+
+    private let defaults: UserDefaults
+    private let localizedBundle: Bundle
+
+    init(defaults: UserDefaults = .standard, resourceBundle: Bundle = BundledResource.bundle) {
+        self.defaults = defaults
+
+        let identifiers = Self.localizationIdentifiers(in: resourceBundle)
+        availableLanguages = identifiers.map(AppLanguage.language)
+
+        let storedLanguage = AppLanguage.stored(in: defaults)
+        let validLanguage: AppLanguage
+        if let identifier = storedLanguage.identifier, identifiers.contains(identifier) {
+            validLanguage = storedLanguage
+        } else {
+            validLanguage = .system
+        }
+
+        activeLanguage = validLanguage
+        selection = validLanguage
+        activeIdentifier = Self.resolveIdentifier(for: validLanguage, available: identifiers)
+        activeLocale = Locale(identifier: activeIdentifier)
+        localizedBundle = Self.localizedBundle(
+            for: activeIdentifier,
+            resourceBundle: resourceBundle
+        )
+    }
+
+    func string(_ keyAndValue: String.LocalizationValue) -> String {
+        String(
+            localized: keyAndValue,
+            bundle: localizedBundle,
+            locale: activeLocale
+        )
+    }
+
+    func string(key: String, defaultValue: String? = nil) -> String {
+        localizedBundle.localizedString(forKey: key, value: defaultValue, table: nil)
+    }
+
+    func displayName(for language: AppLanguage) -> String {
+        guard let identifier = language.identifier else {
+            return string("System Language")
+        }
+        let locale = Locale(identifier: identifier)
+        return locale.localizedString(forIdentifier: identifier) ?? identifier
+    }
+
+    private static func localizationIdentifiers(in bundle: Bundle) -> [String] {
+        bundle.localizations
+            .filter { $0 != "Base" }
+            .sorted { lhs, rhs in
+                let lhsName = Locale(identifier: lhs).localizedString(forIdentifier: lhs) ?? lhs
+                let rhsName = Locale(identifier: rhs).localizedString(forIdentifier: rhs) ?? rhs
+                return lhsName.localizedStandardCompare(rhsName) == .orderedAscending
+            }
+    }
+
+    private static func resolveIdentifier(for language: AppLanguage, available: [String]) -> String {
+        if let identifier = language.identifier {
+            return identifier
+        }
+        return Bundle.preferredLocalizations(
+            from: available,
+            forPreferences: Locale.preferredLanguages
+        ).first ?? "en"
+    }
+
+    private static func localizedBundle(for identifier: String, resourceBundle: Bundle) -> Bundle {
+        guard let url = resourceBundle.url(forResource: identifier, withExtension: "lproj"),
+              let bundle = Bundle(url: url) else {
+            return resourceBundle
+        }
+        return bundle
+    }
+}
+
+extension View {
+    func appLocalization() -> some View {
+        environment(\.locale, AppLocalization.shared.activeLocale)
+    }
+}
+
+@MainActor
+enum L10n {
+    nonisolated static func key(_ value: StaticString) -> String {
+        value.description
+    }
+
+    static func string(_ keyAndValue: String.LocalizationValue) -> String {
+        AppLocalization.shared.string(keyAndValue)
+    }
+
+    static func string(key: String, defaultValue: String? = nil) -> String {
+        AppLocalization.shared.string(key: key, defaultValue: defaultValue)
+    }
+}

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -464,7 +464,7 @@ class VideoProject: NSDocument {
                 TourOverlay()
                     .environment(editorViewModel)
             }
-        let hostingController = NSHostingController(rootView: editorView.tint(AppTheme.Accent.primary))
+        let hostingController = NSHostingController(rootView: editorView.appLocalization().tint(AppTheme.Accent.primary))
         hostingController.sizingOptions = .minSize
 
         let window = NSWindow(contentViewController: hostingController)
@@ -697,7 +697,7 @@ extension NSWindow {
     }
 
     func addTitlebarSwiftUI<V: View>(_ view: V, side: NSLayoutConstraint.Attribute, width: CGFloat) {
-        let host = NSHostingController(rootView: view.tint(AppTheme.Accent.primary))
+        let host = NSHostingController(rootView: view.appLocalization().tint(AppTheme.Accent.primary))
         host.view.translatesAutoresizingMaskIntoConstraints = false
 
         let wrapper = CornerAdaptiveView()

--- a/Sources/PalmierPro/Resources/Info.plist
+++ b/Sources/PalmierPro/Resources/Info.plist
@@ -29,16 +29,6 @@
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>io.palmier.pro</string>
-	<key>CFBundleLocalizations</key>
-	<array>
-		<string>en</string>
-		<string>es</string>
-		<string>fr</string>
-		<string>de</string>
-		<string>ja</string>
-		<string>pt-BR</string>
-		<string>zh-Hans</string>
-	</array>
 	<key>CFBundleName</key>
 	<string>Palmier Pro</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/PalmierPro/Resources/Localization/de.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/de.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "Anmelden und 250 Gratis-Credits erhalten";
-"First-time sign-ups only" = "Nur für Neuanmeldungen";
-"or use your own Anthropic key" = "oder eigenen Anthropic-Schlüssel verwenden";
-"Subscribe" = "Abonnieren";
-"Open Settings" = "Einstellungen öffnen";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/InfoPlist.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Text displayed by macOS for Palmier Pro project packages. */
+
+"CFBundleTypeName" = "Palmier Project";
+"UTTypeDescription" = "Palmier Project";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -1,6 +1,22 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "Log in for 250 free credits";
+/* English source localization. */
+
+"Account" = "Account";
+"Agent" = "Agent";
+"Appearance" = "Appearance";
+"Changes take effect after restarting Palmier Pro." = "Changes take effect after restarting Palmier Pro.";
+"Export Queue" = "Export Queue";
 "First-time sign-ups only" = "First-time sign-ups only";
-"or use your own Anthropic key" = "or use your own Anthropic key";
-"Subscribe" = "Subscribe";
+"General" = "General";
+"Language" = "Language";
+"Language for the editor UI" = "Language for the editor UI";
+"Log in for 250 free credits" = "Log in for 250 free credits";
+"Models" = "Models";
+"Notifications" = "Notifications";
 "Open Settings" = "Open Settings";
+"Privacy & Diagnostics" = "Privacy & Diagnostics";
+"Settings" = "Settings";
+"Skills" = "Skills";
+"Storage" = "Storage";
+"Subscribe" = "Subscribe";
+"System Language" = "System Language";
+"or use your own Anthropic key" = "or use your own Anthropic key";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "Notifications" = "Notifications";
 "Open Settings" = "Open Settings";
 "Privacy & Diagnostics" = "Privacy & Diagnostics";
+"Restart Palmier Pro" = "Restart Palmier Pro";
 "Settings" = "Settings";
 "Skills" = "Skills";
 "Storage" = "Storage";

--- a/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "Inicia sesión y obtén 250 créditos gratis";
-"First-time sign-ups only" = "Solo para nuevos registros";
-"or use your own Anthropic key" = "o usa tu propia clave de Anthropic";
-"Subscribe" = "Suscribirse";
-"Open Settings" = "Abrir ajustes";

--- a/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "Connectez-vous et obtenez 250 crédits gratuits";
-"First-time sign-ups only" = "Réservé aux nouvelles inscriptions";
-"or use your own Anthropic key" = "ou utilisez votre propre clé Anthropic";
-"Subscribe" = "S'abonner";
-"Open Settings" = "Ouvrir les réglages";

--- a/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "ログインして250クレジットを無料でゲット";
-"First-time sign-ups only" = "初回登録者限定";
-"or use your own Anthropic key" = "または自分のAnthropic APIキーを使用";
-"Subscribe" = "登録する";
-"Open Settings" = "設定を開く";

--- a/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "Entre e ganhe 250 créditos grátis";
-"First-time sign-ups only" = "Apenas para novos cadastros";
-"or use your own Anthropic key" = "ou use sua própria chave da Anthropic";
-"Subscribe" = "Assinar";
-"Open Settings" = "Abrir configurações";

--- a/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,6 +1,0 @@
-/* Agent panel — signed-out / no-credits state */
-"Log in for 250 free credits" = "登录即可获得250积分";
-"First-time sign-ups only" = "仅限首次注册";
-"or use your own Anthropic key" = "或使用你自己的 Anthropic 密钥";
-"Subscribe" = "订阅";
-"Open Settings" = "打开设置";

--- a/Sources/PalmierPro/Settings/GeneralPane.swift
+++ b/Sources/PalmierPro/Settings/GeneralPane.swift
@@ -36,10 +36,20 @@ struct GeneralPane: View {
                 }
 
                 if localization.requiresRestart {
-                    Text(L10n.string("Changes take effect after restarting Palmier Pro."))
-                        .font(.system(size: AppTheme.FontSize.sm))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
-                        .fixedSize(horizontal: false, vertical: true)
+                    HStack(alignment: .center, spacing: AppTheme.Spacing.lg) {
+                        Text(L10n.string("Changes take effect after restarting Palmier Pro."))
+                            .font(.system(size: AppTheme.FontSize.sm))
+                            .foregroundStyle(AppTheme.Text.secondaryColor)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Spacer(minLength: AppTheme.Spacing.lg)
+
+                        Button(L10n.string("Restart Palmier Pro")) {
+                            AppDelegate.shared.restart()
+                        }
+                        .buttonStyle(.capsule(.secondary))
+                        .fixedSize()
+                    }
                 }
             }
 

--- a/Sources/PalmierPro/Settings/GeneralPane.swift
+++ b/Sources/PalmierPro/Settings/GeneralPane.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct GeneralPane: View {
+    @Bindable private var localization = AppLocalization.shared
+
+    private var languageOptions: [AppLanguage] {
+        [.system] + localization.availableLanguages
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxl) {
+            SettingsSection(title: L10n.string("General")) {
+                HStack(alignment: .center, spacing: AppTheme.Spacing.lg) {
+                    VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+                        Text(L10n.string("Language"))
+                            .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.regular))
+                            .foregroundStyle(AppTheme.Text.primaryColor)
+
+                        Text(L10n.string("Language for the editor UI"))
+                            .font(.system(size: AppTheme.FontSize.sm))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    }
+
+                    Spacer(minLength: AppTheme.Spacing.lg)
+
+                    Picker(String(), selection: $localization.selection) {
+                        ForEach(languageOptions) { language in
+                            Text(verbatim: localization.displayName(for: language))
+                                .tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                    .accessibilityLabel(L10n.string("Language"))
+                    .accessibilityHint(L10n.string("Language for the editor UI"))
+                }
+
+                if localization.requiresRestart {
+                    Text(L10n.string("Changes take effect after restarting Palmier Pro."))
+                        .font(.system(size: AppTheme.FontSize.sm))
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            SettingsSection(title: L10n.string("Notifications")) {
+                NotificationsPane()
+            }
+
+            SettingsSection(title: L10n.string("Privacy & Diagnostics")) {
+                PrivacyPane()
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -13,13 +13,13 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .account: return "Account"
-        case .general: return "General"
-        case .appearance: return "Appearance"
-        case .models: return "Models"
-        case .agent: return "Agent"
-        case .skills: return "Skills"
-        case .storage: return "Storage"
+        case .account: return L10n.key("Account")
+        case .general: return L10n.key("General")
+        case .appearance: return L10n.key("Appearance")
+        case .models: return L10n.key("Models")
+        case .agent: return L10n.key("Agent")
+        case .skills: return L10n.key("Skills")
+        case .storage: return L10n.key("Storage")
         }
     }
 
@@ -112,7 +112,7 @@ private struct SettingsDetail: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(tab.label)
+            Text(L10n.string(key: tab.label))
                 .font(.system(size: AppTheme.FontSize.title1, weight: AppTheme.FontWeight.regular))
                 .foregroundStyle(AppTheme.Text.primaryColor)
                 .frame(
@@ -134,12 +134,7 @@ private struct SettingsDetail: View {
                             case .account:
                                 AccountPane()
                             case .general:
-                                SettingsSection(title: "Notifications") {
-                                    NotificationsPane()
-                                }
-                                SettingsSection(title: "Privacy & Diagnostics") {
-                                    PrivacyPane()
-                                }
+                                GeneralPane()
                             case .appearance:
                                 AppearancePane()
                             case .models:
@@ -172,7 +167,7 @@ struct SettingsSection<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
-            Text(title)
+            Text(verbatim: title)
                 .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.regular))
                 .foregroundStyle(AppTheme.Text.primaryColor)
 
@@ -193,7 +188,7 @@ struct SettingsGroup<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
-            Text(title)
+            Text(verbatim: title)
                 .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.regular))
                 .foregroundStyle(AppTheme.Text.primaryColor)
             content()
@@ -209,10 +204,10 @@ struct SettingsToggleRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: AppTheme.Spacing.md) {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
-                Text(title)
+                Text(verbatim: title)
                     .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.regular))
                     .foregroundStyle(AppTheme.Text.primaryColor)
-                Text(subtitle)
+                Text(verbatim: subtitle)
                     .font(.system(size: AppTheme.FontSize.sm))
                     .foregroundStyle(AppTheme.Text.tertiaryColor)
                     .fixedSize(horizontal: false, vertical: true)
@@ -220,7 +215,7 @@ struct SettingsToggleRow: View {
 
             Spacer(minLength: AppTheme.Spacing.lg)
 
-            Toggle("", isOn: $isOn)
+            Toggle(String(), isOn: $isOn)
                 .labelsHidden()
                 .toggleStyle(.switch)
                 .controlSize(.mini)
@@ -239,12 +234,12 @@ final class SettingsWindowController: NSWindowController {
 
     private init() {
         let initialView = SettingsView().tint(AppTheme.Accent.primary)
-        let hosting = NSHostingController(rootView: AnyView(initialView))
+        let hosting = NSHostingController(rootView: AnyView(initialView.appLocalization()))
         hosting.sizingOptions = .minSize
         let window = NSWindow(contentViewController: hosting)
         window.setContentSize(AppTheme.Window.settingsDefault)
         window.minSize = AppTheme.Window.settingsMin
-        window.title = "Settings"
+        window.title = L10n.string("Settings")
         window.backgroundColor = AppTheme.Background.base.withAlphaComponent(0.4)
         window.isOpaque = false
         window.titleVisibility = .hidden
@@ -264,6 +259,7 @@ final class SettingsWindowController: NSWindowController {
             hosting?.rootView = AnyView(
                 SettingsView(initialTab: tab)
                     .id(UUID())
+                    .appLocalization()
                     .tint(AppTheme.Accent.primary)
             )
         }

--- a/Sources/PalmierPro/Settings/SettingsView.swift
+++ b/Sources/PalmierPro/Settings/SettingsView.swift
@@ -95,7 +95,7 @@ private struct SettingsSidebar: View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
             ForEach(visibleTabs) { tab in
                 SidebarRowButton(
-                    label: tab.label,
+                    label: L10n.string(key: tab.label),
                     systemImage: tab.systemImage,
                     isSelected: selectedTab == tab,
                     action: { selectedTab = tab }

--- a/Sources/PalmierPro/Utilities/BundledResource.swift
+++ b/Sources/PalmierPro/Utilities/BundledResource.swift
@@ -1,14 +1,16 @@
 import Foundation
 
-private final class BundledResourceToken {}
-
 enum BundledResource {
+    static let bundle: Bundle = {
+        guard Bundle.main.bundleURL.pathExtension != "app" else { return .main }
+        return .module
+    }()
+
     static func url(_ path: String) -> URL? {
-        let buildDirectory = Bundle(for: BundledResourceToken.self).bundleURL.deletingLastPathComponent()
         let candidates = [
+            bundle.resourceURL?.appendingPathComponent(path),
             Bundle.main.resourceURL?.appendingPathComponent(path),
             Bundle.main.resourceURL?.appendingPathComponent("PalmierPro_PalmierPro.bundle/\(path)"),
-            buildDirectory.appendingPathComponent("PalmierPro_PalmierPro.bundle/\(path)"),
         ].compactMap { $0 }
         return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
     }

--- a/Sources/PalmierPro/Utilities/BundledResource.swift
+++ b/Sources/PalmierPro/Utilities/BundledResource.swift
@@ -1,16 +1,21 @@
 import Foundation
 
+private final class BundledResourceToken {}
+
 enum BundledResource {
     static let bundle: Bundle = {
         guard Bundle.main.bundleURL.pathExtension != "app" else { return .main }
-        return .module
+        let buildDirectory = Bundle(for: BundledResourceToken.self).bundleURL.deletingLastPathComponent()
+        let resourceBundleURL = buildDirectory.appendingPathComponent("PalmierPro_PalmierPro.bundle")
+        return Bundle(url: resourceBundleURL) ?? .main
     }()
 
     static func url(_ path: String) -> URL? {
+        let buildDirectory = Bundle(for: BundledResourceToken.self).bundleURL.deletingLastPathComponent()
         let candidates = [
-            bundle.resourceURL?.appendingPathComponent(path),
             Bundle.main.resourceURL?.appendingPathComponent(path),
             Bundle.main.resourceURL?.appendingPathComponent("PalmierPro_PalmierPro.bundle/\(path)"),
+            buildDirectory.appendingPathComponent("PalmierPro_PalmierPro.bundle/\(path)"),
         ].compactMap { $0 }
         return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
     }

--- a/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
+++ b/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
@@ -23,27 +23,17 @@ struct AppLocalizationTests {
         }
     }
 
-    @Test func validStoredLanguageBecomesActiveAtLaunch() throws {
+    @Test(arguments: ["en", "EN"])
+    func storedLanguageBecomesActiveAndCanonical(identifier: String) throws {
         try withDefaults { defaults in
-            defaults.set("en", forKey: AppLanguage.defaultsKey)
+            defaults.set(identifier, forKey: AppLanguage.defaultsKey)
 
             let localization = AppLocalization(defaults: defaults)
 
-            #expect(localization.activeLanguage == .language("en"))
             #expect(localization.activeIdentifier == "en")
             #expect(localization.selection == .language("en"))
-            #expect(!localization.requiresRestart)
-        }
-    }
-
-    @Test func storedLanguageIdentifiersAreCanonicalized() throws {
-        try withDefaults { defaults in
-            defaults.set("EN", forKey: AppLanguage.defaultsKey)
-
-            let localization = AppLocalization(defaults: defaults)
-
-            #expect(localization.activeLanguage == .language("en"))
             #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "en")
+            #expect(!localization.requiresRestart)
         }
     }
 
@@ -53,32 +43,27 @@ struct AppLocalizationTests {
 
             let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
 
-            #expect(localization.activeLanguage == .system)
             #expect(localization.activeIdentifier == "en")
             #expect(localization.selection == .system)
             #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "system")
         }
     }
 
-    @Test func selectingTheActiveSystemLanguageDoesNotRequireRestart() throws {
+    @Test(arguments: [
+        (AppLanguage.language("en"), false),
+        (AppLanguage.language("fr"), true),
+    ])
+    func languageSelectionPersistsAndReportsRestart(
+        language: AppLanguage,
+        requiresRestart: Bool
+    ) throws {
         try withDefaults { defaults in
             let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
 
-            localization.selection = .language("en")
+            localization.selection = language
 
-            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "en")
-            #expect(!localization.requiresRestart)
-        }
-    }
-
-    @Test func selectingAnotherLanguageRequiresRestart() throws {
-        try withDefaults { defaults in
-            let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
-
-            localization.selection = .language("fr")
-
-            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "fr")
-            #expect(localization.requiresRestart)
+            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == language.id)
+            #expect(localization.requiresRestart == requiresRestart)
         }
     }
 

--- a/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
+++ b/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("App localization")
+@MainActor
+struct AppLocalizationTests {
+    @Test func bundledEnglishLocalizationIsAvailable() throws {
+        try withDefaults { defaults in
+            let localization = AppLocalization(defaults: defaults)
+
+            #expect(localization.availableLanguages.contains(.language("en")))
+            #expect(localization.string("System Language") == "System Language")
+            #expect(localization.string(key: "System Language") == "System Language")
+            #expect(localization.string(key: "Export Queue") == "Export Queue")
+            #expect(
+                BundledResource.bundle.localizedString(
+                    forKey: "CFBundleTypeName",
+                    value: nil,
+                    table: "InfoPlist"
+                ) == "Palmier Project"
+            )
+        }
+    }
+
+    @Test func validStoredLanguageBecomesActiveAtLaunch() throws {
+        try withDefaults { defaults in
+            defaults.set("en", forKey: AppLanguage.defaultsKey)
+
+            let localization = AppLocalization(defaults: defaults)
+
+            #expect(localization.activeLanguage == .language("en"))
+            #expect(localization.activeIdentifier == "en")
+            #expect(localization.selection == .language("en"))
+            #expect(!localization.requiresRestart)
+        }
+    }
+
+    @Test func unsupportedStoredLanguageFallsBackToSystem() throws {
+        try withDefaults { defaults in
+            defaults.set("not-a-bundled-language", forKey: AppLanguage.defaultsKey)
+
+            let localization = AppLocalization(defaults: defaults)
+
+            #expect(localization.activeLanguage == .system)
+            #expect(localization.selection == .system)
+            #expect(localization.availableLanguages.contains(.language(localization.activeIdentifier)))
+        }
+    }
+
+    @Test func changingLanguagePersistsAndRequiresRestart() throws {
+        try withDefaults { defaults in
+            let localization = AppLocalization(defaults: defaults)
+
+            localization.selection = .language("en")
+
+            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "en")
+            #expect(localization.requiresRestart == (localization.activeLanguage != .language("en")))
+        }
+    }
+
+    private func withDefaults(_ body: (UserDefaults) throws -> Void) throws {
+        let suiteName = "AppLocalizationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(defaults)
+    }
+}

--- a/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
+++ b/Tests/PalmierProTests/Localization/AppLocalizationTests.swift
@@ -36,26 +36,49 @@ struct AppLocalizationTests {
         }
     }
 
+    @Test func storedLanguageIdentifiersAreCanonicalized() throws {
+        try withDefaults { defaults in
+            defaults.set("EN", forKey: AppLanguage.defaultsKey)
+
+            let localization = AppLocalization(defaults: defaults)
+
+            #expect(localization.activeLanguage == .language("en"))
+            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "en")
+        }
+    }
+
     @Test func unsupportedStoredLanguageFallsBackToSystem() throws {
         try withDefaults { defaults in
             defaults.set("not-a-bundled-language", forKey: AppLanguage.defaultsKey)
 
-            let localization = AppLocalization(defaults: defaults)
+            let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
 
             #expect(localization.activeLanguage == .system)
+            #expect(localization.activeIdentifier == "en")
             #expect(localization.selection == .system)
-            #expect(localization.availableLanguages.contains(.language(localization.activeIdentifier)))
+            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "system")
         }
     }
 
-    @Test func changingLanguagePersistsAndRequiresRestart() throws {
+    @Test func selectingTheActiveSystemLanguageDoesNotRequireRestart() throws {
         try withDefaults { defaults in
-            let localization = AppLocalization(defaults: defaults)
+            let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
 
             localization.selection = .language("en")
 
             #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "en")
-            #expect(localization.requiresRestart == (localization.activeLanguage != .language("en")))
+            #expect(!localization.requiresRestart)
+        }
+    }
+
+    @Test func selectingAnotherLanguageRequiresRestart() throws {
+        try withDefaults { defaults in
+            let localization = AppLocalization(defaults: defaults, preferredLanguages: ["en"])
+
+            localization.selection = .language("fr")
+
+            #expect(defaults.string(forKey: AppLanguage.defaultsKey) == "fr")
+            #expect(localization.requiresRestart)
         }
     }
 

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -156,14 +156,21 @@ rm -rf "$(dirname "$MCPB_FRESH")"
 if [ -d "$RES_BUNDLE/Images" ]; then
   cp -R "$RES_BUNDLE/Images" "$APP/Contents/Resources/"
 fi
-# .lproj folders must live at the bundle root for macOS to resolve them —
-# flatten out of Resources/Localization/ even though that's just an org folder.
-if [ -d "$RES_BUNDLE/Localization" ]; then
-  for locale_dir in "$RES_BUNDLE/Localization"/*.lproj; do
-    [ -d "$locale_dir" ] && cp -R "$locale_dir" "$APP/Contents/Resources/"
+# .lproj folders must live at the bundle root for macOS to resolve them.
+LOCALIZATION_COUNT=0
+for locale_dir in "$RES_BUNDLE"/*.lproj; do
+  [ -d "$locale_dir" ] || continue
+  for strings_file in Localizable.strings InfoPlist.strings; do
+    if [ ! -f "$locale_dir/$strings_file" ]; then
+      echo "!! missing $strings_file in $locale_dir" >&2
+      exit 1
+    fi
   done
-else
-  echo "!! missing Localization/ in SwiftPM resource bundle at $RES_BUNDLE" >&2
+  cp -R "$locale_dir" "$APP/Contents/Resources/"
+  LOCALIZATION_COUNT=$((LOCALIZATION_COUNT + 1))
+done
+if [ "$LOCALIZATION_COUNT" -eq 0 ]; then
+  echo "!! no compiled localizations in SwiftPM resource bundle at $RES_BUNDLE" >&2
   exit 1
 fi
 if [ -d "$RES_BUNDLE/Changelog" ]; then


### PR DESCRIPTION
## Summary

Add Palmier Pro's localization foundation: a persisted app-language preference, bundle-aware lookup, root locale injection, a General settings language row, and packaged localization resources. English is the source language; the app can follow macOS or use an explicitly selected bundled locale after restart.

This is PR 1 of 4. PR 2 extracts UI-facing strings onto this foundation.

## Stack

1. #431 — localization foundation (this PR)
2. #432 — UI-facing string extraction
3. #433 — localization CI and contributor workflow
4. #434 — Simplified and Traditional Chinese

## Approach

- Keep `AppLocalization` as the single owner of the active locale, localized bundle, available languages, and pending selection.
- Discover complete bundled `.lproj` directories instead of maintaining a production-code language list.
- Persist canonical BCP-47 identifiers and map them to SwiftPM's resource-directory spelling at lookup time. Legacy lowercase stored identifiers migrate automatically.
- Compare resolved languages before showing the restart prompt, so choosing explicit English while System already resolves to English does not request a restart.
- Inject the resolved locale at each SwiftUI/AppKit application root and route non-SwiftUI lookup through the same bundle.
- Package localization resources consistently for the app bundle, `swift run`, and SwiftPM tests.
- Remove the existing `de`, `es`, `fr`, `ja`, and `pt-BR` catalogs because each translated only five agent-panel strings. Each can return as a complete resource-only language PR.

## Design

```mermaid
flowchart LR
    A[General > Language] --> B[Canonical locale preference]
    B --> C[AppLocalization]
    D[Complete bundled .lproj directories] --> C
    C --> E[SwiftUI environment locale]
    C --> F[Localized bundle lookup]
    E --> G[SwiftUI]
    F --> H[AppKit and string-returning APIs]
```

`AppLocalization` snapshots the resolved language at launch. A changed selection is persisted for the next launch; it does not create competing live locale state.

## Testing

- `swift test --filter AppLocalizationTests` — passed, 4 tests in 1 suite.
- Final stack: `scripts/localization/sync.sh` — passed, 958 generated source strings and 960 total entries.
- Final stack: `node scripts/localization/check.mjs --require-complete` — passed for `zh-Hans` and `zh-Hant`.
- Final stack: `swift test` — passed, 1,295 tests in 206 suites.
- Manual verification on the completed stack previously confirmed the General language row, restart action, and bundled language selection.
- Existing linker and Swift concurrency warnings remain unchanged.

## Change statistics

- Production code: +311 / -27
- Build scripts and package configuration: +17 / -9
- Localization resources and plist configuration: +25 / -50
- Tests: +76 / -0
- Total: +429 / -86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app termination/relaunch and save-before-close ordering; incorrect bundle paths could break strings in dev builds, but scope is mostly settings and infrastructure rather than core editing logic.
> 
> **Overview**
> Introduces **Palmier Pro’s localization foundation**: persisted language preference, bundle-aware lookup, and locale injection at major SwiftUI roots—ahead of broader string extraction in follow-up PRs.
> 
> **`AppLocalization`** owns the active locale, discovers languages from bundled `.lproj` folders (no hardcoded list), persists canonical BCP-47 IDs in `UserDefaults`, and exposes **`L10n`** plus **`.appLocalization()`** for SwiftUI. Language changes apply on **restart**; the UI only prompts when the resolved language would actually change (e.g. explicit English while System is already English does not ask to restart).
> 
> **General settings** gains a **Language** picker and **Restart Palmier Pro** via a new **`AppDelegate.shared.restart()`** path that saves open projects, schedules relaunch after exit, then tears down MLX.
> 
> **Packaging** switches localization to **`.process("Resources/Localization")`**, sets **`defaultLocalization: "en"`**, resolves **`BundledResource.bundle`** for `swift run`/tests, and updates **`bundle.sh`** to copy compiled `.lproj` trees (with required `Localizable.strings` / `InfoPlist.strings`). **`CFBundleLocalizations`** is removed from Info.plist; partial non-English catalogs are dropped in favor of a fuller English source catalog and **`AppLocalizationTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10923ae2d12d9c301baf6b0ee299aae0d767a300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->