### PR TITLE
[agent] Add clip link management tool

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -24,6 +24,7 @@ enum ToolName: String, CaseIterable, Sendable {
 
     // Clips
     case manageTracks = "manage_tracks"
+    case manageClipLinks = "manage_clip_links"
     case addClips = "add_clips"
     case insertClips = "insert_clips"
     case moveClips = "move_clips"
@@ -377,6 +378,23 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: ["clipIds"]
+            )
+        ),
+        AgentTool(
+            name: .manageClipLinks,
+            description: "Links or unlinks clips as one undoable action without moving, trimming, or aligning them. link merges the complete existing groups touched by clipIds and requires at least two clips of different media types. unlink accepts one or more members and dissolves each member's complete link group. Use unlink before independently trimming the audio or video side of a J-cut or L-cut; relink afterward when the clips should move together again.",
+            inputSchema: objectSchema(
+                properties: [
+                    "action": [
+                        "type": "string",
+                        "enum": ["link", "unlink"],
+                    ],
+                    "clipIds": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                    ],
+                ],
+                required: ["action", "clipIds"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -42,6 +42,17 @@ fileprivate struct MoveClipsInput: DecodableToolArgs {
     }
 }
 
+fileprivate struct ManageClipLinksInput: DecodableToolArgs {
+    enum Action: String, Decodable {
+        case link
+        case unlink
+    }
+
+    let action: Action
+    let clipIds: [String]
+    static let allowedKeys: Set<String> = ["action", "clipIds"]
+}
+
 fileprivate struct SplitClipsInput: DecodableToolArgs {
     let splits: [Split]?
     let trackIndex: Int?
@@ -391,6 +402,43 @@ extension ToolExecutor {
             editor.removeClips(ids: expanded)
         }
         return mutationResult(editor, since: snapshot)
+    }
+
+    // MARK: manage_clip_links
+
+    func manageClipLinks(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: ManageClipLinksInput = try decodeToolArgs(args, path: "manage_clip_links")
+        guard !input.clipIds.isEmpty else {
+            throw ToolError("manage_clip_links.clipIds must be a non-empty array")
+        }
+        for (index, id) in input.clipIds.enumerated() {
+            guard !id.isEmpty else {
+                throw ToolError("manage_clip_links.clipIds[\(index)] must be a non-empty clip ID")
+            }
+            guard editor.findClip(id: id) != nil else { throw ToolError("Clip not found: \(id)") }
+        }
+
+        let clipIds = Set(input.clipIds)
+        let targets: Set<String>
+        switch input.action {
+        case .link:
+            guard let resolved = editor.linkTargets(for: clipIds) else {
+                throw ToolError("Link requires at least two clips of different media types that are not already one link group")
+            }
+            targets = resolved
+        case .unlink:
+            targets = editor.unlinkTargets(for: clipIds)
+            guard !targets.isEmpty else { throw ToolError("None of the provided clips is linked") }
+        }
+
+        let snapshot = timelineSnapshot(editor)
+        switch input.action {
+        case .link:
+            editor.linkClips(ids: targets)
+        case .unlink:
+            editor.unlinkClips(ids: targets)
+        }
+        return mutationResult(editor, since: snapshot, touched: Array(targets))
     }
 
     // MARK: move_clips

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -290,6 +290,7 @@ final class ToolExecutor {
         case .addClips:         return try addClips(editor, args)
         case .insertClips:      return try insertClips(editor, args)
         case .removeClips:      return try removeClips(editor, args)
+        case .manageClipLinks:  return try manageClipLinks(editor, args)
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
         case .applyLayout:      return try applyLayout(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Linking.swift
@@ -142,18 +142,14 @@ extension EditorViewModel {
 
     /// Stamp a new `linkGroupId` on every clip in `ids`, merging pre-existing sub-groups into the new group.
     func linkClips(ids: Set<String>) {
-        guard ids.count >= 2 else { return }
+        guard let ids = linkTargets(for: ids) else { return }
         let newGroup = UUID().uuidString
         mutateClips(ids: ids, actionName: "Link") { $0.linkGroupId = newGroup }
     }
 
     /// Clear `linkGroupId` on every clip that shares a group with any id in `ids`.
     func unlinkClips(ids: Set<String>) {
-        let expanded = expandToLinkGroup(ids).filter { id in
-            guard let loc = findClip(id: id) else { return false }
-            return timeline.tracks[loc.trackIndex].clips[loc.clipIndex].linkGroupId != nil
-        }
-        mutateClips(ids: Set(expanded), actionName: "Unlink") { $0.linkGroupId = nil }
+        mutateClips(ids: unlinkTargets(for: ids), actionName: "Unlink") { $0.linkGroupId = nil }
         selectedClipIds.removeAll()
     }
 
@@ -468,30 +464,29 @@ extension EditorViewModel {
         return insertTrack(at: timeline.tracks.count, type: .audio)
     }
 
-    // MARK: - Context-menu enablement
+    // MARK: - Link eligibility
+
+    func unlinkTargets(for ids: Set<String>) -> Set<String> {
+        expandToLinkGroup(ids).filter { clipFor(id: $0)?.linkGroupId != nil }
+    }
+
+    func linkTargets(for ids: Set<String>) -> Set<String>? {
+        let ids = expandToLinkGroup(ids)
+        guard ids.count >= 2 else { return nil }
+        let clips = ids.compactMap(clipFor)
+        guard clips.count == ids.count, Set(clips.map(\.mediaType)).count >= 2 else { return nil }
+        let linkedGroups = clips.compactMap(\.linkGroupId)
+        let groups = Set(linkedGroups)
+        let ungrouped = clips.count - linkedGroups.count
+        guard groups.count != 1 || ungrouped != 0 else { return nil }
+        return ids
+    }
 
     var canUnlinkSelected: Bool {
-        for track in timeline.tracks {
-            for clip in track.clips where selectedClipIds.contains(clip.id) && clip.linkGroupId != nil {
-                return true
-            }
-        }
-        return false
+        !unlinkTargets(for: selectedClipIds).isEmpty
     }
 
     var canLinkSelected: Bool {
-        guard selectedClipIds.count >= 2 else { return false }
-        var types = Set<ClipType>()
-        var groups = Set<String>()
-        var ungrouped = 0
-        for track in timeline.tracks {
-            for clip in track.clips where selectedClipIds.contains(clip.id) {
-                types.insert(clip.mediaType)
-                if let gid = clip.linkGroupId { groups.insert(gid) } else { ungrouped += 1 }
-            }
-        }
-        guard types.count >= 2 else { return false }
-        // Already all in one group → nothing to do
-        return !(groups.count == 1 && ungrouped == 0)
+        linkTargets(for: selectedClipIds) != nil
     }
 }

--- a/Tests/PalmierProTests/Agent/ManageClipLinksTests.swift
+++ b/Tests/PalmierProTests/Agent/ManageClipLinksTests.swift
@@ -1,0 +1,84 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("ToolExecutor — manage_clip_links")
+@MainActor
+struct ManageClipLinksTests {
+    private func harness(linked: Bool = false) -> ToolHarness {
+        var video = Fixtures.clip(id: "video", start: 10, duration: 40)
+        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 5, duration: 50)
+        if linked {
+            video.linkGroupId = "group"
+            audio.linkGroupId = "group"
+        }
+        return ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+    }
+
+    @Test func linksAndUnlinksWithoutChangingTiming() async throws {
+        let h = harness()
+
+        _ = try await h.runOK("manage_clip_links", args: [
+            "action": "link",
+            "clipIds": ["video", "audio"],
+        ])
+        let group = try #require(h.editor.clipFor(id: "video")?.linkGroupId)
+        #expect(h.editor.clipFor(id: "audio")?.linkGroupId == group)
+        #expect(h.editor.clipFor(id: "video")?.startFrame == 10)
+        #expect(h.editor.clipFor(id: "audio")?.startFrame == 5)
+
+        _ = try await h.runOK("manage_clip_links", args: [
+            "action": "unlink",
+            "clipIds": ["video"],
+        ])
+        #expect(h.editor.clipFor(id: "video")?.linkGroupId == nil)
+        #expect(h.editor.clipFor(id: "audio")?.linkGroupId == nil)
+        #expect(h.editor.clipFor(id: "video")?.durationFrames == 40)
+        #expect(h.editor.clipFor(id: "audio")?.durationFrames == 50)
+    }
+
+    @Test func linkingMergesCompleteExistingGroups() async throws {
+        var video1 = Fixtures.clip(id: "video1", start: 0, duration: 40)
+        var audio1 = Fixtures.clip(id: "audio1", mediaType: .audio, start: 0, duration: 40)
+        var video2 = Fixtures.clip(id: "video2", start: 50, duration: 40)
+        var audio2 = Fixtures.clip(id: "audio2", mediaType: .audio, start: 50, duration: 40)
+        video1.linkGroupId = "group1"
+        audio1.linkGroupId = "group1"
+        video2.linkGroupId = "group2"
+        audio2.linkGroupId = "group2"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video1, video2]),
+            Fixtures.audioTrack(clips: [audio1, audio2]),
+        ]))
+
+        _ = try await h.runOK("manage_clip_links", args: [
+            "action": "link",
+            "clipIds": ["video1", "video2"],
+        ])
+
+        let group = try #require(h.editor.clipFor(id: "video1")?.linkGroupId)
+        #expect(h.editor.clipFor(id: "audio1")?.linkGroupId == group)
+        #expect(h.editor.clipFor(id: "video2")?.linkGroupId == group)
+        #expect(h.editor.clipFor(id: "audio2")?.linkGroupId == group)
+    }
+
+    @Test func rejectsInvalidAndNoOpRequests() async {
+        let h = harness()
+
+        #expect(await h.runRaw("manage_clip_links", args: [
+            "action": "link",
+            "clipIds": ["video"],
+        ]).isError)
+        #expect(await h.runRaw("manage_clip_links", args: [
+            "action": "unlink",
+            "clipIds": ["video"],
+        ]).isError)
+        #expect(await h.runRaw("manage_clip_links", args: [
+            "action": "invalid",
+            "clipIds": ["video", "audio"],
+        ]).isError)
+        #expect(h.editor.timeline.tracks.flatMap(\.clips).allSatisfy { $0.linkGroupId == nil })
+    }
+}


### PR DESCRIPTION
## Summary
- expose a minimal `manage_clip_links` tool for linking and unlinking complete clip groups
- reuse the timeline UI's link eligibility, mutation, and undo behavior for J/L-cut workflows
- cover timing preservation, complete-group merging, and invalid/no-op requests

## Test plan
- [x] `swift test --filter ManageClipLinksTests`
- [x] `swift test --filter LinkingTests`
- [x] Create an L-cut through the debug MCP server and verify differing audio/video ranges survive relinking

Made with [Cursor](https://cursor.com)