### PR TITLE
[agent] Add trim_clips tool for edge trims with ripple support

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -30,6 +30,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case moveClips = "move_clips"
     case removeClips = "remove_clips"
     case splitClips = "split_clips"
+    case trimClips = "trim_clips"
     case rippleDeleteRanges = "ripple_delete_ranges"
     case setClipProperties = "set_clip_properties"
     case setKeyframes = "set_keyframes"
@@ -460,6 +461,28 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: []
+            )
+        ),
+        AgentTool(
+            name: .trimClips,
+            description: "Trim or extend clip edges — move where clips start or end — for one or many clips in a single undoable action. Each edit gives absolute PROJECT frames: startFrame moves the clip's leading edge, endFrame its trailing edge (end-exclusive, matching get_timeline); pass either or both. Moving an edge inward trims material away; outward extends it, revealing more source when the media has headroom (images and text extend freely). Linked audio/video partners trim together so A/V stays in sync — list a clip OR its partner, not both.\n\nripple=false (default): only the edited clips change — extending overwrites whatever the new span overlaps on that track, and trimming leaves a gap.\nripple=true: like a ripple-trim drag — downstream clips and sync-locked tracks shift to close (or open) the gap. The edited clip keeps its start position; each requested frame is read as an amount of material to add or remove at that edge (requested minus current edge), applied before the shift.\n\nRequests are clamped by source headroom, multicam sync bounds, and sync-locked track room; the receipt lists resulting clip frames plus a note for every clamp, skipped no-op edge, and linked partner whose retimed speed rounds to a different move — verify against it instead of assuming the exact frames landed. Refused with no changes when a ripple edit would break a multicam group. Related tools: ripple_delete_ranges cuts ranges mid-clip, split_clips only inserts boundaries, move_clips repositions without changing content, set_clip_properties sets raw source trim offsets without ripple.",
+            inputSchema: objectSchema(
+                properties: [
+                    "edits": [
+                        "type": "array",
+                        "description": "Per-clip edge targets. A clip (or its linked partner) may appear in at most one edit.",
+                        "items": objectSchema(
+                            properties: [
+                                "clipId": ["type": "string", "description": "Clip to trim (from get_timeline)."],
+                                "startFrame": ["type": "integer", "description": "Project frame the leading edge should move to. Greater than the current start trims the head; smaller extends it."],
+                                "endFrame": ["type": "integer", "description": "Project frame the trailing edge should move to (end-exclusive). Smaller than the current end trims the tail; greater extends it."],
+                            ],
+                            required: ["clipId"]
+                        ),
+                    ],
+                    "ripple": ["type": "boolean", "description": "true shifts downstream clips and sync-locked tracks to keep the timeline closed, like a ripple trim. Default false."],
+                ],
+                required: ["edits"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -66,6 +66,19 @@ fileprivate struct SplitClipsInput: DecodableToolArgs {
     }
 }
 
+fileprivate struct TrimClipsInput: DecodableToolArgs {
+    let edits: [Edit]
+    let ripple: Bool?
+    static let allowedKeys: Set<String> = ["edits", "ripple"]
+
+    struct Edit: DecodableToolArgs {
+        let clipId: String
+        let startFrame: Int?
+        let endFrame: Int?
+        static let allowedKeys: Set<String> = ["clipId", "startFrame", "endFrame"]
+    }
+}
+
 fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     let clipIds: [String]?
     let durationFrames: Int?
@@ -219,14 +232,7 @@ extension ToolExecutor {
     func addClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: AddClipsInput = try decodeToolArgs(args, path: "add_clips")
         guard !input.entries.isEmpty else { throw ToolError("Missing or empty 'entries' array") }
-        // Decodable doesn't reject unknown nested keys; check each raw entry.
-        if let raws = args["entries"] as? [Any] {
-            for (idx, raw) in raws.enumerated() {
-                if let d = raw as? [String: Any] {
-                    try validateUnknownKeys(d, allowed: AddClipsInput.Entry.allowedKeys, path: "entries[\(idx)]")
-                }
-            }
-        }
+        try validateEntryKeys(in: args, arrayKey: "entries", allowed: AddClipsInput.Entry.allowedKeys)
 
         var prepared: [(entry: AddClipsInput.Entry, asset: MediaAsset, trackId: String?)] = []
         prepared.reserveCapacity(input.entries.count)
@@ -339,13 +345,7 @@ extension ToolExecutor {
     func insertClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: InsertClipsInput = try decodeToolArgs(args, path: "insert_clips")
         guard !input.entries.isEmpty else { throw ToolError("Missing or empty 'entries' array") }
-        if let raws = args["entries"] as? [Any] {
-            for (idx, raw) in raws.enumerated() {
-                if let d = raw as? [String: Any] {
-                    try validateUnknownKeys(d, allowed: InsertClipsInput.Entry.allowedKeys, path: "entries[\(idx)]")
-                }
-            }
-        }
+        try validateEntryKeys(in: args, arrayKey: "entries", allowed: InsertClipsInput.Entry.allowedKeys)
         guard editor.timeline.tracks.indices.contains(input.trackIndex) else {
             throw ToolError("trackIndex \(input.trackIndex) out of range (0..\(editor.timeline.tracks.count - 1))")
         }
@@ -446,13 +446,7 @@ extension ToolExecutor {
     func moveClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: MoveClipsInput = try decodeToolArgs(args, path: "move_clips")
         guard !input.moves.isEmpty else { throw ToolError("Missing or empty 'moves' array") }
-        if let raws = args["moves"] as? [Any] {
-            for (idx, raw) in raws.enumerated() {
-                if let d = raw as? [String: Any] {
-                    try validateUnknownKeys(d, allowed: MoveClipsInput.Move.allowedKeys, path: "moves[\(idx)]")
-                }
-            }
-        }
+        try validateEntryKeys(in: args, arrayKey: "moves", allowed: MoveClipsInput.Move.allowedKeys)
 
         var parsed: [ParsedMove] = []
         parsed.reserveCapacity(input.moves.count)
@@ -931,6 +925,146 @@ extension ToolExecutor {
             _ = editor.splitClips(at: points)
         }
         return mutationResult(editor, since: snapshot)
+    }
+
+    // MARK: trim_clips
+
+    private struct TrimEdgeEdit {
+        let path: String
+        let clipId: String
+        let edge: EditorViewModel.TrimEdge
+        let deltaFrames: Int
+        let requestedFrame: Int
+        var edgeName: String { edge == .left ? "start" : "end" }
+    }
+
+    func trimClips(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: TrimClipsInput = try decodeToolArgs(args, path: "trim_clips")
+        guard !input.edits.isEmpty else { throw ToolError("Missing or empty 'edits' array") }
+        try validateEntryKeys(in: args, arrayKey: "edits", allowed: TrimClipsInput.Edit.allowedKeys)
+        let ripple = input.ripple ?? false
+
+        // Bound requested frames so delta and speed math stays far from Int overflow.
+        let maxFrame = 500_000_000
+
+        var edgeEdits: [TrimEdgeEdit] = []
+        var claimed: Set<String> = []
+        for (idx, e) in input.edits.enumerated() {
+            let path = "edits[\(idx)]"
+            guard e.startFrame != nil || e.endFrame != nil else {
+                throw ToolError("\(path): at least one of 'startFrame' or 'endFrame' is required")
+            }
+            guard let loc = editor.findClip(id: e.clipId) else {
+                throw ToolError("\(path): clip not found: \(e.clipId)")
+            }
+            let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+
+            if let s = e.startFrame, !(0...maxFrame).contains(s) {
+                throw ToolError("\(path): startFrame must be between 0 and \(maxFrame) (got \(s))")
+            }
+            if let f = e.endFrame, !(1...maxFrame).contains(f) {
+                throw ToolError("\(path): endFrame must be between 1 and \(maxFrame) (got \(f))")
+            }
+            let newStart = e.startFrame ?? clip.startFrame
+            let newEnd = e.endFrame ?? clip.endFrame
+            guard newEnd > newStart else {
+                throw ToolError("\(path): resulting duration must be at least 1 frame (start \(newStart), end \(newEnd))")
+            }
+
+            // Process end edge before start edge to ensure correct delta calculations if both are trimmed.
+            var clipEdges: [TrimEdgeEdit] = []
+            if let f = e.endFrame, f != clip.endFrame {
+                clipEdges.append(TrimEdgeEdit(
+                    path: path, clipId: clip.id, edge: .right,
+                    deltaFrames: f - clip.endFrame, requestedFrame: f))
+            }
+            if let f = e.startFrame, f != clip.startFrame {
+                clipEdges.append(TrimEdgeEdit(
+                    path: path, clipId: clip.id, edge: .left,
+                    deltaFrames: f - clip.startFrame, requestedFrame: f))
+            }
+
+            // Prevent overlapping ripple trims on linked or multicam clips.
+            var group = Set([clip.id] + editor.linkedPartnerIds(of: clip.id))
+            if ripple {
+                for edge in clipEdges {
+                    group.formUnion(editor.rippleTrimTargets(
+                        clipId: clip.id, edge: edge.edge, propagateToLinked: true).map(\.id))
+                }
+            }
+            guard claimed.isDisjoint(with: group) else {
+                throw ToolError("\(path): clip \(e.clipId) overlaps an earlier edit — the same clip, a linked partner, or a multicam group member that trims together")
+            }
+            claimed.formUnion(group)
+            edgeEdits += clipEdges
+        }
+
+        if ripple {
+            for edit in edgeEdits {
+                if let reason = editor.rippleTrimRefusalReason(clipId: edit.clipId, edge: edit.edge, propagateToLinked: true) {
+                    throw ToolError("\(edit.path): \(reason)")
+                }
+            }
+        }
+
+        let snapshot = timelineSnapshot(editor)
+        var notes: [String] = []
+        if edgeEdits.isEmpty {
+            notes.append("No change: every requested edge matches the clip's current frames.")
+        }
+        if !ripple {
+            // Surface differences between lead and linked partners due to speed rounding.
+            for edit in edgeEdits {
+                guard let clip = editor.clipFor(id: edit.clipId) else { continue }
+                let leadDelta = editor.trimDurationDelta(for: clip, edge: edit.edge, delta: edit.deltaFrames)
+                for partnerId in editor.linkedPartnerIds(of: edit.clipId) {
+                    guard let partner = editor.clipFor(id: partnerId) else { continue }
+                    let partnerDelta = editor.trimDurationDelta(for: partner, edge: edit.edge, delta: edit.deltaFrames)
+                    guard partnerDelta != leadDelta else { continue }
+                    notes.append("\(edit.path): linked partner \(partnerId) moves \(abs(partnerDelta)) frames where \(edit.clipId) moves \(abs(leadDelta)) (speed rounding or partner source limits) — their \(edit.edgeName) edges will differ.")
+                }
+            }
+        }
+        editor.undo.perform(input.edits.count == 1 ? "Trim Clip (Agent)" : "Trim Clips (Agent)") {
+            for edit in edgeEdits {
+                if ripple {
+                    guard let plan = editor.planRippleTrim(
+                        clipId: edit.clipId, edge: edit.edge,
+                        deltaFrames: edit.deltaFrames, propagateToLinked: true
+                    ) else {
+                        notes.append("\(edit.path): no headroom to move the \(edit.edgeName) edge — skipped.")
+                        continue
+                    }
+                    let requestedDelta = edit.edge == .right ? edit.deltaFrames : -edit.deltaFrames
+                    if plan.durationDelta != requestedDelta {
+                        var note = "\(edit.path): \(edit.edgeName) edge clamped to \(abs(plan.durationDelta)) of the requested \(abs(requestedDelta)) frames"
+                        if let blocked = plan.blockedAtFrame { note += " (blocked by an obstacle at frame \(blocked))" }
+                        notes.append(note + ".")
+                    }
+                    editor.rippleTrimClip(clipId: edit.clipId, edge: edit.edge,
+                                          deltaFrames: edit.deltaFrames, propagateToLinked: true)
+                } else {
+                    editor.commitTrim(clipId: edit.clipId, edge: edit.edge,
+                                      deltaFrames: edit.deltaFrames, propagateToLinked: true)
+                }
+            }
+        }
+
+        if !ripple {
+            for edit in edgeEdits {
+                guard let loc = editor.findClip(id: edit.clipId) else {
+                    notes.append("\(edit.path): clip \(edit.clipId) was removed when an earlier edit extended over it — this trim was skipped.")
+                    continue
+                }
+                let clip = editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                let landed = edit.edge == .left ? clip.startFrame : clip.endFrame
+                if landed != edit.requestedFrame {
+                    notes.append("\(edit.path): \(edit.edgeName) edge landed at frame \(landed), not the requested \(edit.requestedFrame) (source/multicam bounds or speed rounding).")
+                }
+            }
+        }
+
+        return mutationResult(editor, since: snapshot, touched: input.edits.map(\.clipId), notes: notes)
     }
 
     // MARK: ripple_delete_ranges

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -302,6 +302,7 @@ final class ToolExecutor {
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)
+        case .trimClips:        return try trimClips(editor, args)
         case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)
         case .removeWords:   return try await removeWords(editor, args)
         case .removeSilence: return try removeSilence(editor, args)
@@ -397,6 +398,13 @@ func validateUnknownKeys(_ entry: [String: Any], allowed: Set<String>, path: Str
     guard unknown.isEmpty else {
         let allowedFields = allowed.isEmpty ? "none" : allowed.sorted().joined(separator: ", ")
         throw ToolError("\(path): unknown field(s) '\(unknown.sorted().joined(separator: "', '"))'. Allowed: \(allowedFields).")
+    }
+}
+
+func validateEntryKeys(in args: [String: Any], arrayKey: String, allowed: Set<String>) throws {
+    for (idx, raw) in (args[arrayKey] as? [Any] ?? []).enumerated() {
+        guard let entry = raw as? [String: Any] else { continue }
+        try validateUnknownKeys(entry, allowed: allowed, path: "\(arrayKey)[\(idx)]")
     }
 }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -50,7 +50,7 @@ extension EditorViewModel {
 
         // Each target's own source headroom caps how far it can ripple; bind to the smallest.
         let sourceDelta = targetClips
-            .map { rippleTrimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
+            .map { trimDurationDelta(for: $0, edge: edge, delta: deltaFrames) }
             .min(by: { abs($0) < abs($1) }) ?? 0
 
         // Shrinking shifts sync-locked followers left; clamp to the tightest available room.
@@ -124,6 +124,13 @@ extension EditorViewModel {
         }
     }
 
+    /// Dry-run refusal reason for a ripple trim, or nil when allowed — the same rule `rippleTrimClip` enforces.
+    func rippleTrimRefusalReason(clipId: String, edge: TrimEdge, propagateToLinked: Bool) -> String? {
+        guard let leadLoc = findClip(id: clipId) else { return nil }
+        let targets = rippleTrimTargets(clipId: clipId, edge: edge, propagateToLinked: propagateToLinked)
+        return rippleTrimRefusal(leadLoc: leadLoc, edge: edge, targetIds: Set(targets.map(\.id)))
+    }
+
     func rippleTrimTargets(clipId: String, edge: TrimEdge, propagateToLinked: Bool) -> [Clip] {
         guard clipFor(id: clipId) != nil else { return [] }
         var targetIds: Set<String> = [clipId]
@@ -159,8 +166,8 @@ extension EditorViewModel {
         return multicamManualRippleViolation(shiftingTrackIds: shiftingTrackIds, atFrame: shiftPoint)
     }
 
-    /// Timeline delta from a ripple trim of `clip` by `delta` frames.
-    private func rippleTrimDurationDelta(for clip: Clip, edge: TrimEdge, delta: Int) -> Int {
+    /// Timeline duration change when `clip`'s edge is trimmed by `delta` frames, after per-clip speed rounding.
+    func trimDurationDelta(for clip: Clip, edge: TrimEdge, delta: Int) -> Int {
         let fields = trimValues(for: clip, edge: edge, delta: delta)
         let sourceShift = (fields.trimStart - clip.trimStartFrame) + (fields.trimEnd - clip.trimEndFrame)
         return -Int((Double(sourceShift) / clip.speed).rounded())

--- a/Tests/PalmierProTests/Agent/TrimClipsToolTests.swift
+++ b/Tests/PalmierProTests/Agent/TrimClipsToolTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("ToolExecutor — trim_clips")
+@MainActor
+struct TrimClipsToolTests {
+
+    private func clipFrames(_ h: ToolHarness, _ id: String) -> [Int]? {
+        guard let loc = h.editor.findClip(id: id) else { return nil }
+        let c = h.editor.timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        return [c.startFrame, c.endFrame]
+    }
+
+    @Test func toolIsExposedToAgentAndMCP() {
+        #expect(ToolDefinitions.mcpServer.contains { $0.name == .trimClips })
+        #expect(ToolDefinitions.inAppAgent.contains { $0.name == .trimClips })
+    }
+
+    @Test func trimsBothEdgesWithoutMovingNeighbors() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 100, duration: 100, trimStart: 30, trimEnd: 30),
+                Fixtures.clip(id: "b", start: 250, duration: 50),
+            ])
+        ]))
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "startFrame": 120, "endFrame": 180]]
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "a") == [120, 180])
+        #expect(clipFrames(h, "b") == [250, 300])
+        let clip = h.editor.timeline.tracks[0].clips.first { $0.id == "a" }
+        #expect(clip?.trimStartFrame == 50 && clip?.trimEndFrame == 50)
+        #expect(json?["notes"] == nil)
+    }
+
+    @Test func extendBeyondSourceHeadroomClampsAndReports() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 100, duration: 60, trimStart: 10)
+            ])
+        ]))
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "startFrame": 80]]
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "a") == [90, 160])
+        let notes = json?["notes"] as? [String]
+        #expect(notes?.contains { $0.contains("landed at frame 90") } == true)
+    }
+
+    @Test func rejectsFramesNearIntMaxWithoutTrapping() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "a", start: 0, duration: 60)])
+        ]))
+        let result = await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "a", "endFrame": 9_223_372_036_854_775_000]]
+        ])
+        #expect(result.isError)
+        #expect(clipFrames(h, "a") == [0, 60])
+    }
+
+    @Test func rippleTrimsWholeMulticamCohortFromOneEdit() async throws {
+        var camA = Fixtures.clip(id: "camA", start: 0, duration: 100)
+        var camB = Fixtures.clip(id: "camB", start: 0, duration: 100)
+        camA.multicamGroupId = "mc1"
+        camB.multicamGroupId = "mc1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [camA]),
+            Fixtures.videoTrack(clips: [camB]),
+        ]))
+
+        _ = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "camA", "endFrame": 80]],
+            "ripple": true,
+        ])
+        #expect(clipFrames(h, "camA") == [0, 80])
+        #expect(clipFrames(h, "camB") == [0, 80])
+    }
+
+    @Test func rejectsTwoRippleEditsSharingAMulticamCohort() async throws {
+        var camA = Fixtures.clip(id: "camA", start: 0, duration: 100)
+        var camB = Fixtures.clip(id: "camB", start: 0, duration: 100)
+        camA.multicamGroupId = "mc1"
+        camB.multicamGroupId = "mc1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [camA]),
+            Fixtures.videoTrack(clips: [camB]),
+        ]))
+
+        let result = await h.runRaw("trim_clips", args: [
+            "edits": [
+                ["clipId": "camA", "endFrame": 80],
+                ["clipId": "camB", "endFrame": 90],
+            ],
+            "ripple": true,
+        ])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("multicam"))
+        #expect(clipFrames(h, "camA") == [0, 100])
+        #expect(clipFrames(h, "camB") == [0, 100])
+    }
+
+    @Test func extendOverwritingLaterTargetReportsSkippedTrim() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 0, duration: 100, trimEnd: 50),
+                Fixtures.clip(id: "b", start: 100, duration: 30),
+            ])
+        ]))
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [
+                ["clipId": "a", "endFrame": 140],
+                ["clipId": "b", "endFrame": 120],
+            ]
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "a") == [0, 140])
+        #expect(h.editor.findClip(id: "b") == nil)
+        let notes = json?["notes"] as? [String]
+        #expect(notes?.contains { $0.contains("removed when an earlier edit extended over it") } == true)
+        let removed = json?["removedClipIds"] as? [String]
+        #expect(removed?.contains { "b".hasPrefix($0) || $0 == "b" } == true)
+    }
+
+    @Test func rippleTrimShiftsDownstreamClips() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 0, duration: 100),
+                Fixtures.clip(id: "b", start: 100, duration: 100),
+            ])
+        ]))
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "endFrame": 60]],
+            "ripple": true,
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "a") == [0, 60])
+        #expect(clipFrames(h, "b") == [60, 160])
+        #expect(json?["notes"] == nil)
+    }
+
+    @Test func rippleExtendPushesDownstreamClips() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 0, duration: 100, trimEnd: 30),
+                Fixtures.clip(id: "b", start: 100, duration: 100),
+            ])
+        ]))
+        _ = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "endFrame": 120]],
+            "ripple": true,
+        ])
+
+        #expect(clipFrames(h, "a") == [0, 120])
+        #expect(clipFrames(h, "b") == [120, 220])
+    }
+
+    @Test func rippleExtendWithoutHeadroomSkipsWithNote() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 0, duration: 100),
+                Fixtures.clip(id: "b", start: 100, duration: 100),
+            ])
+        ]))
+        let undoManager = UndoManager()
+        h.editor.undo.attach(undoManager)
+
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "endFrame": 120]],
+            "ripple": true,
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "a") == [0, 100])
+        #expect(clipFrames(h, "b") == [100, 200])
+        let notes = json?["notes"] as? [String]
+        #expect(notes?.contains { $0.contains("no headroom") } == true)
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func multipleClipsUndoAsOneAction() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "a", start: 0, duration: 60),
+                Fixtures.clip(id: "b", start: 100, duration: 60),
+            ])
+        ]))
+        let undoManager = UndoManager()
+        h.editor.undo.attach(undoManager)
+
+        _ = try await h.runOK("trim_clips", args: [
+            "edits": [
+                ["clipId": "a", "endFrame": 40],
+                ["clipId": "b", "endFrame": 120],
+            ]
+        ])
+        #expect(clipFrames(h, "a") == [0, 40])
+        #expect(clipFrames(h, "b") == [100, 120])
+
+        undoManager.undo()
+        #expect(clipFrames(h, "a") == [0, 60])
+        #expect(clipFrames(h, "b") == [100, 160])
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func linkedPartnerTrimsAlong() async throws {
+        var video = Fixtures.clip(id: "v", start: 0, duration: 100)
+        var audio = Fixtures.clip(id: "au", mediaType: .audio, start: 0, duration: 100)
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+
+        _ = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "v", "endFrame": 80]]
+        ])
+        #expect(clipFrames(h, "v") == [0, 80])
+        #expect(clipFrames(h, "au") == [0, 80])
+    }
+
+    @Test func retimedPartnerQuantizationDriftIsReported() async throws {
+        var video = Fixtures.clip(id: "v", start: 0, duration: 100)
+        var audio = Fixtures.clip(id: "au", mediaType: .audio, start: 0, duration: 100, speed: 0.5)
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+
+        // A 25-frame trim maps to 12.5 source frames at 0.5x; rounding moves the audio 26.
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "v", "endFrame": 75]]
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "v") == [0, 75])
+        #expect(clipFrames(h, "au") == [0, 74])
+        let notes = json?["notes"] as? [String]
+        #expect(notes?.contains { $0.contains("linked partner au") && $0.contains("26") && $0.contains("25") } == true)
+    }
+
+    @Test func sameSpeedPartnersTrimWithoutDriftNote() async throws {
+        var video = Fixtures.clip(id: "v", start: 0, duration: 100)
+        var audio = Fixtures.clip(id: "au", mediaType: .audio, start: 0, duration: 100)
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "v", "endFrame": 75]]
+        ]) as? [String: Any]
+
+        #expect(clipFrames(h, "v") == [0, 75])
+        #expect(clipFrames(h, "au") == [0, 75])
+        #expect(json?["notes"] == nil)
+    }
+
+    @Test func rejectsClipOrLinkedPartnerListedTwice() async throws {
+        var video = Fixtures.clip(id: "v", start: 0, duration: 100)
+        var audio = Fixtures.clip(id: "au", mediaType: .audio, start: 0, duration: 100)
+        video.linkGroupId = "g1"
+        audio.linkGroupId = "g1"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+
+        let duplicate = await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "v", "endFrame": 80], ["clipId": "v", "startFrame": 10]]
+        ])
+        #expect(duplicate.isError)
+
+        let partner = await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "v", "endFrame": 80], ["clipId": "au", "endFrame": 90]]
+        ])
+        #expect(partner.isError)
+        #expect(ToolHarness.textOf(partner).contains("linked partner"))
+    }
+
+    @Test func noOpRequestCreatesNoUndoEntry() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "a", start: 0, duration: 60)])
+        ]))
+        let undoManager = UndoManager()
+        h.editor.undo.attach(undoManager)
+
+        let json = try await h.runOK("trim_clips", args: [
+            "edits": [["clipId": "a", "startFrame": 0, "endFrame": 60]]
+        ]) as? [String: Any]
+
+        let notes = json?["notes"] as? [String]
+        #expect(notes?.contains { $0.contains("No change") } == true)
+        #expect(!undoManager.canUndo)
+    }
+
+    @Test func validationRejectsBadEdits() async throws {
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "a", start: 0, duration: 60)])
+        ]))
+
+        #expect((await h.runRaw("trim_clips", args: ["edits": []])).isError)
+        #expect((await h.runRaw("trim_clips", args: ["edits": [["clipId": "a"]]])).isError)
+        #expect((await h.runRaw("trim_clips", args: ["edits": [["clipId": "missing", "endFrame": 30]]])).isError)
+        #expect((await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "a", "startFrame": 50, "endFrame": 50]]
+        ])).isError)
+        #expect((await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "a", "startFrame": -5]]
+        ])).isError)
+        #expect((await h.runRaw("trim_clips", args: [
+            "edits": [["clipId": "a", "endFrame": 30, "bogus": 1]]
+        ])).isError)
+        // Nothing mutated by any rejected call.
+        #expect(clipFrames(h, "a") == [0, 60])
+    }
+}


