### PR TITLE
[ui] Improve onboarding tour, starter prompts, and analytics

### DIFF
--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -5,39 +5,46 @@ struct AgentPanelView: View {
 
     private static let starterPrompts: [AgentStarterPrompt] = [
         AgentStarterPrompt(
-            title: L10n.string("Generate an AI video"),
-            systemImage: "sparkles",
-            prompt: "Generate an AI video of "
+            id: "keep_best_takes",
+            title: L10n.string("Keep the best takes"),
+            systemImage: "scissors",
+            prompt: "Tighten this edit. Keep the strongest takes, cut filler words and long silences, and leave a clean continuous cut."
         ),
         AgentStarterPrompt(
+            id: "sync_multicam",
+            title: L10n.string("Sync my multicam"),
+            systemImage: "rectangle.on.rectangle.angled",
+            prompt: "Set up my multicam. Group the matching camera angles with their audio, verify sync, and leave it ready to switch."
+        ),
+        AgentStarterPrompt(
+            id: "generate_broll",
             title: L10n.string("Generate B-roll"),
             systemImage: "film",
-            prompt: "Generate B-roll for my timeline. Inspect the current edit, identify sections that would benefit from cutaways, generate suitable B-roll, and place it where it supports the story."
+            prompt: "Generate B-roll that fits this edit. Find moments that need cutaways, create matching shots, and place them where they support the story."
         ),
         AgentStarterPrompt(
-            title: L10n.string("Create a letterbox opening"),
-            systemImage: "camera.aperture",
-            prompt: "Create a cinematic opening for my timeline. Use the first visual clip, animate a subtle letterbox matte with top and bottom crop keyframes, starting from crop to uncrop,and keep the motion restrained and polished."
-        ),
-        AgentStarterPrompt(
-            title: L10n.string("Add captions to my timeline"),
-            systemImage: "captions.bubble",
-            prompt: "Add captions to my timeline. Transcribe spoken audio in timeline clips, build readable caption phrases on word boundaries, and place them as text clips aligned to the edit."
-        ),
-        AgentStarterPrompt(
-            title: L10n.string("Create a voiceover"),
-            systemImage: "waveform",
-            prompt: "Create a voiceover for my timeline. Draft concise narration for the current edit, generate the voiceover, and add it to an audio track aligned with the timeline."
-        ),
-        AgentStarterPrompt(
-            title: L10n.string("Generate music and sync to my timeline"),
+            id: "score_timeline",
+            title: L10n.string("Score my timeline"),
             systemImage: "music.note",
-            prompt: "Score my timeline with music. Inspect the edit's mood and pacing, generate music for the full timeline, and place it on an audio track aligned to the edit."
+            prompt: "Generate music for this timeline. Match the mood and length, then place it on an audio track synced to the edit."
         ),
         AgentStarterPrompt(
-            title: L10n.string("Organize my media into structured folders"),
-            systemImage: "folder",
-            prompt: "Organize my media into structured folders. Review all assets, create clearly named folders by role, scene, or type, move assets into them, and rename generic files when useful. Don't delete anything or change the timeline."
+            id: "cut_to_beat",
+            title: L10n.string("Cut to the beat"),
+            systemImage: "metronome",
+            prompt: "Assemble my clips to the beat of a song. Detect the beats and cut or place clips so the edit hits the rhythm."
+        ),
+        AgentStarterPrompt(
+            id: "add_captions",
+            title: L10n.string("Add captions"),
+            systemImage: "captions.bubble",
+            prompt: "Add captions to this timeline. Transcribe the dialogue, phrase it for readability, and place text clips locked to the speech."
+        ),
+        AgentStarterPrompt(
+            id: "make_vertical_shorts",
+            title: L10n.string("Make vertical shorts"),
+            systemImage: "rectangle.portrait",
+            prompt: "Find the strongest moments in this video and turn each into a short-form vertical clip. Create multiple 9:16 timelines, reframe for vertical, and keep every clip tight and self-contained."
         ),
     ]
 
@@ -305,6 +312,9 @@ struct AgentPanelView: View {
                 VStack(spacing: AppTheme.Spacing.xs) {
                     ForEach(Self.starterPrompts) { starterPrompt in
                         AgentStarterPromptButton(starterPrompt: starterPrompt) {
+                            Analytics.capture(.agentStarterPromptClicked, properties: [
+                                "starter_prompt": starterPrompt.id,
+                            ])
                             populatePrompt(starterPrompt.prompt)
                         }
                     }
@@ -417,7 +427,7 @@ struct AgentPanelView: View {
 }
 
 private struct AgentStarterPrompt: Identifiable {
-    let id = UUID()
+    let id: String
     let title: String
     let systemImage: String
     let prompt: String

--- a/Sources/PalmierPro/Editor/Tour/TourController.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourController.swift
@@ -156,7 +156,10 @@ final class TourController {
 
     private func selectAIEditClip(in editor: EditorViewModel) {
         guard let clipId = Self.firstAIEditVisualClipId(in: editor) else { return }
-        editor.selectPreviewClip(clipId)
+        // Replace selection so a prior multi-select cannot hide AI Edit.
+        editor.selectedGap = nil
+        editor.selectedTimelineRange = nil
+        editor.selectedClipIds = editor.expandToLinkGroup([clipId])
     }
 
     // MARK: - Step list

--- a/Sources/PalmierPro/Editor/Tour/TourController.swift
+++ b/Sources/PalmierPro/Editor/Tour/TourController.swift
@@ -9,9 +9,16 @@ struct TourStep: Equatable {
         case spotlight(TourTarget)
         case outro
     }
+    enum Prepare: Equatable {
+        case none
+        case selectAIEditClip
+        case revealInspectorOverview
+        case revealAIEditTab
+    }
     let kind: Kind
     let title: String
     let instruction: String
+    var prepare: Prepare = .none
 }
 
 enum TourTarget: Equatable {
@@ -37,6 +44,8 @@ enum TourAnchorID: Hashable {
     case screenshotButton
     case skillsButton
     case timelineRuler
+    case aiEditTab
+    case aiEditPanel
 
     var hostPanel: EditorViewModel.FocusedPanel {
         switch self {
@@ -44,6 +53,7 @@ enum TourAnchorID: Hashable {
         case .screenshotButton: return .preview
         case .skillsButton: return .agent
         case .timelineRuler: return .timeline
+        case .aiEditTab, .aiEditPanel: return .inspector
         }
     }
 }
@@ -102,13 +112,15 @@ final class TourController {
     func end() {
         stepIndex = nil
         targetFrame = nil
+        editor?.inspectorClipTabRequest = nil
     }
 
     /// Ensure a spotlight step's host panel is visible
     private func applyStep(_ index: Int) {
         guard let editor, steps.indices.contains(index) else { return }
         editor.maximizedPanel = nil
-        if case .spotlight(let target) = steps[index].kind {
+        let step = steps[index]
+        if case .spotlight(let target) = step.kind {
             switch target.hostPanel {
             case .media: editor.mediaPanelVisible = true
             case .agent: editor.agentPanelVisible = true
@@ -119,12 +131,39 @@ final class TourController {
         } else {
             editor.showGenerationPanel = false
         }
+        applyPrepare(step.prepare, to: editor)
         stepIndex = index
+    }
+
+    private func applyPrepare(_ prepare: TourStep.Prepare, to editor: EditorViewModel) {
+        switch prepare {
+        case .none:
+            editor.inspectorClipTabRequest = nil
+        case .selectAIEditClip:
+            editor.inspectorPanelVisible = true
+            selectAIEditClip(in: editor)
+            editor.inspectorClipTabRequest = nil
+        case .revealInspectorOverview:
+            editor.inspectorPanelVisible = true
+            selectAIEditClip(in: editor)
+            editor.inspectorClipTabRequest = .video
+        case .revealAIEditTab:
+            editor.inspectorPanelVisible = true
+            selectAIEditClip(in: editor)
+            editor.inspectorClipTabRequest = .ai
+        }
+    }
+
+    private func selectAIEditClip(in editor: EditorViewModel) {
+        guard let clipId = Self.firstAIEditVisualClipId(in: editor) else { return }
+        editor.selectPreviewClip(clipId)
     }
 
     // MARK: - Step list
 
     private static func makeSteps(editor: EditorViewModel) -> [TourStep] {
+        let hasAIEditClip = firstAIEditVisualClipId(in: editor) != nil
+
         var steps: [TourStep] = [
             TourStep(kind: .intro, title: L10n.string("Tutorial"),
                      instruction: L10n.string("Let's take a quick tour of the workspace and what you can do.")),
@@ -137,7 +176,6 @@ final class TourController {
             TourStep(kind: .spotlight(.element(.generation)), title: L10n.string("Generation panel"),
                      instruction: L10n.string("Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame.")),
         ]
-        // Only shown when the "Smart search" button is present (model not yet installed).
         if smartSearchAvailable(editor: editor) {
             steps.append(TourStep(kind: .spotlight(.element(.smartSearch)), title: L10n.string("Smart search"),
                                   instruction: L10n.string("Download a local model to index your media, so you or your agent can search any clips by describing them. The model runs on-device and nothing leaves your Mac.")))
@@ -147,12 +185,39 @@ final class TourController {
                      instruction: L10n.string("This is your preview panel to play a selected media or the whole timeline.")),
             TourStep(kind: .spotlight(.element(.screenshotButton)), title: L10n.string("Screenshot a frame"),
                      instruction: L10n.string("Take a screenshot of the preview and use it as a reference for generation. Particularly useful for creating AI transitions.")),
-            TourStep(kind: .spotlight(.panel(.inspector)), title: L10n.string("Inspector"),
-                     instruction: L10n.string("This is your inspector panel. Select a clip from the timeline to edit it.")),
-            TourStep(kind: .spotlight(.panel(.timeline)), title: L10n.string("Timeline"),
-                     instruction: L10n.string("Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music.")),
+            TourStep(
+                kind: .spotlight(.panel(.timeline)),
+                title: L10n.string("Timeline"),
+                instruction: hasAIEditClip
+                    ? L10n.string("Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you.")
+                    : L10n.string("Your timeline: the top half is video, the bottom half is audio. This is where you edit."),
+                prepare: hasAIEditClip ? .selectAIEditClip : .none
+            ),
             TourStep(kind: .spotlight(.element(.timelineRuler)), title: L10n.string("Select a range"),
                      instruction: L10n.string("This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range.")),
+        ]
+        if hasAIEditClip {
+            steps += [
+                TourStep(
+                    kind: .spotlight(.panel(.inspector)),
+                    title: L10n.string("Inspector"),
+                    instruction: L10n.string("Your inspector for the selected clip — transform, adjust, audio, and more."),
+                    prepare: .revealInspectorOverview
+                ),
+                TourStep(
+                    kind: .spotlight(.element(.aiEditPanel)),
+                    title: L10n.string("AI Edit"),
+                    instruction: L10n.string("Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip."),
+                    prepare: .revealAIEditTab
+                ),
+            ]
+        } else {
+            steps.append(
+                TourStep(kind: .spotlight(.panel(.inspector)), title: L10n.string("Inspector"),
+                         instruction: L10n.string("Your inspector for the selected clip — transform, adjust, audio, and more."))
+            )
+        }
+        steps += [
             TourStep(kind: .spotlight(.panel(.agent)), title: L10n.string("AI agent"),
                      instruction: L10n.string("Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key.")),
             TourStep(kind: .spotlight(.element(.skillsButton)), title: L10n.string("Skills"),
@@ -168,5 +233,17 @@ final class TourController {
         let model = VisualModelLoader.shared
         guard case .notInstalled = model.state, model.enabled else { return false }
         return editor.mediaAssets.contains { $0.type == .video || $0.type == .image }
+    }
+
+    private static func firstAIEditVisualClipId(in editor: EditorViewModel) -> String? {
+        guard !AccountService.shared.isMisconfigured else { return nil }
+        for track in editor.timeline.tracks {
+            for clip in track.clips where clip.mediaType.isVisual && clip.mediaType != .text {
+                if editor.mediaAssetsById[clip.mediaRef] != nil {
+                    return clip.id
+                }
+            }
+        }
+        return nil
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -92,6 +92,7 @@ final class EditorViewModel {
     // MARK: - Tutorial tour
 
     let tour = TourController()
+    var inspectorClipTabRequest: InspectorView.ClipTab?
 
     // MARK: - Transient UI state
 

--- a/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
+++ b/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TitleTabBar: View {
     let titles: [String]
     let selected: String?
+    var tourAnchors: [String: TourAnchorID] = [:]
     let onSelect: (String) -> Void
     @State private var hoveredTitle: String?
 
@@ -22,10 +23,11 @@ struct TitleTabBar: View {
         }
     }
 
+    @ViewBuilder
     private func tab(_ title: String) -> some View {
         let active = selected == title
         let hovered = hoveredTitle == title
-        return Button {
+        let button = Button {
             onSelect(title)
         } label: {
             Text(L10n.string(key: title))
@@ -46,6 +48,11 @@ struct TitleTabBar: View {
             hoveredTitle = hovering ? title : (hoveredTitle == title ? nil : hoveredTitle)
         }
         .animation(.easeOut(duration: AppTheme.Anim.hover), value: hovered)
+        if let anchor = tourAnchors[title] {
+            button.tourAnchor(anchor)
+        } else {
+            button
+        }
     }
 
     private func tabBackground(active: Bool, hovered: Bool) -> Color {

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -103,6 +103,11 @@ struct InspectorView: View {
         .onChange(of: preferredTab) { _, newTab in
             if newTab != .video { editor.cropEditingActive = false }
         }
+        .onChange(of: editor.inspectorClipTabRequest) { _, request in
+            guard let request else { return }
+            preferredTab = request
+            editor.inspectorClipTabRequest = nil
+        }
         .sheet(item: $customAspectRatioContext) { context in
             CustomAspectRatioSheet(context: context)
         }
@@ -370,6 +375,7 @@ struct InspectorView: View {
             Group {
                 if selectedTab == .ai, let asset = clipAsset {
                     AIEditTab(asset: asset, clipId: selection.firstVisualClip?.id ?? selection.firstAudioClip?.id)
+                        .tourAnchor(.aiEditPanel)
                 } else if selectedTab == .effects {
                     ScrollView { effectsTabContent(clips: selection.nonTextVisualClips) }
                 } else {
@@ -407,7 +413,8 @@ struct InspectorView: View {
     private func tabBar(_ tabs: [ClipTab], selectedTab: ClipTab?) -> some View {
         TitleTabBar(
             titles: tabs.map(\.titleKey),
-            selected: selectedTab?.titleKey
+            selected: selectedTab?.titleKey,
+            tourAnchors: tabs.contains(.ai) ? [ClipTab.ai.titleKey: .aiEditTab] : [:]
         ) { title in
             if let tab = tabs.first(where: { $0.titleKey == title }) { preferredTab = tab }
         }

--- a/Sources/PalmierPro/Resources/Localization/ar.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ar.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "إضافة النطاق إلى الدردشة";
 "Add Text" = "إضافة نص";
 "Add an email above to enable a reply" = "أضف بريدًا إلكترونيًا أعلاه لإتاحة الرد";
-"Add captions to my timeline" = "إضافة تسميات توضيحية إلى مخططي الزمني";
+"Add captions" = "إضافة ترجمات";
 "Add credits" = "إضافة رصيد";
 "Add credits to use Cloud." = "أضف رصيدًا لاستخدام الوضع السحابي.";
 "Add emoji" = "إضافة رمز تعبيري";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "إنشاء مخطط زمني متداخل";
 "Create Video" = "إنشاء فيديو";
 "Create Video only works on images" = "يعمل إنشاء الفيديو مع الصور فقط";
-"Create a letterbox opening" = "إنشاء افتتاحية بإطار سينمائي";
 "Create a skill or browse the Community collection." = "أنشئ مهارة أو استعرض مجموعة المجتمع.";
-"Create a voiceover" = "إنشاء تعليق صوتي";
 "Create matching sound for the video" = "إنشاء صوت ملائم للفيديو";
 "Creating…" = "جارٍ الإنشاء…";
 "Credits" = "الرصيد";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "نسبة عرض إلى ارتفاع مخصصة";
 "Custom…" = "مخصص…";
 "Cut" = "قص";
+"Cut to the beat" = "القص على الإيقاع";
 "Dark" = "داكن";
 "Dark appearance" = "مظهر داكن";
 "Darken" = "تغميق";
@@ -384,9 +383,7 @@
 "Generate SFX" = "إنشاء مؤثرات صوتية";
 "Generate SFX only works on video" = "يعمل إنشاء المؤثرات الصوتية مع الفيديو فقط";
 "Generate SFX…" = "إنشاء مؤثرات صوتية…";
-"Generate an AI video" = "إنشاء فيديو بالذكاء الاصطناعي";
 "Generate audio" = "إنشاء صوت";
-"Generate music and sync to my timeline" = "إنشاء موسيقى ومزامنتها مع مخططي الزمني";
 "Generate music for the timeline" = "إنشاء موسيقى للمخطط الزمني";
 "Generate music that fits the video" = "إنشاء موسيقى تلائم الفيديو";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "أنشئ فيديو أو صورة أو صوتًا باستخدام نماذج وإعدادات مختلفة. اسحب الأصول من لوحة الوسائط أعلاه إلى إطار المرجع.";
@@ -454,6 +451,7 @@
 "Keep Current" = "الاحتفاظ بالحالي";
 "Keep Editing" = "متابعة التحرير";
 "Keep Skill" = "الاحتفاظ بالمهارة";
+"Keep the best takes" = "الإبقاء على أفضل اللقطات";
 "Keeps this much audio before and after detected speech." = "يحتفظ بهذه المدة من الصوت قبل الكلام المكتشف وبعده.";
 "Keyboard Shortcuts" = "اختصارات لوحة المفاتيح";
 "Keyframes" = "الإطارات الرئيسية";
@@ -503,6 +501,7 @@
 "MCP Server" = "خادم MCP";
 "MCP Setup" = "إعداد MCP";
 "Main + Sidebar" = "الرئيسية + الشريط الجانبي";
+"Make vertical shorts" = "إنشاء مقاطع عمودية قصيرة";
 "Manage credits" = "إدارة الرصيد";
 "Manage subscription" = "إدارة الاشتراك";
 "Manual setup" = "إعداد يدوي";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "فتح مجلد المهارات";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "افتح «المهارات» لاستعراض أدلة عمل المجتمع أو إنشاء مهاراتك أو إضافتها إلى وكلاء آخرين.";
 "Open Timeline" = "فتح المخطط الزمني";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "افتح علامة التبويب «تحرير بالذكاء الاصطناعي» لرفع الدقة، أو التحرير عبر مطالبة، أو إنشاء فيديو من إطار، أو توليد موسيقى ومؤثرات صوتية وتنظيف الصوت والدبلجة من المقطع.";
 "Opening Google" = "جارٍ فتح Google";
 "Opening Google…" = "جارٍ فتح Google…";
 "Open…" = "فتح…";
-"Organize my media into structured folders" = "تنظيم وسائطي في مجلدات مرتبة";
 "Organize with Agent" = "تنظيم باستخدام الوكيل";
 "Original" = "الأصلي";
 "Original FPS" = "معدل الإطارات الأصلي";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "احفظ هذا المشروع لعرض النشاط";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "يحفظ نسخة من هذا المشروع مع تضمين كل الوسائط، بحيث يمكن فتحه على أي جهاز.";
 "Scale" = "المقياس";
+"Score my timeline" = "تلحين المخطط الزمني";
 "Screen" = "شاشة";
 "Screenshot a frame" = "التقاط صورة لإطار";
 "Scroll Horizontally" = "تمرير أفقي";
@@ -840,6 +840,7 @@
 "Switch Angle" = "تبديل الزاوية";
 "Switch Angle in Range" = "تبديل الزاوية في النطاق";
 "Switch Mic" = "تبديل الميكروفون";
+"Sync my multicam" = "مزامنة الكاميرات المتعددة";
 "Synchronize" = "مزامنة";
 "Synchronized %lld clips" = "تمت مزامنة ⁨%lld⁩ من المقاطع";
 "Synchronized 1 clip" = "تمت مزامنة مقطع واحد";
@@ -864,7 +865,6 @@
 "Theme" = "السمة";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "هذه مسطرة المخطط الزمني. اضغط على Shift واسحب على المسطرة لتحديد نطاق للتصيير. يمكنك اختيار أي خانة للتحرير بالذكاء الاصطناعي أو إنشاء موسيقى تلائم ذلك النطاق.";
 "This is where all your footage and assets live." = "هنا توجد كل لقطاتك وأصولك.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "هذه لوحة الخصائص. حدد مقطعًا من المخطط الزمني لتحريره.";
 "This is your preview panel to play a selected media or the whole timeline." = "هذه لوحة المعاينة لتشغيل الوسائط المحددة أو المخطط الزمني كاملاً.";
 "This model cannot cap the output at 60 FPS." = "لا يمكن لهذا النموذج تحديد سقف الإخراج عند ⁨60 FPS⁩.";
 "This permanently removes %@." = "يؤدي هذا إلى إزالة ⁨%@⁩ نهائيًا.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "رسم Lottie المتحرك جاهز.";
 "Your audio clip is ready." = "مقطع الصوت جاهز.";
 "Your image is ready." = "صورتك جاهزة.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "لوحة الخصائص للمقطع المحدد — التحويل والضبط والصوت والمزيد.";
 "Your text clip is ready." = "مقطع النص جاهز.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "مخططك الزمني: النصف العلوي للفيديو والسفلي للصوت. هنا تجري التحرير. انقر بزر الماوس الأيمن على مقطع لاستخدام ميزات الذكاء الاصطناعي، مثل رفع الدقة أو التحرير أو إنشاء الموسيقى.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "مخططك الزمني: النصف العلوي للفيديو والسفلي للصوت. انقر أي مقطع لفحصه — وقد حددنا واحدًا لك.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "مخططك الزمني: النصف العلوي للفيديو والسفلي للصوت. هنا تجري التحرير.";
 "Your video is ready." = "الفيديو جاهز.";
 "Zoom In" = "تكبير";
 "Zoom Out" = "تصغير";

--- a/Sources/PalmierPro/Resources/Localization/bn.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/bn.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "চ্যাটে রেঞ্জ যোগ করুন";
 "Add Text" = "টেক্সট যোগ করুন";
 "Add an email above to enable a reply" = "উত্তর পেতে উপরে একটি ইমেইল যোগ করুন";
-"Add captions to my timeline" = "আমার টাইমলাইনে ক্যাপশন যোগ করুন";
+"Add captions" = "ক্যাপশন যোগ করুন";
 "Add credits" = "ক্রেডিট যোগ করুন";
 "Add credits to use Cloud." = "ক্লাউড ব্যবহার করতে ক্রেডিট যোগ করুন।";
 "Add emoji" = "ইমোজি যোগ করুন";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "নেস্টেড টাইমলাইন তৈরি করুন";
 "Create Video" = "ভিডিও তৈরি করুন";
 "Create Video only works on images" = "ভিডিও তৈরি শুধু ইমেজের ক্ষেত্রে কাজ করে";
-"Create a letterbox opening" = "লেটারবক্স ওপেনিং তৈরি করুন";
 "Create a skill or browse the Community collection." = "একটি স্কিল তৈরি করুন অথবা কমিউনিটি কালেকশন দেখুন।";
-"Create a voiceover" = "ভয়েসওভার তৈরি করুন";
 "Create matching sound for the video" = "ভিডিওর সঙ্গে মানানসই সাউন্ড তৈরি করুন";
 "Creating…" = "তৈরি করা হচ্ছে…";
 "Credits" = "ক্রেডিট";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "কাস্টম অ্যাসপেক্ট রেশিও";
 "Custom…" = "কাস্টম…";
 "Cut" = "কাট";
+"Cut to the beat" = "বিট অনুসারে কাটুন";
 "Dark" = "ডার্ক";
 "Dark appearance" = "ডার্ক অ্যাপিয়ারেন্স";
 "Darken" = "গাঢ় করুন";
@@ -384,9 +383,7 @@
 "Generate SFX" = "SFX জেনারেট করুন";
 "Generate SFX only works on video" = "SFX জেনারেট শুধু ভিডিওতে কাজ করে";
 "Generate SFX…" = "SFX জেনারেট করুন…";
-"Generate an AI video" = "একটি AI ভিডিও জেনারেট করুন";
 "Generate audio" = "অডিও জেনারেট করুন";
-"Generate music and sync to my timeline" = "মিউজিক জেনারেট করে আমার টাইমলাইনে সিঙ্ক করুন";
 "Generate music for the timeline" = "টাইমলাইনের জন্য মিউজিক জেনারেট করুন";
 "Generate music that fits the video" = "ভিডিওর সঙ্গে মানানসই মিউজিক জেনারেট করুন";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "বিভিন্ন মডেল ও সেটিংস দিয়ে ভিডিও, ইমেজ বা অডিও জেনারেট করুন। উপরের মিডিয়া প্যানেল থেকে অ্যাসেট রেফারেন্স ফ্রেমে ড্র্যাগ করুন।";
@@ -454,6 +451,7 @@
 "Keep Current" = "বর্তমানটি রাখুন";
 "Keep Editing" = "এডিট চালিয়ে যান";
 "Keep Skill" = "স্কিলটি রাখুন";
+"Keep the best takes" = "সেরা টেক রাখুন";
 "Keeps this much audio before and after detected speech." = "শনাক্ত করা স্পিচের আগে ও পরে এই পরিমাণ অডিও রাখে।";
 "Keyboard Shortcuts" = "কিবোর্ড শর্টকাট";
 "Keyframes" = "কিফ্রেম";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP সার্ভার";
 "MCP Setup" = "MCP সেটআপ";
 "Main + Sidebar" = "মেইন + সাইডবার";
+"Make vertical shorts" = "ভার্টিকাল শর্টস তৈরি করুন";
 "Manage credits" = "ক্রেডিট ম্যানেজ করুন";
 "Manage subscription" = "সাবস্ক্রিপশন ম্যানেজ করুন";
 "Manual setup" = "ম্যানুয়াল সেটআপ";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "স্কিল ফোল্ডার খুলুন";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "কমিউনিটি প্লেবুক দেখতে, নিজের স্কিল তৈরি করতে বা অন্য এজেন্টে যোগ করতে স্কিল খুলুন।";
 "Open Timeline" = "টাইমলাইন খুলুন";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI Edit ট্যাব খুলে আপস্কেল করুন, প্রম্পট দিয়ে এডিট করুন, একটি ফ্রেম থেকে ভিডিও তৈরি করুন, অথবা ক্লিপ থেকে মিউজিক, SFX, ক্লিনআপ ও ডাবিং জেনারেট করুন।";
 "Opening Google" = "Google খোলা হচ্ছে";
 "Opening Google…" = "Google খোলা হচ্ছে…";
 "Open…" = "খুলুন…";
-"Organize my media into structured folders" = "আমার মিডিয়া সুবিন্যস্ত ফোল্ডারে সাজান";
 "Organize with Agent" = "এজেন্ট দিয়ে সাজান";
 "Original" = "অরিজিনাল";
 "Original FPS" = "অরিজিনাল FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "অ্যাক্টিভিটি দেখতে এই প্রজেক্টটি সেভ করুন";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "সব মিডিয়া ভেতরে বান্ডেল করে প্রজেক্টটির একটি কপি সেভ করে, যাতে যেকোনো কম্পিউটারে খোলা যায়।";
 "Scale" = "স্কেল";
+"Score my timeline" = "টাইমলাইনে স্কোর দিন";
 "Screen" = "স্ক্রিন";
 "Screenshot a frame" = "একটি ফ্রেমের স্ক্রিনশট নিন";
 "Scroll Horizontally" = "আড়াআড়ি স্ক্রল করুন";
@@ -840,6 +840,7 @@
 "Switch Angle" = "অ্যাঙ্গেল বদলান";
 "Switch Angle in Range" = "রেঞ্জে অ্যাঙ্গেল বদলান";
 "Switch Mic" = "মাইক বদলান";
+"Sync my multicam" = "মাল্টিক্যাম সিঙ্ক করুন";
 "Synchronize" = "সিঙ্ক্রোনাইজ";
 "Synchronized %lld clips" = "%lldটি ক্লিপ সিঙ্ক্রোনাইজ হয়েছে";
 "Synchronized 1 clip" = "১টি ক্লিপ সিঙ্ক্রোনাইজ হয়েছে";
@@ -864,7 +865,6 @@
 "Theme" = "থিম";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "এটি টাইমলাইন রুলার। রেন্ডারের রেঞ্জ সিলেক্ট করতে রুলারে Shift চেপে ড্র্যাগ করুন। যেকোনো স্লট বেছে নিয়ে AI দিয়ে এডিট করতে বা সেই রেঞ্জের উপযোগী মিউজিক জেনারেট করতে পারেন।";
 "This is where all your footage and assets live." = "আপনার সব ফুটেজ ও অ্যাসেট এখানে থাকে।";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "এটি আপনার ইনস্পেক্টর প্যানেল। এডিট করতে টাইমলাইন থেকে একটি ক্লিপ সিলেক্ট করুন।";
 "This is your preview panel to play a selected media or the whole timeline." = "এটি সিলেক্ট করা মিডিয়া বা পুরো টাইমলাইন প্লে করার প্রিভিউ প্যানেল।";
 "This model cannot cap the output at 60 FPS." = "এই মডেল আউটপুট 60 FPS-এ সীমাবদ্ধ করতে পারে না।";
 "This permanently removes %@." = "এটি %@ স্থায়ীভাবে সরিয়ে দেয়।";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "আপনার Lottie অ্যানিমেশন প্রস্তুত।";
 "Your audio clip is ready." = "আপনার অডিও ক্লিপ প্রস্তুত।";
 "Your image is ready." = "আপনার ইমেজ প্রস্তুত।";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "সিলেক্ট করা ক্লিপের ইনস্পেক্টর — ট্রান্সফর্ম, অ্যাডজাস্ট, অডিও এবং আরও অনেক কিছু।";
 "Your text clip is ready." = "আপনার টেক্সট ক্লিপ প্রস্তুত।";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "আপনার টাইমলাইনের উপরের অর্ধেক ভিডিও, নিচের অর্ধেক অডিও। এখানেই এডিট করবেন। আপস্কেল, এডিট বা মিউজিক জেনারেট করার মতো AI ফিচারের জন্য ক্লিপে রাইট-ক্লিক করুন।";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "আপনার টাইমলাইনের উপরের অর্ধেক ভিডিও, নিচের অর্ধেক অডিও। ইনস্পেক্ট করতে যেকোনো ক্লিপে ক্লিক করুন — আমরা আপনার জন্য একটি সিলেক্ট করে দিয়েছি।";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "আপনার টাইমলাইনের উপরের অর্ধেক ভিডিও, নিচের অর্ধেক অডিও। এখানেই এডিট করবেন।";
 "Your video is ready." = "আপনার ভিডিও প্রস্তুত।";
 "Zoom In" = "জুম ইন";
 "Zoom Out" = "জুম আউট";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Add Range to Chat";
 "Add Text" = "Add Text";
 "Add an email above to enable a reply" = "Add an email above to enable a reply";
-"Add captions to my timeline" = "Add captions to my timeline";
+"Add captions" = "Add captions";
 "Add credits" = "Add credits";
 "Add credits to use Cloud." = "Add credits to use Cloud.";
 "Add emoji" = "Add emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Create Nested Timeline";
 "Create Video" = "Create Video";
 "Create Video only works on images" = "Create Video only works on images";
-"Create a letterbox opening" = "Create a letterbox opening";
 "Create a skill or browse the Community collection." = "Create a skill or browse the Community collection.";
-"Create a voiceover" = "Create a voiceover";
 "Create matching sound for the video" = "Create matching sound for the video";
 "Creating…" = "Creating…";
 "Credits" = "Credits";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Custom Aspect Ratio";
 "Custom…" = "Custom…";
 "Cut" = "Cut";
+"Cut to the beat" = "Cut to the beat";
 "Dark" = "Dark";
 "Dark appearance" = "Dark appearance";
 "Darken" = "Darken";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Generate SFX";
 "Generate SFX only works on video" = "Generate SFX only works on video";
 "Generate SFX…" = "Generate SFX…";
-"Generate an AI video" = "Generate an AI video";
 "Generate audio" = "Generate audio";
-"Generate music and sync to my timeline" = "Generate music and sync to my timeline";
 "Generate music for the timeline" = "Generate music for the timeline";
 "Generate music that fits the video" = "Generate music that fits the video";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Keep Current";
 "Keep Editing" = "Keep Editing";
 "Keep Skill" = "Keep Skill";
+"Keep the best takes" = "Keep the best takes";
 "Keeps this much audio before and after detected speech." = "Keeps this much audio before and after detected speech.";
 "Keyboard Shortcuts" = "Keyboard Shortcuts";
 "Keyframes" = "Keyframes";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP Server";
 "MCP Setup" = "MCP Setup";
 "Main + Sidebar" = "Main + Sidebar";
+"Make vertical shorts" = "Make vertical shorts";
 "Manage credits" = "Manage credits";
 "Manage subscription" = "Manage subscription";
 "Manual setup" = "Manual setup";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Open Skills Folder";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Open Skills to browse community playbooks, create your own, or add them to other agents.";
 "Open Timeline" = "Open Timeline";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip.";
 "Opening Google" = "Opening Google";
 "Opening Google…" = "Opening Google…";
 "Open…" = "Open…";
-"Organize my media into structured folders" = "Organize my media into structured folders";
 "Organize with Agent" = "Organize with Agent";
 "Original" = "Original";
 "Original FPS" = "Original FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Save this project to view activity";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Saves a copy of this project with all media bundled inside, so it opens on any machine.";
 "Scale" = "Scale";
+"Score my timeline" = "Score my timeline";
 "Screen" = "Screen";
 "Screenshot a frame" = "Screenshot a frame";
 "Scroll Horizontally" = "Scroll Horizontally";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Switch Angle";
 "Switch Angle in Range" = "Switch Angle in Range";
 "Switch Mic" = "Switch Mic";
+"Sync my multicam" = "Sync my multicam";
 "Synchronize" = "Synchronize";
 "Synchronized %lld clips" = "Synchronized %lld clips";
 "Synchronized 1 clip" = "Synchronized 1 clip";
@@ -864,7 +865,6 @@
 "Theme" = "Theme";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range.";
 "This is where all your footage and assets live." = "This is where all your footage and assets live.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "This is your inspector panel. Select a clip from the timeline to edit it.";
 "This is your preview panel to play a selected media or the whole timeline." = "This is your preview panel to play a selected media or the whole timeline.";
 "This model cannot cap the output at 60 FPS." = "This model cannot cap the output at 60 FPS.";
 "This permanently removes %@." = "This permanently removes %@.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Your Lottie animation is ready.";
 "Your audio clip is ready." = "Your audio clip is ready.";
 "Your image is ready." = "Your image is ready.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "Your inspector for the selected clip — transform, adjust, audio, and more.";
 "Your text clip is ready." = "Your text clip is ready.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Your timeline: the top half is video, the bottom half is audio. This is where you edit.";
 "Your video is ready." = "Your video is ready.";
 "Zoom In" = "Zoom In";
 "Zoom Out" = "Zoom Out";

--- a/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Añadir intervalo al chat";
 "Add Text" = "Añadir texto";
 "Add an email above to enable a reply" = "Añade un correo electrónico arriba para recibir una respuesta";
-"Add captions to my timeline" = "Añadir subtítulos a mi línea de tiempo";
+"Add captions" = "Añadir subtítulos";
 "Add credits" = "Añadir créditos";
 "Add credits to use Cloud." = "Añade créditos para usar Cloud.";
 "Add emoji" = "Añadir emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Crear línea de tiempo anidada";
 "Create Video" = "Crear vídeo";
 "Create Video only works on images" = "Crear vídeo solo funciona con imágenes";
-"Create a letterbox opening" = "Crear una apertura de formato panorámico";
 "Create a skill or browse the Community collection." = "Crea una habilidad o explora la colección de la comunidad.";
-"Create a voiceover" = "Crear una voz en off";
 "Create matching sound for the video" = "Crear sonido acorde con el vídeo";
 "Creating…" = "Creando…";
 "Credits" = "Créditos";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Relación de aspecto personalizada";
 "Custom…" = "Personalizado…";
 "Cut" = "Cortar";
+"Cut to the beat" = "Cortar al ritmo";
 "Dark" = "Oscuro";
 "Dark appearance" = "Apariencia oscura";
 "Darken" = "Oscurecer";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Generar efectos de sonido";
 "Generate SFX only works on video" = "Generar efectos de sonido solo funciona con vídeo";
 "Generate SFX…" = "Generar efectos de sonido…";
-"Generate an AI video" = "Generar un vídeo con IA";
 "Generate audio" = "Generar audio";
-"Generate music and sync to my timeline" = "Generar música y sincronizarla con mi línea de tiempo";
 "Generate music for the timeline" = "Generar música para la línea de tiempo";
 "Generate music that fits the video" = "Generar música que encaje con el vídeo";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Genera vídeo, imagen o audio con distintos modelos y ajustes. Arrastra recursos desde el panel multimedia de arriba hasta el fotograma de referencia.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Conservar actual";
 "Keep Editing" = "Seguir editando";
 "Keep Skill" = "Conservar habilidad";
+"Keep the best takes" = "Quedarme con las mejores tomas";
 "Keeps this much audio before and after detected speech." = "Conserva esta cantidad de audio antes y después de la voz detectada.";
 "Keyboard Shortcuts" = "Funciones rápidas de teclado";
 "Keyframes" = "Fotogramas clave";
@@ -503,6 +501,7 @@
 "MCP Server" = "Servidor MCP";
 "MCP Setup" = "Configuración de MCP";
 "Main + Sidebar" = "Principal + barra lateral";
+"Make vertical shorts" = "Crear shorts verticales";
 "Manage credits" = "Gestionar créditos";
 "Manage subscription" = "Gestionar suscripción";
 "Manual setup" = "Configuración manual";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Abrir carpeta de habilidades";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Abre Habilidades para explorar guías de la comunidad, crear las tuyas o añadirlas a otros agentes.";
 "Open Timeline" = "Abrir línea de tiempo";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Abre la pestaña Edición con IA para aumentar la resolución, editar con un prompt, crear vídeo a partir de un fotograma, o generar música, efectos de sonido, limpieza de voz y doblaje desde el clip.";
 "Opening Google" = "Abriendo Google";
 "Opening Google…" = "Abriendo Google…";
 "Open…" = "Abrir…";
-"Organize my media into structured folders" = "Organizar mis archivos multimedia en carpetas estructuradas";
 "Organize with Agent" = "Organizar con Agente";
 "Original" = "Original";
 "Original FPS" = "FPS originales";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Guarda este proyecto para ver la actividad";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Guarda una copia de este proyecto con todos los archivos multimedia incluidos para que se pueda abrir en cualquier equipo.";
 "Scale" = "Escala";
+"Score my timeline" = "Poner música a la línea de tiempo";
 "Screen" = "Pantalla";
 "Screenshot a frame" = "Capturar un fotograma";
 "Scroll Horizontally" = "Desplazar horizontalmente";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Cambiar ángulo";
 "Switch Angle in Range" = "Cambiar ángulo en el intervalo";
 "Switch Mic" = "Cambiar micrófono";
+"Sync my multicam" = "Sincronizar mi multicámara";
 "Synchronize" = "Sincronizar";
 "Synchronized %lld clips" = "%lld clips sincronizados";
 "Synchronized 1 clip" = "1 clip sincronizado";
@@ -864,7 +865,6 @@
 "Theme" = "Tema";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Esta es la regla de la línea de tiempo. Pulsa Mayúsculas y arrastra sobre la regla para seleccionar un intervalo que renderizar. Puedes elegir cualquier tramo para editarlo con IA o generar música que encaje en ese intervalo.";
 "This is where all your footage and assets live." = "Aquí se encuentran todo tu material y tus recursos.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Este es el panel Inspector. Selecciona un clip de la línea de tiempo para editarlo.";
 "This is your preview panel to play a selected media or the whole timeline." = "Este es el panel de previsualización, donde puedes reproducir el contenido seleccionado o toda la línea de tiempo.";
 "This model cannot cap the output at 60 FPS." = "Este modelo no puede limitar la salida a 60 FPS.";
 "This permanently removes %@." = "Esto elimina %@ de forma permanente.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Tu animación Lottie está lista.";
 "Your audio clip is ready." = "Tu clip de audio está listo.";
 "Your image is ready." = "Tu imagen está lista.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "El inspector del clip seleccionado: transformar, ajustar, audio y más.";
 "Your text clip is ready." = "Tu clip de texto está listo.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Tu línea de tiempo: la mitad superior es vídeo y la inferior, audio. Aquí es donde editas. Haz clic con el botón derecho en un clip para acceder a funciones de IA como aumentar la resolución, editar o generar música.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Tu línea de tiempo: la mitad superior es vídeo y la inferior, audio. Haz clic en un clip para inspeccionarlo; ya hemos seleccionado uno por ti.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Tu línea de tiempo: la mitad superior es vídeo y la inferior, audio. Aquí es donde editas.";
 "Your video is ready." = "Tu vídeo está listo.";
 "Zoom In" = "Acercar";
 "Zoom Out" = "Alejar";

--- a/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Ajouter la plage au chat";
 "Add Text" = "Ajouter du texte";
 "Add an email above to enable a reply" = "Ajoutez une adresse e-mail ci-dessus pour recevoir une réponse";
-"Add captions to my timeline" = "Ajouter des sous-titres à ma timeline";
+"Add captions" = "Ajouter des sous-titres";
 "Add credits" = "Ajouter des crédits";
 "Add credits to use Cloud." = "Ajoutez des crédits pour utiliser le Cloud.";
 "Add emoji" = "Ajouter un emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Créer une timeline imbriquée";
 "Create Video" = "Créer une vidéo";
 "Create Video only works on images" = "La création de vidéo fonctionne uniquement avec les images";
-"Create a letterbox opening" = "Créer une ouverture en bandes cinéma";
 "Create a skill or browse the Community collection." = "Créez une compétence ou parcourez la collection de la communauté.";
-"Create a voiceover" = "Créer une voix off";
 "Create matching sound for the video" = "Créer un son adapté à la vidéo";
 "Creating…" = "Création…";
 "Credits" = "Crédits";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Format d’image personnalisé";
 "Custom…" = "Personnalisé…";
 "Cut" = "Couper";
+"Cut to the beat" = "Couper sur le rythme";
 "Dark" = "Sombre";
 "Dark appearance" = "Apparence sombre";
 "Darken" = "Assombrir";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Générer des effets sonores";
 "Generate SFX only works on video" = "La génération d’effets sonores fonctionne uniquement avec la vidéo";
 "Generate SFX…" = "Générer des effets sonores…";
-"Generate an AI video" = "Générer une vidéo par IA";
 "Generate audio" = "Générer de l’audio";
-"Generate music and sync to my timeline" = "Générer de la musique et la synchroniser avec ma timeline";
 "Generate music for the timeline" = "Générer de la musique pour la timeline";
 "Generate music that fits the video" = "Générer une musique adaptée à la vidéo";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Générez de la vidéo, des images ou de l’audio avec différents modèles et réglages. Faites glisser les ressources du panneau Médias ci-dessus vers l’image de référence.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Conserver les réglages actuels";
 "Keep Editing" = "Continuer le montage";
 "Keep Skill" = "Conserver la compétence";
+"Keep the best takes" = "Garder les meilleures prises";
 "Keeps this much audio before and after detected speech." = "Conserve cette quantité d’audio avant et après la parole détectée.";
 "Keyboard Shortcuts" = "Raccourcis clavier";
 "Keyframes" = "Images clés";
@@ -503,6 +501,7 @@
 "MCP Server" = "Serveur MCP";
 "MCP Setup" = "Configuration MCP";
 "Main + Sidebar" = "Principal + barre latérale";
+"Make vertical shorts" = "Créer des shorts verticaux";
 "Manage credits" = "Gérer les crédits";
 "Manage subscription" = "Gérer l’abonnement";
 "Manual setup" = "Configuration manuelle";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Ouvrir le dossier Compétences";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Ouvrez Compétences pour parcourir les guides de la communauté, créer les vôtres ou les ajouter à d’autres agents.";
 "Open Timeline" = "Ouvrir la timeline";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Ouvrez l’onglet Montage IA pour augmenter la résolution, modifier via une invite, créer une vidéo à partir d’une image, ou générer musique, effets sonores, nettoyage de la voix et doublage à partir du clip.";
 "Opening Google" = "Ouverture de Google";
 "Opening Google…" = "Ouverture de Google…";
 "Open…" = "Ouvrir…";
-"Organize my media into structured folders" = "Organiser mes médias dans des dossiers structurés";
 "Organize with Agent" = "Organiser avec l’agent";
 "Original" = "Original";
 "Original FPS" = "FPS d’origine";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Enregistrez ce projet pour consulter son activité";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Enregistre une copie de ce projet avec tous ses médias pour pouvoir l’ouvrir sur n’importe quelle machine.";
 "Scale" = "Échelle";
+"Score my timeline" = "Mettre en musique la timeline";
 "Screen" = "Superposition";
 "Screenshot a frame" = "Capturer une image";
 "Scroll Horizontally" = "Faire défiler horizontalement";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Changer d’angle";
 "Switch Angle in Range" = "Changer d’angle dans la plage";
 "Switch Mic" = "Changer de micro";
+"Sync my multicam" = "Synchroniser mon multicam";
 "Synchronize" = "Synchroniser";
 "Synchronized %lld clips" = "%lld clips synchronisés";
 "Synchronized 1 clip" = "1 clip synchronisé";
@@ -864,7 +865,6 @@
 "Theme" = "Thème";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Voici la règle de la timeline. Maintenez Maj et faites glisser sur la règle pour sélectionner une plage à rendre. Vous pouvez choisir n’importe quel segment pour le monter avec l’IA ou générer une musique adaptée à cette plage.";
 "This is where all your footage and assets live." = "Tous vos rushes et toutes vos ressources se trouvent ici.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Voici le panneau Inspecteur. Sélectionnez un clip dans la timeline pour le modifier.";
 "This is your preview panel to play a selected media or the whole timeline." = "Voici le panneau d’aperçu, qui permet de lire le média sélectionné ou toute la timeline.";
 "This model cannot cap the output at 60 FPS." = "Ce modèle ne peut pas limiter la sortie à 60 FPS.";
 "This permanently removes %@." = "Cette action supprime définitivement %@.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Votre animation Lottie est disponible.";
 "Your audio clip is ready." = "Votre clip audio est disponible.";
 "Your image is ready." = "Votre image est disponible.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "L’inspecteur du clip sélectionné — transformation, ajustement, audio et plus encore.";
 "Your text clip is ready." = "Votre clip de texte est disponible.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Votre timeline : la moitié supérieure contient la vidéo et la moitié inférieure l’audio. C’est ici que vous montez. Faites un clic droit sur un clip pour accéder aux fonctions IA telles que l’augmentation de la résolution, la modification ou la génération de musique.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Votre timeline : la moitié supérieure contient la vidéo et la moitié inférieure l’audio. Cliquez sur un clip pour l’inspecter — nous en avons sélectionné un pour vous.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Votre timeline : la moitié supérieure contient la vidéo et la moitié inférieure l’audio. C’est ici que vous montez.";
 "Your video is ready." = "Votre vidéo est disponible.";
 "Zoom In" = "Zoom avant";
 "Zoom Out" = "Zoom arrière";

--- a/Sources/PalmierPro/Resources/Localization/hi.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/hi.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "रेंज को चैट में जोड़ें";
 "Add Text" = "टेक्स्ट जोड़ें";
 "Add an email above to enable a reply" = "जवाब पाने के लिए ऊपर ईमेल जोड़ें";
-"Add captions to my timeline" = "मेरी टाइमलाइन में कैप्शन जोड़ें";
+"Add captions" = "कैप्शन जोड़ें";
 "Add credits" = "क्रेडिट जोड़ें";
 "Add credits to use Cloud." = "क्लाउड का उपयोग करने के लिए क्रेडिट जोड़ें।";
 "Add emoji" = "इमोजी जोड़ें";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "नेस्टेड टाइमलाइन बनाएँ";
 "Create Video" = "वीडियो बनाएँ";
 "Create Video only works on images" = "वीडियो बनाएँ केवल इमेज पर काम करता है";
-"Create a letterbox opening" = "लेटरबॉक्स ओपनिंग बनाएँ";
 "Create a skill or browse the Community collection." = "स्किल बनाएँ या कम्युनिटी कलेक्शन देखें।";
-"Create a voiceover" = "वॉइसओवर बनाएँ";
 "Create matching sound for the video" = "वीडियो से मेल खाता साउंड बनाएँ";
 "Creating…" = "बनाया जा रहा है…";
 "Credits" = "क्रेडिट";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "कस्टम आस्पेक्ट रेशियो";
 "Custom…" = "कस्टम…";
 "Cut" = "कट";
+"Cut to the beat" = "बीट पर कट करें";
 "Dark" = "डार्क";
 "Dark appearance" = "डार्क अपीयरेंस";
 "Darken" = "डार्कन";
@@ -384,9 +383,7 @@
 "Generate SFX" = "SFX जेनरेट करें";
 "Generate SFX only works on video" = "SFX जेनरेट करें केवल वीडियो पर काम करता है";
 "Generate SFX…" = "SFX जेनरेट करें…";
-"Generate an AI video" = "AI वीडियो जेनरेट करें";
 "Generate audio" = "ऑडियो जेनरेट करें";
-"Generate music and sync to my timeline" = "संगीत जेनरेट करके मेरी टाइमलाइन से सिंक करें";
 "Generate music for the timeline" = "टाइमलाइन के लिए संगीत जेनरेट करें";
 "Generate music that fits the video" = "वीडियो के अनुकूल संगीत जेनरेट करें";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "अलग-अलग मॉडल और सेटिंग्स से वीडियो, इमेज या ऑडियो जेनरेट करें। ऊपर के मीडिया पैनल से एसेट को रेफ़रेंस फ़्रेम में ड्रैग करें।";
@@ -454,6 +451,7 @@
 "Keep Current" = "वर्तमान रखें";
 "Keep Editing" = "एडिटिंग जारी रखें";
 "Keep Skill" = "स्किल रखें";
+"Keep the best takes" = "सबसे अच्छे टेक रखें";
 "Keeps this much audio before and after detected speech." = "पहचानी गई स्पीच से पहले और बाद में इतना ऑडियो रखता है।";
 "Keyboard Shortcuts" = "कीबोर्ड शॉर्टकट्स";
 "Keyframes" = "कीफ़्रेम्स";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP सर्वर";
 "MCP Setup" = "MCP सेटअप";
 "Main + Sidebar" = "मुख्य + साइडबार";
+"Make vertical shorts" = "वर्टिकल शॉर्ट्स बनाएँ";
 "Manage credits" = "क्रेडिट मैनेज करें";
 "Manage subscription" = "सब्सक्रिप्शन मैनेज करें";
 "Manual setup" = "मैन्युअल सेटअप";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "स्किल्स फ़ोल्डर खोलें";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "कम्युनिटी प्लेबुक देखने, अपनी स्किल बनाने या दूसरे एजेंट में जोड़ने के लिए स्किल्स खोलें।";
 "Open Timeline" = "टाइमलाइन खोलें";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI Edit टैब खोलकर अपस्केल करें, प्रॉम्प्ट से एडिट करें, किसी फ़्रेम से वीडियो बनाएँ, या क्लिप से संगीत, SFX, क्लीनअप और डबिंग जेनरेट करें।";
 "Opening Google" = "Google खोला जा रहा है";
 "Opening Google…" = "Google खोला जा रहा है…";
 "Open…" = "खोलें…";
-"Organize my media into structured folders" = "मेरे मीडिया को व्यवस्थित फ़ोल्डर में रखें";
 "Organize with Agent" = "एजेंट से व्यवस्थित करें";
 "Original" = "मूल";
 "Original FPS" = "मूल FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "एक्टिविटी देखने के लिए यह प्रोजेक्ट सेव करें";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "इस प्रोजेक्ट की कॉपी सभी मीडिया के साथ सेव करता है, ताकि यह किसी भी मशीन पर खुल सके।";
 "Scale" = "स्केल";
+"Score my timeline" = "टाइमलाइन पर स्कोर बनाएँ";
 "Screen" = "स्क्रीन";
 "Screenshot a frame" = "फ़्रेम का स्क्रीनशॉट लें";
 "Scroll Horizontally" = "हॉरिज़ॉन्टली स्क्रॉल करें";
@@ -840,6 +840,7 @@
 "Switch Angle" = "एंगल बदलें";
 "Switch Angle in Range" = "रेंज में एंगल बदलें";
 "Switch Mic" = "माइक बदलें";
+"Sync my multicam" = "मेरा मल्टीकैम सिंक करें";
 "Synchronize" = "सिंक्रोनाइज़";
 "Synchronized %lld clips" = "%lld क्लिप्स सिंक्रोनाइज़ की गईं";
 "Synchronized 1 clip" = "1 क्लिप सिंक्रोनाइज़ की गई";
@@ -864,7 +865,6 @@
 "Theme" = "थीम";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "यह टाइमलाइन रूलर है। रेंडर करने के लिए रेंज चुनने हेतु रूलर पर Shift+ड्रैग करें। उस रेंज के अनुकूल AI एडिट या संगीत जेनरेट करने के लिए कोई भी स्लॉट चुन सकते हैं।";
 "This is where all your footage and assets live." = "आपका सारा फ़ुटेज और सभी एसेट यहाँ रहते हैं।";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "यह आपका इंस्पेक्टर पैनल है। क्लिप एडिट करने के लिए उसे टाइमलाइन से चुनें।";
 "This is your preview panel to play a selected media or the whole timeline." = "यह चयनित मीडिया या पूरी टाइमलाइन चलाने का प्रीव्यू पैनल है।";
 "This model cannot cap the output at 60 FPS." = "यह मॉडल आउटपुट को 60 FPS पर सीमित नहीं कर सकता।";
 "This permanently removes %@." = "यह %@ को स्थायी रूप से हटाता है।";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "आपका Lottie एनिमेशन तैयार है।";
 "Your audio clip is ready." = "आपकी ऑडियो क्लिप तैयार है।";
 "Your image is ready." = "आपकी इमेज तैयार है।";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "चयनित क्लिप का इंस्पेक्टर — ट्रांसफ़ॉर्म, एडजस्ट, ऑडियो और बहुत कुछ।";
 "Your text clip is ready." = "आपकी टेक्स्ट क्लिप तैयार है।";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "आपकी टाइमलाइन: ऊपर का आधा हिस्सा वीडियो और नीचे का आधा हिस्सा ऑडियो है। आप यहीं एडिट करते हैं। अपस्केल, एडिट या संगीत जेनरेट करने जैसे AI फ़ीचर के लिए क्लिप पर राइट-क्लिक करें।";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "आपकी टाइमलाइन: ऊपर का आधा हिस्सा वीडियो और नीचे का आधा हिस्सा ऑडियो है। इंस्पेक्ट करने के लिए किसी क्लिप पर क्लिक करें — हमने आपके लिए एक चुन दी है।";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "आपकी टाइमलाइन: ऊपर का आधा हिस्सा वीडियो और नीचे का आधा हिस्सा ऑडियो है। आप यहीं एडिट करते हैं।";
 "Your video is ready." = "आपका वीडियो तैयार है।";
 "Zoom In" = "ज़ूम इन";
 "Zoom Out" = "ज़ूम आउट";

--- a/Sources/PalmierPro/Resources/Localization/it.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/it.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Aggiungi intervallo alla chat";
 "Add Text" = "Aggiungi testo";
 "Add an email above to enable a reply" = "Aggiungi un indirizzo email qui sopra per consentire una risposta";
-"Add captions to my timeline" = "Aggiungi sottotitoli alla timeline";
+"Add captions" = "Aggiungi sottotitoli";
 "Add credits" = "Aggiungi crediti";
 "Add credits to use Cloud." = "Aggiungi crediti per usare Cloud.";
 "Add emoji" = "Aggiungi emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Crea timeline annidata";
 "Create Video" = "Crea video";
 "Create Video only works on images" = "Crea video funziona solo con le immagini";
-"Create a letterbox opening" = "Crea un'apertura letterbox";
 "Create a skill or browse the Community collection." = "Crea una competenza o sfoglia la raccolta della community.";
-"Create a voiceover" = "Crea una voce fuori campo";
 "Create matching sound for the video" = "Crea audio corrispondente al video";
 "Creating…" = "Creazione…";
 "Credits" = "Crediti";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Proporzioni personalizzate";
 "Custom…" = "Personalizzato…";
 "Cut" = "Taglia";
+"Cut to the beat" = "Taglia sul beat";
 "Dark" = "Scuro";
 "Dark appearance" = "Aspetto scuro";
 "Darken" = "Scurisci";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Genera effetti sonori";
 "Generate SFX only works on video" = "Genera SFX funziona solo con i video";
 "Generate SFX…" = "Genera effetti sonori…";
-"Generate an AI video" = "Genera un video con l'AI";
 "Generate audio" = "Genera audio";
-"Generate music and sync to my timeline" = "Genera musica e sincronizzala con la timeline";
 "Generate music for the timeline" = "Genera musica per la timeline";
 "Generate music that fits the video" = "Genera musica adatta al video";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Genera video, immagini o audio con modelli e impostazioni diversi. Trascina le risorse dal pannello multimediale qui sopra nel fotogramma di riferimento.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Mantieni attuale";
 "Keep Editing" = "Continua a modificare";
 "Keep Skill" = "Mantieni competenza";
+"Keep the best takes" = "Tieni le migliori take";
 "Keeps this much audio before and after detected speech." = "Mantiene questa quantità di audio prima e dopo il parlato rilevato.";
 "Keyboard Shortcuts" = "Abbreviazioni da tastiera";
 "Keyframes" = "Fotogrammi chiave";
@@ -503,6 +501,7 @@
 "MCP Server" = "Server MCP";
 "MCP Setup" = "Configurazione MCP";
 "Main + Sidebar" = "Principale + barra laterale";
+"Make vertical shorts" = "Crea short verticali";
 "Manage credits" = "Gestisci crediti";
 "Manage subscription" = "Gestisci abbonamento";
 "Manual setup" = "Configurazione manuale";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Apri cartella competenze";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Apri Competenze per sfogliare le procedure della community, crearne di tue o aggiungerle ad altri agenti.";
 "Open Timeline" = "Apri timeline";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Apri la scheda Modifica AI per aumentare la risoluzione, modificare con un prompt, creare un video da un fotogramma oppure generare musica, effetti sonori, pulizia audio e doppiaggio dalla clip.";
 "Opening Google" = "Apertura di Google";
 "Opening Google…" = "Apertura di Google…";
 "Open…" = "Apri…";
-"Organize my media into structured folders" = "Organizza i miei contenuti multimediali in cartelle strutturate";
 "Organize with Agent" = "Organizza con l'agente";
 "Original" = "Originale";
 "Original FPS" = "FPS originali";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Salva questo progetto per visualizzare l’attività";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Salva una copia del progetto con tutti i contenuti multimediali inclusi, così potrà essere aperto su qualsiasi computer.";
 "Scale" = "Scala";
+"Score my timeline" = "Colonna sonora per la timeline";
 "Screen" = "Schermo";
 "Screenshot a frame" = "Acquisisci un fotogramma";
 "Scroll Horizontally" = "Scorri orizzontalmente";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Cambia angolazione";
 "Switch Angle in Range" = "Cambia angolazione nell'intervallo";
 "Switch Mic" = "Cambia microfono";
+"Sync my multicam" = "Sincronizza il multicam";
 "Synchronize" = "Sincronizza";
 "Synchronized %lld clips" = "Sincronizzate %lld clip";
 "Synchronized 1 clip" = "Sincronizzata 1 clip";
@@ -864,7 +865,6 @@
 "Theme" = "Tema";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Questo è il righello della timeline. Tieni premuto Maiuscole e trascina sul righello per selezionare un intervallo da renderizzare. Puoi scegliere qualsiasi spazio per modificare con l'AI o generare musica adatta all'intervallo.";
 "This is where all your footage and assets live." = "Qui si trovano tutti i filmati e le risorse.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Questo è il pannello Inspector. Seleziona una clip dalla timeline per modificarla.";
 "This is your preview panel to play a selected media or the whole timeline." = "Questo è il pannello di anteprima per riprodurre i contenuti multimediali selezionati o l'intera timeline.";
 "This model cannot cap the output at 60 FPS." = "Questo modello non può limitare l'output a 60 FPS.";
 "This permanently removes %@." = "Rimuove definitivamente %@.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "L'animazione Lottie è pronta.";
 "Your audio clip is ready." = "La clip audio è pronta.";
 "Your image is ready." = "L'immagine è pronta.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "L’Inspector della clip selezionata: trasformazioni, regolazioni, audio e altro.";
 "Your text clip is ready." = "La clip di testo è pronta.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "La tua timeline: la metà superiore contiene il video, quella inferiore l'audio. Qui puoi modificare. Fai clic con il pulsante destro su una clip per usare funzioni AI come aumento della risoluzione, modifica o generazione di musica.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "La tua timeline: la metà superiore contiene il video, quella inferiore l’audio. Fai clic su una clip per ispezionarla: ne abbiamo già selezionata una per te.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "La tua timeline: la metà superiore contiene il video, quella inferiore l’audio. Qui puoi modificare.";
 "Your video is ready." = "Il video è pronto.";
 "Zoom In" = "Ingrandisci";
 "Zoom Out" = "Riduci";

--- a/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "範囲をチャットに追加";
 "Add Text" = "テキストを追加";
 "Add an email above to enable a reply" = "返信を受け取るには上にメールアドレスを追加してください";
-"Add captions to my timeline" = "タイムラインにキャプションを追加";
+"Add captions" = "キャプションを追加";
 "Add credits" = "クレジットを追加";
 "Add credits to use Cloud." = "Cloudを使用するにはクレジットを追加してください。";
 "Add emoji" = "絵文字を追加";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "ネストされたタイムラインを作成";
 "Create Video" = "ビデオを作成";
 "Create Video only works on images" = "「ビデオを作成」は画像でのみ使用できます";
-"Create a letterbox opening" = "レターボックスが開く演出を作成";
 "Create a skill or browse the Community collection." = "スキルを作成するか、コミュニティコレクションを参照してください。";
-"Create a voiceover" = "ボイスオーバーを作成";
 "Create matching sound for the video" = "ビデオに合うサウンドを作成";
 "Creating…" = "作成中…";
 "Credits" = "クレジット";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "カスタムアスペクト比";
 "Custom…" = "カスタム…";
 "Cut" = "カット";
+"Cut to the beat" = "ビートに合わせてカット";
 "Dark" = "ダーク";
 "Dark appearance" = "ダークの外観";
 "Darken" = "比較（暗）";
@@ -384,9 +383,7 @@
 "Generate SFX" = "効果音を生成";
 "Generate SFX only works on video" = "「SFXを生成」はビデオでのみ使用できます";
 "Generate SFX…" = "効果音を生成…";
-"Generate an AI video" = "AIビデオを生成";
 "Generate audio" = "オーディオを生成";
-"Generate music and sync to my timeline" = "音楽を生成してタイムラインに同期";
 "Generate music for the timeline" = "タイムライン用の音楽を生成";
 "Generate music that fits the video" = "ビデオに合う音楽を生成";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "さまざまなモデルと設定でビデオ、画像、オーディオを生成します。上のメディアパネルから参照フレームへアセットをドラッグしてください。";
@@ -454,6 +451,7 @@
 "Keep Current" = "現在の設定を維持";
 "Keep Editing" = "編集を続ける";
 "Keep Skill" = "スキルを保持";
+"Keep the best takes" = "ベストテイクを残す";
 "Keeps this much audio before and after detected speech." = "検出した音声の前後に残すオーディオの長さです。";
 "Keyboard Shortcuts" = "キーボードショートカット";
 "Keyframes" = "キーフレーム";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCPサーバ";
 "MCP Setup" = "MCPの設定";
 "Main + Sidebar" = "メイン + サイドバー";
+"Make vertical shorts" = "縦型ショートを作成";
 "Manage credits" = "クレジットを管理";
 "Manage subscription" = "サブスクリプションを管理";
 "Manual setup" = "手動設定";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "スキルフォルダを開く";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "スキルを開いてコミュニティのプレイブックを参照したり、独自のスキルを作成したり、ほかのエージェントに追加したりできます。";
 "Open Timeline" = "タイムラインを開く";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "「AI編集」タブを開いて、アップスケール、プロンプト編集、フレームからのビデオ作成、またはクリップからの音楽・SFX・クリーンアップ・吹き替え生成を行えます。";
 "Opening Google" = "Googleを開いています";
 "Opening Google…" = "Googleを開いています…";
 "Open…" = "開く…";
-"Organize my media into structured folders" = "メディアを整理されたフォルダに分類";
 "Organize with Agent" = "エージェントで整理";
 "Original" = "オリジナル";
 "Original FPS" = "元のFPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "アクティビティを表示するには、このプロジェクトを保存してください";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "すべてのメディアを内部に含めたプロジェクトのコピーを保存し、どのマシンでも開けるようにします。";
 "Scale" = "スケール";
+"Score my timeline" = "タイムラインに音楽を付ける";
 "Screen" = "スクリーン";
 "Screenshot a frame" = "フレームのスクリーンショットを撮る";
 "Scroll Horizontally" = "横方向にスクロール";
@@ -840,6 +840,7 @@
 "Switch Angle" = "アングルを切り替え";
 "Switch Angle in Range" = "範囲内のアングルを切り替え";
 "Switch Mic" = "マイクを切り替え";
+"Sync my multicam" = "マルチカムを同期";
 "Synchronize" = "同期";
 "Synchronized %lld clips" = "%lld個のクリップを同期しました";
 "Synchronized 1 clip" = "1個のクリップを同期しました";
@@ -864,7 +865,6 @@
 "Theme" = "テーマ";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "これはタイムラインルーラーです。ルーラー上でShiftキーを押しながらドラッグすると、レンダリングする範囲を選択できます。任意のスロットを選び、その範囲に合うAI編集や音楽生成を行えます。";
 "This is where all your footage and assets live." = "すべての映像素材とアセットはここに表示されます。";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "これはインスペクタパネルです。タイムラインからクリップを選択して編集します。";
 "This is your preview panel to play a selected media or the whole timeline." = "これは選択したメディアまたはタイムライン全体を再生するプレビューパネルです。";
 "This model cannot cap the output at 60 FPS." = "このモデルでは出力を60 FPSに制限できません。";
 "This permanently removes %@." = "%@を完全に削除します。";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Lottieアニメーションの準備ができました。";
 "Your audio clip is ready." = "オーディオクリップの準備ができました。";
 "Your image is ready." = "画像の準備ができました。";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "選択したクリップのインスペクタです。変形、調整、オーディオなどを確認できます。";
 "Your text clip is ready." = "テキストクリップの準備ができました。";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "タイムラインの上半分はビデオ、下半分はオーディオです。ここで編集を行います。クリップを右クリックすると、アップスケール、編集、音楽生成などのAI機能を使用できます。";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "タイムラインの上半分はビデオ、下半分はオーディオです。クリップをクリックして検査します — 1つ選択済みです。";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "タイムラインの上半分はビデオ、下半分はオーディオです。ここで編集を行います。";
 "Your video is ready." = "ビデオの準備ができました。";
 "Zoom In" = "拡大";
 "Zoom Out" = "縮小";

--- a/Sources/PalmierPro/Resources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ko.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "채팅에 범위 추가";
 "Add Text" = "텍스트 추가";
 "Add an email above to enable a reply" = "답변을 받으려면 위에 이메일을 추가하세요";
-"Add captions to my timeline" = "타임라인에 캡션 추가";
+"Add captions" = "캡션 추가";
 "Add credits" = "크레딧 추가";
 "Add credits to use Cloud." = "Cloud를 사용하려면 크레딧을 추가하세요.";
 "Add emoji" = "이모티콘 추가";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "중첩 타임라인 생성";
 "Create Video" = "비디오 생성";
 "Create Video only works on images" = "비디오 생성은 이미지에서만 사용할 수 있습니다";
-"Create a letterbox opening" = "레터박스 오프닝 생성";
 "Create a skill or browse the Community collection." = "스킬을 생성하거나 커뮤니티 모음을 둘러보세요.";
-"Create a voiceover" = "보이스오버 생성";
 "Create matching sound for the video" = "비디오에 맞는 사운드 생성";
 "Creating…" = "생성하는 중…";
 "Credits" = "크레딧";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "사용자 설정 화면비";
 "Custom…" = "사용자 설정…";
 "Cut" = "오려두기";
+"Cut to the beat" = "비트에 맞춰 컷";
 "Dark" = "다크";
 "Dark appearance" = "다크 모드";
 "Darken" = "어둡게";
@@ -384,9 +383,7 @@
 "Generate SFX" = "SFX 생성";
 "Generate SFX only works on video" = "SFX 생성은 비디오에서만 사용할 수 있습니다";
 "Generate SFX…" = "SFX 생성…";
-"Generate an AI video" = "AI 비디오 생성";
 "Generate audio" = "오디오 생성";
-"Generate music and sync to my timeline" = "음악을 생성하여 타임라인과 동기화";
 "Generate music for the timeline" = "타임라인용 음악 생성";
 "Generate music that fits the video" = "비디오에 맞는 음악 생성";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "다양한 모델과 설정으로 비디오, 이미지 또는 오디오를 생성합니다. 위의 미디어 패널에서 참조 프레임으로 에셋을 드래그하세요.";
@@ -454,6 +451,7 @@
 "Keep Current" = "현재 설정 유지";
 "Keep Editing" = "계속 편집";
 "Keep Skill" = "스킬 유지";
+"Keep the best takes" = "베스트 테이크만 남기기";
 "Keeps this much audio before and after detected speech." = "감지된 음성 전후에 이만큼의 오디오를 유지합니다.";
 "Keyboard Shortcuts" = "키보드 단축키";
 "Keyframes" = "키프레임";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP 서버";
 "MCP Setup" = "MCP 설정";
 "Main + Sidebar" = "메인 + 사이드바";
+"Make vertical shorts" = "세로형 쇼츠 만들기";
 "Manage credits" = "크레딧 관리";
 "Manage subscription" = "구독 관리";
 "Manual setup" = "수동 설정";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "스킬 폴더 열기";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "스킬을 열어 커뮤니티 플레이북을 둘러보고 직접 만들거나 다른 에이전트에 추가하세요.";
 "Open Timeline" = "타임라인 열기";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI 편집 탭을 열어 업스케일, 프롬프트 편집, 프레임에서 비디오 만들기, 또는 클립에서 음악·SFX·클린업·더빙을 생성하세요.";
 "Opening Google" = "Google 여는 중";
 "Opening Google…" = "Google 여는 중…";
 "Open…" = "열기…";
-"Organize my media into structured folders" = "미디어를 체계적인 폴더로 정리";
 "Organize with Agent" = "에이전트로 정리";
 "Original" = "원본";
 "Original FPS" = "원본 FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "활동을 보려면 이 프로젝트를 저장하세요";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "모든 미디어를 내부에 번들로 포함한 프로젝트 사본을 저장하여 어느 컴퓨터에서나 열 수 있게 합니다.";
 "Scale" = "크기 조절";
+"Score my timeline" = "타임라인에 음악 입히기";
 "Screen" = "스크린";
 "Screenshot a frame" = "프레임 스크린샷 찍기";
 "Scroll Horizontally" = "가로로 스크롤";
@@ -840,6 +840,7 @@
 "Switch Angle" = "앵글 전환";
 "Switch Angle in Range" = "범위에서 앵글 전환";
 "Switch Mic" = "마이크 전환";
+"Sync my multicam" = "멀티캠 동기화";
 "Synchronize" = "동기화";
 "Synchronized %lld clips" = "클립 %lld개 동기화됨";
 "Synchronized 1 clip" = "클립 1개 동기화됨";
@@ -864,7 +865,6 @@
 "Theme" = "테마";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "타임라인 눈금자입니다. 눈금자에서 Shift+드래그하여 렌더링할 범위를 선택하세요. 원하는 슬롯을 선택해 AI로 편집하거나 해당 범위에 맞는 음악을 생성할 수 있습니다.";
 "This is where all your footage and assets live." = "모든 푸티지와 에셋이 보관되는 곳입니다.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "인스펙터 패널입니다. 타임라인에서 편집할 클립을 선택하세요.";
 "This is your preview panel to play a selected media or the whole timeline." = "선택한 미디어 또는 전체 타임라인을 재생하는 미리보기 패널입니다.";
 "This model cannot cap the output at 60 FPS." = "이 모델은 출력을 60 FPS로 제한할 수 없습니다.";
 "This permanently removes %@." = "%@이(가) 영구적으로 제거됩니다.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Lottie 애니메이션이 준비되었습니다.";
 "Your audio clip is ready." = "오디오 클립이 준비되었습니다.";
 "Your image is ready." = "이미지가 준비되었습니다.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "선택한 클립의 인스펙터입니다. 변형, 조정, 오디오 등을 확인하세요.";
 "Your text clip is ready." = "텍스트 클립이 준비되었습니다.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "타임라인의 위쪽 절반은 비디오이고 아래쪽 절반은 오디오입니다. 여기에서 편집합니다. 클립을 오른쪽 클릭하여 업스케일, 편집 또는 음악 생성과 같은 AI 기능을 사용하세요.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "타임라인의 위쪽 절반은 비디오이고 아래쪽 절반은 오디오입니다. 클립을 클릭해 검사하세요 — 하나를 미리 선택해 두었습니다.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "타임라인의 위쪽 절반은 비디오이고 아래쪽 절반은 오디오입니다. 여기에서 편집합니다.";
 "Your video is ready." = "비디오가 준비되었습니다.";
 "Zoom In" = "확대";
 "Zoom Out" = "축소";

--- a/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Adicionar intervalo ao chat";
 "Add Text" = "Adicionar texto";
 "Add an email above to enable a reply" = "Adicione um email acima para permitir uma resposta";
-"Add captions to my timeline" = "Adicionar legendas à minha linha do tempo";
+"Add captions" = "Adicionar legendas";
 "Add credits" = "Adicionar créditos";
 "Add credits to use Cloud." = "Adicione créditos para usar a Nuvem.";
 "Add emoji" = "Adicionar emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Criar linha do tempo aninhada";
 "Create Video" = "Criar vídeo";
 "Create Video only works on images" = "Criar vídeo funciona apenas com imagens";
-"Create a letterbox opening" = "Criar uma abertura letterbox";
 "Create a skill or browse the Community collection." = "Crie uma habilidade ou explore a coleção da comunidade.";
-"Create a voiceover" = "Criar uma narração";
 "Create matching sound for the video" = "Criar som correspondente ao vídeo";
 "Creating…" = "Criando…";
 "Credits" = "Créditos";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Proporção personalizada";
 "Custom…" = "Personalizado…";
 "Cut" = "Cortar";
+"Cut to the beat" = "Cortar no ritmo";
 "Dark" = "Escuro";
 "Dark appearance" = "Aparência escura";
 "Darken" = "Escurecer";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Gerar efeitos sonoros";
 "Generate SFX only works on video" = "Gerar SFX funciona apenas com vídeos";
 "Generate SFX…" = "Gerar efeitos sonoros…";
-"Generate an AI video" = "Gerar um vídeo com AI";
 "Generate audio" = "Gerar áudio";
-"Generate music and sync to my timeline" = "Gerar música e sincronizar com minha linha do tempo";
 "Generate music for the timeline" = "Gerar música para a linha do tempo";
 "Generate music that fits the video" = "Gerar música adequada ao vídeo";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Gere vídeo, imagem ou áudio com modelos e ajustes diferentes. Arraste recursos do painel de mídia acima para o quadro de referência.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Manter atual";
 "Keep Editing" = "Continuar editando";
 "Keep Skill" = "Manter habilidade";
+"Keep the best takes" = "Manter as melhores takes";
 "Keeps this much audio before and after detected speech." = "Mantém esta quantidade de áudio antes e depois da fala detectada.";
 "Keyboard Shortcuts" = "Atalhos de teclado";
 "Keyframes" = "Quadros-chave";
@@ -503,6 +501,7 @@
 "MCP Server" = "Servidor MCP";
 "MCP Setup" = "Configuração do MCP";
 "Main + Sidebar" = "Principal + barra lateral";
+"Make vertical shorts" = "Criar shorts verticais";
 "Manage credits" = "Gerenciar créditos";
 "Manage subscription" = "Gerenciar assinatura";
 "Manual setup" = "Configuração manual";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Abrir pasta Habilidades";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Abra Habilidades para explorar guias da comunidade, criar os seus ou adicioná-los a outros agentes.";
 "Open Timeline" = "Abrir linha do tempo";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Abra a aba Edição com AI para aumentar a resolução, editar com um prompt, criar vídeo a partir de um quadro, ou gerar música, efeitos sonoros, limpeza de voz e dublagem a partir do clipe.";
 "Opening Google" = "Abrindo o Google";
 "Opening Google…" = "Abrindo o Google…";
 "Open…" = "Abrir…";
-"Organize my media into structured folders" = "Organizar minha mídia em pastas estruturadas";
 "Organize with Agent" = "Organizar com o Agente";
 "Original" = "Original";
 "Original FPS" = "FPS original";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Salve este projeto para ver a atividade";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Salva uma cópia deste projeto com toda a mídia incluída para que ele possa ser aberto em qualquer máquina.";
 "Scale" = "Escala";
+"Score my timeline" = "Trilha sonora na linha do tempo";
 "Screen" = "Tela";
 "Screenshot a frame" = "Capturar um quadro";
 "Scroll Horizontally" = "Rolar horizontalmente";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Trocar ângulo";
 "Switch Angle in Range" = "Trocar ângulo no intervalo";
 "Switch Mic" = "Trocar microfone";
+"Sync my multicam" = "Sincronizar minha multicâmera";
 "Synchronize" = "Sincronizar";
 "Synchronized %lld clips" = "%lld clipes sincronizados";
 "Synchronized 1 clip" = "1 clipe sincronizado";
@@ -864,7 +865,6 @@
 "Theme" = "Tema";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Esta é a régua da linha do tempo. Pressione Shift e arraste na régua para selecionar um intervalo a ser renderizado. Você pode escolher qualquer espaço para editar com AI ou gerar música adequada ao intervalo.";
 "This is where all your footage and assets live." = "Aqui ficam todas as suas filmagens e recursos.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Este é o painel Inspetor. Selecione um clipe na linha do tempo para editá-lo.";
 "This is your preview panel to play a selected media or the whole timeline." = "Este é o painel de prévia para reproduzir uma mídia selecionada ou toda a linha do tempo.";
 "This model cannot cap the output at 60 FPS." = "Este modelo não pode limitar a saída a 60 FPS.";
 "This permanently removes %@." = "Isso remove %@ permanentemente.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Sua animação Lottie está pronta.";
 "Your audio clip is ready." = "Seu clipe de áudio está pronto.";
 "Your image is ready." = "Sua imagem está pronta.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "O inspetor do clipe selecionado — transformar, ajustar, áudio e muito mais.";
 "Your text clip is ready." = "Seu clipe de texto está pronto.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Sua linha do tempo: a metade superior é vídeo e a inferior é áudio. É aqui que você edita. Clique com o botão direito em um clipe para usar recursos de AI como aumentar resolução, editar ou gerar música.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Sua linha do tempo: a metade superior é vídeo e a inferior é áudio. Clique em um clipe para inspecioná-lo — já selecionamos um para você.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Sua linha do tempo: a metade superior é vídeo e a inferior é áudio. É aqui que você edita.";
 "Your video is ready." = "Seu vídeo está pronto.";
 "Zoom In" = "Ampliar";
 "Zoom Out" = "Reduzir";

--- a/Sources/PalmierPro/Resources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ru.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Добавить диапазон в чат";
 "Add Text" = "Добавить текст";
 "Add an email above to enable a reply" = "Укажите адрес электронной почты выше, чтобы получить ответ";
-"Add captions to my timeline" = "Добавить субтитры на таймлайн";
+"Add captions" = "Добавить субтитры";
 "Add credits" = "Добавить кредиты";
 "Add credits to use Cloud." = "Добавьте кредиты, чтобы использовать облако.";
 "Add emoji" = "Добавить эмодзи";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Создать вложенный таймлайн";
 "Create Video" = "Создать видео";
 "Create Video only works on images" = "Функция «Создать видео» работает только с изображениями";
-"Create a letterbox opening" = "Создать эффект открытия шторками";
 "Create a skill or browse the Community collection." = "Создайте навык или просмотрите коллекцию сообщества.";
-"Create a voiceover" = "Создать закадровый голос";
 "Create matching sound for the video" = "Создать подходящий звук для видео";
 "Creating…" = "Создание…";
 "Credits" = "Кредиты";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Пользовательское соотношение сторон";
 "Custom…" = "Другое…";
 "Cut" = "Вырезать";
+"Cut to the beat" = "Резать под бит";
 "Dark" = "Тёмное";
 "Dark appearance" = "Тёмное оформление";
 "Darken" = "Затемнение";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Создать SFX";
 "Generate SFX only works on video" = "Функция «Создать SFX» работает только с видео";
 "Generate SFX…" = "Создать SFX…";
-"Generate an AI video" = "Создать AI-видео";
 "Generate audio" = "Создать аудио";
-"Generate music and sync to my timeline" = "Создать музыку и синхронизировать её с таймлайном";
 "Generate music for the timeline" = "Создать музыку для таймлайна";
 "Generate music that fits the video" = "Создать музыку, подходящую к видео";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Создавайте видео, изображения или аудио с разными моделями и настройками. Перетащите материалы из панели медиафайлов выше в область референса.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Оставить текущие";
 "Keep Editing" = "Продолжить монтаж";
 "Keep Skill" = "Оставить навык";
+"Keep the best takes" = "Оставить лучшие дубли";
 "Keeps this much audio before and after detected speech." = "Сохраняет указанный фрагмент аудио до и после обнаруженной речи.";
 "Keyboard Shortcuts" = "Сочетания клавиш";
 "Keyframes" = "Ключевые кадры";
@@ -503,6 +501,7 @@
 "MCP Server" = "Сервер MCP";
 "MCP Setup" = "Настройка MCP";
 "Main + Sidebar" = "Основная область + боковая панель";
+"Make vertical shorts" = "Сделать вертикальные шорты";
 "Manage credits" = "Управление кредитами";
 "Manage subscription" = "Управление подпиской";
 "Manual setup" = "Настроить вручную";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Открыть папку навыков";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Откройте раздел «Навыки», чтобы просмотреть сценарии сообщества, создать собственные или добавить их другим агентам.";
 "Open Timeline" = "Открыть таймлайн";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Откройте вкладку «AI-правка», чтобы увеличить разрешение, изменить клип по запросу, создать видео из кадра или сгенерировать музыку, звуковые эффекты, очистку голоса и дубляж.";
 "Opening Google" = "Открывается Google";
 "Opening Google…" = "Открывается Google…";
 "Open…" = "Открыть…";
-"Organize my media into structured folders" = "Упорядочить мои медиафайлы по папкам";
 "Organize with Agent" = "Упорядочить с помощью агента";
 "Original" = "Оригинал";
 "Original FPS" = "Исходный FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Сохраните проект, чтобы просмотреть историю действий";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Сохраняет копию проекта со всеми медиафайлами внутри, чтобы её можно было открыть на любом компьютере.";
 "Scale" = "Масштаб";
+"Score my timeline" = "Положить музыку на таймлайн";
 "Screen" = "Экран";
 "Screenshot a frame" = "Сделать снимок кадра";
 "Scroll Horizontally" = "Прокрутка по горизонтали";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Переключить ракурс";
 "Switch Angle in Range" = "Переключить ракурс в диапазоне";
 "Switch Mic" = "Переключить микрофон";
+"Sync my multicam" = "Синхронизировать мультикамеру";
 "Synchronize" = "Синхронизировать";
 "Synchronized %lld clips" = "Синхронизировано клипов: %lld";
 "Synchronized 1 clip" = "Синхронизирован 1 клип";
@@ -864,7 +865,6 @@
 "Theme" = "Тема";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Это линейка таймлайна. Перетаскивайте по ней с зажатой клавишей Shift, чтобы выбрать диапазон для рендеринга. Можно выбрать любой слот для AI-монтажа или создания музыки под этот диапазон.";
 "This is where all your footage and assets live." = "Здесь хранятся все ваши материалы и ресурсы.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Это панель инспектора. Выберите клип на таймлайне, чтобы изменить его.";
 "This is your preview panel to play a selected media or the whole timeline." = "Это панель предпросмотра для воспроизведения выбранного медиафайла или всего таймлайна.";
 "This model cannot cap the output at 60 FPS." = "Эта модель не может ограничить результат частотой 60 FPS.";
 "This permanently removes %@." = "Это безвозвратно удалит %@.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Ваша анимация Lottie готова.";
 "Your audio clip is ready." = "Ваш аудиоклип готов.";
 "Your image is ready." = "Ваше изображение готово.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "Инспектор выбранного клипа — трансформация, коррекция, аудио и многое другое.";
 "Your text clip is ready." = "Ваш текстовый клип готов.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Ваш таймлайн: в верхней половине находится видео, в нижней — аудио. Здесь выполняется монтаж. Нажмите клип правой кнопкой мыши, чтобы использовать функции AI: увеличить разрешение, изменить или создать музыку.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Ваш таймлайн: в верхней половине находится видео, в нижней — аудио. Нажмите клип, чтобы открыть его в инспекторе — мы уже выбрали один за вас.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Ваш таймлайн: в верхней половине находится видео, в нижней — аудио. Здесь выполняется монтаж.";
 "Your video is ready." = "Ваше видео готово.";
 "Zoom In" = "Увеличить";
 "Zoom Out" = "Уменьшить";

--- a/Sources/PalmierPro/Resources/Localization/tr.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/tr.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Aralığı Sohbete Ekle";
 "Add Text" = "Metin Ekle";
 "Add an email above to enable a reply" = "Yanıt alabilmek için yukarıya bir e-posta adresi ekleyin";
-"Add captions to my timeline" = "Zaman eksenime altyazı ekle";
+"Add captions" = "Altyazı ekle";
 "Add credits" = "Kredi ekle";
 "Add credits to use Cloud." = "Bulut'u kullanmak için kredi ekleyin.";
 "Add emoji" = "Emoji ekle";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "İç İçe Zaman Ekseni Oluştur";
 "Create Video" = "Video Oluştur";
 "Create Video only works on images" = "Video Oluştur yalnızca görüntülerde çalışır";
-"Create a letterbox opening" = "Sinemaskop açılışı oluştur";
 "Create a skill or browse the Community collection." = "Bir beceri oluşturun veya Topluluk koleksiyonuna göz atın.";
-"Create a voiceover" = "Seslendirme oluştur";
 "Create matching sound for the video" = "Videoya uygun ses oluştur";
 "Creating…" = "Oluşturuluyor…";
 "Credits" = "Krediler";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Özel En-Boy Oranı";
 "Custom…" = "Özel…";
 "Cut" = "Kes";
+"Cut to the beat" = "Ritme göre kes";
 "Dark" = "Koyu";
 "Dark appearance" = "Koyu görünüm";
 "Darken" = "Koyulaştır";
@@ -384,9 +383,7 @@
 "Generate SFX" = "SFX Oluştur";
 "Generate SFX only works on video" = "SFX Oluştur yalnızca videoda çalışır";
 "Generate SFX…" = "SFX Oluştur…";
-"Generate an AI video" = "Yapay zekâ videosu oluştur";
 "Generate audio" = "Ses oluştur";
-"Generate music and sync to my timeline" = "Müzik oluştur ve zaman eksenimle eşzamanla";
 "Generate music for the timeline" = "Zaman ekseni için müzik oluştur";
 "Generate music that fits the video" = "Videoya uyan müzik oluştur";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Farklı modeller ve ayarlarla video, görüntü veya ses oluşturun. Yukarıdaki medya panelinden varlıkları referans karesine sürükleyin.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Geçerli Olanı Koru";
 "Keep Editing" = "Düzenlemeyi Sürdür";
 "Keep Skill" = "Beceriyi Koru";
+"Keep the best takes" = "En iyi çekimleri tut";
 "Keeps this much audio before and after detected speech." = "Algılanan konuşmanın öncesinde ve sonrasında bu kadar sesi korur.";
 "Keyboard Shortcuts" = "Klavye Kestirmeleri";
 "Keyframes" = "Anahtar Kareler";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP Sunucusu";
 "MCP Setup" = "MCP Ayarları";
 "Main + Sidebar" = "Ana + Kenar Çubuğu";
+"Make vertical shorts" = "Dikey short’lar oluştur";
 "Manage credits" = "Kredileri yönet";
 "Manage subscription" = "Aboneliği yönet";
 "Manual setup" = "Elle ayarla";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Beceriler Klasörünü Aç";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Topluluk çalışma kitaplarına göz atmak, kendi becerilerinizi oluşturmak veya başka aracılara eklemek için Beceriler'i açın.";
 "Open Timeline" = "Zaman Eksenini Aç";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Çözünürlük yükseltmek, istemle düzenlemek, bir kareden video oluşturmak ya da klipten müzik, ses efektleri, ses temizleme ve dublaj üretmek için Yapay Zekâ Düzenleme sekmesini açın.";
 "Opening Google" = "Google Açılıyor";
 "Opening Google…" = "Google Açılıyor…";
 "Open…" = "Aç…";
-"Organize my media into structured folders" = "Medyamı düzenli klasörler hâlinde organize et";
 "Organize with Agent" = "Aracıyla Organize Et";
 "Original" = "Özgün";
 "Original FPS" = "Özgün FPS";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Etkinliği görüntülemek için bu projeyi kaydedin";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Bu projenin tüm medyayı içinde barındıran bir kopyasını kaydeder; böylece her bilgisayarda açılabilir.";
 "Scale" = "Ölçek";
+"Score my timeline" = "Zaman eksenine müzik ekle";
 "Screen" = "Ekran";
 "Screenshot a frame" = "Bir karenin ekran görüntüsünü al";
 "Scroll Horizontally" = "Yatay Kaydır";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Açıyı Değiştir";
 "Switch Angle in Range" = "Aralıkta Açıyı Değiştir";
 "Switch Mic" = "Mikrofonu Değiştir";
+"Sync my multicam" = "Çok kameralı kurulumu eşitle";
 "Synchronize" = "Eşzamanla";
 "Synchronized %lld clips" = "%lld klip eşzamanlandı";
 "Synchronized 1 clip" = "1 klip eşzamanlandı";
@@ -864,7 +865,6 @@
 "Theme" = "Tema";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Bu, zaman ekseni cetvelidir. İşlenecek bir aralığı seçmek için cetvelde Shift tuşuna basarak sürükleyin. Yapay zekâyla düzenlemek veya bu aralığa uyan müzik oluşturmak için istediğiniz bölümü seçebilirsiniz.";
 "This is where all your footage and assets live." = "Tüm çekimleriniz ve varlıklarınız burada bulunur.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Bu, denetçi panelinizdir. Düzenlemek için zaman ekseninden bir klip seçin.";
 "This is your preview panel to play a selected media or the whole timeline." = "Bu, seçili medyayı veya tüm zaman eksenini oynatabileceğiniz önizleme panelinizdir.";
 "This model cannot cap the output at 60 FPS." = "Bu model çıktıyı 60 FPS ile sınırlayamaz.";
 "This permanently removes %@." = "Bu işlem %@ öğesini kalıcı olarak kaldırır.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Lottie animasyonunuz hazır.";
 "Your audio clip is ready." = "Ses klibiniz hazır.";
 "Your image is ready." = "Görüntünüz hazır.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "Seçili klip için denetçi — dönüştür, ayarla, ses ve daha fazlası.";
 "Your text clip is ready." = "Metin klibiniz hazır.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Zaman ekseninizin üst yarısı video, alt yarısı sestir. Düzenlemeyi burada yaparsınız. Çözünürlük yükseltme, düzenleme veya müzik oluşturma gibi yapay zekâ özellikleri için bir klibi sağ tıklayın.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Zaman ekseninizin üst yarısı video, alt yarısı sestir. İncelemek için bir klibe tıklayın — sizin için birini seçtik.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Zaman ekseninizin üst yarısı video, alt yarısı sestir. Düzenlemeyi burada yaparsınız.";
 "Your video is ready." = "Videonuz hazır.";
 "Zoom In" = "Yakınlaştır";
 "Zoom Out" = "Uzaklaştır";

--- a/Sources/PalmierPro/Resources/Localization/vi.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/vi.lproj/Localizable.strings
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "Thêm vùng vào chat";
 "Add Text" = "Thêm văn bản";
 "Add an email above to enable a reply" = "Thêm email ở trên để nhận phản hồi";
-"Add captions to my timeline" = "Thêm phụ đề vào timeline của tôi";
+"Add captions" = "Thêm phụ đề";
 "Add credits" = "Thêm tín dụng";
 "Add credits to use Cloud." = "Thêm tín dụng để dùng Đám mây.";
 "Add emoji" = "Thêm emoji";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "Tạo timeline lồng nhau";
 "Create Video" = "Tạo video";
 "Create Video only works on images" = "Tạo video chỉ hoạt động với hình ảnh";
-"Create a letterbox opening" = "Tạo hiệu ứng mở màn letterbox";
 "Create a skill or browse the Community collection." = "Tạo kỹ năng hoặc duyệt bộ sưu tập Cộng đồng.";
-"Create a voiceover" = "Tạo lời thuyết minh";
 "Create matching sound for the video" = "Tạo âm thanh phù hợp với video";
 "Creating…" = "Đang tạo…";
 "Credits" = "Tín dụng";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "Tỷ lệ khung hình tùy chỉnh";
 "Custom…" = "Tùy chỉnh…";
 "Cut" = "Cắt";
+"Cut to the beat" = "Cắt theo nhịp";
 "Dark" = "Tối";
 "Dark appearance" = "Giao diện tối";
 "Darken" = "Làm tối";
@@ -384,9 +383,7 @@
 "Generate SFX" = "Tạo hiệu ứng âm thanh";
 "Generate SFX only works on video" = "Tạo hiệu ứng âm thanh chỉ hoạt động với video";
 "Generate SFX…" = "Tạo hiệu ứng âm thanh…";
-"Generate an AI video" = "Tạo video AI";
 "Generate audio" = "Tạo âm thanh";
-"Generate music and sync to my timeline" = "Tạo nhạc và đồng bộ với timeline của tôi";
 "Generate music for the timeline" = "Tạo nhạc cho timeline";
 "Generate music that fits the video" = "Tạo nhạc phù hợp với video";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Tạo video, hình ảnh hoặc âm thanh bằng nhiều mô hình và cài đặt. Kéo tài nguyên từ bảng phương tiện ở trên vào khung tham chiếu.";
@@ -454,6 +451,7 @@
 "Keep Current" = "Giữ hiện tại";
 "Keep Editing" = "Tiếp tục chỉnh sửa";
 "Keep Skill" = "Giữ kỹ năng";
+"Keep the best takes" = "Giữ các take đẹp nhất";
 "Keeps this much audio before and after detected speech." = "Giữ lượng âm thanh này trước và sau giọng nói được phát hiện.";
 "Keyboard Shortcuts" = "Phím tắt";
 "Keyframes" = "Khung hình chính";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP Server";
 "MCP Setup" = "Thiết lập MCP";
 "Main + Sidebar" = "Chính + thanh bên";
+"Make vertical shorts" = "Tạo short dọc";
 "Manage credits" = "Quản lý tín dụng";
 "Manage subscription" = "Quản lý gói đăng ký";
 "Manual setup" = "Thiết lập thủ công";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "Mở thư mục Kỹ năng";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Mở Kỹ năng để duyệt cẩm nang cộng đồng, tự tạo kỹ năng hoặc thêm kỹ năng vào agent khác.";
 "Open Timeline" = "Mở timeline";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Mở tab Chỉnh sửa bằng AI để nâng độ phân giải, chỉnh sửa bằng prompt, tạo video từ một khung hình, hoặc tạo nhạc, SFX, làm sạch âm thanh và lồng tiếng từ clip.";
 "Opening Google" = "Đang mở Google";
 "Opening Google…" = "Đang mở Google…";
 "Open…" = "Mở…";
-"Organize my media into structured folders" = "Sắp xếp phương tiện của tôi vào các thư mục có cấu trúc";
 "Organize with Agent" = "Sắp xếp bằng Agent";
 "Original" = "Gốc";
 "Original FPS" = "FPS gốc";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "Lưu dự án này để xem hoạt động";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Lưu bản sao dự án kèm theo toàn bộ phương tiện để có thể mở trên mọi máy.";
 "Scale" = "Tỷ lệ";
+"Score my timeline" = "Gắn nhạc vào timeline";
 "Screen" = "Màn hình";
 "Screenshot a frame" = "Chụp một khung hình";
 "Scroll Horizontally" = "Cuộn ngang";
@@ -840,6 +840,7 @@
 "Switch Angle" = "Đổi góc";
 "Switch Angle in Range" = "Đổi góc trong vùng";
 "Switch Mic" = "Đổi micrô";
+"Sync my multicam" = "Đồng bộ multicam";
 "Synchronize" = "Đồng bộ hóa";
 "Synchronized %lld clips" = "Đã đồng bộ %lld clip";
 "Synchronized 1 clip" = "Đã đồng bộ 1 clip";
@@ -864,7 +865,6 @@
 "Theme" = "Chủ đề";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Đây là thước timeline. Giữ Shift và kéo trên thước để chọn vùng cần kết xuất. Bạn có thể chọn bất kỳ khoảng nào để chỉnh sửa bằng AI hoặc tạo nhạc phù hợp với vùng đó.";
 "This is where all your footage and assets live." = "Đây là nơi chứa toàn bộ cảnh quay và tài nguyên của bạn.";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "Đây là bảng Trình kiểm tra. Chọn một clip trên timeline để chỉnh sửa.";
 "This is your preview panel to play a selected media or the whole timeline." = "Đây là bảng xem trước để phát phương tiện đã chọn hoặc toàn bộ timeline.";
 "This model cannot cap the output at 60 FPS." = "Mô hình này không thể giới hạn đầu ra ở 60 FPS.";
 "This permanently removes %@." = "Thao tác này sẽ xóa vĩnh viễn %@.";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "Hoạt ảnh Lottie của bạn đã sẵn sàng.";
 "Your audio clip is ready." = "Clip âm thanh của bạn đã sẵn sàng.";
 "Your image is ready." = "Hình ảnh của bạn đã sẵn sàng.";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "Trình kiểm tra của clip đã chọn — biến đổi, điều chỉnh, âm thanh và nhiều hơn nữa.";
 "Your text clip is ready." = "Clip văn bản của bạn đã sẵn sàng.";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "Timeline của bạn có nửa trên là video và nửa dưới là âm thanh. Đây là nơi bạn chỉnh sửa. Bấm chuột phải vào clip để dùng các tính năng AI như nâng độ phân giải, chỉnh sửa hoặc tạo nhạc.";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "Timeline của bạn có nửa trên là video và nửa dưới là âm thanh. Nhấp vào một clip để kiểm tra — chúng tôi đã chọn sẵn một clip cho bạn.";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "Timeline của bạn có nửa trên là video và nửa dưới là âm thanh. Đây là nơi bạn chỉnh sửa.";
 "Your video is ready." = "Video của bạn đã sẵn sàng.";
 "Zoom In" = "Phóng to";
 "Zoom Out" = "Thu nhỏ";

--- a/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Simplified Chinese localization. Keep keys aligned with en.lproj. */
+/* Generated from app-owned UI copy. Translate values only in other locales. */
 
 "$%lld/mo" = "$%lld/月";
 "$%lld–$%lld · Credits expire at renewal." = "$%lld–$%lld · 积分将在续订时到期。";
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "将范围添加到对话";
 "Add Text" = "添加文本";
 "Add an email above to enable a reply" = "在上方添加电子邮件以接收回复";
-"Add captions to my timeline" = "为我的时间线添加字幕";
+"Add captions" = "添加字幕";
 "Add credits" = "添加积分";
 "Add credits to use Cloud." = "添加积分以使用云端。";
 "Add emoji" = "添加表情符号";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "创建嵌套时间线";
 "Create Video" = "创建视频";
 "Create Video only works on images" = "创建视频仅适用于图像";
-"Create a letterbox opening" = "创建宽银幕开场效果";
 "Create a skill or browse the Community collection." = "创建技能或浏览社区合集。";
-"Create a voiceover" = "创建旁白";
 "Create matching sound for the video" = "为视频创建匹配的声音";
 "Creating…" = "正在创建…";
 "Credits" = "积分";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "自定义宽高比";
 "Custom…" = "自定义…";
 "Cut" = "剪切";
+"Cut to the beat" = "按节拍剪辑";
 "Dark" = "深色";
 "Dark appearance" = "深色外观";
 "Darken" = "变暗";
@@ -384,9 +383,7 @@
 "Generate SFX" = "生成音效";
 "Generate SFX only works on video" = "生成音效仅适用于视频";
 "Generate SFX…" = "生成音效…";
-"Generate an AI video" = "生成 AI 视频";
 "Generate audio" = "生成音频";
-"Generate music and sync to my timeline" = "生成音乐并同步到我的时间线";
 "Generate music for the timeline" = "为时间线生成音乐";
 "Generate music that fits the video" = "生成与视频匹配的音乐";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "使用不同模型和设置生成视频、图像或音频。将素材从上方媒体面板拖入参考框。";
@@ -454,6 +451,7 @@
 "Keep Current" = "保留当前设置";
 "Keep Editing" = "继续编辑";
 "Keep Skill" = "保留技能";
+"Keep the best takes" = "保留最佳镜头";
 "Keeps this much audio before and after detected speech." = "在检测到的语音前后保留此时长的音频。";
 "Keyboard Shortcuts" = "键盘快捷键";
 "Keyframes" = "关键帧";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP 服务器";
 "MCP Setup" = "MCP 设置";
 "Main + Sidebar" = "主面板 + 边栏";
+"Make vertical shorts" = "制作竖屏短片";
 "Manage credits" = "管理积分";
 "Manage subscription" = "管理订阅";
 "Manual setup" = "手动设置";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "打开技能文件夹";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "打开“技能”以浏览社区操作手册、创建自己的技能，或将其添加到其他 Agent。";
 "Open Timeline" = "打开时间线";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "打开“AI 编辑”标签页即可放大分辨率、用提示词编辑、从帧创建视频，或从片段生成音乐、音效、清理人声和配音。";
 "Opening Google" = "正在打开 Google";
 "Opening Google…" = "正在打开 Google…";
 "Open…" = "打开…";
-"Organize my media into structured folders" = "将我的媒体整理到结构化文件夹中";
 "Organize with Agent" = "使用 Agent 整理";
 "Original" = "原始";
 "Original FPS" = "原始帧率";
@@ -701,9 +700,9 @@
 "Report a Problem" = "报告问题";
 "Requires a paid plan" = "需要付费方案";
 "Rerun" = "重新运行";
-"Reset: %@" = "还原：%@";
 "Reset All" = "全部还原";
 "Reset Clipping Indicators" = "还原削波指示器";
+"Reset: %@" = "还原：%@";
 "Resets %@" = "还原 %@";
 "Resolution" = "分辨率";
 "Resolution must be at least 2 × 2 pixels." = "分辨率必须至少为 2 × 2 像素。";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "保存此项目以查看活动";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "保存此项目的副本并在其中包含所有媒体，以便在任何设备上打开。";
 "Scale" = "缩放";
+"Score my timeline" = "为时间线配乐";
 "Screen" = "滤色";
 "Screenshot a frame" = "截取一帧";
 "Scroll Horizontally" = "水平滚动";
@@ -840,6 +840,7 @@
 "Switch Angle" = "切换机位";
 "Switch Angle in Range" = "在范围内切换机位";
 "Switch Mic" = "切换麦克风";
+"Sync my multicam" = "同步多机位";
 "Synchronize" = "同步";
 "Synchronized %lld clips" = "已同步 %lld 个片段";
 "Synchronized 1 clip" = "已同步 1 个片段";
@@ -864,7 +865,6 @@
 "Theme" = "主题";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "这是时间线标尺。按住 Shift 在标尺上拖移以选择渲染范围。你可以选择任意区段进行 AI 编辑，或生成适合该范围的音乐。";
 "This is where all your footage and assets live." = "你的所有素材和资源都位于此处。";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "这是检查器面板。从时间线中选择片段即可进行编辑。";
 "This is your preview panel to play a selected media or the whole timeline." = "这是预览面板，用于播放所选媒体或整个时间线。";
 "This model cannot cap the output at 60 FPS." = "此模型无法将输出限制为 60 FPS。";
 "This permanently removes %@." = "这将永久移除 %@。";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "你的 Lottie 动画已准备就绪。";
 "Your audio clip is ready." = "你的音频片段已准备就绪。";
 "Your image is ready." = "你的图像已准备就绪。";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "所选片段的检查器 — 变换、调整、音频等。";
 "Your text clip is ready." = "你的文本片段已准备就绪。";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "这是你的时间线：上半部分是视频，下半部分是音频。你将在这里进行编辑。右键点按片段可使用放大、编辑或生成音乐等 AI 功能。";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "这是你的时间线：上半部分是视频，下半部分是音频。点按片段即可检查 — 我们已为你选好一个。";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "这是你的时间线：上半部分是视频，下半部分是音频。你将在这里进行编辑。";
 "Your video is ready." = "你的视频已准备就绪。";
 "Zoom In" = "放大";
 "Zoom Out" = "缩小";

--- a/Sources/PalmierPro/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Traditional Chinese localization. Keep keys aligned with en.lproj. */
+/* Generated from app-owned UI copy. Translate values only in other locales. */
 
 "$%lld/mo" = "$%lld/月";
 "$%lld–$%lld · Credits expire at renewal." = "$%lld–$%lld · 積分將在續訂時到期。";
@@ -66,7 +66,7 @@
 "Add Range to Chat" = "將範圍加入對話";
 "Add Text" = "加入文字";
 "Add an email above to enable a reply" = "在上方加入電子郵件以接收回覆";
-"Add captions to my timeline" = "為我的時間軸加入字幕";
+"Add captions" = "加入字幕";
 "Add credits" = "加入積分";
 "Add credits to use Cloud." = "加入積分以使用雲端。";
 "Add emoji" = "加入表情符號";
@@ -227,9 +227,7 @@
 "Create Nested Timeline" = "建立巢狀時間軸";
 "Create Video" = "建立影片";
 "Create Video only works on images" = "建立影片僅適用於影像";
-"Create a letterbox opening" = "建立寬銀幕開場效果";
 "Create a skill or browse the Community collection." = "建立技能或瀏覽社群合集。";
-"Create a voiceover" = "建立旁白";
 "Create matching sound for the video" = "為影片建立匹配的聲音";
 "Creating…" = "正在建立…";
 "Credits" = "積分";
@@ -241,6 +239,7 @@
 "Custom Aspect Ratio" = "自訂長寬比";
 "Custom…" = "自訂…";
 "Cut" = "剪下";
+"Cut to the beat" = "按節拍剪輯";
 "Dark" = "深色";
 "Dark appearance" = "深色外觀";
 "Darken" = "變暗";
@@ -384,9 +383,7 @@
 "Generate SFX" = "產生音效";
 "Generate SFX only works on video" = "產生音效僅適用於影片";
 "Generate SFX…" = "產生音效…";
-"Generate an AI video" = "產生 AI 影片";
 "Generate audio" = "產生音訊";
-"Generate music and sync to my timeline" = "產生音樂並同步到我的時間軸";
 "Generate music for the timeline" = "為時間軸產生音樂";
 "Generate music that fits the video" = "產生與影片匹配的音樂";
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "使用不同模型和設定產生影片、圖像或音訊。將素材從上方媒體面板拖入參考框。";
@@ -454,6 +451,7 @@
 "Keep Current" = "保留目前設定";
 "Keep Editing" = "繼續編輯";
 "Keep Skill" = "保留技能";
+"Keep the best takes" = "保留最佳鏡頭";
 "Keeps this much audio before and after detected speech." = "在偵測到的語音前後保留此時長的音訊。";
 "Keyboard Shortcuts" = "鍵盤快速鍵";
 "Keyframes" = "關鍵影格";
@@ -503,6 +501,7 @@
 "MCP Server" = "MCP 服務器";
 "MCP Setup" = "MCP 設定";
 "Main + Sidebar" = "主面板 + 邊欄";
+"Make vertical shorts" = "製作直式短片";
 "Manage credits" = "管理積分";
 "Manage subscription" = "管理訂閱";
 "Manual setup" = "手動設定";
@@ -606,10 +605,10 @@
 "Open Skills Folder" = "打開技能資料夾";
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "打開“技能”以瀏覽社群操作手冊、建立自己的技能，或將其加入其他 Agent。";
 "Open Timeline" = "打開時間軸";
+"Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "打開「AI 編輯」標籤頁即可放大解析度、用提示詞編輯、從影格建立影片，或從片段產生音樂、音效、清理人聲和配音。";
 "Opening Google" = "正在打開 Google";
 "Opening Google…" = "正在打開 Google…";
 "Open…" = "打開…";
-"Organize my media into structured folders" = "將我的媒體整理到結構化資料夾中";
 "Organize with Agent" = "使用 Agent 整理";
 "Original" = "原始";
 "Original FPS" = "原始影格率";
@@ -701,9 +700,9 @@
 "Report a Problem" = "報告問題";
 "Requires a paid plan" = "需要付費方案";
 "Rerun" = "重新運行";
-"Reset: %@" = "還原：%@";
 "Reset All" = "全部還原";
 "Reset Clipping Indicators" = "還原削波指示器";
+"Reset: %@" = "還原：%@";
 "Resets %@" = "還原 %@";
 "Resolution" = "解析度";
 "Resolution must be at least 2 × 2 pixels." = "解析度必須至少為 2 × 2 像素。";
@@ -736,6 +735,7 @@
 "Save this project to view activity" = "儲存此專案以檢視活動";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "儲存此專案的副本並在其中包含所有媒體，以便在任何裝置上打開。";
 "Scale" = "縮放";
+"Score my timeline" = "為時間軸配樂";
 "Screen" = "濾色";
 "Screenshot a frame" = "截取一影格";
 "Scroll Horizontally" = "水平捲動";
@@ -840,6 +840,7 @@
 "Switch Angle" = "切換機位";
 "Switch Angle in Range" = "在範圍內切換機位";
 "Switch Mic" = "切換麥克風";
+"Sync my multicam" = "同步多機位";
 "Synchronize" = "同步";
 "Synchronized %lld clips" = "已同步 %lld 個片段";
 "Synchronized 1 clip" = "已同步 1 個片段";
@@ -864,7 +865,6 @@
 "Theme" = "主題";
 "This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "這是時間軸標尺。按住 Shift 在標尺上拖移以選擇算繪範圍。你可以選擇任意區段進行 AI 編輯，或產生適合該範圍的音樂。";
 "This is where all your footage and assets live." = "你的所有素材和資源都位於此處。";
-"This is your inspector panel. Select a clip from the timeline to edit it." = "這是檢查器面板。從時間軸中選擇片段即可進行編輯。";
 "This is your preview panel to play a selected media or the whole timeline." = "這是預覽面板，用於播放所選媒體或整個時間軸。";
 "This model cannot cap the output at 60 FPS." = "此模型無法將輸出限制為 60 FPS。";
 "This permanently removes %@." = "這將永久移除 %@。";
@@ -974,8 +974,10 @@
 "Your Lottie animation is ready." = "你的 Lottie 動畫已準備就緒。";
 "Your audio clip is ready." = "你的音訊片段已準備就緒。";
 "Your image is ready." = "你的影像已準備就緒。";
+"Your inspector for the selected clip — transform, adjust, audio, and more." = "所選片段的檢查器 — 變換、調整、音訊等。";
 "Your text clip is ready." = "你的文字片段已準備就緒。";
-"Your timeline: the top half is video, the bottom half is audio. This is where you edit. Right-click a clip for some cool AI features such as upscale, edit, or generate music." = "這是你的時間軸：上半部分是影片，下半部分是音訊。你將在這裡進行編輯。右鍵按一下片段可使用放大、編輯或產生音樂等 AI 功能。";
+"Your timeline: the top half is video, the bottom half is audio. Click a clip to inspect it — we've selected one for you." = "這是你的時間軸：上半部分是影片，下半部分是音訊。按一下片段即可檢查 — 我們已為你選好一個。";
+"Your timeline: the top half is video, the bottom half is audio. This is where you edit." = "這是你的時間軸：上半部分是影片，下半部分是音訊。你將在這裡進行編輯。";
 "Your video is ready." = "你的影片已準備就緒。";
 "Zoom In" = "放大";
 "Zoom Out" = "縮小";

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -30,6 +30,7 @@ enum Analytics {
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
         case agentToolCalled = "agent tool called"
+        case agentStarterPromptClicked = "agent starter prompt clicked"
         case mcpSessionActivated = "mcp session activated"
     }
 
@@ -145,6 +146,7 @@ enum Analytics {
             Event.exportFailed.rawValue,
             Event.agentSessionStarted.rawValue,
             Event.agentToolCalled.rawValue,
+            Event.agentStarterPromptClicked.rawValue,
             Event.mcpSessionActivated.rawValue,
             "$identify",
         ])
@@ -209,6 +211,7 @@ enum Analytics {
             "project_id",
             "resolution",
             "source",
+            "starter_prompt",
             "status",
             "timeline_changed",
             "tool_name",

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -157,6 +157,16 @@ if [ -d "$RES_BUNDLE/Images" ]; then
   cp -R "$RES_BUNDLE/Images" "$APP/Contents/Resources/"
 fi
 # .lproj folders must live at the bundle root for macOS to resolve them.
+# Incremental SwiftPM builds can leave removed locales behind — prune those first.
+SRC_LOCALIZATION="$ROOT/Sources/PalmierPro/Resources/Localization"
+for locale_dir in "$RES_BUNDLE"/*.lproj; do
+  [ -d "$locale_dir" ] || continue
+  locale_name="$(basename "$locale_dir")"
+  if [ ! -d "$SRC_LOCALIZATION/$locale_name" ]; then
+    echo "==> removing stale localization $locale_name from resource bundle"
+    rm -rf "$locale_dir"
+  fi
+done
 LOCALIZATION_COUNT=0
 for locale_dir in "$RES_BUNDLE"/*.lproj; do
   [ -d "$locale_dir" ] || continue

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -157,16 +157,6 @@ if [ -d "$RES_BUNDLE/Images" ]; then
   cp -R "$RES_BUNDLE/Images" "$APP/Contents/Resources/"
 fi
 # .lproj folders must live at the bundle root for macOS to resolve them.
-# Incremental SwiftPM builds can leave removed locales behind — prune those first.
-SRC_LOCALIZATION="$ROOT/Sources/PalmierPro/Resources/Localization"
-for locale_dir in "$RES_BUNDLE"/*.lproj; do
-  [ -d "$locale_dir" ] || continue
-  locale_name="$(basename "$locale_dir")"
-  if [ ! -d "$SRC_LOCALIZATION/$locale_name" ]; then
-    echo "==> removing stale localization $locale_name from resource bundle"
-    rm -rf "$locale_dir"
-  fi
-done
 LOCALIZATION_COUNT=0
 for locale_dir in "$RES_BUNDLE"/*.lproj; do
   [ -d "$locale_dir" ] || continue


### PR DESCRIPTION
Tour includes AI edit tab

## Summary
- Reorder the editor tour by panel (media → preview → timeline → inspector → AI Edit → agent) and auto-select a clip to showcase the AI Edit tab.
- Refresh empty-chat agent starter cards (best takes, multicam, B-roll, score, beat cut, captions, vertical shorts) with PostHog `agent starter prompt clicked` tracking via stable `starter_prompt` ids.
- Sync / translate new tour and starter UI copy; prune stale SwiftPM `.lproj` folders in `bundle.sh` so removed locales (e.g. `de`) cannot break `dev.sh`.

## Approach
- Tour steps use a `Prepare` action to select an eligible clip and request Inspector Video / AI Edit tabs through `inspectorClipTabRequest` (consumed by `InspectorView`).
- Starter chip titles stay localized; prompt bodies remain English for the agent. Analytics uses non-localized ids.
- Bundle assembly now drops resource-bundle locales that no longer exist under `Sources/.../Localization` before requiring both `Localizable.strings` and `InfoPlist.strings`.

## Testing
- `swift build` — passed
- `node scripts/localization/check.mjs --require-complete` — passed
- Manual: start tutorial on a sample with clips — confirm Timeline → Inspector (Video) → AI Edit order and spotlight
- Manual: empty agent chat — confirm new starter cards populate the draft and fire analytics in a production-telemetry build
- Manual: `SIGNING_IDENTITY="-" ./scripts/dev.sh` after a build that previously contained stale `de.lproj` — should assemble without missing InfoPlist.strings

## Change statistics
- Logic / UI: ~+170 / −40 across tour, inspector, agent panel, analytics, bundle script
- Localization: ~+130 / −110 across `en` + 14 target locales

Made with [Cursor](https://cursor.com)