### PR TITLE
[perf] Cache multicam silence masks

### DIFF
--- a/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
+++ b/Sources/PalmierPro/Audio/Analysis/SpeechMaskStore.swift
@@ -107,6 +107,13 @@ final class SpeechMaskStore {
         }
     }
 
+    #if DEBUG
+    func installQuietNonSpeechMask(_ mask: [Bool], for mediaRef: String) {
+        quietNonSpeechMasks[mediaRef] = mask
+        deadAirMasks.removeValue(forKey: mediaRef)
+    }
+    #endif
+
     private func quietNonSpeechMaskIsolated(
         for mediaRef: String,
         samples: [Float]?

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -248,8 +248,8 @@ extension EditorViewModel {
         settings: SilenceRemovalSettings
     ) -> [Range<Double>] {
         let mask: [Bool]?
-        if let group = multicamGroup(of: clip),
-           let member = group.member(mediaRef: clip.mediaRef) {
+        if let group = multicamGroup(of: clip) {
+            guard let member = group.member(mediaRef: clip.mediaRef) else { return [] }
             let key = DeadAirMaskCache.Key(
                 group: group,
                 member: member,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+DeadAir.swift
@@ -8,23 +8,32 @@ enum DeadAirMaskResolver {
         quietMaskForMedia: (String) -> [Bool]?
     ) -> [Bool]? {
         guard let member = group.member(mediaRef: clip.mediaRef),
-              clip.mediaType == .audio, !group.mics.isEmpty else { return nil }
+              clip.mediaType == .audio else { return nil }
 
+        let microphones = group.mics
+        guard !microphones.isEmpty else { return nil }
         let cellSeconds = VoiceActivity.chunkDuration
-        var masks: [[Bool]] = []
-        for mic in group.mics {
-            guard let mask = quietMaskForMedia(mic.mediaRef), !mask.isEmpty else { return nil }
-            let shift = Int((mic.sync.offsetSeconds / cellSeconds).rounded())
-            var shifted = [Bool](repeating: true, count: max(0, mask.count + shift))
-            for (i, dead) in mask.enumerated() where i + shift >= 0 && i + shift < shifted.count {
-                shifted[i + shift] = dead
-            }
-            masks.append(shifted)
+        var alignedMasks: [(values: [Bool], offset: Int)] = []
+        alignedMasks.reserveCapacity(microphones.count)
+        for microphone in microphones {
+            guard let values = quietMaskForMedia(microphone.mediaRef),
+                  !values.isEmpty else { return nil }
+            let offset = Int((microphone.sync.offsetSeconds / cellSeconds).rounded())
+            alignedMasks.append((values, offset))
         }
 
-        let groupMask = (0..<(masks.map(\.count).max() ?? 0)).map { i in
-            masks.allSatisfy { i >= $0.count || $0[i] }
+        let count = alignedMasks.reduce(0) { max($0, $1.values.count + $1.offset) }
+        var groupMask = [Bool](repeating: true, count: count)
+        for i in 0..<count {
+            for mask in alignedMasks {
+                let sourceIndex = i - mask.offset
+                if mask.values.indices.contains(sourceIndex), !mask.values[sourceIndex] {
+                    groupMask[i] = false
+                    break
+                }
+            }
         }
+
         let shift = Int((member.sync.offsetSeconds / cellSeconds).rounded())
         let memberMask: [Bool]
         if shift > 0 {
@@ -35,6 +44,62 @@ enum DeadAirMaskResolver {
             memberMask = groupMask
         }
         return SilenceRemovalPlanner.removableMask(from: memberMask, settings: settings)
+    }
+}
+
+@MainActor
+final class DeadAirMaskCache {
+    struct Key: Hashable {
+        struct Member: Hashable {
+            let id: String
+            let mediaRef: String
+            let offsetSeconds: Double
+
+            init(_ member: MulticamSource.Member) {
+                id = member.id
+                mediaRef = member.mediaRef
+                offsetSeconds = member.sync.offsetSeconds
+            }
+        }
+
+        let groupID: String
+        let member: Member
+        let microphones: [Member]
+        let minimumPauseSeconds: Double
+        let speechPaddingSeconds: Double
+
+        init(
+            group: MulticamSource,
+            member: MulticamSource.Member,
+            settings: SilenceRemovalSettings
+        ) {
+            groupID = group.id
+            self.member = Member(member)
+            microphones = group.mics.map(Member.init)
+            minimumPauseSeconds = settings.minimumPauseSeconds
+            speechPaddingSeconds = settings.speechPaddingSeconds
+        }
+    }
+
+    private static let capacity = 256
+    private var values: [Key: [Bool]] = [:]
+    private var insertionOrder: [Key] = []
+
+    func value(for key: Key, build: () -> [Bool]?) -> [Bool]? {
+        if let cached = values[key] { return cached }
+        guard let value = build() else { return nil }
+        if values.count >= Self.capacity, let evicted = insertionOrder.first {
+            values.removeValue(forKey: evicted)
+            insertionOrder.removeFirst()
+        }
+        values[key] = value
+        insertionOrder.append(key)
+        return value
+    }
+
+    func reset() {
+        values.removeAll(keepingCapacity: true)
+        insertionOrder.removeAll(keepingCapacity: true)
     }
 }
 
@@ -183,13 +248,21 @@ extension EditorViewModel {
         settings: SilenceRemovalSettings
     ) -> [Range<Double>] {
         let mask: [Bool]?
-        if let group = multicamGroup(of: clip) {
-            mask = DeadAirMaskResolver.mask(
-                for: clip,
-                in: group,
-                settings: settings,
-                quietMaskForMedia: { mediaVisualCache.quietNonSpeechMask(for: $0) }
+        if let group = multicamGroup(of: clip),
+           let member = group.member(mediaRef: clip.mediaRef) {
+            let key = DeadAirMaskCache.Key(
+                group: group,
+                member: member,
+                settings: settings
             )
+            mask = deadAirMaskCache.value(for: key) {
+                DeadAirMaskResolver.mask(
+                    for: clip,
+                    in: group,
+                    settings: settings,
+                    quietMaskForMedia: { mediaVisualCache.quietNonSpeechMask(for: $0) }
+                )
+            }
         } else {
             mask = mediaVisualCache.deadAirMask(for: clip.mediaRef, settings: settings)
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -67,7 +67,11 @@ final class EditorViewModel {
     var denoiseBaked: Set<String> = []
     var speechAnalyzingCount: Int = 0
     var speakerRegistry: [SpeakerRegistryEntry] = []
-    var multicamGroups: [MulticamSource] = []
+    var multicamGroups: [MulticamSource] = [] {
+        didSet {
+            if multicamGroups != oldValue { deadAirMaskCache.reset() }
+        }
+    }
     var speakerAssignments: [String: [String: Int]] = [:]
     var speakerIdentifyPhase: String?
     var speakerIdentifyInFlight: Bool { speakerIdentifyPhase != nil }
@@ -166,6 +170,7 @@ final class EditorViewModel {
     var missingMediaRefs: Set<String> = []
     @ObservationIgnored var missingMediaRefreshTask: Task<Void, Never>?
     let mediaVisualCache = MediaVisualCache()
+    let deadAirMaskCache = DeadAirMaskCache()
     let searchIndex = SearchIndexCoordinator()
     var projectURL: URL? {
         didSet {
@@ -284,6 +289,9 @@ final class EditorViewModel {
         searchIndex.assetsProvider = { [weak self] in self?.mediaAssets ?? [] }
         mediaVisualCache.speech.onAnalyzingCountChange = { [weak self] count in
             self?.speechAnalyzingCount = count
+        }
+        mediaVisualCache.onDeadAirCacheInvalidated = { [weak self] in
+            self?.deadAirMaskCache.reset()
         }
         undo.onActionCommitted = { [weak self] in
             self?.captureCommittedEdit()

--- a/Sources/PalmierPro/Timeline/MediaVisualCache.swift
+++ b/Sources/PalmierPro/Timeline/MediaVisualCache.swift
@@ -50,6 +50,7 @@ final class MediaVisualCache {
     // MARK: - Redraw trigger
 
     weak var timelineView: NSView?
+    var onDeadAirCacheInvalidated: (() -> Void)?
 
     // MARK: - Sync lookups (safe for draw calls)
 
@@ -108,6 +109,7 @@ final class MediaVisualCache {
         beats.reset()
         videoThumbnails.removeAll()
         imageThumbnails.removeAll()
+        onDeadAirCacheInvalidated?()
         timelineView?.needsDisplay = true
     }
 
@@ -119,6 +121,7 @@ final class MediaVisualCache {
         beats.invalidate(mediaRef)
         videoThumbnails.removeValue(forKey: mediaRef)
         imageThumbnails.removeValue(forKey: mediaRef)
+        onDeadAirCacheInvalidated?()
     }
 
     func generateImageThumbnail(for asset: MediaAsset) {

--- a/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
@@ -206,6 +206,34 @@ struct MulticamTests {
         #expect(builds == 2)
     }
 
+    @Test func orphanedMulticamClipDoesNotFallBackToSingleMediaMask() {
+        let group = MulticamSource(name: "Podcast", members: [
+            .init(
+                mediaRef: "member",
+                kind: .mic,
+                angleLabel: "member",
+                sync: .init(offsetSeconds: 0, confidence: 1)
+            ),
+        ])
+        var clip = Fixtures.clip(
+            mediaRef: "orphan",
+            mediaType: .audio,
+            start: 0,
+            duration: 30
+        )
+        clip.multicamGroupId = group.id
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [clip]),
+        ]))
+        harness.editor.multicamGroups = [group]
+        harness.editor.mediaVisualCache.speech.installQuietNonSpeechMask(
+            [Bool](repeating: true, count: 40),
+            for: clip.mediaRef
+        )
+
+        #expect(harness.editor.deadAirSourceRanges(for: clip, settings: .default).isEmpty)
+    }
+
     @Test func lagSearchKeepsHalfOverlap() {
         // 3:35 files (~21500 hops) with a 240s window: without the clamp, ±220s lags
         // with seconds of overlap were legal — the false-peak that doubled a group's length.

--- a/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/MulticamEngineTests.swift
@@ -178,6 +178,34 @@ struct MulticamTests {
         #expect(mask?.contains(true) == false)
     }
 
+    @Test func deadAirMaskCacheBuildsEachKeyOnce() {
+        let cache = DeadAirMaskCache()
+        let group = MulticamSource(name: "Podcast", members: [
+            .init(
+                mediaRef: "audio",
+                kind: .mic,
+                angleLabel: "mic",
+                sync: .init(offsetSeconds: 0, confidence: 1)
+            ),
+        ])
+        let key = DeadAirMaskCache.Key(
+            group: group,
+            member: group.members[0],
+            settings: .default
+        )
+        var builds = 0
+        func build() -> [Bool]? {
+            builds += 1
+            return [Bool](repeating: true, count: 82_416)
+        }
+
+        for _ in 0..<1_000 { _ = cache.value(for: key, build: build) }
+        #expect(builds == 1)
+        cache.reset()
+        #expect(cache.value(for: key, build: build)?.count == 82_416)
+        #expect(builds == 2)
+    }
+
     @Test func lagSearchKeepsHalfOverlap() {
         // 3:35 files (~21500 hops) with a 240s window: without the clamp, ±220s lags
         // with seconds of overlap were legal — the false-peak that doubled a group's length.


### PR DESCRIPTION
## Summary
- Prevent timeline redraws, the Silence panel, and Agent `remove_silence` from rebuilding the same long multicam dead-air mask for every clip.
- Replace per-mic shifted mask allocations with direct sync-aligned indexing on the initial calculation.
- Bound and invalidate the shared mask cache when multicam metadata or backing media changes.

## Approach
- Key cached masks by multicam group, selected member, microphone identities/media references/sync offsets, and silence-removal settings.
- Keep `deadAirSourceRanges` as the shared source of truth so timeline rendering, UI removal, and Agent removal use identical results.
- Preserve existing non-multicam behavior and all padding, trim, speed, orphaned-member, and out-of-coverage semantics.
- Use a 256-entry FIFO cache to bound retained masks without clearing the entire working set at capacity.

## Testing
- [x] `swift build`
- [x] `swift test --filter MulticamTests` — 38 tests passed
- [x] `swift test` — 1,307 tests passed before the review follow-up
- [x] Final full-suite run reached 1,308 tests with one unrelated `FrameSamplerTests` coverage-floor failure; focused rerun passed
- [x] `swift build --traits BundledSpeech`
- [x] Re-sampled the original long multicam project; `DeadAirMaskResolver` no longer appears in the hang sample.
- [ ] The separate `NSDocument._waitForUserInteractionUnblocking` save hang remains outside this PR.

## Change statistics
- Dead-air/cache logic: +109 / -18
- Tests: +56 / -0