### PR TITLE
[fix/sentry crash] Avoid active timeline access conflict

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -584,7 +584,9 @@ extension EditorViewModel {
     }
 
     private func mutateActiveTimeline(_ mutation: (inout Timeline) -> Void) {
-        mutation(&timeline)
+        var updatedTimeline = timeline
+        mutation(&updatedTimeline)
+        timeline = updatedTimeline
     }
 
     private func clipLocations(for clipIds: [String]) -> [String: ClipLocation] {

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -527,6 +527,30 @@ struct ClipPropertyCommitTests {
         #expect(e.clipFor(id: clip.id)?.effects == nil)
     }
 
+    @Test func committingScaleResetCanReadActiveTimeline() {
+        var clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
+        clip.transform.width = 0.5
+        clip.transform.height = 0.5
+        let e = editor([Fixtures.videoTrack(clips: [clip])])
+        let asset = MediaAsset(
+            id: clip.mediaRef,
+            url: URL(fileURLWithPath: "/tmp/media.mov"),
+            type: .video,
+            name: "media",
+            duration: 1
+        )
+        asset.sourceWidth = 1_920
+        asset.sourceHeight = 1_080
+        e.mediaAssets = [asset]
+
+        e.commitClipProperties(clipIds: [clip.id], actionName: "Reset Scale") {
+            $0.transform = e.fitTransform(for: $0)
+        }
+
+        #expect(e.clipFor(id: clip.id)?.transform.width == 1)
+        #expect(e.clipFor(id: clip.id)?.transform.height == 1)
+    }
+
     @Test func commitClipPropertiesGroupsMultipleClipUndo() {
         var a = Fixtures.clip(id: "a", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
         var b = Fixtures.clip(id: "b", mediaRef: "text", mediaType: .text, start: 30, duration: 30)


### PR DESCRIPTION
## Summary
- Prevent Inspector transform resets from crashing when batched clip mutations read the active timeline.
- Add a regression test covering the Sentry-reported access-conflict path.

## Approach
- Apply batched edits to a local `Timeline` value, then assign it to the active timeline after the mutation callback completes.
- This preserves a single committed timeline update while ensuring callbacks can safely read editor state without overlapping the `timelines` inout access.

## Testing
- `swift test --filter ClipPropertyCommitTests/committingScaleResetCanReadActiveTimeline` — reproduced the pre-fix signal 6 access-conflict crash; passes after the fix.
- `swift test --filter ClipPropertyCommitTests` — passed (8 tests).
- `swift build` — passed.
- `swift test` — 1,354/1,355 passed; unrelated `MCPToolListAnnouncementTests.sessionAnnouncesToolListChangedOnceOnGetStreamAttach` timed out connecting to its localhost MCP endpoint.
- Manual: verified Inspector scale reset and transform reset on a timeline clip no longer crash, including undo/redo and multi-selection.

## Change statistics
- Code logic: +3 / -1
- Tests: +24 / -0

Made with [Cursor](https://cursor.com)