### PR TITLE
[ci/docs] Enforce localization coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,10 @@ jobs:
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-
 
+      - name: Check localization
+        run: |
+          scripts/localization/sync.sh
+          git diff --exit-code -- Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+
       - name: Test
         run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Show toolchain
         run: swift --version
@@ -30,7 +32,14 @@ jobs:
 
       - name: Check localization
         run: |
-          scripts/localization/sync.sh
+          localization_args=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]] &&
+             ! git diff --quiet HEAD^1 HEAD -- \
+               ':(glob)Sources/PalmierPro/Resources/Localization/*.lproj/*.strings' \
+               ':(exclude,glob)Sources/PalmierPro/Resources/Localization/en.lproj/*.strings'; then
+            localization_args+=(--require-complete)
+          fi
+          scripts/localization/sync.sh "${localization_args[@]}"
           git diff --exit-code -- Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
 
       - name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,17 @@ Rule: **any drop target that spans an area containing other drop targets must us
 - When adding a bundled resource, update `Package.swift`, bundle scripts, and tests as required. Verify the final `.app` layout when packaging behavior changes.
 - Keep optional feature-trait code buildable both with and without the trait.
 
+## Localization
+
+- Localize fixed app-owned UI copy with `L10n.string`. Keep interpolation inside the localized value so translations can reorder it.
+- Register app-owned UI labels stored in models with `L10n.key`, then resolve them at the UI boundary with `L10n.string(key:)`.
+- Render user content, filenames, technical values, provider metadata, and other non-translatable values with `Text(verbatim:)` or an equivalent verbatim API.
+- Never localize Agent or MCP contracts, persistence values, stable identifiers, machine-readable errors, or analytics values.
+- Run `scripts/localization/sync.sh` after changing UI copy. Run `node scripts/localization/check.mjs` after editing localization files.
+- The generated `en.lproj/Localizable.strings` file is the source inventory. Do not edit it manually.
+- A language PR must add only complete `<locale>.lproj` directories containing `Localizable.strings` and `InfoPlist.strings`. Translate values, never keys, and do not add production-code language lists.
+- Follow `docs/Localization.md` for source patterns, translation boundaries, and manual verification.
+
 ## Errors, logging, and observability
 
 - Every user-initiated or Agent-initiated operation must reach an observable success, failure, refusal, or cancellation state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Rule: **any drop target that spans an area containing other drop targets must us
 - Register app-owned UI labels stored in models with `L10n.key`, then resolve them at the UI boundary with `L10n.string(key:)`.
 - Render user content, filenames, technical values, provider metadata, and other non-translatable values with `Text(verbatim:)` or an equivalent verbatim API.
 - Never localize Agent or MCP contracts, persistence values, stable identifiers, machine-readable errors, or analytics values.
-- Run `scripts/localization/sync.sh` after changing UI copy. Run `node scripts/localization/check.mjs --require-complete` for language PRs.
+- Run `scripts/localization/sync.sh` after changing UI copy. CI requires complete coverage when a PR changes a non-English catalog.
 - The generated `en.lproj/Localizable.strings` file is the source inventory. Do not edit it manually.
 - A language PR must add only complete `<locale>.lproj` directories containing `Localizable.strings` and `InfoPlist.strings`. Translate values, never keys, and do not add production-code language lists.
 - Follow `docs/Localization.md` for source patterns, translation boundaries, and manual verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Rule: **any drop target that spans an area containing other drop targets must us
 - Register app-owned UI labels stored in models with `L10n.key`, then resolve them at the UI boundary with `L10n.string(key:)`.
 - Render user content, filenames, technical values, provider metadata, and other non-translatable values with `Text(verbatim:)` or an equivalent verbatim API.
 - Never localize Agent or MCP contracts, persistence values, stable identifiers, machine-readable errors, or analytics values.
-- Run `scripts/localization/sync.sh` after changing UI copy. Run `node scripts/localization/check.mjs` after editing localization files.
+- Run `scripts/localization/sync.sh` after changing UI copy. Run `node scripts/localization/check.mjs --require-complete` for language PRs.
 - The generated `en.lproj/Localizable.strings` file is the source inventory. Do not edit it manually.
 - A language PR must add only complete `<locale>.lproj` directories containing `Localizable.strings` and `InfoPlist.strings`. Translate values, never keys, and do not add production-code language lists.
 - Follow `docs/Localization.md` for source patterns, translation boundaries, and manual verification.

--- a/docs/Localization.md
+++ b/docs/Localization.md
@@ -16,7 +16,7 @@ After adding or removing UI copy, run:
 scripts/localization/sync.sh
 ```
 
-This extracts compiler-known Swift strings, adds registered model keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, raw literals in known UI state assignments, malformed catalogs, and incompatible format placeholders. Missing or obsolete target-language entries produce warnings so feature and release PRs can use the English fallback.
+This extracts compiler-known Swift strings, adds registered model keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, raw literals in known UI state assignments, malformed catalogs, and incompatible format placeholders. Missing or obsolete target-language entries produce warnings so feature and release PRs can use the English fallback; PRs that change a non-English catalog require complete coverage.
 
 ## Adding a language
 

--- a/docs/Localization.md
+++ b/docs/Localization.md
@@ -8,7 +8,7 @@ Use `L10n.string("Copy")` for fixed UI copy. Swift interpolation is supported an
 
 Use `L10n.key("Copy")` only when a model stores an app-owned UI label for a view to resolve later with `L10n.string(key:)`. This keeps the source key discoverable without storing localized text in domain state.
 
-Use `Text(verbatim:)` for user content, filenames, model/provider metadata, timecodes, identifiers, and other values that must not be translated. Do not localize Agent or MCP contracts, persisted values, stable identifiers, machine-readable errors, or analytics values.
+Use `Text(verbatim:)` for user content, filenames, release notes, model/provider metadata, timecodes, identifiers, and other values that must not be translated. Do not localize Agent or MCP contracts, persisted values, stable identifiers, machine-readable errors, or analytics values.
 
 After adding or removing UI copy, run:
 
@@ -16,7 +16,7 @@ After adding or removing UI copy, run:
 scripts/localization/sync.sh
 ```
 