### PR DESCRIPTION


## Summary

Adds the `trim_clips` Agent/MCP tool: trim or extend clip edges — where clips start or end on the timeline — for one or many clips in a single undoable action. Until now edge timing required raw source offsets via `set_clip_properties` (no ripple, no edge vocabulary) or multi-step workarounds.

- Each edit passes absolute project frames per edge (`startFrame` / `endFrame`, either or both) — the vocabulary `get_timeline`, `get_transcript`, and `search_media` already speak, so transcript-driven trims need no client-side arithmetic.
- `ripple=false` matches a regular edge drag: extending overwrites what the new span overlaps, shrinking leaves a gap.
- `ripple=true` matches a Shift-drag ripple trim: downstream clips and sync-locked tracks shift to close or open the gap. Batched ripple edits resolve deltas against pre-call frames, so one call retimes many cuts and undoes as one step.
- Linked A/V partners and multicam cohorts trim together through the same expansion rules as the timeline UI.

## Change statistics

- Tool contract + executor: ~205 insertions / 25 deletions (`ToolDefinitions.swift`, `ToolExecutor+Clips.swift`, `ToolExecutor.swift`)
- Editor domain seams: 13 insertions (`EditorViewModel+Ripple.swift`)
- Tests: 322 insertions (`TrimClipsToolTests.swift`)

Related: #436 / #437 build a `trim_clip` tool on a deeper domain refactor with exact-or-nothing semantics; this PR is the minimal-reuse alternative with batched ripple and clamp-and-report receipts.

Made with [Cursor](https://cursor.com)