### PR TITLE
[refactor] Share trim planning between ripple and standard trims

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -163,26 +163,93 @@ extension EditorViewModel {
         case left, right
     }
 
-    /// Apply a trim-drag commit. Expands the edit set to linked partners when `propagateToLinked` is on and hands off to `trimClips`.
+    struct StandardTrimPlan {
+        struct Edit {
+            let clipId: String
+            let durationDelta: Int
+        }
+
+        let edge: TrimEdge
+        let edgeDeltaFrames: Int
+        let edits: [Edit]
+        var leadDurationDelta: Int { edits.first?.durationDelta ?? 0 }
+        var resizedClipIds: [String] { edits.map(\.clipId) }
+    }
+
+    struct StandardTrimReport {
+        let durationDelta: Int
+        let resizedClipIds: [String]
+    }
+
     func commitTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
-        guard let loc = findClip(id: clipId) else { return }
-        let leadClip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
-        var targets = [leadClip]
-        if propagateToLinked {
-            targets += linkedPartnerIds(of: clipId).compactMap { pid in
-                findClip(id: pid).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex] }
+        guard let plan = planStandardTrim(
+            clipId: clipId,
+            edge: edge,
+            deltaFrames: deltaFrames,
+            propagateToLinked: propagateToLinked
+        ) else { return }
+        applyStandardTrim(plan)
+    }
+
+    func planStandardTrim(
+        clipId: String,
+        edge: TrimEdge,
+        deltaFrames: Int,
+        propagateToLinked: Bool
+    ) -> StandardTrimPlan? {
+        guard deltaFrames != 0 else { return nil }
+        let targets = standardTrimTargets(clipId: clipId, propagateToLinked: propagateToLinked)
+        guard !targets.isEmpty else { return nil }
+
+        var appliedEdgeDelta = deltaFrames
+        let shrinkLimit = targets.map { max(0, $0.durationFrames - 1) }.min() ?? 0
+        switch edge {
+        case .left:
+            appliedEdgeDelta = min(appliedEdgeDelta, shrinkLimit)
+            if appliedEdgeDelta < 0 {
+                let limit = maximumTrimExtensionFrames(
+                    targets: targets,
+                    edge: edge,
+                    ripple: false
+                ) ?? Int.max
+                appliedEdgeDelta = max(appliedEdgeDelta, -limit)
+            }
+        case .right:
+            appliedEdgeDelta = max(appliedEdgeDelta, -shrinkLimit)
+            if appliedEdgeDelta > 0 {
+                let limit = maximumTrimExtensionFrames(
+                    targets: targets,
+                    edge: edge,
+                    ripple: false
+                ) ?? Int.max
+                appliedEdgeDelta = min(appliedEdgeDelta, limit)
             }
         }
-        var deltaFrames = deltaFrames
-        for target in targets {
-            guard let bounds = multicamTrimBounds(for: target) else { continue }
-            deltaFrames = edge == .left ? max(deltaFrames, -bounds.left) : min(deltaFrames, bounds.right)
+        guard appliedEdgeDelta != 0 else { return nil }
+
+        let edits = targets.map { clip in
+            StandardTrimPlan.Edit(
+                clipId: clip.id,
+                durationDelta: trimDurationDelta(for: clip, edge: edge, delta: appliedEdgeDelta)
+            )
         }
-        let edits = targets.map { clip -> (clipId: String, trimStartFrame: Int, trimEndFrame: Int) in
-            let v = trimValues(for: clip, edge: edge, delta: deltaFrames)
-            return (clip.id, v.trimStart, v.trimEnd)
+        return StandardTrimPlan(edge: edge, edgeDeltaFrames: appliedEdgeDelta, edits: edits)
+    }
+
+    /// Recomputes trim values from live clip state so plans queued in a batch
+    /// compose with edits (e.g. the other edge, or an earlier overwrite) applied before them.
+    @discardableResult
+    func applyStandardTrim(_ plan: StandardTrimPlan) -> StandardTrimReport {
+        let edits = plan.edits.compactMap { edit -> (clipId: String, trimStartFrame: Int, trimEndFrame: Int)? in
+            guard let clip = clipFor(id: edit.clipId) else { return nil }
+            let values = trimValues(for: clip, edge: plan.edge, delta: plan.edgeDeltaFrames)
+            return (edit.clipId, values.trimStart, values.trimEnd)
         }
         trimClips(edits)
+        return StandardTrimReport(
+            durationDelta: plan.leadDurationDelta,
+            resizedClipIds: plan.resizedClipIds
+        )
     }
 
     /// Nest trim limits come from the child's live length, not creation time.
@@ -244,6 +311,26 @@ extension EditorViewModel {
         }
     }
 
+    func maximumTrimExtensionFrames(
+        clipId: String,
+        edge: TrimEdge,
+        propagateToLinked: Bool,
+        ripple: Bool
+    ) -> Int? {
+        let targets = ripple
+            ? rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
+            : standardTrimTargets(clipId: clipId, propagateToLinked: propagateToLinked)
+        guard !targets.isEmpty else { return 0 }
+        return maximumTrimExtensionFrames(targets: targets, edge: edge, ripple: ripple)
+    }
+
+    func trimDurationDelta(for clip: Clip, edge: TrimEdge, delta: Int) -> Int {
+        let fields = trimValues(for: clip, edge: edge, delta: delta)
+        let startShift = fields.trimStart - clip.trimStartFrame
+        let endShift = fields.trimEnd - clip.trimEndFrame
+        return -Int((Double(startShift + endShift) / clip.speed).rounded())
+    }
+
     func trimValues(for clip: Clip, edge: TrimEdge, delta: Int) -> (trimStart: Int, trimEnd: Int) {
         let sourceDelta = Int((Double(delta) * clip.speed).rounded())
         // Image/Text clips have no source-material bound, so their trim fields can go negative
@@ -256,6 +343,41 @@ extension EditorViewModel {
             let newEnd = clip.trimEndFrame - sourceDelta
             return (clip.trimStartFrame, unbounded ? newEnd : max(0, newEnd))
         }
+    }
+
+    private func standardTrimTargets(clipId: String, propagateToLinked: Bool) -> [Clip] {
+        guard let lead = clipFor(id: clipId) else { return [] }
+        guard propagateToLinked else { return [lead] }
+        return [lead] + linkedPartnerIds(of: clipId).compactMap { clipFor(id: $0) }
+    }
+
+    private func maximumTrimExtensionFrames(
+        targets: [Clip],
+        edge: TrimEdge,
+        ripple: Bool
+    ) -> Int? {
+        var limits: [Int] = []
+        for clip in targets {
+            if clip.mediaType != .image && clip.mediaType != .text {
+                let sourceFrames = edge == .left ? clip.trimStartFrame : effectiveTrimEnd(for: clip)
+                limits.append(timelineFramesForSourceRoom(sourceFrames, speed: clip.speed))
+            }
+            guard !ripple else { continue }
+            if edge == .left {
+                limits.append(max(0, clip.startFrame))
+            }
+            if let bounds = multicamTrimBounds(for: clip) {
+                limits.append(edge == .left ? bounds.left : bounds.right)
+            }
+        }
+        return limits.min()
+    }
+
+    private func timelineFramesForSourceRoom(_ sourceFrames: Int, speed: Double) -> Int {
+        guard sourceFrames > 0, speed.isFinite, speed > 0 else { return 0 }
+        let value = (Double(sourceFrames) / speed).rounded()
+        guard value.isFinite, value > 0 else { return 0 }
+        return Int(exactly: value) ?? Int.max
     }
 
     // MARK: - Track-zone routing for drops

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -14,6 +14,24 @@ enum RippleRangesOutcome: Sendable {
     case refused(String)
 }
 
+enum RippleTrimLimit: Equatable, Sendable {
+    case sourceMedia
+    case clipLength
+    case syncLockedTrack(atFrame: Int)
+}
+
+struct RippleTrimReport: Sendable {
+    let durationDelta: Int
+    let resizedClipIds: [String]
+    let shiftedClipIds: [String]
+    let limit: RippleTrimLimit?
+}
+
+enum RippleTrimOutcome: Sendable {
+    case ok(RippleTrimReport)
+    case refused(String)
+}
+
 /// Ripple editing syncs trims, deletes, and inserts across tracks.
 extension EditorViewModel {
 
@@ -37,6 +55,7 @@ extension EditorViewModel {
         let resizes: [Resize]
         let shifts: [ClipShift]
         let blockedAtFrame: Int?
+        let achievableDurationDeltas: [Int]
         var targetIds: Set<String> { Set(resizes.map(\.clipId)) }
     }
 
@@ -50,7 +69,7 @@ extension EditorViewModel {
 
         // Each target's own source headroom caps how far it can ripple; bind to the smallest.
         let sourceDelta = targetClips
-            .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
+            .map { trimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
             .min(by: { abs($0) < abs($1) }) ?? 0
 
         // Shrinking shifts sync-locked followers left; clamp to the tightest available room.
@@ -78,6 +97,9 @@ extension EditorViewModel {
             return .init(clipId: c.id, trimStart: fields.trimStart, trimEnd: fields.trimEnd,
                          duration: c.durationFrames + durationDelta)
         }
+        let achievableDurationDeltas = targetClips.map {
+            trimDurationDelta(for: $0, edge: edge, delta: edge == .right ? durationDelta : -durationDelta)
+        }
 
         var shifts: [ClipShift] = []
         for ti in timeline.tracks.indices {
@@ -88,7 +110,13 @@ extension EditorViewModel {
                 clips: track.clips, insertFrame: targetEnd ?? leadEnd, pushAmount: durationDelta, excludeIds: targetIds
             )
         }
-        return RippleTrimPlan(durationDelta: durationDelta, resizes: resizes, shifts: shifts, blockedAtFrame: blockedAtFrame)
+        return RippleTrimPlan(
+            durationDelta: durationDelta,
+            resizes: resizes,
+            shifts: shifts,
+            blockedAtFrame: blockedAtFrame,
+            achievableDurationDeltas: achievableDurationDeltas
+        )
     }
 
     /// Max left shift for sync-locked clips before hitting the next obstacle; nil if no shift possible.
@@ -98,17 +126,36 @@ extension EditorViewModel {
         return (max(0, first - prevEnd), prevEnd)
     }
 
-    /// Ripple trim: resize a clip from the dragged edge and shift every clip after it
     func rippleTrimClip(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) {
-        if let leadLoc = findClip(id: clipId) {
-            let targets = rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
-            if let reason = rippleTrimRefusal(leadLoc: leadLoc, edge: edge, targetIds: Set(targets.map(\.id))) {
-                refuseRipple(reason: reason)
-                return
-            }
+        if case .refused(let reason) = rippleTrim(
+            clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked
+        ) {
+            refuseRipple(reason: reason)
         }
-        guard let plan = planRippleTrim(clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked) else { return }
+    }
 
+    @discardableResult
+    func rippleTrim(clipId: String, edge: TrimEdge, deltaFrames: Int, propagateToLinked: Bool) -> RippleTrimOutcome {
+        if let reason = rippleTrimRefusalReason(
+            clipId: clipId,
+            edge: edge,
+            propagateToLinked: propagateToLinked
+        ) {
+            return .refused(reason)
+        }
+
+        let plan = planRippleTrim(clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked)
+        let requested = edge == .right ? deltaFrames : -deltaFrames
+        let applied = plan?.durationDelta ?? 0
+        let limit = Self.rippleTrimLimit(requested: requested, applied: applied, blockedAtFrame: plan?.blockedAtFrame)
+        guard let plan, applied != 0 else {
+            return .ok(RippleTrimReport(durationDelta: 0, resizedClipIds: [], shiftedClipIds: [], limit: limit))
+        }
+        return .ok(applyRippleTrim(plan, limit: limit))
+    }
+
+    @discardableResult
+    func applyRippleTrim(_ plan: RippleTrimPlan, limit: RippleTrimLimit? = nil) -> RippleTrimReport {
         let touched = plan.targetIds.union(plan.shifts.map(\.clipId))
         withTimelineSwap(actionName: "Ripple Trim") {
             for r in plan.resizes {
@@ -122,6 +169,28 @@ extension EditorViewModel {
                 sortClips(trackIndex: ti)
             }
         }
+        return RippleTrimReport(
+            durationDelta: plan.durationDelta,
+            resizedClipIds: plan.resizes.map(\.clipId),
+            shiftedClipIds: plan.shifts.map(\.clipId),
+            limit: limit
+        )
+    }
+
+    func rippleTrimRefusalReason(
+        clipId: String,
+        edge: TrimEdge,
+        propagateToLinked: Bool
+    ) -> String? {
+        guard let leadLoc = findClip(id: clipId) else { return "Clip not found: \(clipId)" }
+        let targets = rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
+        return rippleTrimRefusal(leadLoc: leadLoc, edge: edge, targetIds: Set(targets.map(\.id)))
+    }
+
+    private static func rippleTrimLimit(requested: Int, applied: Int, blockedAtFrame: Int?) -> RippleTrimLimit? {
+        guard applied != requested else { return nil }
+        if let blockedAtFrame { return .syncLockedTrack(atFrame: blockedAtFrame) }
+        return requested > 0 ? .sourceMedia : .clipLength
     }
 
     func rippleTrimTargets(clipId: String, edge: TrimEdge, propagateToLinked: Bool) -> [Clip] {
@@ -157,13 +226,6 @@ extension EditorViewModel {
         }
         let shiftPoint = edge == .left ? lead.startFrame : lead.endFrame
         return multicamManualRippleViolation(shiftingTrackIds: shiftingTrackIds, atFrame: shiftPoint)
-    }
-
-    /// Timeline delta from a ripple trim of `clip` by `delta` frames.
-    private func rippleTrimDurationDelta(for clip: Clip, edge: TrimEdge, delta: Int) -> Int {
-        let fields = trimValues(for: clip, edge: edge, delta: delta)
-        let sourceShift = (fields.trimStart - clip.trimStartFrame) + (fields.trimEnd - clip.trimEndFrame)
-        return -Int((Double(sourceShift) / clip.speed).rounded())
     }
 
     /// Ripple delete: remove selected clips and shift sync-locked tracks to keep them aligned.

--- a/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleTrimTests.swift
@@ -165,6 +165,40 @@ struct RippleTrimTests {
         #expect(plan?.blockedAtFrame == nil)
     }
 
+    @Test func reportsSourceCapWhenAnExtendRunsOutOfHandles() {
+        let track = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 10),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+        let e = editor([track])
+        guard case .ok(let report) = e.rippleTrim(clipId: "c1", edge: .right, deltaFrames: 40, propagateToLinked: false) else {
+            Issue.record("expected an applied trim")
+            return
+        }
+        #expect(report.durationDelta == 10)
+        #expect(report.limit == .sourceMedia)
+        #expect(spans(e.timeline.tracks[0]) == [[0, 110], [110, 160]])
+    }
+
+    @Test func fullyBlockedShrinkMakesNoEditAndNoUndoStep() {
+        let a = Fixtures.videoTrack(clips: [Fixtures.clip(id: "c1", start: 0, duration: 100)])
+        let b = Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "b0", start: 60, duration: 40),
+            Fixtures.clip(id: "b1", start: 100, duration: 50),
+        ])
+        let e = editor([a, b])
+        let undoManager = UndoManager()
+        e.undo.attach(undoManager)
+        guard case .ok(let report) = e.rippleTrim(clipId: "c1", edge: .right, deltaFrames: -20, propagateToLinked: false) else {
+            Issue.record("expected a reported no-op, not a refusal")
+            return
+        }
+        #expect(report.durationDelta == 0)
+        #expect(report.limit == .syncLockedTrack(atFrame: 100))
+        #expect(spans(e.timeline.tracks[0]) == [[0, 100]])
+        #expect(undoManager.canUndo == false)
+    }
+
     @Test func unlinkedTrimLeavesPartnerTrackAlone() {
         // propagateToLinked off: only the lead's track ripples.
         var v1 = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
@@ -178,5 +212,52 @@ struct RippleTrimTests {
         e.rippleTrimClip(clipId: "v1", edge: .right, deltaFrames: 20, propagateToLinked: false)
         #expect(spans(e.timeline.tracks[0]) == [[0, 120]])
         #expect(spans(e.timeline.tracks[1]) == [[0, 100]])
+    }
+
+    @Test func standardTrimPlanReportsEveryLinkedClipsExactDelta() {
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var audio = Fixtures.clip(
+            id: "a1",
+            mediaType: .audio,
+            start: 0,
+            duration: 100,
+            trimEnd: 50,
+            speed: 0.5
+        )
+        video.linkGroupId = "g"
+        audio.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        let plan = e.planStandardTrim(
+            clipId: "v1",
+            edge: .right,
+            deltaFrames: 1,
+            propagateToLinked: true
+        )
+
+        #expect(plan?.edits.map(\.durationDelta).sorted() == [1, 2])
+        #expect(e.timeline.tracks[0].clips[0].durationFrames == 100)
+        #expect(e.timeline.tracks[1].clips[0].durationFrames == 100)
+    }
+
+    @Test func maximumStandardExtensionUsesTheTightestLinkedSourceHandle() {
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 100, trimEnd: 50)
+        var audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 100, trimEnd: 5)
+        video.linkGroupId = "g"
+        audio.linkGroupId = "g"
+        let e = editor([
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        #expect(e.maximumTrimExtensionFrames(
+            clipId: "v1",
+            edge: .right,
+            propagateToLinked: true,
+            ripple: false
+        ) == 5)
     }
 }