-This extracts compiler-known Swift strings, adds registered model and changelog keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, common unclassified UI literals, incomplete locale coverage, unknown keys, and incompatible format placeholders.
+This extracts compiler-known Swift strings, adds registered model keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, common unclassified UI literals, malformed catalogs, and incompatible format placeholders. Missing or obsolete target-language entries produce warnings so feature and release PRs can use the English fallback.
 
 ## Adding a language
 
@@ -40,8 +40,11 @@ Validate the result with:
 
 ```bash
 node scripts/localization/check.mjs
+node scripts/localization/check.mjs --require-complete
 swift build
 ```
+
+The strict check is required for a language PR and rejects missing or obsolete entries.
 
 Manually launch the app, select the language in Settings > General, restart, and check menus, settings, editor panels, alerts, empty states, truncation, and Finder project-type text.
 

--- a/docs/Localization.md
+++ b/docs/Localization.md
@@ -1,0 +1,48 @@
+# Localization
+
+Palmier Pro uses UTF-8 `.strings` files and a small runtime wrapper so the app language can follow macOS or use an explicit in-app choice. Language changes take effect after the app restarts. English is the source language.
+
+## Source code
+
+Use `L10n.string("Copy")` for fixed UI copy. Swift interpolation is supported and must remain inside the localized value so translators can reorder it.
+
+Use `L10n.key("Copy")` only when a model stores an app-owned UI label for a view to resolve later with `L10n.string(key:)`. This keeps the source key discoverable without storing localized text in domain state.
+
+Use `Text(verbatim:)` for user content, filenames, model/provider metadata, timecodes, identifiers, and other values that must not be translated. Do not localize Agent or MCP contracts, persisted values, stable identifiers, machine-readable errors, or analytics values.
+
+After adding or removing UI copy, run:
+
+```bash
+scripts/localization/sync.sh
+```
+
+This extracts compiler-known Swift strings, adds registered model and changelog keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, common unclassified UI literals, incomplete locale coverage, unknown keys, and incompatible format placeholders.
+
+## Adding a language
+
+A language PR adds one or more locale directories:
+
+```text
+Sources/PalmierPro/Resources/Localization/
+├── en.lproj/
+│   ├── Localizable.strings
+│   └── InfoPlist.strings
+└── fr.lproj/
+    ├── Localizable.strings
+    └── InfoPlist.strings
+```
+
+Copy both files from `en.lproj` into the new locale directory. In `Localizable.strings`, keep every left-hand key unchanged and translate every right-hand value. Do the same for the values in `InfoPlist.strings`. Do not change Swift, `Package.swift`, `Info.plist`, the bundle script, the English inventory, or the language picker. Available languages are discovered from the bundled `.lproj` directories.
+
+Keep interpolation placeholders intact. Positional placeholders such as `%2$@` may be used when the translated sentence needs a different word order. Use complete singular and plural sentences instead of interpolating English suffixes. Translate the meaning, not technical tokens such as product names, keyboard shortcuts, filenames, codecs, model names, or service names unless the source entry clearly treats them as prose.
+
+Validate the result with:
+
+```bash
+node scripts/localization/check.mjs
+swift build
+```
+
+Manually launch the app, select the language in Settings > General, restart, and check menus, settings, editor panels, alerts, empty states, truncation, and Finder project-type text.
+
+The current inventory contains simple strings and format placeholders. A feature that requires locale-specific plural categories must add a shared `.stringsdict` design and matching validation before language-only PRs translate it.

