### PR TITLE
[build] Make development traits opt in

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -4,20 +4,39 @@ set -euo pipefail
 # Usage:
 #   scripts/bundle.sh [release|debug]           # ad-hoc signed dev build
 #   scripts/bundle.sh debug --fast              # fastest: skip dSYM + deep sign, just env+build
+#   scripts/bundle.sh debug --speech             # include bundled speech and MLX
+#   scripts/bundle.sh debug --telemetry          # include production telemetry
+#   scripts/bundle.sh debug --all                # include all optional traits
 #   scripts/bundle.sh release --sign            # build + Developer ID codesign
 #   scripts/bundle.sh release --dist            # build + sign + notarize + staple + DMG
 
 CONFIG="release"
 MODE="dev"
+ENABLE_ALL_TRAITS=false
+INCLUDE_BUNDLED_SPEECH=false
+INCLUDE_PRODUCTION_TELEMETRY=false
 for arg in "$@"; do
   case "$arg" in
     release|debug) CONFIG="$arg" ;;
     --fast)        MODE="fast" ;;
     --sign)        MODE="sign" ;;
     --dist)        MODE="dist" ;;
+    --speech)      INCLUDE_BUNDLED_SPEECH=true ;;
+    --telemetry)   INCLUDE_PRODUCTION_TELEMETRY=true ;;
+    --all)
+      ENABLE_ALL_TRAITS=true
+      INCLUDE_BUNDLED_SPEECH=true
+      INCLUDE_PRODUCTION_TELEMETRY=true
+      ;;
     *) echo "unknown arg: $arg" >&2; exit 1 ;;
   esac
 done
+
+if [ "$CONFIG" = "release" ]; then
+  ENABLE_ALL_TRAITS=true
+  INCLUDE_BUNDLED_SPEECH=true
+  INCLUDE_PRODUCTION_TELEMETRY=true
+fi
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -46,12 +65,28 @@ APP="$ROOT/.build/PalmierPro.app"
 ZIP="$ROOT/.build/PalmierPro.zip"
 DMG="$ROOT/.build/PalmierPro.dmg"
 
-echo "==> Building ($CONFIG)"
-TRAITS="BundledSpeech"
-if [ "$CONFIG" = "release" ]; then
-  TRAITS="$TRAITS,ProductionTelemetry"
+BUILD_ARGS=(-c "$CONFIG")
+if $ENABLE_ALL_TRAITS; then
+  TRAITS="all"
+  BUILD_ARGS+=(--enable-all-traits)
+else
+  TRAITS=""
+  if $INCLUDE_BUNDLED_SPEECH; then
+    TRAITS="BundledSpeech"
+  fi
+  if $INCLUDE_PRODUCTION_TELEMETRY; then
+    if [ -n "$TRAITS" ]; then
+      TRAITS="$TRAITS,ProductionTelemetry"
+    else
+      TRAITS="ProductionTelemetry"
+    fi
+  fi
+  if [ -n "$TRAITS" ]; then
+    BUILD_ARGS+=(--traits "$TRAITS")
+  fi
 fi
-BUILD_ARGS=(-c "$CONFIG" --traits "$TRAITS")
+
+echo "==> Building ($CONFIG, traits: ${TRAITS:-none})"
 swift build "${BUILD_ARGS[@]}"
 BIN="$(swift build "${BUILD_ARGS[@]}" --show-bin-path)/PalmierPro"
 SPARKLE_FW="$ROOT/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