### PR DESCRIPTION
## Summary

Extracts a shared plan/apply structure for clip edge trims in the editor domain. This is PR 1 of a 3-PR stack that ends with the Agent `trim_clip` tool; it contains no tool or UI-visible behavior changes.

- `StandardTrimPlan` / `applyStandardTrim`: a regular (non-ripple) trim is planned as an exact, per-linked-clip set of duration deltas, then applied by recomputing trim values from live clip state.
- `applyRippleTrim` is split out of `rippleTrim`, so a caller can preflight (`rippleTrimRefusalReason`, `planRippleTrim`) and apply a validated plan separately. `RippleTrimPlan` gains per-clip `achievableDurationDeltas` for exactness checks.
- `maximumTrimExtensionFrames` reports the tightest source handle across a clip and its linked partners, for both ripple and standard trims.
- The UI trim commit path (`commitTrim`) now applies a validated plan instead of trimming inline, so UI and Agent callers share one eligibility/clamping/mutation path.

## Approach

Planning is separated from application so batch callers can validate an entire request atomically before mutating the timeline. `applyStandardTrim` recomputes trim values from live state at apply time (rather than storing absolute source values at plan time) so multiple plans in one undo group compose — e.g. trimming both edges of the same clip, or trimming a clip after an earlier plan overwrote its neighbor.

## Testing

- `swift build --build-tests`
- `swift test --filter 'RippleTrimTests|LinkedClip|ClipMutations'` — 59 tests, 12 suites, all pass. New domain tests cover per-linked-clip exact deltas on retimed partners and the tightest linked source handle for extensions.

## Change statistics

- Editor domain logic: ~215 insertions / 31 deletions (`EditorViewModel+Linking.swift`, `EditorViewModel+Ripple.swift`)
- Tests: ~81 insertions (`RippleTrimTests.swift`)

Made with [Cursor](https://cursor.com)