--- a/docs/Localization.md
+++ b/docs/Localization.md
@@ -16,7 +16,7 @@ After adding or removing UI copy, run:
 scripts/localization/sync.sh
 ```
 
-This extracts compiler-known Swift strings, adds registered model keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, common unclassified UI literals, malformed catalogs, and incompatible format placeholders. Missing or obsolete target-language entries produce warnings so feature and release PRs can use the English fallback.
+This extracts compiler-known Swift strings, adds registered model keys, regenerates `en.lproj/Localizable.strings`, and checks localization integrity. CI rejects a stale English inventory, raw literals in known UI state assignments, malformed catalogs, and incompatible format placeholders. Missing or obsolete target-language entries produce warnings so feature and release PRs can use the English fallback.
 
 ## Adding a language
 

--- a/scripts/localization/check.mjs
+++ b/scripts/localization/check.mjs
@@ -35,15 +35,22 @@ function lineNumber(source, index) {
   return source.slice(0, index).split("\n").length;
 }
 
-function placeholders(value) {
+export function placeholderSignature(value) {
   const result = [];
-  const pattern = /%%|%(?:\d+\$)?[-+#0 ']*\d*(?:\.\d+)?(?:hh|h|ll|l|L|z|t|j|q)?([@diuoxXfFeEgGaAcCsSp])/g;
+  let nextIndex = 1;
+  const pattern = /%%|%(?:(\d+)\$)?[-+#0 ']*\d*(?:\.\d+)?(?:hh|h|ll|l|L|z|t|j|q)?([@diuoxXfFeEgGaAcCsSp])/g;
   for (const match of value.matchAll(pattern)) {
     if (match[0] === "%%") continue;
-    const type = match[1].toLowerCase();
-    result.push("diuox".includes(type) ? "integer" : "fega".includes(type) ? "floating" : type);
+    const type = match[2].toLowerCase();
+    result.push({
+      index: match[1] ? Number(match[1]) : nextIndex++,
+      type: "diuox".includes(type) ? "integer" : "fega".includes(type) ? "floating" : type,
+    });
   }
-  return result.sort().join(",");
+  return result
+    .sort((lhs, rhs) => lhs.index - rhs.index || lhs.type.localeCompare(rhs.type))
+    .map(({ index, type }) => `${index}:${type}`)
+    .join(",");
 }
 
 function parseStrings(file) {
@@ -114,7 +121,7 @@ for (const tableName of tableNames) {
       const value = targetEntries.get(key);
       if (!value.trim()) {
         errors.push(`${relative(targetFile)}: empty translation for ${JSON.stringify(key)}`);
-      } else if (placeholders(value) !== placeholders(sourceEntries.get(key))) {
+      } else if (placeholderSignature(value) !== placeholderSignature(sourceEntries.get(key))) {
         errors.push(`${relative(targetFile)}: incompatible placeholders for ${JSON.stringify(key)}`);
       }
     }
@@ -131,97 +138,6 @@ const localizable = sourceTables.get("Localizable") ?? new Map();
 for (const key of sourceKeys()) {
   if (!localizable.has(key)) {
     errors.push(`en.lproj/Localizable.strings: missing registered source key ${JSON.stringify(key)}`);
-  }
-}
-
-function firstArgument(source, openIndex) {
-  let depth = 1;
-  let blockCommentDepth = 0;
-  let state = "normal";
-  let quoteLength = 0;
-  for (let index = openIndex + 1; index < source.length; index += 1) {
-    const current = source[index];
-    const next = source[index + 1];
-
-    if (state === "lineComment") {
-      if (current === "\n") state = "normal";
-      continue;
-    }
-    if (state === "blockComment") {
-      if (current === "/" && next === "*") {
-        blockCommentDepth += 1;
-        index += 1;
-      } else if (current === "*" && next === "/") {
-        blockCommentDepth -= 1;
-        index += 1;
-        if (blockCommentDepth === 0) state = "normal";
-      }
-      continue;
-    }
-    if (state === "string") {
-      if (current === "\\") {
-        index += 1;
-      } else if (quoteLength === 3 && source.slice(index, index + 3) === '"""') {
-        index += 2;
-        state = "normal";
-      } else if (quoteLength === 1 && current === '"') {
-        state = "normal";
-      }
-      continue;
-    }
-
-    if (current === "/" && next === "/") {
-      state = "lineComment";
-      index += 1;
-    } else if (current === "/" && next === "*") {
-      state = "blockComment";
-      blockCommentDepth = 1;
-      index += 1;
-    } else if (source.slice(index, index + 3) === '"""') {
-      state = "string";
-      quoteLength = 3;
-      index += 2;
-    } else if (current === '"') {
-      state = "string";
-      quoteLength = 1;
-    } else if (current === "(") {
-      depth += 1;
-    } else if (current === ")") {
-      depth -= 1;
-      if (depth === 0) return source.slice(openIndex + 1, index);
-    } else if (current === "," && depth === 1) {
-      return source.slice(openIndex + 1, index);
-    }
-  }
-  return null;
-}
-
-const localizedAPIs = new Set([
-  "Button", "ColorPicker", "ContentUnavailableView", "GroupBox", "Label", "LabeledContent",
-  "Link", "Menu", "NavigationLink", "Picker", "ProgressView", "Section", "SecureField", "Text",
-  "TextField", "Toggle", "accessibilityAction", "accessibilityHint", "accessibilityLabel",
-  "accessibilityValue", "alert", "confirmationDialog", "help", "navigationTitle",
-  "EditorPanelGroup", "GeneratingOverlay", "InspectorRow", "MediaPanelToast", "SettingsGroup",
-  "SettingsSection", "SettingsToggleRow",
-]);
-const appKitAPIs = new Set(["NSMenu", "NSMenuItem", "addItem"]);
-
-function checkUICalls(file, source) {
-  const identifierPattern = /[A-Za-z_][A-Za-z0-9_]*/g;
-  for (const match of source.matchAll(identifierPattern)) {
-    const name = match[0];
-    if (!localizedAPIs.has(name) && !appKitAPIs.has(name)) continue;
-    let openIndex = match.index + name.length;
-    while (/\s/.test(source[openIndex] ?? "")) openIndex += 1;
-    if (source[openIndex] !== "(") continue;
-    const argument = firstArgument(source, openIndex);
-    if (argument === null || !/(?:#*)"/.test(argument)) continue;
-    if (argument.includes("L10n.") || argument.includes("verbatim:") || argument.trim() === "String()") continue;
-    if (name === "Section" && /^\s*id\s*:/.test(argument)) continue;
-    if (name === "NSMenuItem" && !/^\s*title\s*:/.test(argument)) continue;
-    if (name === "NSMenu" && !/^\s*title\s*:/.test(argument)) continue;
-    if (name === "addItem" && !/^\s*withTitle\s*:/.test(argument)) continue;
-    errors.push(`${relative(file)}:${lineNumber(source, match.index)}: ${name} contains an unclassified string literal`);
   }
 }
 
@@ -244,7 +160,6 @@ function checkNamedUILiterals(file, source) {
 
 for (const file of filesUnder(sourceRoot, ".swift")) {
   const source = fs.readFileSync(file, "utf8");
-  checkUICalls(file, source);
   checkNamedUILiterals(file, source);
   if (file.includes(`${path.sep}Agent${path.sep}Tools${path.sep}`) && source.includes("L10n.")) {
     errors.push(`${relative(file)}: Agent tool contracts must not use UI localization`);

--- a/scripts/localization/check.mjs
+++ b/scripts/localization/check.mjs
@@ -13,6 +13,12 @@ const catalogRoot = path.join(sourceRoot, "Resources", "Localization");
 const sourceLocale = "en";
 const tableNames = ["Localizable", "InfoPlist"];
 const errors = [];
+const warnings = [];
+const requiresCompleteCoverage = process.argv.includes("--require-complete");
+
+function reportCoverageIssue(message) {
+  (requiresCompleteCoverage ? errors : warnings).push(message);
+}
 
 function filesUnder(directory, suffix) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -102,7 +108,7 @@ for (const tableName of tableNames) {
 
     for (const key of sourceEntries.keys()) {
       if (!targetEntries.has(key)) {
-        errors.push(`${relative(targetFile)}: missing ${JSON.stringify(key)}`);
+        reportCoverageIssue(`${relative(targetFile)}: missing ${JSON.stringify(key)}`);
         continue;
       }
       const value = targetEntries.get(key);
@@ -115,7 +121,7 @@ for (const tableName of tableNames) {
 
     for (const key of targetEntries.keys()) {
       if (!sourceEntries.has(key)) {
-        errors.push(`${relative(targetFile)}: unknown key ${JSON.stringify(key)}`);
+        reportCoverageIssue(`${relative(targetFile)}: unknown key ${JSON.stringify(key)}`);
       }
     }
   }
@@ -245,6 +251,8 @@ for (const file of filesUnder(sourceRoot, ".swift")) {
   }
 }
 
+for (const warning of warnings) console.warn(`warning: ${warning}`);
+
 if (errors.length > 0) {
   for (const error of errors) console.error(`error: ${error}`);
   process.exit(1);
@@ -252,4 +260,5 @@ if (errors.length > 0) {
 
 const stringCount = [...sourceTables.values()].reduce((sum, entries) => sum + entries.size, 0);
 const localeSummary = targetLocales.join(", ") || "source language only";
-console.log(`Localization checks passed: ${stringCount} strings; ${localeSummary}.`);
+const warningSummary = warnings.length > 0 ? `; ${warnings.length} coverage warnings` : "";
+console.log(`Localization checks passed: ${stringCount} strings; ${localeSummary}${warningSummary}.`);

--- a/scripts/localization/check.mjs
+++ b/scripts/localization/check.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Validates localization catalogs, placeholders, registered keys, and protected UI and Agent boundaries.
 
 import fs from "node:fs";
 import path from "node:path";

--- a/scripts/localization/check.mjs
+++ b/scripts/localization/check.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { sourceKeys } from "./sync.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(scriptPath), "../..");
+const sourceRoot = path.join(root, "Sources", "PalmierPro");
+const catalogRoot = path.join(sourceRoot, "Resources", "Localization");
+const sourceLocale = "en";
+const tableNames = ["Localizable", "InfoPlist"];
+const errors = [];
+
+function filesUnder(directory, suffix) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(child, suffix) : entry.name.endsWith(suffix) ? [child] : [];
+  });
+}
+
+function relative(file) {
+  return path.relative(root, file);
+}
+
+function lineNumber(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+function placeholders(value) {
+  const result = [];
+  const pattern = /%%|%(?:\d+\$)?[-+#0 ']*\d*(?:\.\d+)?(?:hh|h|ll|l|L|z|t|j|q)?([@diuoxXfFeEgGaAcCsSp])/g;
+  for (const match of value.matchAll(pattern)) {
+    if (match[0] === "%%") continue;
+    const type = match[1].toLowerCase();
+    result.push("diuox".includes(type) ? "integer" : "fega".includes(type) ? "floating" : type);
+  }
+  return result.sort().join(",");
+}
+
+function parseStrings(file) {
+  try {
+    const output = execFileSync(
+      "/usr/bin/plutil",
+      ["-convert", "json", "-o", "-", file],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const values = JSON.parse(output);
+    if (Array.isArray(values) || values === null || typeof values !== "object") {
+      throw new Error("expected a string dictionary");
+    }
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value !== "string") throw new Error(`${JSON.stringify(key)} does not contain a string value`);
+    }
+    return new Map(Object.entries(values));
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message;
+    errors.push(`${relative(file)}: ${detail}`);
+    return null;
+  }
+}
+
+let locales = [];
+try {
+  locales = fs.readdirSync(catalogRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith(".lproj"))
+    .map((entry) => entry.name.slice(0, -".lproj".length))
+    .sort();
+} catch (error) {
+  errors.push(`${relative(catalogRoot)}: ${error.message}`);
+}
+
+if (!locales.includes(sourceLocale)) {
+  errors.push(`${relative(catalogRoot)}: missing ${sourceLocale}.lproj source localization`);
+}
+
+const targetLocales = locales.filter((locale) => locale !== sourceLocale);
+const sourceTables = new Map();
+
+for (const tableName of tableNames) {
+  const fileName = `${tableName}.strings`;
+  const sourceFile = path.join(catalogRoot, `${sourceLocale}.lproj`, fileName);
+  const sourceEntries = parseStrings(sourceFile) ?? new Map();
+  sourceTables.set(tableName, sourceEntries);
+
+  for (const [key, value] of sourceEntries) {
+    if (!key) errors.push(`${relative(sourceFile)}: contains an empty key`);
+    if (!value.trim()) {
+      errors.push(`${relative(sourceFile)}: empty source value for ${JSON.stringify(key)}`);
+    }
+    if (tableName === "Localizable" && value !== key) {
+      errors.push(`${relative(sourceFile)}: source value must match its key for ${JSON.stringify(key)}`);
+    }
+  }
+
+  for (const locale of targetLocales) {
+    const targetFile = path.join(catalogRoot, `${locale}.lproj`, fileName);
+    const targetEntries = parseStrings(targetFile);
+    if (!targetEntries) continue;
+
+    for (const key of sourceEntries.keys()) {
+      if (!targetEntries.has(key)) {
+        errors.push(`${relative(targetFile)}: missing ${JSON.stringify(key)}`);
+        continue;
+      }
+      const value = targetEntries.get(key);
+      if (!value.trim()) {
+        errors.push(`${relative(targetFile)}: empty translation for ${JSON.stringify(key)}`);
+      } else if (placeholders(value) !== placeholders(sourceEntries.get(key))) {
+        errors.push(`${relative(targetFile)}: incompatible placeholders for ${JSON.stringify(key)}`);
+      }
+    }
+
+    for (const key of targetEntries.keys()) {
+      if (!sourceEntries.has(key)) {
+        errors.push(`${relative(targetFile)}: unknown key ${JSON.stringify(key)}`);
+      }
+    }
+  }
+}
+
+const localizable = sourceTables.get("Localizable") ?? new Map();
+for (const key of sourceKeys()) {
+  if (!localizable.has(key)) {
+    errors.push(`en.lproj/Localizable.strings: missing registered source key ${JSON.stringify(key)}`);
+  }
+}
+
+function firstArgument(source, openIndex) {
+  let depth = 1;
+  let blockCommentDepth = 0;
+  let state = "normal";
+  let quoteLength = 0;
+  for (let index = openIndex + 1; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+
+    if (state === "lineComment") {
+      if (current === "\n") state = "normal";
+      continue;
+    }
+    if (state === "blockComment") {
+      if (current === "/" && next === "*") {
+        blockCommentDepth += 1;
+        index += 1;
+      } else if (current === "*" && next === "/") {
+        blockCommentDepth -= 1;
+        index += 1;
+        if (blockCommentDepth === 0) state = "normal";
+      }
+      continue;
+    }
+    if (state === "string") {
+      if (current === "\\") {
+        index += 1;
+      } else if (quoteLength === 3 && source.slice(index, index + 3) === '"""') {
+        index += 2;
+        state = "normal";
+      } else if (quoteLength === 1 && current === '"') {
+        state = "normal";
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      state = "lineComment";
+      index += 1;
+    } else if (current === "/" && next === "*") {
+      state = "blockComment";
+      blockCommentDepth = 1;
+      index += 1;
+    } else if (source.slice(index, index + 3) === '"""') {
+      state = "string";
+      quoteLength = 3;
+      index += 2;
+    } else if (current === '"') {
+      state = "string";
+      quoteLength = 1;
+    } else if (current === "(") {
+      depth += 1;
+    } else if (current === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex + 1, index);
+    } else if (current === "," && depth === 1) {
+      return source.slice(openIndex + 1, index);
+    }
+  }
+  return null;
+}
+
+const localizedAPIs = new Set([
+  "Button", "ColorPicker", "ContentUnavailableView", "GroupBox", "Label", "LabeledContent",
+  "Link", "Menu", "NavigationLink", "Picker", "ProgressView", "Section", "SecureField", "Text",
+  "TextField", "Toggle", "accessibilityAction", "accessibilityHint", "accessibilityLabel",
+  "accessibilityValue", "alert", "confirmationDialog", "help", "navigationTitle",
+  "EditorPanelGroup", "GeneratingOverlay", "InspectorRow", "MediaPanelToast", "SettingsGroup",
+  "SettingsSection", "SettingsToggleRow",
+]);
+const appKitAPIs = new Set(["NSMenu", "NSMenuItem", "addItem"]);
+
+function checkUICalls(file, source) {
+  const identifierPattern = /[A-Za-z_][A-Za-z0-9_]*/g;
+  for (const match of source.matchAll(identifierPattern)) {
+    const name = match[0];
+    if (!localizedAPIs.has(name) && !appKitAPIs.has(name)) continue;
+    let openIndex = match.index + name.length;
+    while (/\s/.test(source[openIndex] ?? "")) openIndex += 1;
+    if (source[openIndex] !== "(") continue;
+    const argument = firstArgument(source, openIndex);
+    if (argument === null || !/(?:#*)"/.test(argument)) continue;
+    if (argument.includes("L10n.") || argument.includes("verbatim:") || argument.trim() === "String()") continue;
+    if (name === "Section" && /^\s*id\s*:/.test(argument)) continue;
+    if (name === "NSMenuItem" && !/^\s*title\s*:/.test(argument)) continue;
+    if (name === "NSMenu" && !/^\s*title\s*:/.test(argument)) continue;
+    if (name === "addItem" && !/^\s*withTitle\s*:/.test(argument)) continue;
+    errors.push(`${relative(file)}:${lineNumber(source, match.index)}: ${name} contains an unclassified string literal`);
+  }
+}
+
+function checkNamedUILiterals(file, source) {
+  const patterns = [
+    ["panel text", /\bpanel\.(?:message|prompt|title)\s*=\s*(?:#*)"/g],
+    ["mediaPanelToast", /\b(?:[A-Za-z_][A-Za-z0-9_]*\.)?mediaPanelToast\s*=\s*(?:#*)"/g],
+    ["deletionMessage", /\bdeletionMessage\s*=\s*(?:#*)"/g],
+    ["submissionError", /\bsubmissionError\s*=\s*(?:#*)"/g],
+  ];
+  if (!file.includes(`${path.sep}Agent${path.sep}`)) {
+    patterns.push(["labelHelp", /\blabelHelp\s*:\s*(?:#*)"/g]);
+  }
+  for (const [name, pattern] of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      errors.push(`${relative(file)}:${lineNumber(source, match.index)}: ${name} contains an unclassified string literal`);
+    }
+  }
+}
+
+for (const file of filesUnder(sourceRoot, ".swift")) {
+  const source = fs.readFileSync(file, "utf8");
+  checkUICalls(file, source);
+  checkNamedUILiterals(file, source);
+  if (file.includes(`${path.sep}Agent${path.sep}Tools${path.sep}`) && source.includes("L10n.")) {
+    errors.push(`${relative(file)}: Agent tool contracts must not use UI localization`);
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+const stringCount = [...sourceTables.values()].reduce((sum, entries) => sum + entries.size, 0);
+const localeSummary = targetLocales.join(", ") || "source language only";
+console.log(`Localization checks passed: ${stringCount} strings; ${localeSummary}.`);

--- a/scripts/localization/sync.mjs
+++ b/scripts/localization/sync.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Merges compiler-extracted strings and registered model keys into the generated English source catalog.
 
 import fs from "node:fs";
 import path from "node:path";

--- a/scripts/localization/sync.mjs
+++ b/scripts/localization/sync.mjs
@@ -35,6 +35,20 @@ export function sourceKeys() {
   return [...keys].sort();
 }
 
+function localizedSourceNames() {
+  const names = new Set();
+  const pattern = /L10n\.string\(\s*(?:#*)?"/;
+
+  for (const file of filesUnder(sourceRoot, ".swift")) {
+    if (!pattern.test(fs.readFileSync(file, "utf8"))) continue;
+    const name = path.basename(file, ".swift");
+    if (names.has(name)) throw new Error(`Duplicate Swift filename prevents localization sync: ${name}.swift`);
+    names.add(name);
+  }
+
+  return [...names].sort();
+}
+
 function argumentValues(name) {
   const values = [];
   for (let index = 2; index < process.argv.length; index += 1) {
@@ -92,4 +106,10 @@ function synchronize() {
   console.log(`Synchronized ${keys.size} source strings.`);
 }
 
-if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) synchronize();
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  if (process.argv.includes("--list-localized-source-names")) {
+    for (const name of localizedSourceNames()) console.log(name);
+  } else {
+    synchronize();
+  }
+}

--- a/scripts/localization/sync.mjs
+++ b/scripts/localization/sync.mjs
@@ -36,18 +36,33 @@ export function sourceKeys() {
   return [...keys].sort();
 }
 
-function localizedSourceNames() {
-  const names = new Set();
-  const pattern = /L10n\.string\(\s*(?:#*)?"/;
-
-  for (const file of filesUnder(sourceRoot, ".swift")) {
-    if (!pattern.test(fs.readFileSync(file, "utf8"))) continue;
-    const name = path.basename(file, ".swift");
-    if (names.has(name)) throw new Error(`Duplicate Swift filename prevents localization sync: ${name}.swift`);
-    names.add(name);
+function appStringsDataPaths(directory) {
+  const sourceFiles = filesUnder(sourceRoot, ".swift").map((file) => path.resolve(file));
+  const sourceNames = new Set();
+  for (const file of sourceFiles) {
+    const name = path.basename(file);
+    if (sourceNames.has(name)) throw new Error(`Duplicate Swift filename prevents localization sync: ${name}`);
+    sourceNames.add(name);
   }
 
-  return [...names].sort();
+  const expectedSources = new Set(sourceFiles);
+  const foundSources = new Set();
+  const dataPaths = [];
+  for (const entry of fs.readdirSync(directory)) {
+    if (!entry.endsWith(".stringsdata")) continue;
+    const dataPath = path.join(directory, entry);
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+    const source = path.resolve(data.source);
+    if (!expectedSources.has(source)) continue;
+    foundSources.add(source);
+    if ((data.tables?.Localizable ?? []).length > 0) dataPaths.push(dataPath);
+  }
+
+  const missingSources = sourceFiles.filter((file) => !foundSources.has(file));
+  if (missingSources.length > 0) {
+    throw new Error(`Missing compiler localization output for: ${missingSources.map((file) => path.relative(root, file)).join(", ")}`);
+  }
+  return dataPaths.sort();
 }
 
 function argumentValues(name) {
@@ -108,8 +123,10 @@ function synchronize() {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
-  if (process.argv.includes("--list-localized-source-names")) {
-    for (const name of localizedSourceNames()) console.log(name);
+  if (process.argv.includes("--list-app-stringsdata")) {
+    const directories = argumentValues("--list-app-stringsdata");
+    if (directories.length !== 1) throw new Error("--list-app-stringsdata is required exactly once");
+    for (const dataPath of appStringsDataPaths(directories[0])) console.log(dataPath);
   } else {
     synchronize();
   }

--- a/scripts/localization/sync.mjs
+++ b/scripts/localization/sync.mjs
@@ -7,7 +7,6 @@ import { fileURLToPath } from "node:url";
 const scriptPath = fileURLToPath(import.meta.url);
 const root = path.resolve(path.dirname(scriptPath), "../..");
 const sourceRoot = path.join(root, "Sources", "PalmierPro");
-const changelogPath = path.join(sourceRoot, "Resources", "Changelog", "changelog.json");
 
 function filesUnder(directory, suffix) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -31,14 +30,6 @@ export function sourceKeys() {
   for (const file of filesUnder(sourceRoot, ".swift")) {
     const source = fs.readFileSync(file, "utf8");
     for (const match of source.matchAll(pattern)) keys.add(decodeSwiftLiteral(match[1]));
-  }
-
-  const changelog = JSON.parse(fs.readFileSync(changelogPath, "utf8"));
-  for (const entry of changelog.entries ?? []) {
-    for (const section of entry.sections ?? []) {
-      if (section.heading) keys.add(section.heading);
-      for (const item of section.items ?? []) keys.add(item);
-    }
   }
 
   return [...keys].sort();
@@ -75,7 +66,11 @@ function synchronize() {
   const keys = new Set(sourceKeys());
   for (const stringsDataPath of stringsDataPaths) {
     const data = JSON.parse(fs.readFileSync(stringsDataPath, "utf8"));
-    for (const entry of data.tables?.Localizable ?? []) {
+    const entries = data.tables?.Localizable ?? [];
+    if (entries.length === 0) {
+      throw new Error(`${stringsDataPath} contains no compiler-extracted localization keys`);
+    }
+    for (const entry of entries) {
       if (!entry.key) throw new Error(`${stringsDataPath} contains an empty localization key`);
       keys.add(entry.key);
     }

--- a/scripts/localization/sync.mjs
+++ b/scripts/localization/sync.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(scriptPath), "../..");
+const sourceRoot = path.join(root, "Sources", "PalmierPro");
+const changelogPath = path.join(sourceRoot, "Resources", "Changelog", "changelog.json");
+
+function filesUnder(directory, suffix) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(child, suffix) : entry.name.endsWith(suffix) ? [child] : [];
+  });
+}
+
+function decodeSwiftLiteral(value) {
+  return value
+    .replaceAll("\\\"", "\"")
+    .replaceAll("\\n", "\n")
+    .replaceAll("\\t", "\t")
+    .replaceAll("\\\\", "\\");
+}
+
+export function sourceKeys() {
+  const keys = new Set();
+  const pattern = /L10n\.key\("((?:\\.|[^"\\])*)"\)/g;
+
+  for (const file of filesUnder(sourceRoot, ".swift")) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const match of source.matchAll(pattern)) keys.add(decodeSwiftLiteral(match[1]));
+  }
+
+  const changelog = JSON.parse(fs.readFileSync(changelogPath, "utf8"));
+  for (const entry of changelog.entries ?? []) {
+    for (const section of entry.sections ?? []) {
+      if (section.heading) keys.add(section.heading);
+      for (const item of section.items ?? []) keys.add(item);
+    }
+  }
+
+  return [...keys].sort();
+}
+
+function argumentValues(name) {
+  const values = [];
+  for (let index = 2; index < process.argv.length; index += 1) {
+    if (process.argv[index] === name) {
+      const value = process.argv[index + 1];
+      if (!value) throw new Error(`${name} requires a value`);
+      values.push(value);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+function escapeStringsValue(value) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\t", "\\t");
+}
+
+function synchronize() {
+  const outputPaths = argumentValues("--output");
+  const stringsDataPaths = argumentValues("--stringsdata");
+  if (outputPaths.length !== 1) throw new Error("--output is required exactly once");
+  if (stringsDataPaths.length === 0) throw new Error("at least one --stringsdata is required");
+
+  const keys = new Set(sourceKeys());
+  for (const stringsDataPath of stringsDataPaths) {
+    const data = JSON.parse(fs.readFileSync(stringsDataPath, "utf8"));
+    for (const entry of data.tables?.Localizable ?? []) {
+      if (!entry.key) throw new Error(`${stringsDataPath} contains an empty localization key`);
+      keys.add(entry.key);
+    }
+  }
+
+  const entries = [...keys]
+    .sort()
+    .map((key) => `"${escapeStringsValue(key)}" = "${escapeStringsValue(key)}";`);
+  const output = [
+    "/* Generated from app-owned UI copy. Translate values only in other locales. */",
+    "",
+    ...entries,
+    "",
+  ].join("\n");
+
+  const outputPath = outputPaths[0];
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, output);
+  console.log(`Synchronized ${keys.size} source strings.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) synchronize();

