### PR TITLE
Report every skipped item on media import

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -45,12 +45,18 @@ private struct MediaImportPlan: Sendable {
     var folders: [Folder] = []
     var files: [File] = []
     var rejectedUnsupportedNames: [String] = []
+    var rejectedNestedUnsupportedNames: [String] = []
     var rejectedLottieNames: [String] = []
     var rejectedUnreadableFolderNames: [String] = []
 
     var rejectionToast: MediaPanelToast? {
+        // Non-media inside a dropped folder is expected filtering, not a failure,
+        // so it is only worth reporting when the drop imported nothing at all.
+        let unsupported = files.isEmpty
+            ? rejectedUnsupportedNames + rejectedNestedUnsupportedNames
+            : rejectedUnsupportedNames
         let groups: [(names: [String], reason: String, tag: String)] = [
-            (rejectedUnsupportedNames, "unsupported file type", "unsupported"),
+            (unsupported, "unsupported file type", "unsupported"),
             (rejectedLottieNames, "not a Lottie animation", "not Lottie"),
             (rejectedUnreadableFolderNames, "couldn't be read", "unreadable")
         ].filter { !$0.names.isEmpty }
@@ -80,7 +86,7 @@ private enum MediaImportScanner {
             if isDirectory(root.url) {
                 scanFolder(at: root.url, parent: parent, into: &plan)
             } else {
-                scanFile(at: root.url, parent: parent, into: &plan)
+                scanFile(at: root.url, parent: parent, isRootItem: true, into: &plan)
             }
         }
         return plan
@@ -98,7 +104,7 @@ private enum MediaImportScanner {
             if isDirectory(entry) {
                 scanFolder(at: entry, parent: parent, into: &plan)
             } else {
-                scanFile(at: entry, parent: parent, into: &plan)
+                scanFile(at: entry, parent: parent, isRootItem: false, into: &plan)
             }
         }
     }
@@ -128,10 +134,15 @@ private enum MediaImportScanner {
     private static func scanFile(
         at url: URL,
         parent: MediaImportPlan.Parent,
+        isRootItem: Bool,
         into plan: inout MediaImportPlan
     ) {
         guard let type = ClipType(fileExtension: url.pathExtension.lowercased()) else {
-            plan.rejectedUnsupportedNames.append(url.lastPathComponent)
+            if isRootItem {
+                plan.rejectedUnsupportedNames.append(url.lastPathComponent)
+            } else {
+                plan.rejectedNestedUnsupportedNames.append(url.lastPathComponent)
+            }
             return
         }
         if type == .lottie, !LottieVideoGenerator.isLottie(at: url) {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -46,6 +46,25 @@ private struct MediaImportPlan: Sendable {
     var files: [File] = []
     var rejectedUnsupportedNames: [String] = []
     var rejectedLottieNames: [String] = []
+    var rejectedUnreadableFolderNames: [String] = []
+
+    var rejectionToast: MediaPanelToast? {
+        let groups: [(names: [String], reason: String, tag: String)] = [
+            (rejectedUnsupportedNames, "unsupported file type", "unsupported"),
+            (rejectedLottieNames, "not a Lottie animation", "not Lottie"),
+            (rejectedUnreadableFolderNames, "couldn't be read", "unreadable")
+        ].filter { !$0.names.isEmpty }
+        guard let first = groups.first else { return nil }
+        if groups.count == 1 {
+            guard first.names.count > 1 else {
+                return "Can't import \"\(first.names[0])\" — \(first.reason)."
+            }
+            return "Can't import \(first.names.count) items — \(first.reason)."
+        }
+        let total = groups.reduce(0) { $0 + $1.names.count }
+        let detail = groups.map { "\($0.names.count) \($0.tag)" }.joined(separator: ", ")
+        return "Can't import \(total) items — \(detail)."
+    }
 }
 
 private enum MediaImportScanner {
@@ -61,7 +80,7 @@ private enum MediaImportScanner {
             if isDirectory(root.url) {
                 scanFolder(at: root.url, parent: parent, into: &plan)
             } else {
-                scanFile(at: root.url, parent: parent, isRootItem: true, into: &plan)
+                scanFile(at: root.url, parent: parent, into: &plan)
             }
         }
         return plan
@@ -79,7 +98,7 @@ private enum MediaImportScanner {
             if isDirectory(entry) {
                 scanFolder(at: entry, parent: parent, into: &plan)
             } else {
-                scanFile(at: entry, parent: parent, isRootItem: false, into: &plan)
+                scanFile(at: entry, parent: parent, into: &plan)
             }
         }
     }
@@ -89,7 +108,10 @@ private enum MediaImportScanner {
         parent: MediaImportPlan.Parent,
         into plan: inout MediaImportPlan
     ) {
-        guard let entries = directoryEntries(at: url) else { return }
+        guard let entries = directoryEntries(at: url) else {
+            plan.rejectedUnreadableFolderNames.append(url.lastPathComponent)
+            return
+        }
         let folderIndex = plan.folders.count
         plan.folders.append(.init(name: url.lastPathComponent, parent: parent))
         scan(entries: entries, parent: .plannedFolder(folderIndex), into: &plan)
@@ -106,11 +128,10 @@ private enum MediaImportScanner {
     private static func scanFile(
         at url: URL,
         parent: MediaImportPlan.Parent,
-        isRootItem: Bool,
         into plan: inout MediaImportPlan
     ) {
         guard let type = ClipType(fileExtension: url.pathExtension.lowercased()) else {
-            if isRootItem { plan.rejectedUnsupportedNames.append(url.lastPathComponent) }
+            plan.rejectedUnsupportedNames.append(url.lastPathComponent)
             return
         }
         if type == .lottie, !LottieVideoGenerator.isLottie(at: url) {
@@ -343,10 +364,8 @@ extension EditorViewModel {
             return importedAssets
         }
 
-        if let name = plan.rejectedUnsupportedNames.last {
-            mediaPanelToast = "Can't import \"\(name)\" — unsupported file type."
-        } else if let name = plan.rejectedLottieNames.last {
-            mediaPanelToast = "Can't import \"\(name)\" — not a Lottie animation."
+        if let toast = plan.rejectionToast {
+            mediaPanelToast = toast
         }
 
         let summary = MediaImportSummary(

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -80,6 +80,53 @@ struct FolderReadTests {
         #expect(e.assetsIn(folderId: nestedFolder.id).map(\.name) == ["child"])
     }
 
+    @Test func importFinderItemsReportsUnsupportedFileNestedInFolder() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-\(UUID().uuidString)", isDirectory: true)
+        let nested = root.appendingPathComponent("Nested", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data().write(to: nested.appendingPathComponent("ignored.txt"))
+
+        _ = try await e.importFinderItems([root], into: nil)
+
+        #expect(e.mediaPanelToast?.message.contains("ignored.txt") == true)
+    }
+
+    @Test func importFinderItemsReportsEveryRejectedFileNotJustTheLast() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for name in ["notes.txt", "readme.md", "sheet.csv"] {
+            try Data().write(to: root.appendingPathComponent(name))
+        }
+
+        _ = try await e.importFinderItems([root], into: nil)
+
+        #expect(e.mediaPanelToast?.message.contains("3 items") == true)
+    }
+
+    @Test func importFinderItemsReportsFolderThatCannotBeRead() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-denied-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: root.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        _ = try await e.importFinderItems([root], into: nil)
+
+        #expect(e.mediaPanelToast?.message.contains(root.lastPathComponent) == true)
+    }
+
     @Test func importFinderItemsDoesNotCreateRootFolderWhenDirectoryCannotBeRead() async throws {
         let e = editor()
         let root = FileManager.default.temporaryDirectory

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -80,7 +80,7 @@ struct FolderReadTests {
         #expect(e.assetsIn(folderId: nestedFolder.id).map(\.name) == ["child"])
     }
 
-    @Test func importFinderItemsReportsUnsupportedFileNestedInFolder() async throws {
+    @Test func importFinderItemsReportsNestedUnsupportedFileWhenNothingImports() async throws {
         let e = editor()
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("folder-import-\(UUID().uuidString)", isDirectory: true)
@@ -93,6 +93,35 @@ struct FolderReadTests {
         _ = try await e.importFinderItems([root], into: nil)
 
         #expect(e.mediaPanelToast?.message.contains("ignored.txt") == true)
+    }
+
+    @Test func importFinderItemsStaysQuietWhenNonMediaAccompaniesImportedMedia() async throws {
+        let e = editor()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-import-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data().write(to: root.appendingPathComponent("clip.mp4"))
+        try Data().write(to: root.appendingPathComponent("clip.thm"))
+        try Data().write(to: root.appendingPathComponent("notes.txt"))
+
+        let summary = try await e.importFinderItems([root], into: nil)
+
+        #expect(summary.assetCount == 1)
+        #expect(e.mediaPanelToast == nil)
+    }
+
+    @Test func importFinderItemsReportsUnsupportedFileDroppedDirectly() async throws {
+        let e = editor()
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("direct-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: file) }
+        try Data().write(to: file)
+
+        _ = try await e.importFinderItems([file], into: nil)
+
+        #expect(e.mediaPanelToast?.message.contains(file.lastPathComponent) == true)
     }
 
     @Test func importFinderItemsReportsEveryRejectedFileNotJustTheLast() async throws {


### PR DESCRIPTION
Fixes #453

Dropping a folder with no importable media, or one that can't be read, silently did nothing. Added a toast so you know what got skipped.

Doesn't fire when the import works fine, otherwise camera cards would complain about their .LRV/.THM sidecars every time.

`swift test --filter FolderReadTests`