### PR TITLE
[agent] Stream summarized thinking in chat

### DIFF
--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -413,11 +413,12 @@ final class AgentService {
                 }
 
                 dropEmptyAssistantTurn(id: assistantID)
-                if Task.isCancelled { break loop }
                 if stopReason == .toolUse {
                     await runPendingToolUses(assistantID: assistantID, conversationID: conversationID)
+                    if Task.isCancelled { break loop }
                     continue loop
                 }
+                if Task.isCancelled { break loop }
                 break loop
             } catch is CancellationError {
                 dropEmptyAssistantTurn(id: assistantID)

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -401,6 +401,8 @@ final class AgentService {
                         appendThinkingDelta(chunk, toAssistant: assistantID)
                     case .thinkingSignature(let signature):
                         appendThinkingSignature(signature, toAssistant: assistantID)
+                    case .redactedThinking(let data):
+                        appendRedactedThinking(data, toAssistant: assistantID)
                     case .textDelta(let chunk):
                         appendTextDelta(chunk, toAssistant: assistantID)
                     case .toolUseComplete(let id, let name, let inputJSON):
@@ -410,6 +412,8 @@ final class AgentService {
                     }
                 }
 
+                dropEmptyAssistantTurn(id: assistantID)
+                if Task.isCancelled { break loop }
                 if stopReason == .toolUse {
                     await runPendingToolUses(assistantID: assistantID, conversationID: conversationID)
                     continue loop
@@ -434,9 +438,10 @@ final class AgentService {
         messages.firstIndex { $0.id == id && $0.role == .assistant }
     }
 
-    private func dropEmptyAssistantTurn(id: UUID) {
-        guard let index = assistantMessageIndex(id: id),
-              messages[index].blocks.isEmpty else { return }
+    func dropEmptyAssistantTurn(id: UUID) {
+        guard let index = assistantMessageIndex(id: id) else { return }
+        messages[index].blocks.removeAll { Self.contentBlockJSON($0) == nil }
+        guard messages[index].blocks.isEmpty else { return }
         messages.remove(at: index)
     }
 
@@ -462,6 +467,11 @@ final class AgentService {
         } else {
             messages[index].blocks.append(.thinking(text: "", signature: chunk))
         }
+    }
+
+    private func appendRedactedThinking(_ data: String, toAssistant id: UUID) {
+        guard let index = assistantMessageIndex(id: id) else { return }
+        messages[index].blocks.append(.redactedThinking(data: data))
     }
 
     private func appendTextDelta(_ chunk: String, toAssistant id: UUID) {
@@ -636,11 +646,13 @@ final class AgentService {
         return out
     }
 
-    private static func contentBlockJSON(_ block: AgentContentBlock) -> [String: Any]? {
+    static func contentBlockJSON(_ block: AgentContentBlock) -> [String: Any]? {
         switch block {
         case .thinking(let text, let signature):
             guard !signature.isEmpty else { return nil }
             return ["type": "thinking", "thinking": text, "signature": signature]
+        case .redactedThinking(let data):
+            return ["type": "redacted_thinking", "data": data]
         case .text(let s):
             guard !s.isEmpty else { return nil }
             return ["type": "text", "text": s]
@@ -694,13 +706,14 @@ struct AgentMessage: Identifiable, Codable {
 
 enum AgentContentBlock: Codable {
     case thinking(text: String, signature: String)
+    case redactedThinking(data: String)
     case text(String)
     case toolUse(id: String, name: String, inputJSON: String)
     case toolResult(toolUseId: String, content: [ToolResult.Block], isError: Bool)
 
-    private enum Kind: String, Codable { case thinking, text, toolUse, toolResult }
+    private enum Kind: String, Codable { case thinking, redactedThinking, text, toolUse, toolResult }
     private enum CodingKeys: String, CodingKey {
-        case kind, text, signature, id, name, input, toolUseId, content, isError
+        case kind, text, signature, data, id, name, input, toolUseId, content, isError
     }
 
     init(from decoder: Decoder) throws {
@@ -711,6 +724,8 @@ enum AgentContentBlock: Codable {
                 text: try c.decode(String.self, forKey: .text),
                 signature: try c.decode(String.self, forKey: .signature)
             )
+        case .redactedThinking:
+            self = .redactedThinking(data: try c.decode(String.self, forKey: .data))
         case .text:
             self = .text(try c.decode(String.self, forKey: .text))
         case .toolUse:
@@ -735,6 +750,9 @@ enum AgentContentBlock: Codable {
             try c.encode(Kind.thinking, forKey: .kind)
             try c.encode(text, forKey: .text)
             try c.encode(signature, forKey: .signature)
+        case .redactedThinking(let data):
+            try c.encode(Kind.redactedThinking, forKey: .kind)
+            try c.encode(data, forKey: .data)
         case .text(let s):
             try c.encode(Kind.text, forKey: .kind)
             try c.encode(s, forKey: .text)

--- a/Sources/PalmierPro/Agent/AgentService.swift
+++ b/Sources/PalmierPro/Agent/AgentService.swift
@@ -397,6 +397,10 @@ final class AgentService {
                 for try await event in stream {
                     try Task.checkCancellation()
                     switch event {
+                    case .thinkingDelta(let chunk):
+                        appendThinkingDelta(chunk, toAssistant: assistantID)
+                    case .thinkingSignature(let signature):
+                        appendThinkingSignature(signature, toAssistant: assistantID)
                     case .textDelta(let chunk):
                         appendTextDelta(chunk, toAssistant: assistantID)
                     case .toolUseComplete(let id, let name, let inputJSON):
@@ -434,6 +438,30 @@ final class AgentService {
         guard let index = assistantMessageIndex(id: id),
               messages[index].blocks.isEmpty else { return }
         messages.remove(at: index)
+    }
+
+    private func appendThinkingDelta(_ chunk: String, toAssistant id: UUID) {
+        guard let index = assistantMessageIndex(id: id) else { return }
+        if case .thinking(let existing, let signature)? = messages[index].blocks.last {
+            messages[index].blocks[messages[index].blocks.count - 1] = .thinking(
+                text: existing + chunk,
+                signature: signature
+            )
+        } else {
+            messages[index].blocks.append(.thinking(text: chunk, signature: ""))
+        }
+    }
+
+    private func appendThinkingSignature(_ chunk: String, toAssistant id: UUID) {
+        guard let index = assistantMessageIndex(id: id) else { return }
+        if case .thinking(let text, let existing)? = messages[index].blocks.last {
+            messages[index].blocks[messages[index].blocks.count - 1] = .thinking(
+                text: text,
+                signature: existing + chunk
+            )
+        } else {
+            messages[index].blocks.append(.thinking(text: "", signature: chunk))
+        }
     }
 
     private func appendTextDelta(_ chunk: String, toAssistant id: UUID) {
@@ -610,6 +638,9 @@ final class AgentService {
 
     private static func contentBlockJSON(_ block: AgentContentBlock) -> [String: Any]? {
         switch block {
+        case .thinking(let text, let signature):
+            guard !signature.isEmpty else { return nil }
+            return ["type": "thinking", "thinking": text, "signature": signature]
         case .text(let s):
             guard !s.isEmpty else { return nil }
             return ["type": "text", "text": s]
@@ -662,18 +693,24 @@ struct AgentMessage: Identifiable, Codable {
 }
 
 enum AgentContentBlock: Codable {
+    case thinking(text: String, signature: String)
     case text(String)
     case toolUse(id: String, name: String, inputJSON: String)
     case toolResult(toolUseId: String, content: [ToolResult.Block], isError: Bool)
 
-    private enum Kind: String, Codable { case text, toolUse, toolResult }
+    private enum Kind: String, Codable { case thinking, text, toolUse, toolResult }
     private enum CodingKeys: String, CodingKey {
-        case kind, text, id, name, input, toolUseId, content, isError
+        case kind, text, signature, id, name, input, toolUseId, content, isError
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         switch try c.decode(Kind.self, forKey: .kind) {
+        case .thinking:
+            self = .thinking(
+                text: try c.decode(String.self, forKey: .text),
+                signature: try c.decode(String.self, forKey: .signature)
+            )
         case .text:
             self = .text(try c.decode(String.self, forKey: .text))
         case .toolUse:
@@ -694,6 +731,10 @@ enum AgentContentBlock: Codable {
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case .thinking(let text, let signature):
+            try c.encode(Kind.thinking, forKey: .kind)
+            try c.encode(text, forKey: .text)
+            try c.encode(signature, forKey: .signature)
         case .text(let s):
             try c.encode(Kind.text, forKey: .kind)
             try c.encode(s, forKey: .text)

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -74,6 +74,7 @@ struct AgentRequestContext: Equatable, Sendable {
 enum AnthropicStreamEvent: Sendable {
     case thinkingDelta(String)
     case thinkingSignature(String)
+    case redactedThinking(String)
     case textDelta(String)
     case toolUseComplete(id: String, name: String, inputJSON: String)
     case messageStop(stopReason: AnthropicStopReason)
@@ -144,10 +145,15 @@ enum AnthropicSSE {
             case "content_block_start":
                 if let index = event["index"] as? Int,
                    let block = event["content_block"] as? [String: Any],
-                   block["type"] as? String == "tool_use",
-                   let id = block["id"] as? String,
-                   let name = block["name"] as? String {
-                    pendingTools[index] = (id, name, "")
+                   let blockType = block["type"] as? String {
+                    if blockType == "tool_use",
+                       let id = block["id"] as? String,
+                       let name = block["name"] as? String {
+                        pendingTools[index] = (id, name, "")
+                    } else if blockType == "redacted_thinking",
+                              let data = block["data"] as? String {
+                        continuation.yield(.redactedThinking(data))
+                    }
                 }
 
             case "content_block_delta":

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -5,22 +5,27 @@ import Foundation
 enum AnthropicModel: String, CaseIterable, Sendable {
     case sonnet5 = "claude-sonnet-5"
     case opus48 = "claude-opus-4-8"
-    case haiku45 = "claude-haiku-4-5-20251001"
 
     var displayName: String {
         switch self {
         case .sonnet5: "Sonnet 5"
         case .opus48: "Opus 4.8"
-        case .haiku45: "Haiku 4.5"
         }
     }
 
     var requestExtras: [String: Any] {
         switch self {
-        case .sonnet5: ["output_config": ["effort": "low"]]
-        default: [:]
+        case .sonnet5:
+            [
+                "output_config": ["effort": "low"],
+                "thinking": ["type": "adaptive", "display": "summarized"],
+            ]
+        case .opus48:
+            ["thinking": ["type": "adaptive", "display": "summarized"]]
         }
     }
+
+    var maxOutputTokens: Int { 128_000 }
 }
 
 enum AnthropicStopReason: String, Sendable {
@@ -67,6 +72,8 @@ struct AgentRequestContext: Equatable, Sendable {
 }
 
 enum AnthropicStreamEvent: Sendable {
+    case thinkingDelta(String)
+    case thinkingSignature(String)
     case textDelta(String)
     case toolUseComplete(id: String, name: String, inputJSON: String)
     case messageStop(stopReason: AnthropicStopReason)
@@ -149,6 +156,14 @@ enum AnthropicSSE {
                       let deltaType = delta["type"] as? String else { break }
                 if deltaType == "text_delta", let text = delta["text"] as? String, !text.isEmpty {
                     continuation.yield(.textDelta(text))
+                } else if deltaType == "thinking_delta",
+                          let thinking = delta["thinking"] as? String,
+                          !thinking.isEmpty {
+                    continuation.yield(.thinkingDelta(thinking))
+                } else if deltaType == "signature_delta",
+                          let signature = delta["signature"] as? String,
+                          !signature.isEmpty {
+                    continuation.yield(.thinkingSignature(signature))
                 } else if deltaType == "input_json_delta",
                           let partial = delta["partial_json"] as? String,
                           var acc = pendingTools[index] {

--- a/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/AnthropicClient.swift
@@ -32,7 +32,7 @@ enum AnthropicKeychain {
 struct AnthropicClient: AgentClient {
     let apiKey: String
     let model: AnthropicModel
-    var maxTokens: Int = 8192
+    var maxTokens: Int { model.maxOutputTokens }
 
     private static let endpoint = URL(string: "https://api.anthropic.com/v1/messages")!
 

--- a/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/PalmierClient.swift
@@ -3,7 +3,7 @@ import ClerkKit
 
 struct PalmierClient: AgentClient {
     let model: AnthropicModel
-    var maxTokens: Int = 8192
+    var maxTokens: Int { model.maxOutputTokens }
 
     func stream(
         system: String,

--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -68,6 +68,10 @@ struct AgentMessageView: View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             ForEach(Array(message.blocks.enumerated()), id: \.offset) { _, block in
                 switch block {
+                case .thinking(let text, _):
+                    if !text.isEmpty {
+                        ThinkingSummaryView(text: text)
+                    }
                 case .text(let text):
                     MarkdownText(text: text)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -86,6 +90,24 @@ struct AgentMessageView: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .animation(.easeOut(duration: AppTheme.Anim.hover), value: isHovering)
+    }
+}
+
+private struct ThinkingSummaryView: View {
+    let text: String
+
+    var body: some View {
+        Text(verbatim: text)
+            .font(.system(size: AppTheme.FontSize.xs))
+            .foregroundStyle(AppTheme.Text.tertiaryColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, AppTheme.Spacing.md)
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(AppTheme.Border.subtleColor)
+                    .frame(width: AppTheme.BorderWidth.medium)
+            }
+            .textSelection(.enabled)
     }
 }
 

--- a/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentMessageView.swift
@@ -72,6 +72,8 @@ struct AgentMessageView: View {
                     if !text.isEmpty {
                         ThinkingSummaryView(text: text)
                     }
+                case .redactedThinking:
+                    EmptyView()
                 case .text(let text):
                     MarkdownText(text: text)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/PalmierProTests/Agent/AgentThinkingTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentThinkingTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Agent thinking")
+@MainActor
+struct AgentThinkingTests {
+    @Test func redactedThinkingRoundTripsUnchanged() throws {
+        let block = AgentContentBlock.redactedThinking(data: "opaque")
+        let json = try #require(AgentService.contentBlockJSON(block))
+        let decoded = try JSONDecoder().decode(
+            AgentContentBlock.self,
+            from: JSONEncoder().encode(block)
+        )
+
+        #expect(json["type"] as? String == "redacted_thinking")
+        #expect(json["data"] as? String == "opaque")
+        guard case .redactedThinking(let data) = decoded else {
+            Issue.record("Expected redacted thinking")
+            return
+        }
+        #expect(data == "opaque")
+    }
+
+    @Test func cancellationDropsUnsignedThinkingTurn() {
+        let service = AgentService()
+        let message = AgentMessage(
+            role: .assistant,
+            blocks: [.thinking(text: "partial", signature: "")]
+        )
+        service.messages = [message]
+
+        service.dropEmptyAssistantTurn(id: message.id)
+
+        #expect(service.messages.isEmpty)
+    }
+
+    @Test func cancellationKeepsCompleteRedactedThinking() {
+        let service = AgentService()
+        let message = AgentMessage(
+            role: .assistant,
+            blocks: [.redactedThinking(data: "opaque")]
+        )
+        service.messages = [message]
+
+        service.dropEmptyAssistantTurn(id: message.id)
+
+        #expect(service.messages.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Stream Anthropic summarized thinking into Agent chat so long reasoning turns show progress before the final response.
- Raise the model output budget from 8,192 to 128,000 tokens to prevent adaptive thinking from exhausting the turn before visible output.
- Remove Haiku 4.5 from the supported model list, leaving Sonnet 5 and Opus 4.8.
- Preserve complete redacted thinking and discard incomplete unsigned thinking so tool continuations remain valid.

## Approach
- Configure both supported models for adaptive thinking with summarized display while retaining Sonnet's low effort setting.
- Parse thinking, signature, and redacted-thinking SSE content; persist opaque Anthropic blocks unchanged and replay them in their original order.
- Remove unserializable partial thinking when cancellation or stream termination interrupts a turn.
- Resolve emitted tool uses with explicit canceled results before ending a canceled turn.
- Render thinking summaries as subdued verbatim text while keeping redacted thinking hidden. Anthropic does not expose raw chain-of-thought.

## Testing
- [x] `swift build`
- [x] `swift test --filter AgentThinkingTests` — 3 tests passed
- [x] `swift test` — 1,309 tests passed
- [ ] Manually run a complex Sonnet 5 and Opus 4.8 chat, confirm thinking streams before the answer, cancel during thinking and tool use, and verify subsequent tool continuations succeed.

## Change statistics
- Agent protocol and state logic: +98 / -17
- Agent chat UI: +24 / -0
- Tests: +50 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent streaming, message serialization, and multi-turn API replay for thinking blocks; incorrect handling could break tool loops or send invalid content to Anthropic.
> 
> **Overview**
> Adds **adaptive summarized thinking** to Sonnet 5 and Opus 4.8 agent turns: requests include thinking config, the SSE parser emits thinking/signature/redacted events, and the chat UI shows summarized thinking as subdued verbatim text (redacted blocks stay hidden).
> 
> **Persistence and cleanup:** New `AgentContentBlock` cases round-trip through Codable and API replay; unsigned partial thinking is stripped via `dropEmptyAssistantTurn` / `contentBlockJSON` so cancellations and tool continuations stay valid. The agent loop also breaks out cleanly on cancellation after tool runs.
> 
> **Model surface:** Haiku 4.5 is removed from the picker; **max output tokens** moves from 8,192 to **128,000** on both Anthropic and Palmier clients. Tests cover redacted thinking serialization and cancellation behavior for incomplete vs complete thinking blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8727c6bfe270eef2218657817344e34da34c8f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->