--- a/scripts/localization/sync.sh
+++ b/scripts/localization/sync.sh
@@ -14,6 +14,7 @@ swift build \
   -Xswiftc "$temporary_directory"
 
 typeset -A source_names
+localized_source_names=()
 stringsdata_arguments=()
 while IFS= read -r source; do
   name="${source:t:r}"
@@ -22,9 +23,31 @@ while IFS= read -r source; do
     exit 1
   fi
   source_names[$name]="$source"
+  if grep -Eq 'L10n\.string\((#*)?"' "$source"; then
+    localized_source_names+=("$name")
+  fi
+done < <(find "$source_root" -type f -name '*.swift' -print)
+
+typeset -A dependency_names
+while IFS= read -r source_list; do
+  while IFS= read -r dependency_source; do
+    [[ "$dependency_source" == "$source_root/"* ]] && continue
+    dependency_names[${dependency_source:t:r}]="$dependency_source"
+  done < "$source_list"
+done < <(find "$repo_root/.build" -type f -name sources -path '*.build/sources' -print)
+
+for name in "${localized_source_names[@]}"; do
+  if [[ -n "${dependency_names[$name]-}" ]]; then
+    print -u2 "Dependency Swift filename collides with localized app source: $name.swift"
+    exit 1
+  fi
   data="$temporary_directory/$name.stringsdata"
