### PR TITLE
[telemetry] Attribute editor and generation activity

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -407,7 +407,7 @@ final class AgentService {
                 }
 
                 if stopReason == .toolUse {
-                    await runPendingToolUses(assistantID: assistantID)
+                    await runPendingToolUses(assistantID: assistantID, conversationID: conversationID)
                     continue loop
                 }
                 break loop
@@ -450,7 +450,7 @@ final class AgentService {
         messages[index].blocks.append(.toolUse(id: toolUseID, name: name, inputJSON: inputJSON))
     }
 
-    private func runPendingToolUses(assistantID: UUID) async {
+    private func runPendingToolUses(assistantID: UUID, conversationID: UUID) async {
         guard let assistantIndex = assistantMessageIndex(id: assistantID) else { return }
         guard let executor = toolExecutor else {
             messages.append(AgentMessage(role: .user, blocks: [.text("Tool executor unavailable.")]))
@@ -469,7 +469,11 @@ final class AgentService {
                 resultBlocks.append(.toolResult(toolUseId: use.id, content: [.text("Cancelled")], isError: true))
                 continue
             }
-            let result = await executor.execute(name: use.name, args: Self.parseJSONObject(use.input))
+            let result = await executor.execute(
+                name: use.name,
+                args: Self.parseJSONObject(use.input),
+                sessionID: conversationID.uuidString
+            )
             resultBlocks.append(.toolResult(toolUseId: use.id, content: result.content, isError: result.isError))
         }
         if !resultBlocks.isEmpty {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -63,8 +63,18 @@ final class ToolExecutor {
         source: String = "agent",
         sessionID: String? = nil
     ) async -> ToolResult {
-        let started = ContinuousClock.now
         let origin = Analytics.Origin(source: source, sessionID: sessionID ?? analyticsSessionID)
+        return await Analytics.$origin.withValue(origin) {
+            await executeWithOrigin(name: name, args: args, origin: origin)
+        }
+    }
+
+    private func executeWithOrigin(
+        name: String,
+        args: [String: Any],
+        origin: Analytics.Origin
+    ) async -> ToolResult {
+        let started = ContinuousClock.now
         guard let tool = ToolName(rawValue: name) else {
             let result = ToolResult.error("Unknown tool: \(name)")
             captureToolAnalytics(
@@ -130,9 +140,7 @@ final class ToolExecutor {
         )
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
-            result = try await Analytics.$origin.withValue(origin) {
-                try await run(tool, editor, resolved)
-            }
+            result = try await run(tool, editor, resolved)
         } catch let err as ToolError {
             result = .error(err.message)
         } catch {
@@ -253,7 +261,7 @@ final class ToolExecutor {
                 options: .regularExpression
             )
             .replacingOccurrences(
-                of: #"/(?:Users|Volumes|private|tmp)/[^\s,\"']+"#,
+                of: #"/(?:Users|Volumes|private|tmp)(?:/[^\r\n]*)?"#,
                 with: "[path redacted]",
                 options: .regularExpression
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -15,6 +15,7 @@ final class ToolExecutor {
     private weak var boundProject: VideoProject?
     private var mcpClientInfo: MCPClientInfo?
     private(set) var mcpSessionActivation = Analytics.SessionActivation()
+    private let analyticsSessionID = UUID().uuidString
     let exportQueue: ExportQueue
 
     var editor: EditorViewModel? {
@@ -56,20 +57,27 @@ final class ToolExecutor {
     var feedbackState = FeedbackState()
     var lastTranscriptContext: TranscriptionToolContext?
 
-    func execute(name: String, args: [String: Any], source: String = "agent") async -> ToolResult {
+    func execute(
+        name: String,
+        args: [String: Any],
+        source: String = "agent",
+        sessionID: String? = nil
+    ) async -> ToolResult {
         let started = ContinuousClock.now
+        let origin = Analytics.Origin(source: source, sessionID: sessionID ?? analyticsSessionID)
         guard let tool = ToolName(rawValue: name) else {
+            let result = ToolResult.error("Unknown tool: \(name)")
             captureToolAnalytics(
                 toolName: name,
-                source: source,
+                origin: origin,
                 projectId: editor?.projectId,
-                status: "failed",
+                result: result,
                 started: started,
                 failureReason: "unknown_tool"
             )
-            return .error("Unknown tool: \(name)")
+            return result
         }
-        activateMCPSessionIfNeeded(source: source, toolName: tool.rawValue)
+        activateMCPSessionIfNeeded(source: origin.source, toolName: tool.rawValue)
 
         // project tools act on AppState before editor is available
         switch tool {
@@ -77,9 +85,9 @@ final class ToolExecutor {
             let result = await manageProject(args)
             captureToolAnalytics(
                 toolName: tool.rawValue,
-                source: source,
+                origin: origin,
                 projectId: editor?.projectId,
-                status: result.isError ? "failed" : "finished",
+                result: result,
                 started: started
             )
             return result
@@ -88,19 +96,29 @@ final class ToolExecutor {
         }
 
         if !Self.canReadInactiveProject(tool), let error = projectFocusError() {
-            return .error(error)
+            let result = ToolResult.error(error)
+            captureToolAnalytics(
+                toolName: tool.rawValue,
+                origin: origin,
+                projectId: editor?.projectId,
+                result: result,
+                started: started,
+                failureReason: "project_inactive"
+            )
+            return result
         }
 
         guard let editor else {
+            let result = ToolResult.error("Editor not available")
             captureToolAnalytics(
                 toolName: tool.rawValue,
-                source: source,
+                origin: origin,
                 projectId: nil,
-                status: "failed",
+                result: result,
                 started: started,
                 failureReason: "editor_unavailable"
             )
-            return .error("Editor not available")
+            return result
         }
         let before = editor.timelines
         let idsBefore = currentIdUniverse(editor)
@@ -112,7 +130,9 @@ final class ToolExecutor {
         )
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
-            result = try await run(tool, editor, resolved)
+            result = try await Analytics.$origin.withValue(origin) {
+                try await run(tool, editor, resolved)
+            }
         } catch let err as ToolError {
             result = .error(err.message)
         } catch {
@@ -141,9 +161,9 @@ final class ToolExecutor {
         }
         captureToolAnalytics(
             toolName: tool.rawValue,
-            source: source,
+            origin: origin,
             projectId: editor.projectId,
-            status: result.isError ? "failed" : "finished",
+            result: result,
             started: started,
             timelineChanged: editor.timelines != before
         )
@@ -159,6 +179,7 @@ final class ToolExecutor {
     func mcpSessionActivationProperties(toolName: String) -> Analytics.Payload {
         var properties: Analytics.Payload = [
             "source": "mcp",
+            "session_id": analyticsSessionID,
             "tool_name": toolName,
         ]
         if let mcpClientInfo {
@@ -189,18 +210,19 @@ final class ToolExecutor {
 
     private func captureToolAnalytics(
         toolName: String,
-        source: String,
+        origin: Analytics.Origin,
         projectId: String?,
-        status: String,
+        result: ToolResult,
         started: ContinuousClock.Instant? = nil,
         timelineChanged: Bool? = nil,
         failureReason: String? = nil
     ) {
         var payload: [String: Any] = [
             "tool_name": toolName,
-            "source": source,
+            "source": origin.source,
             "project_id": projectId ?? "unknown",
-            "status": status,
+            "session_id": origin.sessionID,
+            "status": result.isError ? "failed" : "finished",
         ]
         if let started {
             payload["tool_duration_seconds"] = durationSeconds(since: started)
@@ -208,10 +230,33 @@ final class ToolExecutor {
         if let timelineChanged {
             payload["timeline_changed"] = timelineChanged
         }
-        if let failureReason {
+        if let failureReason = failureReason ?? (result.isError ? "tool_error" : nil) {
             payload["failure_reason"] = failureReason
         }
+        if let errorMessage = Self.sanitizedToolErrorMessage(result) {
+            payload["error_message"] = errorMessage
+        }
         Analytics.capture(.agentToolCalled, properties: payload)
+    }
+
+    static func sanitizedToolErrorMessage(_ result: ToolResult) -> String? {
+        guard result.isError else { return nil }
+        let message = result.content.compactMap { block -> String? in
+            guard case .text(let text) = block else { return nil }
+            return text
+        }.joined(separator: "\n")
+        guard !message.isEmpty else { return nil }
+        return String(message.prefix(2_048))
+            .replacingOccurrences(
+                of: #"(?:https?|file)://[^\s\"']+"#,
+                with: "[url redacted]",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"/(?:Users|Volumes|private|tmp)/[^\s,\"']+"#,
+                with: "[path redacted]",
+                options: .regularExpression
+            )
     }
 
     private func durationSeconds(since started: ContinuousClock.Instant) -> Double {

--- a/Sources/PalmierPro/Editor/EditorUndo.swift
+++ b/Sources/PalmierPro/Editor/EditorUndo.swift
@@ -5,6 +5,7 @@ final class EditorUndo {
     private weak var manager: UndoManager?
     private var transactionActive = false
     private var transactionGroupOpened = false
+    var onActionCommitted: (() -> Void)?
 
     func attach(_ manager: UndoManager?) {
         self.manager = manager
@@ -29,6 +30,7 @@ final class EditorUndo {
             if groupOpened {
                 manager.setActionName(actionName)
                 manager.endUndoGrouping()
+                onActionCommitted?()
             }
             if restoresEventGrouping { manager.groupsByEvent = true }
             assert(manager.groupingLevel == initialGroupingLevel)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -284,6 +284,9 @@ final class EditorViewModel {
         mediaVisualCache.speech.onAnalyzingCountChange = { [weak self] count in
             self?.speechAnalyzingCount = count
         }
+        undo.onActionCommitted = { [weak self] in
+            self?.captureCommittedEdit()
+        }
 
         // Re-check media presence when the app regains focus: a user may have
         // deleted/moved backing files in Finder (or ejected a volume) while we
@@ -293,6 +296,12 @@ final class EditorViewModel {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshMissingMediaCache() }
         }
+    }
+
+    private func captureCommittedEdit() {
+        var payload = Analytics.originProperties()
+        payload["project_id"] = projectId ?? "unknown"
+        Analytics.capture(.editorEditCommitted, properties: payload)
     }
 
     @ObservationIgnored private nonisolated(unsafe) var didBecomeActiveObserver: NSObjectProtocol?

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -71,6 +71,7 @@ final class GenerationService {
             placeholders.append(placeholder)
         }
         let primaryId = placeholders[0].id
+        captureSubmission(genInput: genInput, assetType: assetType, outputCount: count, editor: editor)
 
         Task { @MainActor in
             do {
@@ -122,6 +123,24 @@ final class GenerationService {
         }
 
         return primaryId
+    }
+
+    private func captureSubmission(
+        genInput: GenerationInput,
+        assetType: ClipType,
+        outputCount: Int,
+        editor: EditorViewModel
+    ) {
+        var payload = Analytics.originProperties()
+        payload["project_id"] = editor.projectId ?? "unknown"
+        payload["model"] = genInput.model
+        payload["generation_type"] = Self.generationType(assetType: assetType, genInput: genInput)
+        payload["output_count"] = outputCount
+        Analytics.capture(.generationSubmitted, properties: payload)
+    }
+
+    nonisolated static func generationType(assetType: ClipType, genInput: GenerationInput) -> String {
+        genInput.upscaleSettings == nil ? assetType.rawValue : "upscale"
     }
 
     private func prepareReferences(

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -6,6 +6,21 @@ import PostHog
 enum Analytics {
     typealias Payload = [String: Any]
 
+    struct Origin: Sendable {
+        let source: String
+        let sessionID: String
+    }
+
+    /// Attributes synchronous work started by the agent or an MCP client.
+    @TaskLocal static var origin: Origin?
+
+    static let manualSource = "manual"
+
+    static func originProperties() -> Payload {
+        guard let origin else { return ["source": manualSource] }
+        return ["source": origin.source, "session_id": origin.sessionID]
+    }
+
     struct SessionActivation {
         private(set) var isActivated: Bool
 
@@ -30,6 +45,7 @@ enum Analytics {
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
         case agentToolCalled = "agent tool called"
+        case generationSubmitted = "generation submitted"
         case mcpSessionActivated = "mcp session activated"
     }
 
@@ -145,6 +161,7 @@ enum Analytics {
             Event.exportFailed.rawValue,
             Event.agentSessionStarted.rawValue,
             Event.agentToolCalled.rawValue,
+            Event.generationSubmitted.rawValue,
             Event.mcpSessionActivated.rawValue,
             "$identify",
         ])
@@ -201,13 +218,17 @@ enum Analytics {
         Set([
             "active_day",
             "client_info",
+            "error_message",
             "export_duration_seconds",
             "failure_reason",
             "format",
+            "generation_type",
             "mode",
             "model",
+            "output_count",
             "project_id",
             "resolution",
+            "session_id",
             "source",
             "status",
             "timeline_changed",

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -35,7 +35,7 @@ enum Analytics {
         }
     }
 
-    enum Event: String {
+    enum Event: String, CaseIterable {
         case appOpened = "app opened"
         case projectCreated = "project created"
         case projectOpened = "project opened"
@@ -45,6 +45,7 @@ enum Analytics {
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
         case agentToolCalled = "agent tool called"
+        case editorEditCommitted = "editor edit committed"
         case generationSubmitted = "generation submitted"
         case mcpSessionActivated = "mcp session activated"
     }
@@ -52,6 +53,7 @@ enum Analytics {
     #if PRODUCTION_TELEMETRY
     private static let projectToken = Bundle.main.object(forInfoDictionaryKey: "PostHogProjectToken") as? String ?? ""
     private static let host = Bundle.main.object(forInfoDictionaryKey: "PostHogHost") as? String ?? PostHogConfig.defaultHost
+    private static let captureQueue = DispatchQueue(label: "io.palmier.pro.analytics.capture")
     #endif
     private static let enabledKey = "io.palmier.pro.analytics.enabled"
 
@@ -126,7 +128,12 @@ enum Analytics {
     static func capture(_ event: Event, properties: Payload = [:]) -> Bool {
         #if PRODUCTION_TELEMETRY
         guard didStart, isEnabled else { return false }
-        PostHogSDK.shared.capture(event.rawValue, properties: cleanedPayload(properties))
+        let properties = cleanedPayload(properties)
+        guard let data = try? JSONSerialization.data(withJSONObject: properties) else { return false }
+        captureQueue.async {
+            guard let properties = try? JSONSerialization.jsonObject(with: data) as? Payload else { return }
+            PostHogSDK.shared.capture(event.rawValue, properties: properties)
+        }
         return true
         #else
         return false
@@ -150,22 +157,7 @@ enum Analytics {
         }
     }
 
-    private static var allowedEvents: Set<String> {
-        Set([
-            Event.appOpened.rawValue,
-            Event.projectCreated.rawValue,
-            Event.projectOpened.rawValue,
-            Event.projectActive.rawValue,
-            Event.exportStarted.rawValue,
-            Event.exportFinished.rawValue,
-            Event.exportFailed.rawValue,
-            Event.agentSessionStarted.rawValue,
-            Event.agentToolCalled.rawValue,
-            Event.generationSubmitted.rawValue,
-            Event.mcpSessionActivated.rawValue,
-            "$identify",
-        ])
-    }
+    private static let allowedEvents = Set(Event.allCases.map(\.rawValue)).union(["$identify"])
 
     private static func cleanedPayload(_ payload: Payload) -> Payload {
         var out: Payload = [:]

--- a/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
+++ b/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
@@ -52,8 +52,21 @@ struct AnalyticsSessionActivationTests {
         let clientInfo = try #require(properties["client_info"] as? Analytics.Payload)
 
         #expect(properties["source"] as? String == "mcp")
+        #expect((properties["session_id"] as? String)?.isEmpty == false)
         #expect(properties["tool_name"] as? String == "get_timeline")
         #expect(clientInfo["name"] as? String == "Cursor")
         #expect(clientInfo["version"] as? String == "1.0.0")
+    }
+
+    @Test @MainActor func toolErrorMessageOmitsAbsolutePathsAndURLs() {
+        let result = ToolResult.error(
+            "Import failed at /Users/editor/Movies/secret.mov from https://example.com/private"
+        )
+
+        let message = ToolExecutor.sanitizedToolErrorMessage(result)
+
+        #expect(message?.contains("Import failed") == true)
+        #expect(message?.contains("secret.mov") == false)
+        #expect(message?.contains("example.com") == false)
     }
 }

--- a/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
+++ b/Tests/PalmierProTests/Agent/AnalyticsSessionActivationTests.swift
@@ -60,13 +60,19 @@ struct AnalyticsSessionActivationTests {
 
     @Test @MainActor func toolErrorMessageOmitsAbsolutePathsAndURLs() {
         let result = ToolResult.error(
-            "Import failed at /Users/editor/Movies/secret.mov from https://example.com/private"
+            """
+            Import failed at /Users/editor/Library/Application Support/secret.mov
+            Download failed from https://example.com/private
+            Retry the operation.
+            """
         )
 
         let message = ToolExecutor.sanitizedToolErrorMessage(result)
 
         #expect(message?.contains("Import failed") == true)
+        #expect(message?.contains("Application Support") == false)
         #expect(message?.contains("secret.mov") == false)
         #expect(message?.contains("example.com") == false)
+        #expect(message?.contains("Retry the operation.") == true)
     }
 }

--- a/Tests/PalmierProTests/Editor/EditorUndoTests.swift
+++ b/Tests/PalmierProTests/Editor/EditorUndoTests.swift
@@ -82,6 +82,40 @@ struct EditorUndoTests {
         #expect(manager.undoActionName == "Outer")
     }
 
+    @Test func reportsOnlyCommittedOutermostActionsWithOrigin() {
+        let (undo, manager, counter) = harness()
+        var committedActionCount = 0
+        var origin: Analytics.Origin?
+        undo.onActionCommitted = {
+            committedActionCount += 1
+            origin = Analytics.origin
+        }
+
+        undo.perform("No-op") {}
+        Analytics.$origin.withValue(Analytics.Origin(source: "agent", sessionID: "session-1")) {
+            undo.perform("Outer") {
+                setCounter(1, actionName: "Inner", counter: counter, undo: undo)
+            }
+        }
+
+        #expect(committedActionCount == 1)
+        #expect(origin?.source == "agent")
+        #expect(origin?.sessionID == "session-1")
+        withExtendedLifetime(manager) {}
+    }
+
+    @Test func replayingAnActionReportsNoNewCommit() {
+        let (undo, manager, counter) = harness()
+        setCounter(1, actionName: "Set Counter", counter: counter, undo: undo)
+        var committedActionCount = 0
+        undo.onActionCommitted = { committedActionCount += 1 }
+
+        manager.undo()
+        manager.redo()
+
+        #expect(committedActionCount == 0)
+    }
+
     @Test func transactionDoesNotCloseArmedEventGroup() {
         let (undo, manager, counter) = harness()
         let textStorage = UndoCounter()

--- a/Tests/PalmierProTests/Generation/GenerationTelemetryTests.swift
+++ b/Tests/PalmierProTests/Generation/GenerationTelemetryTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Generation telemetry")
+struct GenerationTelemetryTests {
+    private func genInput(upscale: UpscaleSettings? = nil) -> GenerationInput {
+        GenerationInput(
+            prompt: "a wide shot of a harbor at dawn",
+            model: "seedance-2.0",
+            duration: 5,
+            aspectRatio: "16:9",
+            resolution: nil,
+            upscaleSettings: upscale
+        )
+    }
+
+    @Test(arguments: [ClipType.video, .image, .audio])
+    func generationTypeMatchesAssetType(assetType: ClipType) {
+        let type = GenerationService.generationType(assetType: assetType, genInput: genInput())
+
+        #expect(type == assetType.rawValue)
+    }
+
+    @Test func upscaleIsReportedSeparatelyFromItsAssetType() {
+        let input = genInput(upscale: UpscaleSettings())
+
+        #expect(GenerationService.generationType(assetType: .video, genInput: input) == "upscale")
+        #expect(GenerationService.generationType(assetType: .image, genInput: input) == "upscale")
+    }
+
+    @Test func submissionOutsideAToolRunIsAttributedToTheUser() {
+        let properties = Analytics.originProperties()
+
+        #expect(properties["source"] as? String == Analytics.manualSource)
+        #expect(properties["session_id"] == nil)
+    }
+
+    @Test func submissionInsideAToolRunCarriesItsSourceAndSession() {
+        let origin = Analytics.Origin(source: "mcp", sessionID: "session-1")
+
+        let properties = Analytics.$origin.withValue(origin) { Analytics.originProperties() }
+
+        #expect(properties["source"] as? String == "mcp")
+        #expect(properties["session_id"] as? String == "session-1")
+    }
+}


### PR DESCRIPTION
1. manual generation vs agent generation
2. manual edit vs agent edit
3. tool error msg

## Summary
- Distinguish manual, Agent, and MCP generation submissions and committed editor actions in PostHog.
- Record sanitized tool error messages so failed automation can be diagnosed without exposing URLs or filesystem paths.
- Move PostHog event capture off the main thread to avoid synchronous SDK filesystem work during editing.

## Approach
- Propagate a stable source and session ID through `TaskLocal` context for each tool execution, then reuse that context in generation and editor telemetry.
- Emit generation telemetry from the shared generation service so panel and tool submissions use one path.
- Emit edit telemetry only after the outermost undoable action commits; no-ops, undo, and redo do not create edit events.
- Serialize cleaned payloads into a Sendable snapshot and deliver them through a dedicated serial queue, preserving order while keeping PostHog disk writes off-main.
- Truncate tool errors to 2,048 characters and redact URLs and absolute paths before capture.
- 
## Change statistics
- Production logic: +131 / -39 lines.
- Tests: +94 / -0 lines.
- Total: +225 / -39 lines across 9 files.

Made with [Cursor](https://cursor.com)