@@ -150,17 +185,19 @@ if ! ls "$RES_BUNDLE"/*.metallib >/dev/null 2>&1; then
 fi
 cp "$RES_BUNDLE"/*.metallib "$APP/Contents/Resources/"
 
-MLX_METALLIB="$ROOT/.build/$CONFIG/mlx.metallib"
-if [ ! -f "$MLX_METALLIB" ]; then
-  echo "==> Building MLX metallib ($CONFIG)"
-  BUILD_DIR="$ROOT/.build" "$ROOT/.build/checkouts/speech-swift/scripts/build_mlx_metallib.sh" "$CONFIG"
+if $INCLUDE_BUNDLED_SPEECH; then
+  MLX_METALLIB="$ROOT/.build/$CONFIG/mlx.metallib"
+  if [ ! -f "$MLX_METALLIB" ]; then
+    echo "==> Building MLX metallib ($CONFIG)"
+    BUILD_DIR="$ROOT/.build" "$ROOT/.build/checkouts/speech-swift/scripts/build_mlx_metallib.sh" "$CONFIG"
+  fi
+  if [ ! -f "$MLX_METALLIB" ]; then
+    echo "!! missing $MLX_METALLIB — on-device speech features (VAD, speaker ID) would die silently" >&2
+    exit 1
+  fi
+  mkdir -p "$APP/Contents/Resources/mlx-swift_Cmlx.bundle"
+  cp "$MLX_METALLIB" "$APP/Contents/Resources/mlx-swift_Cmlx.bundle/default.metallib"
 fi
-if [ ! -f "$MLX_METALLIB" ]; then
-  echo "!! missing $MLX_METALLIB — on-device speech features (VAD, speaker ID) would die silently" >&2
-  exit 1
-fi
-mkdir -p "$APP/Contents/Resources/mlx-swift_Cmlx.bundle"
-cp "$MLX_METALLIB" "$APP/Contents/Resources/mlx-swift_Cmlx.bundle/default.metallib"
 
 install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/PalmierPro"
 touch "$APP"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 # scripts/dev.sh — build the debug bundle, launch it, and stream its OSLog.
+# Usage: scripts/dev.sh [--speech] [--telemetry] [--all] [--no-stream]
 
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 stream=true
+bundle_args=(debug --fast)
 for arg in "$@"; do
     case "$arg" in
         --no-stream) stream=false ;;
+        *) bundle_args+=("$arg") ;;
     esac
 done
 
-"$ROOT/scripts/bundle.sh" debug --fast
+"$ROOT/scripts/bundle.sh" "${bundle_args[@]}"
 
 if ! $stream; then
     open "$ROOT/.build/PalmierPro.app"


### PR DESCRIPTION
## Summary

Make optional development traits opt in so routine debug bundles do not build MLX speech resources unless requested. Release bundles continue to include every package trait.

## Approach

- Default debug bundles to no optional traits.
- Add `--speech`, `--telemetry`, and `--all` flags to `bundle.sh`; `dev.sh` forwards the same flags.
- Build and install the MLX metallib only when bundled speech is enabled.
- Use SwiftPM's `--enable-all-traits` for every release build so newly added traits are included automatically.
- Keep `release.sh` unchanged: its `bundle.sh release --dist` call inherits the all-traits release behavior.

## Testing

- `bash -n scripts/bundle.sh scripts/dev.sh scripts/release.sh` — passed.
- `git diff --check main..HEAD` — passed.
- Full debug/release bundle builds were not run; release signing and notarization require the release environment.

## Change statistics

- Build scripts: +56 / -16
- Total: +56 / -16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change; release paths still enable all traits, with the main risk being developers forgetting `--speech` when testing on-device speech.
> 
> **Overview**
> **Debug bundles no longer enable optional SwiftPM traits by default**, so routine `bundle.sh debug` / `dev.sh` runs skip `BundledSpeech` and `ProductionTelemetry` unless you ask for them.
> 
> `bundle.sh` adds **`--speech`**, **`--telemetry`**, and **`--all`** (and documents them in usage). Debug builds pass only the selected traits via `--traits`; **release builds always use `--enable-all-traits`** and still turn on speech + telemetry flags internally so dist/sign behavior stays fully featured. **MLX metallib build and copy into the app bundle run only when bundled speech is enabled**, not on every debug bundle.
> 
> `dev.sh` forwards the same flags to `bundle.sh` (along with `debug --fast`), so local dev can opt into speech/telemetry without changing release scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44aed35e2a852a82d8bde4d0a15ffc859df7d418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->