-  [[ -f "$data" ]] && stringsdata_arguments+=(--stringsdata "$data")
-done < <(rg --files "$source_root" -g '*.swift')
+  if [[ ! -f "$data" ]]; then
+    print -u2 "Missing compiler localization output for: $name.swift"
+    exit 1
+  fi
+  stringsdata_arguments+=(--stringsdata "$data")
+done
 
 node scripts/localization/sync.mjs \
   --output "$source_strings" \

--- a/scripts/localization/sync.sh
+++ b/scripts/localization/sync.sh
@@ -1,0 +1,32 @@
+#!/bin/zsh
+set -euo pipefail
+
+repo_root="${0:A:h:h:h}"
+source_strings="$repo_root/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings"
+source_root="$repo_root/Sources/PalmierPro"
+temporary_directory="$(mktemp -d /private/tmp/palmier-localization.XXXXXX)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+cd "$repo_root"
+swift build \
+  -Xswiftc -emit-localized-strings \
+  -Xswiftc -emit-localized-strings-path \
+  -Xswiftc "$temporary_directory"
+
+typeset -A source_names
+stringsdata_arguments=()
+while IFS= read -r source; do
+  name="${source:t:r}"
+  if [[ -n "${source_names[$name]-}" ]]; then
+    print -u2 "Duplicate Swift filename prevents localization sync: $name.swift"
+    exit 1
+  fi
+  source_names[$name]="$source"
+  data="$temporary_directory/$name.stringsdata"
+  [[ -f "$data" ]] && stringsdata_arguments+=(--stringsdata "$data")
+done < <(rg --files "$source_root" -g '*.swift')
+
+node scripts/localization/sync.mjs \
+  --output "$source_strings" \
+  "${stringsdata_arguments[@]}"
+node scripts/localization/check.mjs

--- a/scripts/localization/sync.sh
+++ b/scripts/localization/sync.sh
@@ -13,20 +13,13 @@ swift build \
   -Xswiftc -emit-localized-strings-path \
   -Xswiftc "$temporary_directory"
 
-typeset -A source_names
 localized_source_names=()
 stringsdata_arguments=()
-while IFS= read -r source; do
-  name="${source:t:r}"
-  if [[ -n "${source_names[$name]-}" ]]; then
-    print -u2 "Duplicate Swift filename prevents localization sync: $name.swift"
-    exit 1
-  fi
-  source_names[$name]="$source"
-  if grep -Eq 'L10n\.string\((#*)?"' "$source"; then
-    localized_source_names+=("$name")
-  fi
-done < <(find "$source_root" -type f -name '*.swift' -print)
+localized_source_list="$temporary_directory/localized-sources"
+node scripts/localization/sync.mjs --list-localized-source-names > "$localized_source_list"
+while IFS= read -r name; do
+  localized_source_names+=("$name")
+done < "$localized_source_list"
 
 typeset -A dependency_names
 while IFS= read -r source_list; do

--- a/scripts/localization/sync.sh
+++ b/scripts/localization/sync.sh
@@ -1,4 +1,5 @@
 #!/bin/zsh
+# Builds app localization output, selects app-owned data safely, then regenerates and validates English.
 set -euo pipefail
 
 repo_root="${0:A:h:h:h}"

--- a/scripts/localization/sync.sh
+++ b/scripts/localization/sync.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 repo_root="${0:A:h:h:h}"
 source_strings="$repo_root/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings"
-source_root="$repo_root/Sources/PalmierPro"
 temporary_directory="$(mktemp -d /private/tmp/palmier-localization.XXXXXX)"
 trap 'rm -rf "$temporary_directory"' EXIT
 
@@ -14,36 +13,15 @@ swift build \
   -Xswiftc -emit-localized-strings-path \
   -Xswiftc "$temporary_directory"
 
-localized_source_names=()
 stringsdata_arguments=()
-localized_source_list="$temporary_directory/localized-sources"
-node scripts/localization/sync.mjs --list-localized-source-names > "$localized_source_list"
-while IFS= read -r name; do
-  localized_source_names+=("$name")
-done < "$localized_source_list"
-
-typeset -A dependency_names
-while IFS= read -r source_list; do
-  while IFS= read -r dependency_source; do
-    [[ "$dependency_source" == "$source_root/"* ]] && continue
-    dependency_names[${dependency_source:t:r}]="$dependency_source"
-  done < "$source_list"
-done < <(find "$repo_root/.build" -type f -name sources -path '*.build/sources' -print)
-
-for name in "${localized_source_names[@]}"; do
-  if [[ -n "${dependency_names[$name]-}" ]]; then
-    print -u2 "Dependency Swift filename collides with localized app source: $name.swift"
-    exit 1
-  fi
-  data="$temporary_directory/$name.stringsdata"
-  if [[ ! -f "$data" ]]; then
-    print -u2 "Missing compiler localization output for: $name.swift"
-    exit 1
-  fi
+app_stringsdata_list="$temporary_directory/app-stringsdata"
+node scripts/localization/sync.mjs \
+  --list-app-stringsdata "$temporary_directory" > "$app_stringsdata_list"
+while IFS= read -r data; do
   stringsdata_arguments+=(--stringsdata "$data")
-done
+done < "$app_stringsdata_list"
 
 node scripts/localization/sync.mjs \
   --output "$source_strings" \
   "${stringsdata_arguments[@]}"
-node scripts/localization/check.mjs
+node scripts/localization/check.mjs "$@"


### PR DESCRIPTION
## Summary

Add a lean localization maintenance workflow. One command extracts compiler-known UI strings, regenerates the English source catalog, and validates source integrity. Feature and release PRs receive warnings for untranslated target-language entries and continue using the runtime English fallback; CI requires complete coverage when a PR changes a non-English catalog.

This is PR 3 of 4 and depends on #432.

## Stack

1. #431 — localization foundation
2. #432 — UI-facing string extraction
3. #433 — localization CI and contributor workflow (this PR)
4. #434 — Simplified and Traditional Chinese

## Approach

- `scripts/localization/sync.sh` builds with Swift localized-string emission, regenerates English, and validates the result.
- Select compiler output by its recorded source path instead of its flat filename, so dependency basename collisions cannot contaminate the app inventory.
- Require compiler metadata for every app Swift source and reject empty extraction data, preventing collisions or toolchain failures from silently shrinking the inventory.
- Exclude release notes from localization coverage and render them verbatim, so releases do not require same-PR translation updates.
- Keep malformed catalogs, empty values, placeholder argument mismatches, stale English inventory, known raw UI state assignments, and localized Agent/MCP contracts blocking.
- Report missing or obsolete target-language entries as warnings by default. CI passes `--require-complete` when a PR changes a non-English `.strings` file.
- Document the workflow in `AGENTS.md` and `docs/Localization.md`.

## Testing

- `scripts/localization/sync.sh` — passed without `rg`; synchronized 993 source strings and validated 995 English entries.
- `node scripts/localization/check.mjs` — passed on this branch.
- `scripts/localization/sync.sh --require-complete` — passed on the completed stack for `zh-Hans` and `zh-Hant`.
- `swift build` — passed on the completed stack.
- `swift test` — passed on the completed stack, 1,299 tests in 207 suites.
- Existing linker and Swift concurrency warnings remain unchanged.

## Change statistics

- Localization automation: +340 / -0
- CI: +14 / -0
- Documentation and contributor guidance: +62 / -0
- Total: +416 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI, Node validation scripts, and documentation only; no runtime app behavior or security-sensitive paths.
> 
> **Overview**
> Adds **localization automation and CI enforcement** so English catalogs stay in sync with Swift UI copy and translation PRs meet coverage rules.
> 
> **CI** (`ci.yml`): checkout uses `fetch-depth: 2` so PRs can diff against the merge base. A new **Check localization** step runs `scripts/localization/sync.sh`, passes `--require-complete` when the PR touches non-English `.strings` (excluding `en.lproj`), and fails if regenerated `en.lproj/Localizable.strings` would differ from the commit.
> 
> **Scripts**: `sync.sh` builds with Swift localized-string emission, merges compiler `.stringsdata` (matched by source path, not basename) with `L10n.key` registrations via `sync.mjs`, regenerates English, then runs `check.mjs`. The checker validates catalogs, placeholders, registered keys, raw UI literals in known patterns, and blocks `L10n` in Agent tools; missing target-locale keys are warnings unless `--require-complete`.
> 
> **Docs**: New `docs/Localization.md` and a **Localization** section in `AGENTS.md` describe `L10n` usage, `sync.sh`, language PR expectations, and boundaries (verbatim user content, no Agent/MCP localization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273c86443787dd61ef04861b1ad68874eee4004a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->