### PR TITLE
[ui] Complete Agent chat localization

### DIFF
--- a/Sources/PalmierPro/Resources/Localization/ar.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ar.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "النشاط غير متاح";
 "Add Range to Chat" = "إضافة النطاق إلى الدردشة";
 "Add Text" = "إضافة نص";
+"Add an Anthropic API key or credits to use this model." = "أضف مفتاح واجهة API من Anthropic أو رصيدًا لاستخدام هذا النموذج.";
+"Add an OpenAI API key or credits to use this model." = "أضف مفتاح واجهة API من OpenAI أو رصيدًا لاستخدام هذا النموذج.";
 "Add an email above to enable a reply" = "أضف بريدًا إلكترونيًا أعلاه لإتاحة الرد";
 "Add captions" = "إضافة ترجمات";
 "Add credits" = "إضافة رصيد";
@@ -158,6 +160,7 @@
 "Change to Match" = "التغيير للمطابقة";
 "Changes take effect after restarting Palmier Pro." = "تسري التغييرات بعد إعادة تشغيل Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "يحافظ تغيير النسبة على الحافة الأقصر.";
+"Chat" = "الدردشة";
 "Chat history" = "سجل الدردشة";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "تحدث مع وكيلك. يمكنه إنشاء المحتوى وتحرير المقاطع وتنظيم أصولك وغير ذلك. ابدأ بتسجيل الدخول أو استخدم مفتاح واجهة API الخاص بك من Anthropic.";
 "Check for Updates…" = "التحقق من وجود تحديثات…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "الإنشاء قيد التنفيذ";
 "Generation panel" = "لوحة الإنشاء";
 "Get Anthropic API key" = "الحصول على مفتاح واجهة API من Anthropic";
+"Get OpenAI API key" = "الحصول على مفتاح واجهة API من OpenAI";
 "Get a notification when a generation finishes." = "تلقي إشعار عند اكتمال الإنشاء.";
 "Getting the search model ready." = "جارٍ إعداد نموذج البحث.";
 "Glow" = "توهج";
@@ -418,6 +422,8 @@
 "Height" = "الارتفاع";
 "Help" = "مساعدة";
 "Hide keyframe timeline" = "إخفاء المخطط الزمني للإطارات الرئيسية";
+"Hide reasoning" = "إخفاء الاستدلال";
+"High" = "مرتفع";
 "Highlight" = "تمييز";
 "Highlight Block" = "كتلة التمييز";
 "Highlights" = "الإضاءات";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "جارٍ الفهرسة ⁨%lld/%lld⁩";
 "Input" = "الإدخال";
 "Inspector" = "لوحة الخصائص";
+"Inspector Panel" = "لوحة الخصائص";
 "Install" = "تثبيت";
 "Install in Claude Desktop" = "التثبيت في Claude Desktop";
 "Install in Cursor" = "التثبيت في Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "يعمل الوضع المحلي باستخدام SpeechAnalyzer من Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "يعمل الوضع المحلي باستخدام SpeechAnalyzer من Apple. يستخدم الوضع السحابي الرصيد ونموذجًا أدق بإمكانات أكثر.";
 "Log in for 250 free credits" = "سجّل الدخول للحصول على 250 رصيدًا مجانيًا";
+"Low" = "منخفض";
 "Luma" = "لوما";
 "Luminosity" = "الإضاءة";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "كلمات الأغنية (اختيارية). علامتا ⁨[Verse]⁩ و⁨[Chorus]⁩ مدعومتان.";
@@ -526,6 +534,7 @@
 "Match Timeline" = "مطابقة المخطط الزمني";
 "Match mouth movement to replacement audio" = "مطابقة حركة الفم مع الصوت البديل";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "يطابق الأصوات بين المقاطع، مع تفريغ مقاطع المخطط الزمني غير المفرّغة أولاً (يستخدم الرصيد). تُحفظ النصوص المفرّغة وبصمات الصوت في ذاكرة التخزين المؤقت، لذلك تكون عمليات التشغيل التالية سريعة.";
+"Max" = "الحد الأقصى";
 "Max plan" = "خطة Max";
 "Max words" = "الحد الأقصى للكلمات";
 "Maximize Focused Panel" = "تكبير اللوحة النشطة";
@@ -539,6 +548,7 @@
 "Medium" = "متوسط";
 "Mic" = "الميكروفون";
 "Midpoint" = "نقطة المنتصف";
+"Minimal" = "الحد الأدنى";
 "Minimum Pause" = "الحد الأدنى للتوقف";
 "Mixed" = "مختلط";
 "Mode" = "الوضع";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "افتح «المهارات» لاستعراض أدلة عمل المجتمع أو إنشاء مهاراتك أو إضافتها إلى وكلاء آخرين.";
 "Open Timeline" = "فتح المخطط الزمني";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "افتح علامة التبويب «تحرير بالذكاء الاصطناعي» لرفع الدقة، أو التحرير عبر مطالبة، أو إنشاء فيديو من إطار، أو توليد موسيقى ومؤثرات صوتية وتنظيف الصوت والدبلجة من المقطع.";
+"OpenAI API Key" = "مفتاح واجهة API من OpenAI";
 "Opening Google" = "جارٍ فتح Google";
 "Opening Google…" = "جارٍ فتح Google…";
 "Open…" = "فتح…";
@@ -671,6 +682,7 @@
 "Range" = "النطاق";
 "Razor (C)" = "الشفرة ⁨(C)⁩";
 "Razor Tool" = "أداة الشفرة";
+"Reasoning effort" = "مستوى الاستدلال";
 "Redetect Beats" = "إعادة اكتشاف الإيقاعات";
 "Redo" = "إعادة";
 "Redo (⇧⌘Z)" = "إعادة ⁨(⇧⌘Z)⁩";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "تحديد إلى الأمام على كل المسارات";
 "Select Forward on Track" = "تحديد إلى الأمام على المسار";
 "Select Range" = "تحديد نطاق";
-"Select a range" = "حدد نطاقًا";
 "Select a single clip to enable" = "حدد مقطعًا واحدًا للتمكين";
 "Select media files or folders to import" = "حدد ملفات الوسائط أو المجلدات لاستيرادها";
 "Selected" = "محدد";
@@ -794,6 +805,7 @@
 "Show in Finder" = "إظهار في Finder";
 "Show keyframe timeline" = "إظهار المخطط الزمني للإطارات الرئيسية";
 "Show notifications" = "إظهار الإشعارات";
+"Show reasoning" = "إظهار الاستدلال";
 "Side by Side" = "جنبًا إلى جنب";
 "Sign In" = "تسجيل الدخول";
 "Sign in" = "تسجيل الدخول";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "سجّل الدخول للحصول على 250 رصيدًا مجانيًا لدردشة الذكاء الاصطناعي والإنشاء.";
 "Sign in to subscribe and use AI generation." = "سجّل الدخول للاشتراك واستخدام الإنشاء بالذكاء الاصطناعي.";
 "Sign in to use AI" = "سجّل الدخول لاستخدام الذكاء الاصطناعي";
+"Sign in to use AI chat." = "سجّل الدخول لاستخدام دردشة الذكاء الاصطناعي.";
 "Sign in to use Cloud transcription." = "سجّل الدخول لاستخدام التفريغ النصي السحابي.";
 "Sign in to use Cloud." = "سجّل الدخول لاستخدام الوضع السحابي.";
 "Sign in with Google" = "تسجيل الدخول باستخدام Google";
@@ -848,11 +861,13 @@
 "Stopped" = "متوقف";
 "Storage" = "التخزين";
 "Streaming through your Anthropic API key (BYOK)" = "جارٍ البث عبر مفتاح واجهة API الخاص بك من Anthropic ‏(BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "جارٍ البث عبر مفتاح واجهة API الخاص بك من OpenAI ‏(BYOK)";
 "Strikethrough" = "يتوسطه خط";
 "Student" = "طالب";
 "Style" = "النمط";
 "Style instructions (optional). e.g., warm and slow, British accent." = "تعليمات النمط (اختيارية)، مثل: دافئ وبطيء، بلهجة بريطانية.";
 "Subscribe" = "اشتراك";
+"Subscribe or add your own API key to use this model." = "اشترك أو أضف مفتاح واجهة API الخاص بك لاستخدام هذا النموذج.";
 "Subscription" = "الاشتراك";
 "Swap Media" = "تبديل الوسائط";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "بدّل وسائط المقطع عند اكتمال الإنشاء. يتم الاحتفاظ بالسرعة ومستوى الصوت والتشذيب والتحويل.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "للمقطع الذي تضيفه إعدادات مختلفة عن المشروع الحالي.";
 "The export" = "الملف";
 "The project will be moved to the Trash." = "سيتم نقل المشروع إلى سلة المهملات.";
+"The selected model refused this request. Revise the prompt and try again." = "رفض النموذج المحدد هذا الطلب. عدّل المطالبة وأعد المحاولة.";
 "The selected projects will be moved to the Trash." = "سيتم نقل المشاريع المحددة إلى سلة المهملات.";
 "The timeline settings changed. Close this sheet and try again." = "تغيرت إعدادات المخطط الزمني. أغلق هذه اللوحة وأعد المحاولة.";
 "Theme" = "السمة";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "هذه مسطرة المخطط الزمني. اضغط على Shift واسحب على المسطرة لتحديد نطاق للتصيير. يمكنك اختيار أي خانة للتحرير بالذكاء الاصطناعي أو إنشاء موسيقى تلائم ذلك النطاق.";
 "This is where all your footage and assets live." = "هنا توجد كل لقطاتك وأصولك.";
 "This is your preview panel to play a selected media or the whole timeline." = "هذه لوحة المعاينة لتشغيل الوسائط المحددة أو المخطط الزمني كاملاً.";
 "This model cannot cap the output at 60 FPS." = "لا يمكن لهذا النموذج تحديد سقف الإخراج عند ⁨60 FPS⁩.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "انزلاق الكلمات";
 "Working on %@" = "جارٍ العمل على ⁨%@⁩";
 "Workspace layout" = "تخطيط مساحة العمل";
+"X High" = "مرتفع جدًا";
 "You're all set" = "أصبح كل شيء جاهزًا";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "رسم Lottie المتحرك جاهز.";
@@ -1019,7 +1035,9 @@
 "error" = "خطأ";
 "group moved right to fit" = "تم تحريك المجموعة إلى اليمين للملاءمة";
 "lowercase" = "أحرف صغيرة";
-"or use your own Anthropic key" = "أو استخدم مفتاح Anthropic الخاص بك";
+"or add your own Anthropic key" = "أو أضف مفتاح Anthropic الخاص بك";
+"or add your own OpenAI key" = "أو أضف مفتاح OpenAI الخاص بك";
 "result" = "النتيجة";
-"using API key" = "باستخدام مفتاح واجهة API";
+"using Anthropic API key" = "باستخدام مفتاح واجهة API من Anthropic";
+"using OpenAI API key" = "باستخدام مفتاح واجهة API من OpenAI";
 "you@example.com — so we can reply" = "⁨you@example.com⁩ حتى نتمكن من الرد";

--- a/Sources/PalmierPro/Resources/Localization/bn.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/bn.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "অ্যাক্টিভিটি পাওয়া যাচ্ছে না";
 "Add Range to Chat" = "চ্যাটে রেঞ্জ যোগ করুন";
 "Add Text" = "টেক্সট যোগ করুন";
+"Add an Anthropic API key or credits to use this model." = "এই মডেল ব্যবহার করতে Anthropic API কী বা ক্রেডিট যোগ করুন।";
+"Add an OpenAI API key or credits to use this model." = "এই মডেল ব্যবহার করতে OpenAI API কী বা ক্রেডিট যোগ করুন।";
 "Add an email above to enable a reply" = "উত্তর পেতে উপরে একটি ইমেইল যোগ করুন";
 "Add captions" = "ক্যাপশন যোগ করুন";
 "Add credits" = "ক্রেডিট যোগ করুন";
@@ -158,6 +160,7 @@
 "Change to Match" = "ম্যাচ করতে পরিবর্তন করুন";
 "Changes take effect after restarting Palmier Pro." = "Palmier Pro রিস্টার্ট করার পরে পরিবর্তন কার্যকর হবে।";
 "Changing the ratio preserves the shorter edge." = "রেশিও পরিবর্তন করলে ছোট দিকটি অপরিবর্তিত থাকে।";
+"Chat" = "চ্যাট";
 "Chat history" = "চ্যাট হিস্ট্রি";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "আপনার এজেন্টের সঙ্গে চ্যাট করুন। এটি কনটেন্ট জেনারেট, ক্লিপ এডিট, অ্যাসেট সাজানোসহ আরও অনেক কিছু করতে পারে। সাইন ইন করে বা নিজের Anthropic API কী দিয়ে শুরু করুন।";
 "Check for Updates…" = "আপডেট দেখুন…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "জেনারেশন চলছে";
 "Generation panel" = "জেনারেশন প্যানেল";
 "Get Anthropic API key" = "Anthropic API কী নিন";
+"Get OpenAI API key" = "OpenAI API কী নিন";
 "Get a notification when a generation finishes." = "জেনারেশন শেষ হলে নোটিফিকেশন নিন।";
 "Getting the search model ready." = "সার্চ মডেল প্রস্তুত করা হচ্ছে।";
 "Glow" = "গ্লো";
@@ -418,6 +422,8 @@
 "Height" = "উচ্চতা";
 "Help" = "সহায়তা";
 "Hide keyframe timeline" = "কিফ্রেম টাইমলাইন লুকান";
+"Hide reasoning" = "চিন্তাপ্রক্রিয়া লুকান";
+"High" = "উচ্চ";
 "Highlight" = "হাইলাইট";
 "Highlight Block" = "হাইলাইট ব্লক";
 "Highlights" = "হাইলাইটস";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "ইনডেক্স হচ্ছে %lld/%lld";
 "Input" = "ইনপুট";
 "Inspector" = "ইনস্পেক্টর";
+"Inspector Panel" = "ইনস্পেক্টর প্যানেল";
 "Install" = "ইনস্টল";
 "Install in Claude Desktop" = "Claude Desktop-এ ইনস্টল করুন";
 "Install in Cursor" = "Cursor-এ ইনস্টল করুন";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "লোকাল মোড Apple-এর SpeechAnalyzer দিয়ে চলে।";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "লোকাল মোড Apple-এর SpeechAnalyzer দিয়ে চলে। ক্লাউড ক্রেডিট ব্যবহার করে এবং আরও বেশি ক্ষমতাসম্পন্ন নির্ভুল মডেল ব্যবহার করে।";
 "Log in for 250 free credits" = "২৫০ ফ্রি ক্রেডিট পেতে লগ ইন করুন";
+"Low" = "নিম্ন";
 "Luma" = "লুমা";
 "Luminosity" = "লুমিনোসিটি";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "লিরিক্স (ঐচ্ছিক)। [Verse] ও [Chorus] ট্যাগ সাপোর্টেড।";
@@ -526,6 +534,7 @@
 "Match Timeline" = "টাইমলাইনের সঙ্গে ম্যাচ করুন";
 "Match mouth movement to replacement audio" = "রিপ্লেসমেন্ট অডিওর সঙ্গে মুখের নড়াচড়া মেলান";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "সব ক্লিপের ভয়েস ম্যাচ করে এবং প্রথমে ট্রান্সক্রিপ্ট না থাকা টাইমলাইন ক্লিপ ট্রান্সক্রাইব করে (ক্রেডিট ব্যবহার করে)। ট্রান্সক্রিপ্ট ও ভয়েস ফিঙ্গারপ্রিন্ট ক্যাশ করা থাকে, তাই আবার চালালে দ্রুত হয়।";
+"Max" = "সর্বোচ্চ";
 "Max plan" = "Max প্ল্যান";
 "Max words" = "সর্বোচ্চ শব্দ";
 "Maximize Focused Panel" = "ফোকাস করা প্যানেল ম্যাক্সিমাইজ করুন";
@@ -539,6 +548,7 @@
 "Medium" = "মাঝারি";
 "Mic" = "মাইক";
 "Midpoint" = "মিডপয়েন্ট";
+"Minimal" = "সর্বনিম্ন";
 "Minimum Pause" = "সর্বনিম্ন বিরতি";
 "Mixed" = "মিশ্র";
 "Mode" = "মোড";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "কমিউনিটি প্লেবুক দেখতে, নিজের স্কিল তৈরি করতে বা অন্য এজেন্টে যোগ করতে স্কিল খুলুন।";
 "Open Timeline" = "টাইমলাইন খুলুন";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI Edit ট্যাব খুলে আপস্কেল করুন, প্রম্পট দিয়ে এডিট করুন, একটি ফ্রেম থেকে ভিডিও তৈরি করুন, অথবা ক্লিপ থেকে মিউজিক, SFX, ক্লিনআপ ও ডাবিং জেনারেট করুন।";
+"OpenAI API Key" = "OpenAI API কী";
 "Opening Google" = "Google খোলা হচ্ছে";
 "Opening Google…" = "Google খোলা হচ্ছে…";
 "Open…" = "খুলুন…";
@@ -671,6 +682,7 @@
 "Range" = "রেঞ্জ";
 "Razor (C)" = "রেজর (C)";
 "Razor Tool" = "রেজর টুল";
+"Reasoning effort" = "চিন্তাপ্রক্রিয়ার মাত্রা";
 "Redetect Beats" = "বিট আবার শনাক্ত করুন";
 "Redo" = "রিডু";
 "Redo (⇧⌘Z)" = "রিডু (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "সব ট্র্যাকে সামনেরগুলো সিলেক্ট করুন";
 "Select Forward on Track" = "ট্র্যাকে সামনেরগুলো সিলেক্ট করুন";
 "Select Range" = "রেঞ্জ সিলেক্ট করুন";
-"Select a range" = "একটি রেঞ্জ সিলেক্ট করুন";
 "Select a single clip to enable" = "সক্রিয় করতে একটি ক্লিপ সিলেক্ট করুন";
 "Select media files or folders to import" = "ইমপোর্ট করার মিডিয়া ফাইল বা ফোল্ডার সিলেক্ট করুন";
 "Selected" = "সিলেক্ট করা";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Finder-এ দেখান";
 "Show keyframe timeline" = "কিফ্রেম টাইমলাইন দেখান";
 "Show notifications" = "নোটিফিকেশন দেখান";
+"Show reasoning" = "চিন্তাপ্রক্রিয়া দেখান";
 "Side by Side" = "পাশাপাশি";
 "Sign In" = "সাইন ইন";
 "Sign in" = "সাইন ইন করুন";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "AI চ্যাট ও জেনারেশনের জন্য ২৫০ ফ্রি ক্রেডিট পেতে সাইন ইন করুন।";
 "Sign in to subscribe and use AI generation." = "সাবস্ক্রাইব ও AI জেনারেশন ব্যবহার করতে সাইন ইন করুন।";
 "Sign in to use AI" = "AI ব্যবহার করতে সাইন ইন করুন";
+"Sign in to use AI chat." = "AI চ্যাট ব্যবহার করতে সাইন ইন করুন।";
 "Sign in to use Cloud transcription." = "ক্লাউড ট্রান্সক্রিপশন ব্যবহার করতে সাইন ইন করুন।";
 "Sign in to use Cloud." = "ক্লাউড ব্যবহার করতে সাইন ইন করুন।";
 "Sign in with Google" = "Google দিয়ে সাইন ইন করুন";
@@ -848,11 +861,13 @@
 "Stopped" = "থামানো হয়েছে";
 "Storage" = "স্টোরেজ";
 "Streaming through your Anthropic API key (BYOK)" = "আপনার Anthropic API কী দিয়ে স্ট্রিম হচ্ছে (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "আপনার OpenAI API কী দিয়ে স্ট্রিম হচ্ছে (BYOK)";
 "Strikethrough" = "স্ট্রাইকথ্রু";
 "Student" = "শিক্ষার্থী";
 "Style" = "স্টাইল";
 "Style instructions (optional). e.g., warm and slow, British accent." = "স্টাইল নির্দেশনা (ঐচ্ছিক)। যেমন: উষ্ণ ও ধীর, ব্রিটিশ অ্যাকসেন্ট।";
 "Subscribe" = "সাবস্ক্রাইব";
+"Subscribe or add your own API key to use this model." = "এই মডেল ব্যবহার করতে সাবস্ক্রাইব করুন অথবা নিজের API কী যোগ করুন।";
 "Subscription" = "সাবস্ক্রিপশন";
 "Swap Media" = "মিডিয়া সোয়াপ করুন";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "জেনারেশন শেষ হলে ক্লিপের মিডিয়া সোয়াপ করে। স্পিড, ভলিউম, ট্রিম ও ট্রান্সফর্ম অপরিবর্তিত থাকে।";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "আপনি যে ক্লিপ যোগ করছেন তার সেটিংস বর্তমান প্রজেক্ট থেকে আলাদা।";
 "The export" = "এক্সপোর্টটি";
 "The project will be moved to the Trash." = "প্রজেক্টটি ট্র্যাশে সরানো হবে।";
+"The selected model refused this request. Revise the prompt and try again." = "সিলেক্ট করা মডেলটি এই অনুরোধ প্রত্যাখ্যান করেছে। প্রম্পট সংশোধন করে আবার চেষ্টা করুন।";
 "The selected projects will be moved to the Trash." = "সিলেক্ট করা প্রজেক্টগুলো ট্র্যাশে সরানো হবে।";
 "The timeline settings changed. Close this sheet and try again." = "টাইমলাইন সেটিংস বদলেছে। এই শিট বন্ধ করে আবার চেষ্টা করুন।";
 "Theme" = "থিম";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "এটি টাইমলাইন রুলার। রেন্ডারের রেঞ্জ সিলেক্ট করতে রুলারে Shift চেপে ড্র্যাগ করুন। যেকোনো স্লট বেছে নিয়ে AI দিয়ে এডিট করতে বা সেই রেঞ্জের উপযোগী মিউজিক জেনারেট করতে পারেন।";
 "This is where all your footage and assets live." = "আপনার সব ফুটেজ ও অ্যাসেট এখানে থাকে।";
 "This is your preview panel to play a selected media or the whole timeline." = "এটি সিলেক্ট করা মিডিয়া বা পুরো টাইমলাইন প্লে করার প্রিভিউ প্যানেল।";
 "This model cannot cap the output at 60 FPS." = "এই মডেল আউটপুট 60 FPS-এ সীমাবদ্ধ করতে পারে না।";
@@ -997,6 +1012,7 @@
 "Word Slide" = "ওয়ার্ড স্লাইড";
 "Working on %@" = "%@ নিয়ে কাজ হচ্ছে";
 "Workspace layout" = "ওয়ার্কস্পেস লেআউট";
+"X High" = "অতি উচ্চ";
 "You're all set" = "সব প্রস্তুত";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "আপনার Lottie অ্যানিমেশন প্রস্তুত।";
@@ -1019,7 +1035,9 @@
 "error" = "এরর";
 "group moved right to fit" = "ফিট করতে গ্রুপ ডানে সরানো হয়েছে";
 "lowercase" = "ছোট হাতের অক্ষর";
-"or use your own Anthropic key" = "অথবা নিজের Anthropic কী ব্যবহার করুন";
+"or add your own Anthropic key" = "অথবা নিজের Anthropic কী যোগ করুন";
+"or add your own OpenAI key" = "অথবা নিজের OpenAI কী যোগ করুন";
 "result" = "ফলাফল";
-"using API key" = "API কী ব্যবহার হচ্ছে";
+"using Anthropic API key" = "Anthropic API কী ব্যবহার হচ্ছে";
+"using OpenAI API key" = "OpenAI API কী ব্যবহার হচ্ছে";
 "you@example.com — so we can reply" = "you@example.com — যাতে আমরা উত্তর দিতে পারি";

--- a/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/es.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "La actividad no está disponible";
 "Add Range to Chat" = "Añadir intervalo al chat";
 "Add Text" = "Añadir texto";
+"Add an Anthropic API key or credits to use this model." = "Añade una clave de API de Anthropic o créditos para usar este modelo.";
+"Add an OpenAI API key or credits to use this model." = "Añade una clave de API de OpenAI o créditos para usar este modelo.";
 "Add an email above to enable a reply" = "Añade un correo electrónico arriba para recibir una respuesta";
 "Add captions" = "Añadir subtítulos";
 "Add credits" = "Añadir créditos";
@@ -158,6 +160,7 @@
 "Change to Match" = "Cambiar para que coincidan";
 "Changes take effect after restarting Palmier Pro." = "Los cambios se aplicarán después de reiniciar Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "Al cambiar la relación, se conserva el borde más corto.";
+"Chat" = "Chat";
 "Chat history" = "Historial del chat";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Chatea con tu agente. Puede generar contenido, editar clips, organizar tus recursos y mucho más. Para empezar, inicia sesión o usa tu propia clave de API de Anthropic.";
 "Check for Updates…" = "Buscar actualizaciones…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Generación en curso";
 "Generation panel" = "Panel de generación";
 "Get Anthropic API key" = "Obtener clave de API de Anthropic";
+"Get OpenAI API key" = "Obtener clave de API de OpenAI";
 "Get a notification when a generation finishes." = "Recibe una notificación cuando finalice una generación.";
 "Getting the search model ready." = "Preparando el modelo de búsqueda.";
 "Glow" = "Resplandor";
@@ -418,6 +422,8 @@
 "Height" = "Altura";
 "Help" = "Ayuda";
 "Hide keyframe timeline" = "Ocultar línea de tiempo de fotogramas clave";
+"Hide reasoning" = "Ocultar razonamiento";
+"High" = "Alto";
 "Highlight" = "Resaltar";
 "Highlight Block" = "Bloque resaltado";
 "Highlights" = "Zonas claras";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Indexando %lld/%lld";
 "Input" = "Entrada";
 "Inspector" = "Inspector";
+"Inspector Panel" = "Panel del inspector";
 "Install" = "Instalar";
 "Install in Claude Desktop" = "Instalar en Claude Desktop";
 "Install in Cursor" = "Instalar en Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "Local se ejecuta con SpeechAnalyzer de Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "Local se ejecuta con SpeechAnalyzer de Apple. Cloud usa créditos y un modelo más preciso con más funciones.";
 "Log in for 250 free credits" = "Inicia sesión para obtener 250 créditos gratis";
+"Low" = "Bajo";
 "Luma" = "Luma";
 "Luminosity" = "Luminosidad";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Letra (opcional). Se admiten las etiquetas [Verse] y [Chorus].";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Igualar línea de tiempo";
 "Match mouth movement to replacement audio" = "Sincronizar el movimiento de la boca con el audio de sustitución";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Busca las mismas voces en distintos clips y primero transcribe los clips sin transcripción de la línea de tiempo (usa créditos). Las transcripciones y huellas de voz se guardan en caché para agilizar las repeticiones.";
+"Max" = "Máximo";
 "Max plan" = "Plan Max";
 "Max words" = "Máximo de palabras";
 "Maximize Focused Panel" = "Maximizar panel seleccionado";
@@ -539,6 +548,7 @@
 "Medium" = "Mediano";
 "Mic" = "Micrófono";
 "Midpoint" = "Punto medio";
+"Minimal" = "Mínimo";
 "Minimum Pause" = "Pausa mínima";
 "Mixed" = "Mixto";
 "Mode" = "Modo";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Abre Habilidades para explorar guías de la comunidad, crear las tuyas o añadirlas a otros agentes.";
 "Open Timeline" = "Abrir línea de tiempo";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Abre la pestaña Edición con IA para aumentar la resolución, editar con un prompt, crear vídeo a partir de un fotograma, o generar música, efectos de sonido, limpieza de voz y doblaje desde el clip.";
+"OpenAI API Key" = "Clave de API de OpenAI";
 "Opening Google" = "Abriendo Google";
 "Opening Google…" = "Abriendo Google…";
 "Open…" = "Abrir…";
@@ -671,6 +682,7 @@
 "Range" = "Intervalo";
 "Razor (C)" = "Cuchilla (C)";
 "Razor Tool" = "Herramienta Cuchilla";
+"Reasoning effort" = "Esfuerzo de razonamiento";
 "Redetect Beats" = "Volver a detectar pulsos";
 "Redo" = "Rehacer";
 "Redo (⇧⌘Z)" = "Rehacer (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Seleccionar hacia delante en todas las pistas";
 "Select Forward on Track" = "Seleccionar hacia delante en la pista";
 "Select Range" = "Seleccionar intervalo";
-"Select a range" = "Selecciona un intervalo";
 "Select a single clip to enable" = "Selecciona un solo clip para activar";
 "Select media files or folders to import" = "Selecciona archivos o carpetas multimedia para importar";
 "Selected" = "Seleccionado";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Mostrar en el Finder";
 "Show keyframe timeline" = "Mostrar línea de tiempo de fotogramas clave";
 "Show notifications" = "Mostrar notificaciones";
+"Show reasoning" = "Mostrar razonamiento";
 "Side by Side" = "Lado a lado";
 "Sign In" = "Iniciar sesión";
 "Sign in" = "Iniciar sesión";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Inicia sesión para recibir 250 créditos gratis para chat y generación con IA.";
 "Sign in to subscribe and use AI generation." = "Inicia sesión para suscribirte y usar la generación con IA.";
 "Sign in to use AI" = "Inicia sesión para usar la IA";
+"Sign in to use AI chat." = "Inicia sesión para usar el chat con IA.";
 "Sign in to use Cloud transcription." = "Inicia sesión para usar la transcripción de Cloud.";
 "Sign in to use Cloud." = "Inicia sesión para usar Cloud.";
 "Sign in with Google" = "Iniciar sesión con Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Detenido";
 "Storage" = "Almacenamiento";
 "Streaming through your Anthropic API key (BYOK)" = "Transmitiendo mediante tu clave de API de Anthropic (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Transmitiendo mediante tu clave de API de OpenAI (BYOK)";
 "Strikethrough" = "Tachado";
 "Student" = "Estudiante";
 "Style" = "Estilo";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Instrucciones de estilo (opcional). Por ejemplo: cálido y lento, acento británico.";
 "Subscribe" = "Suscribirse";
+"Subscribe or add your own API key to use this model." = "Suscríbete o añade tu propia clave de API para usar este modelo.";
 "Subscription" = "Suscripción";
 "Swap Media" = "Sustituir contenido multimedia";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Sustituye el contenido multimedia del clip cuando finalice la generación. Se conservan la velocidad, el volumen, el recorte y la transformación.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "El clip que estás añadiendo tiene ajustes distintos a los del proyecto actual.";
 "The export" = "La exportación";
 "The project will be moved to the Trash." = "El proyecto se trasladará a la Papelera.";
+"The selected model refused this request. Revise the prompt and try again." = "El modelo seleccionado ha rechazado esta solicitud. Reformula la indicación y vuelve a intentarlo.";
 "The selected projects will be moved to the Trash." = "Los proyectos seleccionados se trasladarán a la Papelera.";
 "The timeline settings changed. Close this sheet and try again." = "Los ajustes de la línea de tiempo han cambiado. Cierra esta hoja y vuelve a intentarlo.";
 "Theme" = "Tema";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Esta es la regla de la línea de tiempo. Pulsa Mayúsculas y arrastra sobre la regla para seleccionar un intervalo que renderizar. Puedes elegir cualquier tramo para editarlo con IA o generar música que encaje en ese intervalo.";
 "This is where all your footage and assets live." = "Aquí se encuentran todo tu material y tus recursos.";
 "This is your preview panel to play a selected media or the whole timeline." = "Este es el panel de previsualización, donde puedes reproducir el contenido seleccionado o toda la línea de tiempo.";
 "This model cannot cap the output at 60 FPS." = "Este modelo no puede limitar la salida a 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Deslizamiento de palabras";
 "Working on %@" = "Trabajando en %@";
 "Workspace layout" = "Disposición del espacio de trabajo";
+"X High" = "Muy alto";
 "You're all set" = "Todo está listo";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Tu animación Lottie está lista.";
@@ -1019,7 +1035,9 @@
 "error" = "error";
 "group moved right to fit" = "grupo desplazado a la derecha para encajar";
 "lowercase" = "minúsculas";
-"or use your own Anthropic key" = "o usa tu propia clave de Anthropic";
+"or add your own Anthropic key" = "o añade tu propia clave de Anthropic";
+"or add your own OpenAI key" = "o añade tu propia clave de OpenAI";
 "result" = "resultado";
-"using API key" = "usando clave de API";
+"using Anthropic API key" = "usando la clave de API de Anthropic";
+"using OpenAI API key" = "usando la clave de API de OpenAI";
 "you@example.com — so we can reply" = "tu@ejemplo.com — para que podamos responder";

--- a/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/fr.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "Activité indisponible";
 "Add Range to Chat" = "Ajouter la plage au chat";
 "Add Text" = "Ajouter du texte";
+"Add an Anthropic API key or credits to use this model." = "Ajoutez une clé API Anthropic ou des crédits pour utiliser ce modèle.";
+"Add an OpenAI API key or credits to use this model." = "Ajoutez une clé API OpenAI ou des crédits pour utiliser ce modèle.";
 "Add an email above to enable a reply" = "Ajoutez une adresse e-mail ci-dessus pour recevoir une réponse";
 "Add captions" = "Ajouter des sous-titres";
 "Add credits" = "Ajouter des crédits";
@@ -158,6 +160,7 @@
 "Change to Match" = "Modifier pour correspondre";
 "Changes take effect after restarting Palmier Pro." = "Les modifications prennent effet après le redémarrage de Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "Le changement de format conserve le côté le plus court.";
+"Chat" = "Chat";
 "Chat history" = "Historique du chat";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Échangez avec votre agent. Il peut générer du contenu, monter des clips, organiser vos ressources et bien plus. Pour commencer, connectez-vous ou utilisez votre propre clé API Anthropic.";
 "Check for Updates…" = "Rechercher les mises à jour…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Génération en cours";
 "Generation panel" = "Panneau de génération";
 "Get Anthropic API key" = "Obtenir une clé API Anthropic";
+"Get OpenAI API key" = "Obtenir une clé API OpenAI";
 "Get a notification when a generation finishes." = "Recevez une notification à la fin d’une génération.";
 "Getting the search model ready." = "Préparation du modèle de recherche.";
 "Glow" = "Lueur";
@@ -418,6 +422,8 @@
 "Height" = "Hauteur";
 "Help" = "Aide";
 "Hide keyframe timeline" = "Masquer la timeline des images clés";
+"Hide reasoning" = "Masquer le raisonnement";
+"High" = "Élevé";
 "Highlight" = "Surligner";
 "Highlight Block" = "Bloc de surbrillance";
 "Highlights" = "Hautes lumières";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Indexation %lld/%lld";
 "Input" = "Entrée";
 "Inspector" = "Inspecteur";
+"Inspector Panel" = "Panneau Inspecteur";
 "Install" = "Installer";
 "Install in Claude Desktop" = "Installer dans Claude Desktop";
 "Install in Cursor" = "Installer dans Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "Le mode Local utilise SpeechAnalyzer d’Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "Le mode Local utilise SpeechAnalyzer d’Apple. Le Cloud consomme des crédits et utilise un modèle plus précis et plus complet.";
 "Log in for 250 free credits" = "Connectez-vous pour obtenir 250 crédits gratuits";
+"Low" = "Faible";
 "Luma" = "Luma";
 "Luminosity" = "Luminosité";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Paroles (facultatif). Les balises [Verse] et [Chorus] sont prises en charge.";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Adapter à la timeline";
 "Match mouth movement to replacement audio" = "Synchroniser les mouvements de la bouche avec l’audio de remplacement";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Associe les voix entre les clips après avoir transcrit les clips sans transcription de la timeline (utilise des crédits). Les transcriptions et empreintes vocales sont mises en cache pour accélérer les exécutions suivantes.";
+"Max" = "Maximum";
 "Max plan" = "Formule Max";
 "Max words" = "Nombre maximal de mots";
 "Maximize Focused Panel" = "Agrandir le panneau actif";
@@ -539,6 +548,7 @@
 "Medium" = "Moyenne";
 "Mic" = "Micro";
 "Midpoint" = "Point central";
+"Minimal" = "Minimal";
 "Minimum Pause" = "Pause minimale";
 "Mixed" = "Mixte";
 "Mode" = "Mode";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Ouvrez Compétences pour parcourir les guides de la communauté, créer les vôtres ou les ajouter à d’autres agents.";
 "Open Timeline" = "Ouvrir la timeline";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Ouvrez l’onglet Montage IA pour augmenter la résolution, modifier via une invite, créer une vidéo à partir d’une image, ou générer musique, effets sonores, nettoyage de la voix et doublage à partir du clip.";
+"OpenAI API Key" = "Clé API OpenAI";
 "Opening Google" = "Ouverture de Google";
 "Opening Google…" = "Ouverture de Google…";
 "Open…" = "Ouvrir…";
@@ -671,6 +682,7 @@
 "Range" = "Plage";
 "Razor (C)" = "Lame (C)";
 "Razor Tool" = "Outil Lame";
+"Reasoning effort" = "Effort de raisonnement";
 "Redetect Beats" = "Redétecter les temps";
 "Redo" = "Rétablir";
 "Redo (⇧⌘Z)" = "Rétablir (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Sélectionner vers l’avant sur toutes les pistes";
 "Select Forward on Track" = "Sélectionner vers l’avant sur la piste";
 "Select Range" = "Sélectionner une plage";
-"Select a range" = "Sélectionner une plage";
 "Select a single clip to enable" = "Sélectionnez un seul clip pour activer";
 "Select media files or folders to import" = "Sélectionner les fichiers ou dossiers média à importer";
 "Selected" = "Sélectionné";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Afficher dans le Finder";
 "Show keyframe timeline" = "Afficher la timeline des images clés";
 "Show notifications" = "Afficher les notifications";
+"Show reasoning" = "Afficher le raisonnement";
 "Side by Side" = "Côte à côte";
 "Sign In" = "Se connecter";
 "Sign in" = "Se connecter";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Connectez-vous pour recevoir 250 crédits gratuits pour le chat et la génération IA.";
 "Sign in to subscribe and use AI generation." = "Connectez-vous pour vous abonner et utiliser la génération par IA.";
 "Sign in to use AI" = "Connectez-vous pour utiliser l’IA";
+"Sign in to use AI chat." = "Connectez-vous pour utiliser le chat IA.";
 "Sign in to use Cloud transcription." = "Connectez-vous pour utiliser la transcription dans le Cloud.";
 "Sign in to use Cloud." = "Connectez-vous pour utiliser le Cloud.";
 "Sign in with Google" = "Se connecter avec Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Arrêté";
 "Storage" = "Stockage";
 "Streaming through your Anthropic API key (BYOK)" = "Diffusion via votre clé API Anthropic (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Diffusion via votre clé API OpenAI (BYOK)";
 "Strikethrough" = "Barré";
 "Student" = "Étudiant";
 "Style" = "Style";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Instructions de style (facultatives). Par ex. : chaleureux et lent, accent britannique.";
 "Subscribe" = "S’abonner";
+"Subscribe or add your own API key to use this model." = "Abonnez-vous ou ajoutez votre propre clé API pour utiliser ce modèle.";
 "Subscription" = "Abonnement";
 "Swap Media" = "Remplacer le média";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Remplace le média du clip à la fin de la génération. La vitesse, le volume, l’élagage et la transformation sont conservés.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "Le clip que vous ajoutez possède des réglages différents de ceux du projet actuel.";
 "The export" = "L’exportation";
 "The project will be moved to the Trash." = "Le projet sera placé dans la Corbeille.";
+"The selected model refused this request. Revise the prompt and try again." = "Le modèle sélectionné a refusé cette demande. Modifiez le prompt et réessayez.";
 "The selected projects will be moved to the Trash." = "Les projets sélectionnés seront placés dans la Corbeille.";
 "The timeline settings changed. Close this sheet and try again." = "Les réglages de la timeline ont changé. Fermez cette feuille et réessayez.";
 "Theme" = "Thème";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Voici la règle de la timeline. Maintenez Maj et faites glisser sur la règle pour sélectionner une plage à rendre. Vous pouvez choisir n’importe quel segment pour le monter avec l’IA ou générer une musique adaptée à cette plage.";
 "This is where all your footage and assets live." = "Tous vos rushes et toutes vos ressources se trouvent ici.";
 "This is your preview panel to play a selected media or the whole timeline." = "Voici le panneau d’aperçu, qui permet de lire le média sélectionné ou toute la timeline.";
 "This model cannot cap the output at 60 FPS." = "Ce modèle ne peut pas limiter la sortie à 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Glissement des mots";
 "Working on %@" = "Traitement de %@";
 "Workspace layout" = "Disposition de l’espace de travail";
+"X High" = "Très élevé";
 "You're all set" = "Tout est prêt";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Votre animation Lottie est disponible.";
@@ -1019,7 +1035,9 @@
 "error" = "erreur";
 "group moved right to fit" = "groupe déplacé vers la droite pour tenir";
 "lowercase" = "minuscules";
-"or use your own Anthropic key" = "ou utilisez votre propre clé Anthropic";
+"or add your own Anthropic key" = "ou ajoutez votre propre clé Anthropic";
+"or add your own OpenAI key" = "ou ajoutez votre propre clé OpenAI";
 "result" = "résultat";
-"using API key" = "avec la clé API";
+"using Anthropic API key" = "avec la clé API Anthropic";
+"using OpenAI API key" = "avec la clé API OpenAI";
 "you@example.com — so we can reply" = "you@example.com — pour pouvoir vous répondre";

--- a/Sources/PalmierPro/Resources/Localization/hi.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/hi.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "एक्टिविटी उपलब्ध नहीं है";
 "Add Range to Chat" = "रेंज को चैट में जोड़ें";
 "Add Text" = "टेक्स्ट जोड़ें";
+"Add an Anthropic API key or credits to use this model." = "इस मॉडल का उपयोग करने के लिए Anthropic API कुंजी या क्रेडिट जोड़ें।";
+"Add an OpenAI API key or credits to use this model." = "इस मॉडल का उपयोग करने के लिए OpenAI API कुंजी या क्रेडिट जोड़ें।";
 "Add an email above to enable a reply" = "जवाब पाने के लिए ऊपर ईमेल जोड़ें";
 "Add captions" = "कैप्शन जोड़ें";
 "Add credits" = "क्रेडिट जोड़ें";
@@ -158,6 +160,7 @@
 "Change to Match" = "मैच करने के लिए बदलें";
 "Changes take effect after restarting Palmier Pro." = "बदलाव Palmier Pro को रीस्टार्ट करने के बाद लागू होंगे।";
 "Changing the ratio preserves the shorter edge." = "रेशियो बदलने पर छोटी किनारी बनी रहती है।";
+"Chat" = "चैट";
 "Chat history" = "चैट इतिहास";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "अपने एजेंट से चैट करें। यह कंटेंट जेनरेट कर सकता है, क्लिप एडिट कर सकता है, एसेट व्यवस्थित कर सकता है और बहुत कुछ। शुरू करने के लिए साइन इन करें या अपनी Anthropic API कुंजी इस्तेमाल करें।";
 "Check for Updates…" = "अपडेट जाँचें…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "जेनरेशन जारी है";
 "Generation panel" = "जेनरेशन पैनल";
 "Get Anthropic API key" = "Anthropic API कुंजी पाएँ";
+"Get OpenAI API key" = "OpenAI API कुंजी पाएँ";
 "Get a notification when a generation finishes." = "जेनरेशन पूर्ण होने पर सूचना पाएँ।";
 "Getting the search model ready." = "सर्च मॉडल तैयार हो रहा है।";
 "Glow" = "ग्लो";
@@ -418,6 +422,8 @@
 "Height" = "ऊँचाई";
 "Help" = "मदद";
 "Hide keyframe timeline" = "कीफ़्रेम टाइमलाइन छिपाएँ";
+"Hide reasoning" = "रीज़निंग छिपाएँ";
+"High" = "उच्च";
 "Highlight" = "हाइलाइट";
 "Highlight Block" = "हाइलाइट ब्लॉक";
 "Highlights" = "हाइलाइट्स";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "इंडेक्स हो रहा है %lld/%lld";
 "Input" = "इनपुट";
 "Inspector" = "इंस्पेक्टर";
+"Inspector Panel" = "इंस्पेक्टर पैनल";
 "Install" = "इंस्टॉल करें";
 "Install in Claude Desktop" = "Claude Desktop में इंस्टॉल करें";
 "Install in Cursor" = "Cursor में इंस्टॉल करें";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "लोकल मोड Apple के SpeechAnalyzer से चलता है।";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "लोकल मोड Apple के SpeechAnalyzer से चलता है। क्लाउड क्रेडिट और अधिक क्षमताओं वाला ज़्यादा सटीक मॉडल उपयोग करता है।";
 "Log in for 250 free credits" = "250 मुफ़्त क्रेडिट के लिए लॉग इन करें";
+"Low" = "कम";
 "Luma" = "लूमा";
 "Luminosity" = "ल्यूमिनोसिटी";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "लिरिक्स (वैकल्पिक)। [Verse] और [Chorus] टैग समर्थित हैं।";
@@ -526,6 +534,7 @@
 "Match Timeline" = "टाइमलाइन से मैच करें";
 "Match mouth movement to replacement audio" = "मुँह की गति को बदले गए ऑडियो से मैच करें";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "क्लिप्स के बीच आवाज़ों को मैच करता है और पहले बिना ट्रांसक्रिप्ट वाली टाइमलाइन क्लिप्स को ट्रांसक्राइब करता है (क्रेडिट उपयोग होते हैं)। ट्रांसक्रिप्ट और वॉइस फ़िंगरप्रिंट कैश किए जाते हैं, इसलिए दोबारा चलाना तेज़ है।";
+"Max" = "अधिकतम";
 "Max plan" = "Max प्लान";
 "Max words" = "अधिकतम शब्द";
 "Maximize Focused Panel" = "फ़ोकस किए गए पैनल को बड़ा करें";
@@ -539,6 +548,7 @@
 "Medium" = "मध्यम";
 "Mic" = "माइक";
 "Midpoint" = "मिडपॉइंट";
+"Minimal" = "न्यूनतम";
 "Minimum Pause" = "न्यूनतम पॉज़";
 "Mixed" = "मिश्रित";
 "Mode" = "मोड";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "कम्युनिटी प्लेबुक देखने, अपनी स्किल बनाने या दूसरे एजेंट में जोड़ने के लिए स्किल्स खोलें।";
 "Open Timeline" = "टाइमलाइन खोलें";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI Edit टैब खोलकर अपस्केल करें, प्रॉम्प्ट से एडिट करें, किसी फ़्रेम से वीडियो बनाएँ, या क्लिप से संगीत, SFX, क्लीनअप और डबिंग जेनरेट करें।";
+"OpenAI API Key" = "OpenAI API कुंजी";
 "Opening Google" = "Google खोला जा रहा है";
 "Opening Google…" = "Google खोला जा रहा है…";
 "Open…" = "खोलें…";
@@ -671,6 +682,7 @@
 "Range" = "रेंज";
 "Razor (C)" = "रेज़र (C)";
 "Razor Tool" = "रेज़र टूल";
+"Reasoning effort" = "रीज़निंग स्तर";
 "Redetect Beats" = "बीट्स दोबारा पहचानें";
 "Redo" = "रीडू";
 "Redo (⇧⌘Z)" = "रीडू (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "सभी ट्रैक पर आगे चुनें";
 "Select Forward on Track" = "ट्रैक पर आगे चुनें";
 "Select Range" = "रेंज चुनें";
-"Select a range" = "रेंज चुनें";
 "Select a single clip to enable" = "सक्षम करने के लिए एक क्लिप चुनें";
 "Select media files or folders to import" = "इम्पोर्ट करने के लिए मीडिया फ़ाइलें या फ़ोल्डर चुनें";
 "Selected" = "चयनित";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Finder में दिखाएँ";
 "Show keyframe timeline" = "कीफ़्रेम टाइमलाइन दिखाएँ";
 "Show notifications" = "सूचनाएँ दिखाएँ";
+"Show reasoning" = "रीज़निंग दिखाएँ";
 "Side by Side" = "साथ-साथ";
 "Sign In" = "साइन इन";
 "Sign in" = "साइन इन";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "AI चैट और जेनरेशन के लिए 250 मुफ़्त क्रेडिट पाने के लिए साइन इन करें।";
 "Sign in to subscribe and use AI generation." = "सब्सक्राइब करने और AI जेनरेशन इस्तेमाल करने के लिए साइन इन करें।";
 "Sign in to use AI" = "AI इस्तेमाल करने के लिए साइन इन करें";
+"Sign in to use AI chat." = "AI चैट इस्तेमाल करने के लिए साइन इन करें।";
 "Sign in to use Cloud transcription." = "क्लाउड ट्रांसक्रिप्शन इस्तेमाल करने के लिए साइन इन करें।";
 "Sign in to use Cloud." = "क्लाउड इस्तेमाल करने के लिए साइन इन करें।";
 "Sign in with Google" = "Google से साइन इन करें";
@@ -848,11 +861,13 @@
 "Stopped" = "रुका हुआ";
 "Storage" = "स्टोरेज";
 "Streaming through your Anthropic API key (BYOK)" = "आपकी Anthropic API कुंजी (BYOK) से स्ट्रीम हो रहा है";
+"Streaming through your OpenAI API key (BYOK)" = "आपकी OpenAI API कुंजी (BYOK) से स्ट्रीम हो रहा है";
 "Strikethrough" = "स्ट्राइकथ्रू";
 "Student" = "छात्र";
 "Style" = "स्टाइल";
 "Style instructions (optional). e.g., warm and slow, British accent." = "स्टाइल निर्देश (वैकल्पिक)। उदाहरण: गर्म और धीमा, ब्रिटिश उच्चारण।";
 "Subscribe" = "सब्सक्राइब करें";
+"Subscribe or add your own API key to use this model." = "इस मॉडल का उपयोग करने के लिए सब्सक्राइब करें या अपनी API कुंजी जोड़ें।";
 "Subscription" = "सब्सक्रिप्शन";
 "Swap Media" = "मीडिया स्वैप करें";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "जेनरेशन पूर्ण होने पर क्लिप का मीडिया स्वैप करें। स्पीड, वॉल्यूम, ट्रिम और ट्रांसफ़ॉर्म बने रहते हैं।";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "आप जो क्लिप जोड़ रहे हैं उसकी सेटिंग्स मौजूदा प्रोजेक्ट से अलग हैं।";
 "The export" = "एक्सपोर्ट";
 "The project will be moved to the Trash." = "प्रोजेक्ट ट्रैश में ले जाया जाएगा।";
+"The selected model refused this request. Revise the prompt and try again." = "चयनित मॉडल ने इस अनुरोध को अस्वीकार कर दिया। प्रॉम्प्ट में बदलाव करके फिर कोशिश करें।";
 "The selected projects will be moved to the Trash." = "चयनित प्रोजेक्ट ट्रैश में भेज दिए जाएँगे।";
 "The timeline settings changed. Close this sheet and try again." = "टाइमलाइन सेटिंग्स बदल गई हैं। यह शीट बंद करके फिर कोशिश करें।";
 "Theme" = "थीम";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "यह टाइमलाइन रूलर है। रेंडर करने के लिए रेंज चुनने हेतु रूलर पर Shift+ड्रैग करें। उस रेंज के अनुकूल AI एडिट या संगीत जेनरेट करने के लिए कोई भी स्लॉट चुन सकते हैं।";
 "This is where all your footage and assets live." = "आपका सारा फ़ुटेज और सभी एसेट यहाँ रहते हैं।";
 "This is your preview panel to play a selected media or the whole timeline." = "यह चयनित मीडिया या पूरी टाइमलाइन चलाने का प्रीव्यू पैनल है।";
 "This model cannot cap the output at 60 FPS." = "यह मॉडल आउटपुट को 60 FPS पर सीमित नहीं कर सकता।";
@@ -997,6 +1012,7 @@
 "Word Slide" = "वर्ड स्लाइड";
 "Working on %@" = "%@ पर काम हो रहा है";
 "Workspace layout" = "वर्कस्पेस लेआउट";
+"X High" = "बहुत उच्च";
 "You're all set" = "सब तैयार है";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "आपका Lottie एनिमेशन तैयार है।";
@@ -1019,7 +1035,9 @@
 "error" = "एरर";
 "group moved right to fit" = "फ़िट करने के लिए ग्रुप को दाएँ ले जाया गया";
 "lowercase" = "लोअरकेस";
-"or use your own Anthropic key" = "या अपनी Anthropic कुंजी उपयोग करें";
+"or add your own Anthropic key" = "या अपनी Anthropic कुंजी जोड़ें";
+"or add your own OpenAI key" = "या अपनी OpenAI कुंजी जोड़ें";
 "result" = "परिणाम";
-"using API key" = "API कुंजी उपयोग हो रही है";
+"using Anthropic API key" = "Anthropic API कुंजी उपयोग हो रही है";
+"using OpenAI API key" = "OpenAI API कुंजी उपयोग हो रही है";
 "you@example.com — so we can reply" = "you@example.com — ताकि हम जवाब दे सकें";

--- a/Sources/PalmierPro/Resources/Localization/it.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/it.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "Attività non disponibile";
 "Add Range to Chat" = "Aggiungi intervallo alla chat";
 "Add Text" = "Aggiungi testo";
+"Add an Anthropic API key or credits to use this model." = "Aggiungi una chiave API Anthropic o crediti per usare questo modello.";
+"Add an OpenAI API key or credits to use this model." = "Aggiungi una chiave API OpenAI o crediti per usare questo modello.";
 "Add an email above to enable a reply" = "Aggiungi un indirizzo email qui sopra per consentire una risposta";
 "Add captions" = "Aggiungi sottotitoli";
 "Add credits" = "Aggiungi crediti";
@@ -158,6 +160,7 @@
 "Change to Match" = "Modifica per corrispondere";
 "Changes take effect after restarting Palmier Pro." = "Le modifiche avranno effetto dopo il riavvio di Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "La modifica delle proporzioni mantiene il lato più corto.";
+"Chat" = "Chat";
 "Chat history" = "Cronologia chat";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Chatta con il tuo agente. Può generare contenuti, modificare clip, organizzare risorse e molto altro. Per iniziare, accedi oppure usa la tua chiave API Anthropic.";
 "Check for Updates…" = "Controlla aggiornamenti…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Generazione in corso";
 "Generation panel" = "Pannello di generazione";
 "Get Anthropic API key" = "Ottieni chiave API Anthropic";
+"Get OpenAI API key" = "Ottieni chiave API OpenAI";
 "Get a notification when a generation finishes." = "Ricevi una notifica al termine di una generazione.";
 "Getting the search model ready." = "Preparazione del modello di ricerca.";
 "Glow" = "Bagliore";
@@ -418,6 +422,8 @@
 "Height" = "Altezza";
 "Help" = "Aiuto";
 "Hide keyframe timeline" = "Nascondi timeline fotogrammi chiave";
+"Hide reasoning" = "Nascondi ragionamento";
+"High" = "Alto";
 "Highlight" = "Luce";
 "Highlight Block" = "Blocco evidenziazione";
 "Highlights" = "Luci";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Indicizzazione %lld/%lld";
 "Input" = "Input";
 "Inspector" = "Inspector";
+"Inspector Panel" = "Pannello Inspector";
 "Install" = "Installa";
 "Install in Claude Desktop" = "Installa in Claude Desktop";
 "Install in Cursor" = "Installa in Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "La modalità locale usa SpeechAnalyzer di Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "La modalità locale usa SpeechAnalyzer di Apple. Cloud usa crediti e un modello più accurato con più funzioni.";
 "Log in for 250 free credits" = "Accedi per ottenere 250 crediti gratuiti";
+"Low" = "Basso";
 "Luma" = "Luma";
 "Luminosity" = "Luminosità";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Testo (facoltativo). Sono supportati i tag [Verse] e [Chorus].";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Adatta alla timeline";
 "Match mouth movement to replacement audio" = "Adatta il movimento della bocca all'audio sostitutivo";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Abbina le voci tra le clip, trascrivendo prima le clip della timeline non ancora trascritte (usa crediti). Trascrizioni e impronte vocali vengono memorizzate nella cache, quindi le esecuzioni successive sono rapide.";
+"Max" = "Massimo";
 "Max plan" = "Piano Max";
 "Max words" = "Numero massimo di parole";
 "Maximize Focused Panel" = "Massimizza pannello attivo";
@@ -539,6 +548,7 @@
 "Medium" = "Medio";
 "Mic" = "Microfono";
 "Midpoint" = "Punto medio";
+"Minimal" = "Minimo";
 "Minimum Pause" = "Pausa minima";
 "Mixed" = "Misto";
 "Mode" = "Modalità";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Apri Competenze per sfogliare le procedure della community, crearne di tue o aggiungerle ad altri agenti.";
 "Open Timeline" = "Apri timeline";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Apri la scheda Modifica AI per aumentare la risoluzione, modificare con un prompt, creare un video da un fotogramma oppure generare musica, effetti sonori, pulizia audio e doppiaggio dalla clip.";
+"OpenAI API Key" = "Chiave API OpenAI";
 "Opening Google" = "Apertura di Google";
 "Opening Google…" = "Apertura di Google…";
 "Open…" = "Apri…";
@@ -671,6 +682,7 @@
 "Range" = "Intervallo";
 "Razor (C)" = "Lametta (C)";
 "Razor Tool" = "Strumento lametta";
+"Reasoning effort" = "Livello di ragionamento";
 "Redetect Beats" = "Rileva nuovamente i battiti";
 "Redo" = "Ripeti";
 "Redo (⇧⌘Z)" = "Ripeti (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Seleziona in avanti su tutte le tracce";
 "Select Forward on Track" = "Seleziona in avanti sulla traccia";
 "Select Range" = "Seleziona intervallo";
-"Select a range" = "Seleziona un intervallo";
 "Select a single clip to enable" = "Seleziona una singola clip per abilitare";
 "Select media files or folders to import" = "Seleziona file o cartelle multimediali da importare";
 "Selected" = "Selezionato";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Mostra nel Finder";
 "Show keyframe timeline" = "Mostra timeline fotogrammi chiave";
 "Show notifications" = "Mostra notifiche";
+"Show reasoning" = "Mostra ragionamento";
 "Side by Side" = "Affiancati";
 "Sign In" = "Accedi";
 "Sign in" = "Accedi";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Accedi per ricevere 250 crediti gratuiti per chat e generazione AI.";
 "Sign in to subscribe and use AI generation." = "Accedi per abbonarti e usare la generazione AI.";
 "Sign in to use AI" = "Accedi per usare l'AI";
+"Sign in to use AI chat." = "Accedi per usare la chat AI.";
 "Sign in to use Cloud transcription." = "Accedi per usare la trascrizione Cloud.";
 "Sign in to use Cloud." = "Accedi per usare Cloud.";
 "Sign in with Google" = "Accedi con Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Interrotto";
 "Storage" = "Archiviazione";
 "Streaming through your Anthropic API key (BYOK)" = "Streaming tramite la tua chiave API Anthropic (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Streaming tramite la tua chiave API OpenAI (BYOK)";
 "Strikethrough" = "Barrato";
 "Student" = "Studente";
 "Style" = "Stile";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Istruzioni di stile (facoltative), ad es. caldo e lento, accento britannico.";
 "Subscribe" = "Abbonati";
+"Subscribe or add your own API key to use this model." = "Abbonati o aggiungi la tua chiave API per usare questo modello.";
 "Subscription" = "Abbonamento";
 "Swap Media" = "Scambia contenuti multimediali";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Scambia i contenuti multimediali della clip al termine della generazione. Velocità, volume, ritaglio e trasformazione vengono mantenuti.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "La clip che stai aggiungendo ha impostazioni diverse dal progetto attuale.";
 "The export" = "L'esportazione";
 "The project will be moved to the Trash." = "Il progetto verrà spostato nel Cestino.";
+"The selected model refused this request. Revise the prompt and try again." = "Il modello selezionato ha rifiutato questa richiesta. Modifica il prompt e riprova.";
 "The selected projects will be moved to the Trash." = "I progetti selezionati verranno spostati nel Cestino.";
 "The timeline settings changed. Close this sheet and try again." = "Le impostazioni della timeline sono cambiate. Chiudi questo pannello e riprova.";
 "Theme" = "Tema";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Questo è il righello della timeline. Tieni premuto Maiuscole e trascina sul righello per selezionare un intervallo da renderizzare. Puoi scegliere qualsiasi spazio per modificare con l'AI o generare musica adatta all'intervallo.";
 "This is where all your footage and assets live." = "Qui si trovano tutti i filmati e le risorse.";
 "This is your preview panel to play a selected media or the whole timeline." = "Questo è il pannello di anteprima per riprodurre i contenuti multimediali selezionati o l'intera timeline.";
 "This model cannot cap the output at 60 FPS." = "Questo modello non può limitare l'output a 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Scorrimento parole";
 "Working on %@" = "Elaborazione di %@";
 "Workspace layout" = "Layout area di lavoro";
+"X High" = "Molto alto";
 "You're all set" = "Tutto pronto";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "L'animazione Lottie è pronta.";
@@ -1019,7 +1035,9 @@
 "error" = "errore";
 "group moved right to fit" = "gruppo spostato a destra per adattarlo";
 "lowercase" = "minuscolo";
-"or use your own Anthropic key" = "oppure usa la tua chiave Anthropic";
+"or add your own Anthropic key" = "oppure aggiungi la tua chiave Anthropic";
+"or add your own OpenAI key" = "oppure aggiungi la tua chiave OpenAI";
 "result" = "risultato";
-"using API key" = "con chiave API";
+"using Anthropic API key" = "con la chiave API Anthropic";
+"using OpenAI API key" = "con la chiave API OpenAI";
 "you@example.com — so we can reply" = "you@example.com — per consentirci di rispondere";

--- a/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ja.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "アクティビティを利用できません";
 "Add Range to Chat" = "範囲をチャットに追加";
 "Add Text" = "テキストを追加";
+"Add an Anthropic API key or credits to use this model." = "このモデルを使用するには、Anthropic APIキーまたはクレジットを追加してください。";
+"Add an OpenAI API key or credits to use this model." = "このモデルを使用するには、OpenAI APIキーまたはクレジットを追加してください。";
 "Add an email above to enable a reply" = "返信を受け取るには上にメールアドレスを追加してください";
 "Add captions" = "キャプションを追加";
 "Add credits" = "クレジットを追加";
@@ -158,6 +160,7 @@
 "Change to Match" = "設定を一致させる";
 "Changes take effect after restarting Palmier Pro." = "変更はPalmier Proの再起動後に反映されます。";
 "Changing the ratio preserves the shorter edge." = "比率を変更しても短い辺の長さは維持されます。";
+"Chat" = "チャット";
 "Chat history" = "チャット履歴";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "エージェントとチャットできます。コンテンツの生成、クリップの編集、アセットの整理などが可能です。まずサインインするか、ご自身のAnthropic APIキーを使用してください。";
 "Check for Updates…" = "アップデートを確認…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "生成中";
 "Generation panel" = "生成パネル";
 "Get Anthropic API key" = "Anthropic APIキーを取得";
+"Get OpenAI API key" = "OpenAI APIキーを取得";
 "Get a notification when a generation finishes." = "生成の完了時に通知を受け取ります。";
 "Getting the search model ready." = "検索モデルを準備しています。";
 "Glow" = "グロー";
@@ -418,6 +422,8 @@
 "Height" = "高さ";
 "Help" = "ヘルプ";
 "Hide keyframe timeline" = "キーフレームタイムラインを非表示";
+"Hide reasoning" = "推論を非表示";
+"High" = "高";
 "Highlight" = "ハイライト";
 "Highlight Block" = "ハイライトブロック";
 "Highlights" = "ハイライト";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "インデックス作成中 %lld/%lld";
 "Input" = "入力";
 "Inspector" = "インスペクタ";
+"Inspector Panel" = "インスペクタパネル";
 "Install" = "インストール";
 "Install in Claude Desktop" = "Claude Desktopにインストール";
 "Install in Cursor" = "Cursorにインストール";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "ローカルではAppleのSpeechAnalyzerを使用します。";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "ローカルではAppleのSpeechAnalyzerを使用します。Cloudではクレジットを使用し、より高精度で多機能なモデルを利用します。";
 "Log in for 250 free credits" = "ログインして250無料クレジットを獲得";
+"Low" = "低";
 "Luma" = "輝度";
 "Luminosity" = "光度";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "歌詞（任意）。[Verse]タグと[Chorus]タグを使用できます。";
@@ -526,6 +534,7 @@
 "Match Timeline" = "タイムラインに合わせる";
 "Match mouth movement to replacement audio" = "口の動きを差し替えオーディオに合わせる";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "クリップ間で声を照合します。文字起こしされていないタイムラインクリップは先に文字起こしされます（クレジットを使用）。文字起こしと声紋はキャッシュされるため、再実行は高速です。";
+"Max" = "最大";
 "Max plan" = "Maxプラン";
 "Max words" = "最大単語数";
 "Maximize Focused Panel" = "フォーカス中のパネルを最大化";
@@ -539,6 +548,7 @@
 "Medium" = "中";
 "Mic" = "マイク";
 "Midpoint" = "中間点";
+"Minimal" = "最小";
 "Minimum Pause" = "最小の間隔";
 "Mixed" = "混在";
 "Mode" = "モード";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "スキルを開いてコミュニティのプレイブックを参照したり、独自のスキルを作成したり、ほかのエージェントに追加したりできます。";
 "Open Timeline" = "タイムラインを開く";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "「AI編集」タブを開いて、アップスケール、プロンプト編集、フレームからのビデオ作成、またはクリップからの音楽・SFX・クリーンアップ・吹き替え生成を行えます。";
+"OpenAI API Key" = "OpenAI APIキー";
 "Opening Google" = "Googleを開いています";
 "Opening Google…" = "Googleを開いています…";
 "Open…" = "開く…";
@@ -671,6 +682,7 @@
 "Range" = "範囲";
 "Razor (C)" = "レーザー（C）";
 "Razor Tool" = "レーザーツール";
+"Reasoning effort" = "推論レベル";
 "Redetect Beats" = "ビートを再検出";
 "Redo" = "やり直す";
 "Redo (⇧⌘Z)" = "やり直す（⇧⌘Z）";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "すべてのトラックで前方を選択";
 "Select Forward on Track" = "トラック上の前方を選択";
 "Select Range" = "範囲を選択";
-"Select a range" = "範囲を選択";
 "Select a single clip to enable" = "有効にするにはクリップを1つ選択してください";
 "Select media files or folders to import" = "読み込むメディアファイルまたはフォルダを選択";
 "Selected" = "選択中";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Finderに表示";
 "Show keyframe timeline" = "キーフレームタイムラインを表示";
 "Show notifications" = "通知を表示";
+"Show reasoning" = "推論を表示";
 "Side by Side" = "左右に並べる";
 "Sign In" = "サインイン";
 "Sign in" = "サインイン";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "サインインすると、AIチャットと生成に使える250クレジットを無料で獲得できます。";
 "Sign in to subscribe and use AI generation." = "サブスクリプションに登録してAI生成を使用するには、サインインしてください。";
 "Sign in to use AI" = "AIを使用するにはサインイン";
+"Sign in to use AI chat." = "AIチャットを使用するにはサインインしてください。";
 "Sign in to use Cloud transcription." = "Cloud文字起こしを使用するにはサインインしてください。";
 "Sign in to use Cloud." = "Cloudを使用するにはサインインしてください。";
 "Sign in with Google" = "Googleでサインイン";
@@ -848,11 +861,13 @@
 "Stopped" = "停止済み";
 "Storage" = "ストレージ";
 "Streaming through your Anthropic API key (BYOK)" = "Anthropic APIキー（BYOK）でストリーミング中";
+"Streaming through your OpenAI API key (BYOK)" = "OpenAI APIキー（BYOK）でストリーミング中";
 "Strikethrough" = "取り消し線";
 "Student" = "学生";
 "Style" = "スタイル";
 "Style instructions (optional). e.g., warm and slow, British accent." = "スタイルの指示（任意）。例：暖かくゆっくり、イギリス英語のアクセント。";
 "Subscribe" = "登録";
+"Subscribe or add your own API key to use this model." = "このモデルを使用するには、サブスクリプションに登録するか、ご自身のAPIキーを追加してください。";
 "Subscription" = "サブスクリプション";
 "Swap Media" = "メディアを入れ替え";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "生成が完了したらクリップのメディアを入れ替えます。速度、音量、トリム、トランスフォームは維持されます。";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "追加しようとしているクリップの設定が現在のプロジェクトと異なります。";
 "The export" = "書き出し";
 "The project will be moved to the Trash." = "プロジェクトはゴミ箱に移動されます。";
+"The selected model refused this request. Revise the prompt and try again." = "選択したモデルがこのリクエストを拒否しました。プロンプトを修正して、もう一度お試しください。";
 "The selected projects will be moved to the Trash." = "選択したプロジェクトはゴミ箱に移動されます。";
 "The timeline settings changed. Close this sheet and try again." = "タイムライン設定が変更されました。このシートを閉じてもう一度お試しください。";
 "Theme" = "テーマ";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "これはタイムラインルーラーです。ルーラー上でShiftキーを押しながらドラッグすると、レンダリングする範囲を選択できます。任意のスロットを選び、その範囲に合うAI編集や音楽生成を行えます。";
 "This is where all your footage and assets live." = "すべての映像素材とアセットはここに表示されます。";
 "This is your preview panel to play a selected media or the whole timeline." = "これは選択したメディアまたはタイムライン全体を再生するプレビューパネルです。";
 "This model cannot cap the output at 60 FPS." = "このモデルでは出力を60 FPSに制限できません。";
@@ -997,6 +1012,7 @@
 "Word Slide" = "単語スライド";
 "Working on %@" = "%@を処理中";
 "Workspace layout" = "ワークスペースレイアウト";
+"X High" = "最高";
 "You're all set" = "準備ができました";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Lottieアニメーションの準備ができました。";
@@ -1019,7 +1035,9 @@
 "error" = "エラー";
 "group moved right to fit" = "収まるようにグループを右へ移動しました";
 "lowercase" = "小文字";
-"or use your own Anthropic key" = "またはご自身のAnthropicキーを使用";
+"or add your own Anthropic key" = "またはご自身のAnthropicキーを追加";
+"or add your own OpenAI key" = "またはご自身のOpenAIキーを追加";
 "result" = "結果";
-"using API key" = "APIキーを使用中";
+"using Anthropic API key" = "Anthropic APIキーを使用中";
+"using OpenAI API key" = "OpenAI APIキーを使用中";
 "you@example.com — so we can reply" = "you@example.com — 返信先として使用します";

--- a/Sources/PalmierPro/Resources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ko.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "활동을 사용할 수 없음";
 "Add Range to Chat" = "채팅에 범위 추가";
 "Add Text" = "텍스트 추가";
+"Add an Anthropic API key or credits to use this model." = "이 모델을 사용하려면 Anthropic API 키 또는 크레딧을 추가하세요.";
+"Add an OpenAI API key or credits to use this model." = "이 모델을 사용하려면 OpenAI API 키 또는 크레딧을 추가하세요.";
 "Add an email above to enable a reply" = "답변을 받으려면 위에 이메일을 추가하세요";
 "Add captions" = "캡션 추가";
 "Add credits" = "크레딧 추가";
@@ -158,6 +160,7 @@
 "Change to Match" = "일치하도록 변경";
 "Changes take effect after restarting Palmier Pro." = "변경 사항은 Palmier Pro를 재시동한 후 적용됩니다.";
 "Changing the ratio preserves the shorter edge." = "화면비를 변경해도 짧은 쪽은 유지됩니다.";
+"Chat" = "채팅";
 "Chat history" = "채팅 기록";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "에이전트와 채팅하세요. 콘텐츠 생성, 클립 편집, 에셋 정리 등을 할 수 있습니다. 로그인하거나 자체 Anthropic API 키로 시작하세요.";
 "Check for Updates…" = "업데이트 확인…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "생성 진행 중";
 "Generation panel" = "생성 패널";
 "Get Anthropic API key" = "Anthropic API 키 받기";
+"Get OpenAI API key" = "OpenAI API 키 받기";
 "Get a notification when a generation finishes." = "생성이 완료되면 알림을 받습니다.";
 "Getting the search model ready." = "검색 모델을 준비하는 중입니다.";
 "Glow" = "광선";
@@ -418,6 +422,8 @@
 "Height" = "높이";
 "Help" = "도움말";
 "Hide keyframe timeline" = "키프레임 타임라인 가리기";
+"Hide reasoning" = "추론 가리기";
+"High" = "높음";
 "Highlight" = "하이라이트";
 "Highlight Block" = "강조 블록";
 "Highlights" = "하이라이트";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "%lld/%lld 인덱싱 중";
 "Input" = "입력";
 "Inspector" = "인스펙터";
+"Inspector Panel" = "인스펙터 패널";
 "Install" = "설치";
 "Install in Claude Desktop" = "Claude Desktop에 설치";
 "Install in Cursor" = "Cursor에 설치";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "로컬은 Apple의 SpeechAnalyzer로 실행됩니다.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "로컬은 Apple의 SpeechAnalyzer로 실행됩니다. Cloud는 크레딧을 사용하며 더 많은 기능을 갖춘 더 정확한 모델을 사용합니다.";
 "Log in for 250 free credits" = "로그인하고 무료 크레딧 250개 받기";
+"Low" = "낮음";
 "Luma" = "루마";
 "Luminosity" = "광도";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "가사(선택 사항). [Verse] 및 [Chorus] 태그가 지원됩니다.";
@@ -526,6 +534,7 @@
 "Match Timeline" = "타임라인 일치";
 "Match mouth movement to replacement audio" = "입 움직임을 대체 오디오에 맞추기";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "클립 간 음성을 일치시키며, 먼저 트랜스크립트가 없는 타임라인 클립을 트랜스크립션합니다(크레딧 사용). 트랜스크립트와 음성 지문이 캐시되므로 다시 실행할 때는 빠릅니다.";
+"Max" = "최대";
 "Max plan" = "Max 요금제";
 "Max words" = "최대 단어 수";
 "Maximize Focused Panel" = "포커스된 패널 최대화";
@@ -539,6 +548,7 @@
 "Medium" = "중간";
 "Mic" = "마이크";
 "Midpoint" = "중간 지점";
+"Minimal" = "최소";
 "Minimum Pause" = "최소 일시 정지";
 "Mixed" = "혼합됨";
 "Mode" = "모드";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "스킬을 열어 커뮤니티 플레이북을 둘러보고 직접 만들거나 다른 에이전트에 추가하세요.";
 "Open Timeline" = "타임라인 열기";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "AI 편집 탭을 열어 업스케일, 프롬프트 편집, 프레임에서 비디오 만들기, 또는 클립에서 음악·SFX·클린업·더빙을 생성하세요.";
+"OpenAI API Key" = "OpenAI API 키";
 "Opening Google" = "Google 여는 중";
 "Opening Google…" = "Google 여는 중…";
 "Open…" = "열기…";
@@ -671,6 +682,7 @@
 "Range" = "범위";
 "Razor (C)" = "면도날(C)";
 "Razor Tool" = "면도날 도구";
+"Reasoning effort" = "추론 수준";
 "Redetect Beats" = "비트 다시 감지";
 "Redo" = "다시 실행";
 "Redo (⇧⌘Z)" = "다시 실행(⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "모든 트랙에서 이후 항목 선택";
 "Select Forward on Track" = "트랙에서 이후 항목 선택";
 "Select Range" = "범위 선택";
-"Select a range" = "범위 선택";
 "Select a single clip to enable" = "사용하려면 클립 하나 선택";
 "Select media files or folders to import" = "가져올 미디어 파일 또는 폴더 선택";
 "Selected" = "선택됨";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Finder에서 보기";
 "Show keyframe timeline" = "키프레임 타임라인 보기";
 "Show notifications" = "알림 보기";
+"Show reasoning" = "추론 보기";
 "Side by Side" = "나란히";
 "Sign In" = "로그인";
 "Sign in" = "로그인";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "로그인하면 AI 채팅과 생성에 쓸 수 있는 무료 크레딧 250개를 받습니다.";
 "Sign in to subscribe and use AI generation." = "구독하고 AI 생성을 사용하려면 로그인하세요.";
 "Sign in to use AI" = "AI를 사용하려면 로그인";
+"Sign in to use AI chat." = "AI 채팅을 사용하려면 로그인하세요.";
 "Sign in to use Cloud transcription." = "Cloud 트랜스크립션을 사용하려면 로그인하세요.";
 "Sign in to use Cloud." = "Cloud를 사용하려면 로그인하세요.";
 "Sign in with Google" = "Google로 로그인";
@@ -848,11 +861,13 @@
 "Stopped" = "중단됨";
 "Storage" = "저장 공간";
 "Streaming through your Anthropic API key (BYOK)" = "Anthropic API 키(BYOK)를 통해 스트리밍 중";
+"Streaming through your OpenAI API key (BYOK)" = "OpenAI API 키(BYOK)를 통해 스트리밍 중";
 "Strikethrough" = "취소선";
 "Student" = "학생";
 "Style" = "스타일";
 "Style instructions (optional). e.g., warm and slow, British accent." = "스타일 지침(선택 사항). 예: 따뜻하고 느리게, 영국식 억양.";
 "Subscribe" = "구독";
+"Subscribe or add your own API key to use this model." = "이 모델을 사용하려면 구독하거나 자체 API 키를 추가하세요.";
 "Subscription" = "구독";
 "Swap Media" = "미디어 교체";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "생성이 완료되면 클립의 미디어를 교체합니다. 속도, 음량, 트리밍 및 변형은 유지됩니다.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "추가하려는 클립의 설정이 현재 프로젝트와 다릅니다.";
 "The export" = "내보내기";
 "The project will be moved to the Trash." = "프로젝트가 휴지통으로 이동됩니다.";
+"The selected model refused this request. Revise the prompt and try again." = "선택한 모델이 이 요청을 거부했습니다. 프롬프트를 수정한 후 다시 시도하세요.";
 "The selected projects will be moved to the Trash." = "선택한 프로젝트가 휴지통으로 이동됩니다.";
 "The timeline settings changed. Close this sheet and try again." = "타임라인 설정이 변경되었습니다. 이 시트를 닫고 다시 시도하세요.";
 "Theme" = "테마";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "타임라인 눈금자입니다. 눈금자에서 Shift+드래그하여 렌더링할 범위를 선택하세요. 원하는 슬롯을 선택해 AI로 편집하거나 해당 범위에 맞는 음악을 생성할 수 있습니다.";
 "This is where all your footage and assets live." = "모든 푸티지와 에셋이 보관되는 곳입니다.";
 "This is your preview panel to play a selected media or the whole timeline." = "선택한 미디어 또는 전체 타임라인을 재생하는 미리보기 패널입니다.";
 "This model cannot cap the output at 60 FPS." = "이 모델은 출력을 60 FPS로 제한할 수 없습니다.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "단어 슬라이드";
 "Working on %@" = "%@ 작업 중";
 "Workspace layout" = "작업 공간 레이아웃";
+"X High" = "매우 높음";
 "You're all set" = "준비가 완료되었습니다";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Lottie 애니메이션이 준비되었습니다.";
@@ -1019,7 +1035,9 @@
 "error" = "오류";
 "group moved right to fit" = "맞추기 위해 그룹을 오른쪽으로 이동함";
 "lowercase" = "소문자";
-"or use your own Anthropic key" = "또는 자체 Anthropic 키 사용";
+"or add your own Anthropic key" = "또는 자체 Anthropic 키 추가";
+"or add your own OpenAI key" = "또는 자체 OpenAI 키 추가";
 "result" = "결과";
-"using API key" = "API 키 사용 중";
+"using Anthropic API key" = "Anthropic API 키 사용 중";
+"using OpenAI API key" = "OpenAI API 키 사용 중";
 "you@example.com — so we can reply" = "you@example.com — 답변을 받을 이메일";

--- a/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "Atividade indisponível";
 "Add Range to Chat" = "Adicionar intervalo ao chat";
 "Add Text" = "Adicionar texto";
+"Add an Anthropic API key or credits to use this model." = "Adicione uma chave de API da Anthropic ou créditos para usar este modelo.";
+"Add an OpenAI API key or credits to use this model." = "Adicione uma chave de API da OpenAI ou créditos para usar este modelo.";
 "Add an email above to enable a reply" = "Adicione um email acima para permitir uma resposta";
 "Add captions" = "Adicionar legendas";
 "Add credits" = "Adicionar créditos";
@@ -158,6 +160,7 @@
 "Change to Match" = "Alterar para corresponder";
 "Changes take effect after restarting Palmier Pro." = "As alterações entram em vigor após reiniciar o Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "Alterar a proporção preserva a borda mais curta.";
+"Chat" = "Chat";
 "Chat history" = "Histórico do chat";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Converse com seu agente. Ele pode gerar conteúdo, editar clipes, organizar recursos e muito mais. Para começar, inicie uma sessão ou use sua própria chave de API da Anthropic.";
 "Check for Updates…" = "Buscar atualizações…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Geração em andamento";
 "Generation panel" = "Painel de geração";
 "Get Anthropic API key" = "Obter chave de API da Anthropic";
+"Get OpenAI API key" = "Obter chave de API da OpenAI";
 "Get a notification when a generation finishes." = "Receba uma notificação quando uma geração terminar.";
 "Getting the search model ready." = "Preparando o modelo de busca.";
 "Glow" = "Brilho";
@@ -418,6 +422,8 @@
 "Height" = "Altura";
 "Help" = "Ajuda";
 "Hide keyframe timeline" = "Ocultar linha do tempo de quadros-chave";
+"Hide reasoning" = "Ocultar raciocínio";
+"High" = "Alto";
 "Highlight" = "Destaque";
 "Highlight Block" = "Bloco de destaque";
 "Highlights" = "Realces";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Indexando %lld/%lld";
 "Input" = "Entrada";
 "Inspector" = "Inspetor";
+"Inspector Panel" = "Painel do Inspetor";
 "Install" = "Instalar";
 "Install in Claude Desktop" = "Instalar no Claude Desktop";
 "Install in Cursor" = "Instalar no Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "O modo Local usa o SpeechAnalyzer da Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "O modo Local usa o SpeechAnalyzer da Apple. A Nuvem usa créditos e um modelo mais preciso com mais recursos.";
 "Log in for 250 free credits" = "Entrar para receber 250 créditos grátis";
+"Low" = "Baixo";
 "Luma" = "Luma";
 "Luminosity" = "Luminosidade";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Letra (opcional). Compatível com as tags [Verse] e [Chorus].";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Corresponder à linha do tempo";
 "Match mouth movement to replacement audio" = "Sincronizar o movimento da boca com o áudio substituto";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Corresponde vozes entre clipes e primeiro transcreve os clipes não transcritos da linha do tempo (usa créditos). Transcrições e impressões vocais ficam em cache, por isso novas execuções são rápidas.";
+"Max" = "Máximo";
 "Max plan" = "Plano Max";
 "Max words" = "Máximo de palavras";
 "Maximize Focused Panel" = "Maximizar painel em foco";
@@ -539,6 +548,7 @@
 "Medium" = "Médio";
 "Mic" = "Microfone";
 "Midpoint" = "Ponto médio";
+"Minimal" = "Mínimo";
 "Minimum Pause" = "Pausa mínima";
 "Mixed" = "Misto";
 "Mode" = "Modo";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Abra Habilidades para explorar guias da comunidade, criar os seus ou adicioná-los a outros agentes.";
 "Open Timeline" = "Abrir linha do tempo";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Abra a aba Edição com AI para aumentar a resolução, editar com um prompt, criar vídeo a partir de um quadro, ou gerar música, efeitos sonoros, limpeza de voz e dublagem a partir do clipe.";
+"OpenAI API Key" = "Chave de API da OpenAI";
 "Opening Google" = "Abrindo o Google";
 "Opening Google…" = "Abrindo o Google…";
 "Open…" = "Abrir…";
@@ -671,6 +682,7 @@
 "Range" = "Intervalo";
 "Razor (C)" = "Lâmina (C)";
 "Razor Tool" = "Ferramenta Lâmina";
+"Reasoning effort" = "Nível de raciocínio";
 "Redetect Beats" = "Detectar batidas novamente";
 "Redo" = "Refazer";
 "Redo (⇧⌘Z)" = "Refazer (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Selecionar adiante em todas as faixas";
 "Select Forward on Track" = "Selecionar adiante na faixa";
 "Select Range" = "Selecionar intervalo";
-"Select a range" = "Selecionar um intervalo";
 "Select a single clip to enable" = "Selecione um único clipe para ativar";
 "Select media files or folders to import" = "Selecione arquivos de mídia ou pastas para importar";
 "Selected" = "Selecionado";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Mostrar no Finder";
 "Show keyframe timeline" = "Mostrar linha do tempo de quadros-chave";
 "Show notifications" = "Mostrar notificações";
+"Show reasoning" = "Mostrar raciocínio";
 "Side by Side" = "Lado a lado";
 "Sign In" = "Entrar";
 "Sign in" = "Entrar";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Entre para receber 250 créditos grátis para chat e geração com AI.";
 "Sign in to subscribe and use AI generation." = "Entre para assinar e usar a geração com AI.";
 "Sign in to use AI" = "Entrar para usar AI";
+"Sign in to use AI chat." = "Entre para usar o chat com AI.";
 "Sign in to use Cloud transcription." = "Entre para usar a transcrição na Nuvem.";
 "Sign in to use Cloud." = "Entre para usar a Nuvem.";
 "Sign in with Google" = "Entrar com o Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Parado";
 "Storage" = "Armazenamento";
 "Streaming through your Anthropic API key (BYOK)" = "Transmitindo pela sua chave de API da Anthropic (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Transmitindo pela sua chave de API da OpenAI (BYOK)";
 "Strikethrough" = "Tachado";
 "Student" = "Estudante";
 "Style" = "Estilo";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Instruções de estilo (opcional). Por exemplo: acolhedor e lento, sotaque britânico.";
 "Subscribe" = "Assinar";
+"Subscribe or add your own API key to use this model." = "Assine ou adicione sua própria chave de API para usar este modelo.";
 "Subscription" = "Assinatura";
 "Swap Media" = "Trocar mídia";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Troque a mídia do clipe quando a geração terminar. Velocidade, volume, corte e transformação são preservados.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "O clipe que você está adicionando tem ajustes diferentes do projeto atual.";
 "The export" = "A exportação";
 "The project will be moved to the Trash." = "O projeto será movido para o Lixo.";
+"The selected model refused this request. Revise the prompt and try again." = "O modelo selecionado recusou esta solicitação. Revise o prompt e tente novamente.";
 "The selected projects will be moved to the Trash." = "Os projetos selecionados serão movidos para o Lixo.";
 "The timeline settings changed. Close this sheet and try again." = "Os ajustes da linha do tempo foram alterados. Feche esta janela e tente novamente.";
 "Theme" = "Tema";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Esta é a régua da linha do tempo. Pressione Shift e arraste na régua para selecionar um intervalo a ser renderizado. Você pode escolher qualquer espaço para editar com AI ou gerar música adequada ao intervalo.";
 "This is where all your footage and assets live." = "Aqui ficam todas as suas filmagens e recursos.";
 "This is your preview panel to play a selected media or the whole timeline." = "Este é o painel de prévia para reproduzir uma mídia selecionada ou toda a linha do tempo.";
 "This model cannot cap the output at 60 FPS." = "Este modelo não pode limitar a saída a 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Deslizamento de palavras";
 "Working on %@" = "Processando %@";
 "Workspace layout" = "Layout do espaço de trabalho";
+"X High" = "Muito alto";
 "You're all set" = "Tudo pronto";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Sua animação Lottie está pronta.";
@@ -1019,7 +1035,9 @@
 "error" = "erro";
 "group moved right to fit" = "grupo movido para a direita para caber";
 "lowercase" = "minúsculas";
-"or use your own Anthropic key" = "ou use sua própria chave da Anthropic";
+"or add your own Anthropic key" = "ou adicione sua própria chave da Anthropic";
+"or add your own OpenAI key" = "ou adicione sua própria chave da OpenAI";
 "result" = "resultado";
-"using API key" = "usando chave de API";
+"using Anthropic API key" = "usando a chave de API da Anthropic";
+"using OpenAI API key" = "usando a chave de API da OpenAI";
 "you@example.com — so we can reply" = "you@example.com — para podermos responder";

--- a/Sources/PalmierPro/Resources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/ru.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "История действий недоступна";
 "Add Range to Chat" = "Добавить диапазон в чат";
 "Add Text" = "Добавить текст";
+"Add an Anthropic API key or credits to use this model." = "Добавьте API-ключ Anthropic или кредиты, чтобы использовать эту модель.";
+"Add an OpenAI API key or credits to use this model." = "Добавьте API-ключ OpenAI или кредиты, чтобы использовать эту модель.";
 "Add an email above to enable a reply" = "Укажите адрес электронной почты выше, чтобы получить ответ";
 "Add captions" = "Добавить субтитры";
 "Add credits" = "Добавить кредиты";
@@ -158,6 +160,7 @@
 "Change to Match" = "Изменить под клип";
 "Changes take effect after restarting Palmier Pro." = "Изменения вступят в силу после перезапуска Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "При изменении соотношения сохраняется более короткая сторона.";
+"Chat" = "Чат";
 "Chat history" = "История чата";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Общайтесь со своим агентом. Он может создавать контент, монтировать клипы, упорядочивать материалы и многое другое. Для начала войдите в систему или используйте свой API-ключ Anthropic.";
 "Check for Updates…" = "Проверить обновления…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Идёт генерация";
 "Generation panel" = "Панель генерации";
 "Get Anthropic API key" = "Получить API-ключ Anthropic";
+"Get OpenAI API key" = "Получить API-ключ OpenAI";
 "Get a notification when a generation finishes." = "Уведомлять о завершении генерации.";
 "Getting the search model ready." = "Подготавливаем модель поиска.";
 "Glow" = "Свечение";
@@ -418,6 +422,8 @@
 "Height" = "Высота";
 "Help" = "Справка";
 "Hide keyframe timeline" = "Скрыть таймлайн ключевых кадров";
+"Hide reasoning" = "Скрыть ход рассуждений";
+"High" = "Высокий";
 "Highlight" = "Выделение";
 "Highlight Block" = "Блок выделения";
 "Highlights" = "Светлые тона";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Индексация: %lld/%lld";
 "Input" = "Ввод";
 "Inspector" = "Инспектор";
+"Inspector Panel" = "Панель инспектора";
 "Install" = "Установить";
 "Install in Claude Desktop" = "Установить в Claude Desktop";
 "Install in Cursor" = "Установить в Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "Локальный режим работает на базе Apple SpeechAnalyzer.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "Локальный режим работает на базе Apple SpeechAnalyzer. Облачный режим использует кредиты и более точную модель с дополнительными возможностями.";
 "Log in for 250 free credits" = "Войдите и получите 250 бесплатных кредитов";
+"Low" = "Низкий";
 "Luma" = "Яркостный канал";
 "Luminosity" = "Светимость";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Текст песни (необязательно). Поддерживаются теги [Verse] и [Chorus].";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Подогнать под таймлайн";
 "Match mouth movement to replacement audio" = "Синхронизировать движения губ с заменённым аудио";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Сопоставляет голоса в клипах, предварительно расшифровывая клипы таймлайна без расшифровки (используются кредиты). Расшифровки и голосовые отпечатки кэшируются, поэтому повторный запуск выполняется быстро.";
+"Max" = "Максимальный";
 "Max plan" = "План Max";
 "Max words" = "Максимум слов";
 "Maximize Focused Panel" = "Развернуть активную панель";
@@ -539,6 +548,7 @@
 "Medium" = "Средний";
 "Mic" = "Микрофон";
 "Midpoint" = "Средняя точка";
+"Minimal" = "Минимальный";
 "Minimum Pause" = "Минимальная пауза";
 "Mixed" = "Смешанный";
 "Mode" = "Режим";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Откройте раздел «Навыки», чтобы просмотреть сценарии сообщества, создать собственные или добавить их другим агентам.";
 "Open Timeline" = "Открыть таймлайн";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Откройте вкладку «AI-правка», чтобы увеличить разрешение, изменить клип по запросу, создать видео из кадра или сгенерировать музыку, звуковые эффекты, очистку голоса и дубляж.";
+"OpenAI API Key" = "API-ключ OpenAI";
 "Opening Google" = "Открывается Google";
 "Opening Google…" = "Открывается Google…";
 "Open…" = "Открыть…";
@@ -671,6 +682,7 @@
 "Range" = "Диапазон";
 "Razor (C)" = "Лезвие (C)";
 "Razor Tool" = "Инструмент «Лезвие»";
+"Reasoning effort" = "Уровень рассуждений";
 "Redetect Beats" = "Повторно определить ритм";
 "Redo" = "Повторить";
 "Redo (⇧⌘Z)" = "Повторить (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Выбрать всё справа на всех дорожках";
 "Select Forward on Track" = "Выбрать всё справа на дорожке";
 "Select Range" = "Выбрать диапазон";
-"Select a range" = "Выберите диапазон";
 "Select a single clip to enable" = "Выберите один клип, чтобы включить";
 "Select media files or folders to import" = "Выберите медиафайлы или папки для импорта";
 "Selected" = "Выбрано";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Показать в Finder";
 "Show keyframe timeline" = "Показать таймлайн ключевых кадров";
 "Show notifications" = "Показывать уведомления";
+"Show reasoning" = "Показать ход рассуждений";
 "Side by Side" = "Бок о бок";
 "Sign In" = "Войти";
 "Sign in" = "Войти";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Войдите и получите 250 бесплатных кредитов на AI-чат и генерацию.";
 "Sign in to subscribe and use AI generation." = "Войдите, чтобы оформить подписку и использовать AI-генерацию.";
 "Sign in to use AI" = "Войдите, чтобы использовать AI";
+"Sign in to use AI chat." = "Войдите, чтобы использовать AI-чат.";
 "Sign in to use Cloud transcription." = "Войдите, чтобы использовать облачную расшифровку.";
 "Sign in to use Cloud." = "Войдите, чтобы использовать облако.";
 "Sign in with Google" = "Войти с Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Остановлено";
 "Storage" = "Хранилище";
 "Streaming through your Anthropic API key (BYOK)" = "Потоковая передача через ваш API-ключ Anthropic (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Потоковая передача через ваш API-ключ OpenAI (BYOK)";
 "Strikethrough" = "Зачёркивание";
 "Student" = "Студент";
 "Style" = "Стиль";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Инструкции по стилю (необязательно). Например: тёплый и медленный голос, британский акцент.";
 "Subscribe" = "Подписаться";
+"Subscribe or add your own API key to use this model." = "Оформите подписку или добавьте собственный API-ключ, чтобы использовать эту модель.";
 "Subscription" = "Подписка";
 "Swap Media" = "Заменить медиафайл";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Заменить медиафайл клипа после завершения генерации. Скорость, громкость, обрезка и трансформация сохраняются.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "У добавляемого клипа настройки отличаются от текущего проекта.";
 "The export" = "задачу экспорта";
 "The project will be moved to the Trash." = "Проект будет перемещён в Корзину.";
+"The selected model refused this request. Revise the prompt and try again." = "Выбранная модель отказалась выполнить этот запрос. Измените запрос и повторите попытку.";
 "The selected projects will be moved to the Trash." = "Выбранные проекты будут перемещены в Корзину.";
 "The timeline settings changed. Close this sheet and try again." = "Настройки таймлайна изменились. Закройте это окно и повторите попытку.";
 "Theme" = "Тема";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Это линейка таймлайна. Перетаскивайте по ней с зажатой клавишей Shift, чтобы выбрать диапазон для рендеринга. Можно выбрать любой слот для AI-монтажа или создания музыки под этот диапазон.";
 "This is where all your footage and assets live." = "Здесь хранятся все ваши материалы и ресурсы.";
 "This is your preview panel to play a selected media or the whole timeline." = "Это панель предпросмотра для воспроизведения выбранного медиафайла или всего таймлайна.";
 "This model cannot cap the output at 60 FPS." = "Эта модель не может ограничить результат частотой 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Сдвиг слов";
 "Working on %@" = "Выполняется: %@";
 "Workspace layout" = "Расположение рабочей области";
+"X High" = "Очень высокий";
 "You're all set" = "Всё готово";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Ваша анимация Lottie готова.";
@@ -1019,7 +1035,9 @@
 "error" = "ошибка";
 "group moved right to fit" = "группа сдвинута вправо, чтобы поместиться";
 "lowercase" = "строчные";
-"or use your own Anthropic key" = "или используйте свой ключ Anthropic";
+"or add your own Anthropic key" = "или добавьте собственный ключ Anthropic";
+"or add your own OpenAI key" = "или добавьте собственный ключ OpenAI";
 "result" = "результат";
-"using API key" = "используется API-ключ";
+"using Anthropic API key" = "используется API-ключ Anthropic";
+"using OpenAI API key" = "используется API-ключ OpenAI";
 "you@example.com — so we can reply" = "you@example.com — чтобы мы могли ответить";

--- a/Sources/PalmierPro/Resources/Localization/tr.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/tr.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "Etkinlik kullanılamıyor";
 "Add Range to Chat" = "Aralığı Sohbete Ekle";
 "Add Text" = "Metin Ekle";
+"Add an Anthropic API key or credits to use this model." = "Bu modeli kullanmak için bir Anthropic API anahtarı veya kredi ekleyin.";
+"Add an OpenAI API key or credits to use this model." = "Bu modeli kullanmak için bir OpenAI API anahtarı veya kredi ekleyin.";
 "Add an email above to enable a reply" = "Yanıt alabilmek için yukarıya bir e-posta adresi ekleyin";
 "Add captions" = "Altyazı ekle";
 "Add credits" = "Kredi ekle";
@@ -158,6 +160,7 @@
 "Change to Match" = "Eşleşecek Şekilde Değiştir";
 "Changes take effect after restarting Palmier Pro." = "Değişiklikler Palmier Pro yeniden başlatıldıktan sonra geçerli olur.";
 "Changing the ratio preserves the shorter edge." = "Oran değiştirildiğinde kısa kenar korunur.";
+"Chat" = "Sohbet";
 "Chat history" = "Sohbet geçmişi";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Aracınızla sohbet edin. İçerik oluşturabilir, klipleri düzenleyebilir, varlıklarınızı organize edebilir ve çok daha fazlasını yapabilir. Oturum açarak veya kendi Anthropic API anahtarınızı kullanarak başlayın.";
 "Check for Updates…" = "Güncellemeleri Denetle…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Oluşturma sürüyor";
 "Generation panel" = "Oluşturma paneli";
 "Get Anthropic API key" = "Anthropic API anahtarı al";
+"Get OpenAI API key" = "OpenAI API anahtarı al";
 "Get a notification when a generation finishes." = "Oluşturma tamamlandığında bildirim alın.";
 "Getting the search model ready." = "Arama modeli hazırlanıyor.";
 "Glow" = "Parlama";
@@ -418,6 +422,8 @@
 "Height" = "Yükseklik";
 "Help" = "Yardım";
 "Hide keyframe timeline" = "Anahtar kare zaman eksenini gizle";
+"Hide reasoning" = "Akıl yürütmeyi gizle";
+"High" = "Yüksek";
 "Highlight" = "Vurgu";
 "Highlight Block" = "Vurgu Bloğu";
 "Highlights" = "Açık Tonlar";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Dizine ekleniyor: %lld/%lld";
 "Input" = "Giriş";
 "Inspector" = "Denetçi";
+"Inspector Panel" = "Denetçi Paneli";
 "Install" = "Yükle";
 "Install in Claude Desktop" = "Claude Desktop'a Yükle";
 "Install in Cursor" = "Cursor'a Yükle";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "Yerel, Apple'ın SpeechAnalyzer özelliğiyle çalışır.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "Yerel, Apple'ın SpeechAnalyzer özelliğiyle çalışır. Bulut kredi ve daha fazla özelliğe sahip, daha doğru bir model kullanır.";
 "Log in for 250 free credits" = "250 ücretsiz kredi için oturum açın";
+"Low" = "Düşük";
 "Luma" = "Parlaklık";
 "Luminosity" = "Işıklılık";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Şarkı sözleri (isteğe bağlı). [Verse] ve [Chorus] etiketleri desteklenir.";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Zaman Ekseniyle Eşleştir";
 "Match mouth movement to replacement audio" = "Ağız hareketini yeni sesle eşleştir";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Kliplerdeki sesleri eşleştirir ve önce dökümü olmayan zaman ekseni kliplerini yazıya çevirir (kredi kullanır). Dökümler ve ses parmak izleri önbelleğe alındığı için sonraki çalıştırmalar hızlıdır.";
+"Max" = "Maksimum";
 "Max plan" = "Max planı";
 "Max words" = "En fazla sözcük";
 "Maximize Focused Panel" = "Odaklanılan Paneli Büyüt";
@@ -539,6 +548,7 @@
 "Medium" = "Orta";
 "Mic" = "Mikrofon";
 "Midpoint" = "Orta Nokta";
+"Minimal" = "En Düşük";
 "Minimum Pause" = "En Kısa Duraklama";
 "Mixed" = "Karışık";
 "Mode" = "Mod";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Topluluk çalışma kitaplarına göz atmak, kendi becerilerinizi oluşturmak veya başka aracılara eklemek için Beceriler'i açın.";
 "Open Timeline" = "Zaman Eksenini Aç";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Çözünürlük yükseltmek, istemle düzenlemek, bir kareden video oluşturmak ya da klipten müzik, ses efektleri, ses temizleme ve dublaj üretmek için Yapay Zekâ Düzenleme sekmesini açın.";
+"OpenAI API Key" = "OpenAI API Anahtarı";
 "Opening Google" = "Google Açılıyor";
 "Opening Google…" = "Google Açılıyor…";
 "Open…" = "Aç…";
@@ -671,6 +682,7 @@
 "Range" = "Aralık";
 "Razor (C)" = "Kesme (C)";
 "Razor Tool" = "Kesme Aracı";
+"Reasoning effort" = "Akıl yürütme düzeyi";
 "Redetect Beats" = "Vuruşları Yeniden Algıla";
 "Redo" = "Yinele";
 "Redo (⇧⌘Z)" = "Yinele (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Tüm İzlerde İlerisini Seç";
 "Select Forward on Track" = "İzde İlerisini Seç";
 "Select Range" = "Aralık Seç";
-"Select a range" = "Bir aralık seçin";
 "Select a single clip to enable" = "Etkinleştirmek için tek bir klip seçin";
 "Select media files or folders to import" = "İçe aktarılacak medya dosyalarını veya klasörleri seçin";
 "Selected" = "Seçili";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Finder'da Göster";
 "Show keyframe timeline" = "Anahtar kare zaman eksenini göster";
 "Show notifications" = "Bildirimleri göster";
+"Show reasoning" = "Akıl yürütmeyi göster";
 "Side by Side" = "Yan Yana";
 "Sign In" = "Oturum Aç";
 "Sign in" = "Oturum aç";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Yapay zekâ sohbeti ve oluşturma için 250 ücretsiz kredi almak üzere oturum açın.";
 "Sign in to subscribe and use AI generation." = "Abone olmak ve yapay zekâ oluşturmayı kullanmak için oturum açın.";
 "Sign in to use AI" = "Yapay zekâyı kullanmak için oturum açın";
+"Sign in to use AI chat." = "Yapay zekâ sohbetini kullanmak için oturum açın.";
 "Sign in to use Cloud transcription." = "Bulut yazıya çevirmeyi kullanmak için oturum açın.";
 "Sign in to use Cloud." = "Bulut'u kullanmak için oturum açın.";
 "Sign in with Google" = "Google ile Oturum Aç";
@@ -848,11 +861,13 @@
 "Stopped" = "Durduruldu";
 "Storage" = "Saklama Alanı";
 "Streaming through your Anthropic API key (BYOK)" = "Anthropic API anahtarınızla yayınlanıyor (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "OpenAI API anahtarınızla yayınlanıyor (BYOK)";
 "Strikethrough" = "Üstü Çizili";
 "Student" = "Öğrenci";
 "Style" = "Stil";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Stil yönergeleri (isteğe bağlı). Örn. sıcak ve yavaş, İngiliz aksanı.";
 "Subscribe" = "Abone Ol";
+"Subscribe or add your own API key to use this model." = "Bu modeli kullanmak için abone olun veya kendi API anahtarınızı ekleyin.";
 "Subscription" = "Abonelik";
 "Swap Media" = "Medyayı Değiştir";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Oluşturma tamamlandığında klibin medyasını değiştirir. Hız, ses düzeyi, kırpma ve dönüşüm korunur.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "Eklediğiniz klibin ayarları geçerli projeden farklı.";
 "The export" = "Dışa aktarma";
 "The project will be moved to the Trash." = "Proje Çöp Sepeti'ne taşınacak.";
+"The selected model refused this request. Revise the prompt and try again." = "Seçilen model bu isteği reddetti. İstemi değiştirip yeniden deneyin.";
 "The selected projects will be moved to the Trash." = "Seçili projeler Çöp Sepeti'ne taşınacak.";
 "The timeline settings changed. Close this sheet and try again." = "Zaman ekseni ayarları değişti. Bu sayfayı kapatıp yeniden deneyin.";
 "Theme" = "Tema";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Bu, zaman ekseni cetvelidir. İşlenecek bir aralığı seçmek için cetvelde Shift tuşuna basarak sürükleyin. Yapay zekâyla düzenlemek veya bu aralığa uyan müzik oluşturmak için istediğiniz bölümü seçebilirsiniz.";
 "This is where all your footage and assets live." = "Tüm çekimleriniz ve varlıklarınız burada bulunur.";
 "This is your preview panel to play a selected media or the whole timeline." = "Bu, seçili medyayı veya tüm zaman eksenini oynatabileceğiniz önizleme panelinizdir.";
 "This model cannot cap the output at 60 FPS." = "Bu model çıktıyı 60 FPS ile sınırlayamaz.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Sözcük Kaydırma";
 "Working on %@" = "%@ üzerinde çalışılıyor";
 "Workspace layout" = "Çalışma alanı düzeni";
+"X High" = "Çok Yüksek";
 "You're all set" = "Her şey hazır";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Lottie animasyonunuz hazır.";
@@ -1019,7 +1035,9 @@
 "error" = "hata";
 "group moved right to fit" = "grup sığması için sağa taşındı";
 "lowercase" = "küçük harf";
-"or use your own Anthropic key" = "veya kendi Anthropic anahtarınızı kullanın";
+"or add your own Anthropic key" = "veya kendi Anthropic anahtarınızı ekleyin";
+"or add your own OpenAI key" = "veya kendi OpenAI anahtarınızı ekleyin";
 "result" = "sonuç";
-"using API key" = "API anahtarı kullanılıyor";
+"using Anthropic API key" = "Anthropic API anahtarı kullanılıyor";
+"using OpenAI API key" = "OpenAI API anahtarı kullanılıyor";
 "you@example.com — so we can reply" = "siz@example.com — yanıt verebilmemiz için";

--- a/Sources/PalmierPro/Resources/Localization/vi.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/vi.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "Hoạt động không khả dụng";
 "Add Range to Chat" = "Thêm vùng vào chat";
 "Add Text" = "Thêm văn bản";
+"Add an Anthropic API key or credits to use this model." = "Thêm khóa API Anthropic hoặc tín dụng để dùng mô hình này.";
+"Add an OpenAI API key or credits to use this model." = "Thêm khóa API OpenAI hoặc tín dụng để dùng mô hình này.";
 "Add an email above to enable a reply" = "Thêm email ở trên để nhận phản hồi";
 "Add captions" = "Thêm phụ đề";
 "Add credits" = "Thêm tín dụng";
@@ -158,6 +160,7 @@
 "Change to Match" = "Đổi cho khớp";
 "Changes take effect after restarting Palmier Pro." = "Thay đổi có hiệu lực sau khi khởi động lại Palmier Pro.";
 "Changing the ratio preserves the shorter edge." = "Thay đổi tỷ lệ sẽ giữ nguyên cạnh ngắn hơn.";
+"Chat" = "Chat";
 "Chat history" = "Lịch sử chat";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Chat với agent của bạn. Agent có thể tạo nội dung, chỉnh sửa clip, sắp xếp tài nguyên và nhiều việc khác. Hãy đăng nhập hoặc dùng khóa API Anthropic của riêng bạn để bắt đầu.";
 "Check for Updates…" = "Kiểm tra bản cập nhật…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "Đang tạo";
 "Generation panel" = "Bảng tạo nội dung";
 "Get Anthropic API key" = "Lấy khóa API Anthropic";
+"Get OpenAI API key" = "Lấy khóa API OpenAI";
 "Get a notification when a generation finishes." = "Nhận thông báo khi hoàn tất tạo nội dung.";
 "Getting the search model ready." = "Đang chuẩn bị mô hình tìm kiếm.";
 "Glow" = "Phát sáng";
@@ -418,6 +422,8 @@
 "Height" = "Chiều cao";
 "Help" = "Trợ giúp";
 "Hide keyframe timeline" = "Ẩn timeline khung hình chính";
+"Hide reasoning" = "Ẩn phần suy luận";
+"High" = "Cao";
 "Highlight" = "Tô sáng";
 "Highlight Block" = "Khối tô sáng";
 "Highlights" = "Vùng sáng";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "Đang lập chỉ mục %lld/%lld";
 "Input" = "Đầu vào";
 "Inspector" = "Trình kiểm tra";
+"Inspector Panel" = "Bảng kiểm tra";
 "Install" = "Cài đặt";
 "Install in Claude Desktop" = "Cài đặt trong Claude Desktop";
 "Install in Cursor" = "Cài đặt trong Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "Chế độ Cục bộ sử dụng SpeechAnalyzer của Apple.";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "Chế độ Cục bộ sử dụng SpeechAnalyzer của Apple. Đám mây dùng tín dụng và mô hình chính xác hơn với nhiều khả năng hơn.";
 "Log in for 250 free credits" = "Đăng nhập để nhận 250 tín dụng miễn phí";
+"Low" = "Thấp";
 "Luma" = "Luma";
 "Luminosity" = "Độ sáng";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "Lời bài hát (không bắt buộc). Hỗ trợ thẻ [Verse] và [Chorus].";
@@ -526,6 +534,7 @@
 "Match Timeline" = "Khớp với timeline";
 "Match mouth movement to replacement audio" = "Khớp chuyển động miệng với âm thanh thay thế";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Khớp giọng nói giữa các clip, trước tiên chép lời những clip chưa có bản chép lời trên timeline (dùng tín dụng). Bản chép lời và dấu giọng nói được lưu vào bộ nhớ đệm nên lần chạy lại sẽ nhanh.";
+"Max" = "Tối đa";
 "Max plan" = "Gói Max";
 "Max words" = "Số từ tối đa";
 "Maximize Focused Panel" = "Phóng to bảng đang chọn";
@@ -539,6 +548,7 @@
 "Medium" = "Vừa";
 "Mic" = "Micrô";
 "Midpoint" = "Điểm giữa";
+"Minimal" = "Tối thiểu";
 "Minimum Pause" = "Khoảng dừng tối thiểu";
 "Mixed" = "Hỗn hợp";
 "Mode" = "Chế độ";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "Mở Kỹ năng để duyệt cẩm nang cộng đồng, tự tạo kỹ năng hoặc thêm kỹ năng vào agent khác.";
 "Open Timeline" = "Mở timeline";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "Mở tab Chỉnh sửa bằng AI để nâng độ phân giải, chỉnh sửa bằng prompt, tạo video từ một khung hình, hoặc tạo nhạc, SFX, làm sạch âm thanh và lồng tiếng từ clip.";
+"OpenAI API Key" = "Khóa API OpenAI";
 "Opening Google" = "Đang mở Google";
 "Opening Google…" = "Đang mở Google…";
 "Open…" = "Mở…";
@@ -671,6 +682,7 @@
 "Range" = "Vùng";
 "Razor (C)" = "Dao cắt (C)";
 "Razor Tool" = "Công cụ Dao cắt";
+"Reasoning effort" = "Mức độ suy luận";
 "Redetect Beats" = "Phát hiện lại nhịp";
 "Redo" = "Làm lại";
 "Redo (⇧⌘Z)" = "Làm lại (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "Chọn về phía trước trên tất cả track";
 "Select Forward on Track" = "Chọn về phía trước trên track";
 "Select Range" = "Chọn vùng";
-"Select a range" = "Chọn một vùng";
 "Select a single clip to enable" = "Chọn một clip để bật";
 "Select media files or folders to import" = "Chọn tệp hoặc thư mục phương tiện để nhập";
 "Selected" = "Đã chọn";
@@ -794,6 +805,7 @@
 "Show in Finder" = "Hiển thị trong Finder";
 "Show keyframe timeline" = "Hiển thị timeline khung hình chính";
 "Show notifications" = "Hiển thị thông báo";
+"Show reasoning" = "Hiển thị phần suy luận";
 "Side by Side" = "Cạnh nhau";
 "Sign In" = "Đăng nhập";
 "Sign in" = "Đăng nhập";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "Đăng nhập để nhận 250 tín dụng miễn phí cho chat và tạo nội dung bằng AI.";
 "Sign in to subscribe and use AI generation." = "Đăng nhập để đăng ký và dùng tính năng tạo nội dung AI.";
 "Sign in to use AI" = "Đăng nhập để dùng AI";
+"Sign in to use AI chat." = "Đăng nhập để dùng chat AI.";
 "Sign in to use Cloud transcription." = "Đăng nhập để dùng tính năng chép lời trên đám mây.";
 "Sign in to use Cloud." = "Đăng nhập để dùng Đám mây.";
 "Sign in with Google" = "Đăng nhập bằng Google";
@@ -848,11 +861,13 @@
 "Stopped" = "Đã dừng";
 "Storage" = "Dung lượng lưu trữ";
 "Streaming through your Anthropic API key (BYOK)" = "Đang truyền qua khóa API Anthropic của bạn (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "Đang truyền qua khóa API OpenAI của bạn (BYOK)";
 "Strikethrough" = "Gạch ngang";
 "Student" = "Sinh viên";
 "Style" = "Kiểu";
 "Style instructions (optional). e.g., warm and slow, British accent." = "Hướng dẫn phong cách (không bắt buộc). Ví dụ: ấm áp và chậm rãi, giọng Anh.";
 "Subscribe" = "Đăng ký";
+"Subscribe or add your own API key to use this model." = "Đăng ký hoặc thêm khóa API của riêng bạn để dùng mô hình này.";
 "Subscription" = "Gói đăng ký";
 "Swap Media" = "Thay phương tiện";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "Thay phương tiện của clip khi hoàn tất tạo nội dung. Tốc độ, âm lượng, phần cắt và biến đổi được giữ nguyên.";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "Clip bạn đang thêm có cài đặt khác với dự án hiện tại.";
 "The export" = "Bản xuất";
 "The project will be moved to the Trash." = "Dự án sẽ được chuyển vào Thùng rác.";
+"The selected model refused this request. Revise the prompt and try again." = "Mô hình đã chọn từ chối yêu cầu này. Hãy sửa câu lệnh rồi thử lại.";
 "The selected projects will be moved to the Trash." = "Các dự án đã chọn sẽ được chuyển vào Thùng rác.";
 "The timeline settings changed. Close this sheet and try again." = "Cài đặt timeline đã thay đổi. Đóng bảng này và thử lại.";
 "Theme" = "Chủ đề";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "Đây là thước timeline. Giữ Shift và kéo trên thước để chọn vùng cần kết xuất. Bạn có thể chọn bất kỳ khoảng nào để chỉnh sửa bằng AI hoặc tạo nhạc phù hợp với vùng đó.";
 "This is where all your footage and assets live." = "Đây là nơi chứa toàn bộ cảnh quay và tài nguyên của bạn.";
 "This is your preview panel to play a selected media or the whole timeline." = "Đây là bảng xem trước để phát phương tiện đã chọn hoặc toàn bộ timeline.";
 "This model cannot cap the output at 60 FPS." = "Mô hình này không thể giới hạn đầu ra ở 60 FPS.";
@@ -997,6 +1012,7 @@
 "Word Slide" = "Trượt từ";
 "Working on %@" = "Đang xử lý %@";
 "Workspace layout" = "Bố cục không gian làm việc";
+"X High" = "Rất cao";
 "You're all set" = "Mọi thứ đã sẵn sàng";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Hoạt ảnh Lottie của bạn đã sẵn sàng.";
@@ -1019,7 +1035,9 @@
 "error" = "lỗi";
 "group moved right to fit" = "đã di chuyển nhóm sang phải để vừa chỗ";
 "lowercase" = "chữ thường";
-"or use your own Anthropic key" = "hoặc dùng khóa Anthropic của riêng bạn";
+"or add your own Anthropic key" = "hoặc thêm khóa Anthropic của riêng bạn";
+"or add your own OpenAI key" = "hoặc thêm khóa OpenAI của riêng bạn";
 "result" = "kết quả";
-"using API key" = "đang dùng khóa API";
+"using Anthropic API key" = "đang dùng khóa API Anthropic";
+"using OpenAI API key" = "đang dùng khóa API OpenAI";
 "you@example.com — so we can reply" = "ban@example.com — để chúng tôi có thể phản hồi";

--- a/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "活动不可用";
 "Add Range to Chat" = "将范围添加到对话";
 "Add Text" = "添加文本";
+"Add an Anthropic API key or credits to use this model." = "添加 Anthropic API key 或积分以使用此模型。";
+"Add an OpenAI API key or credits to use this model." = "添加 OpenAI API key 或积分以使用此模型。";
 "Add an email above to enable a reply" = "在上方添加电子邮件以接收回复";
 "Add captions" = "添加字幕";
 "Add credits" = "添加积分";
@@ -158,6 +160,7 @@
 "Change to Match" = "更改以匹配";
 "Changes take effect after restarting Palmier Pro." = "更改将在重新启动 Palmier Pro 后生效。";
 "Changing the ratio preserves the shorter edge." = "更改比例时会保留较短边。";
+"Chat" = "对话";
 "Chat history" = "对话历史";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "与 Agent 对话。它可以生成内容、编辑片段、整理素材等。登录即可开始，也可以使用自己的 Anthropic API key。";
 "Check for Updates…" = "检查更新…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "正在生成";
 "Generation panel" = "生成面板";
 "Get Anthropic API key" = "获取 Anthropic API key";
+"Get OpenAI API key" = "获取 OpenAI API key";
 "Get a notification when a generation finishes." = "在生成完成时接收通知。";
 "Getting the search model ready." = "正在准备搜索模型。";
 "Glow" = "辉光";
@@ -418,6 +422,8 @@
 "Height" = "高度";
 "Help" = "帮助";
 "Hide keyframe timeline" = "隐藏关键帧时间线";
+"Hide reasoning" = "隐藏推理过程";
+"High" = "高";
 "Highlight" = "高光";
 "Highlight Block" = "高亮色块";
 "Highlights" = "高光";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "正在索引 %lld/%lld";
 "Input" = "输入";
 "Inspector" = "检查器";
+"Inspector Panel" = "检查器面板";
 "Install" = "安装";
 "Install in Claude Desktop" = "安装到 Claude Desktop";
 "Install in Cursor" = "安装到 Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "本地转录使用 Apple SpeechAnalyzer。";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "本地转录使用 Apple SpeechAnalyzer。云端会使用积分，并提供更准确、功能更多的模型。";
 "Log in for 250 free credits" = "登录即可获得 250 免费积分";
+"Low" = "低";
 "Luma" = "亮度";
 "Luminosity" = "明度";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "歌词（可选）。支持 [Verse] 和 [Chorus] 标签。";
@@ -526,6 +534,7 @@
 "Match Timeline" = "匹配时间线";
 "Match mouth movement to replacement audio" = "让嘴部动作与替换音频匹配";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "匹配不同片段中的声音，并先转录时间线上尚未转录的片段（使用积分）。转录和声音指纹会被缓存，因此再次运行速度很快。";
+"Max" = "最高";
 "Max plan" = "Max 方案";
 "Max words" = "最多字词数";
 "Maximize Focused Panel" = "最大化聚焦面板";
@@ -539,6 +548,7 @@
 "Medium" = "中";
 "Mic" = "麦克风";
 "Midpoint" = "中点";
+"Minimal" = "最低";
 "Minimum Pause" = "最短停顿";
 "Mixed" = "混合";
 "Mode" = "模式";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "打开“技能”以浏览社区操作手册、创建自己的技能，或将其添加到其他 Agent。";
 "Open Timeline" = "打开时间线";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "打开“AI 编辑”标签页即可放大分辨率、用提示词编辑、从帧创建视频，或从片段生成音乐、音效、清理人声和配音。";
+"OpenAI API Key" = "OpenAI API key";
 "Opening Google" = "正在打开 Google";
 "Opening Google…" = "正在打开 Google…";
 "Open…" = "打开…";
@@ -671,6 +682,7 @@
 "Range" = "范围";
 "Razor (C)" = "剃刀 (C)";
 "Razor Tool" = "剃刀工具";
+"Reasoning effort" = "推理强度";
 "Redetect Beats" = "重新检测节拍";
 "Redo" = "重做";
 "Redo (⇧⌘Z)" = "重做 (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "选择所有轨道上的后续片段";
 "Select Forward on Track" = "选择轨道上的后续片段";
 "Select Range" = "选择范围";
-"Select a range" = "选择范围";
 "Select a single clip to enable" = "选择单个片段以启用";
 "Select media files or folders to import" = "选择要导入的媒体文件或文件夹";
 "Selected" = "已选择";
@@ -794,6 +805,7 @@
 "Show in Finder" = "在“访达”中显示";
 "Show keyframe timeline" = "显示关键帧时间线";
 "Show notifications" = "显示通知";
+"Show reasoning" = "显示推理过程";
 "Side by Side" = "并排";
 "Sign In" = "登录";
 "Sign in" = "登录";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "登录即可获得 250 个免费积分，用于 AI 聊天和生成。";
 "Sign in to subscribe and use AI generation." = "登录以订阅并使用 AI 生成。";
 "Sign in to use AI" = "登录以使用 AI";
+"Sign in to use AI chat." = "登录以使用 AI 对话。";
 "Sign in to use Cloud transcription." = "登录以使用云端转录。";
 "Sign in to use Cloud." = "登录以使用云端。";
 "Sign in with Google" = "使用 Google 登录";
@@ -848,11 +861,13 @@
 "Stopped" = "已停止";
 "Storage" = "储存空间";
 "Streaming through your Anthropic API key (BYOK)" = "正在通过你的 Anthropic API key 流式传输 (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "正在通过你的 OpenAI API key 流式传输 (BYOK)";
 "Strikethrough" = "删除线";
 "Student" = "学生";
 "Style" = "样式";
 "Style instructions (optional). e.g., warm and slow, British accent." = "样式说明（可选），例如温暖舒缓、英式口音。";
 "Subscribe" = "订阅";
+"Subscribe or add your own API key to use this model." = "订阅或添加你自己的 API key 以使用此模型。";
 "Subscription" = "订阅";
 "Swap Media" = "替换媒体";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "生成完成后替换片段的媒体。速度、音量、修剪和变换将保留。";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "要添加的片段与当前项目的设置不同。";
 "The export" = "导出任务";
 "The project will be moved to the Trash." = "项目将被移到废纸篓。";
+"The selected model refused this request. Revise the prompt and try again." = "所选模型拒绝了此请求。请修改提示词后重试。";
 "The selected projects will be moved to the Trash." = "所选项目将被移到废纸篓。";
 "The timeline settings changed. Close this sheet and try again." = "时间线设置已更改。请关闭此表单后重试。";
 "Theme" = "主题";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "这是时间线标尺。按住 Shift 在标尺上拖移以选择渲染范围。你可以选择任意区段进行 AI 编辑，或生成适合该范围的音乐。";
 "This is where all your footage and assets live." = "你的所有素材和资源都位于此处。";
 "This is your preview panel to play a selected media or the whole timeline." = "这是预览面板，用于播放所选媒体或整个时间线。";
 "This model cannot cap the output at 60 FPS." = "此模型无法将输出限制为 60 FPS。";
@@ -997,6 +1012,7 @@
 "Word Slide" = "字词滑入";
 "Working on %@" = "正在处理 %@";
 "Workspace layout" = "工作区布局";
+"X High" = "极高";
 "You're all set" = "一切就绪";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "你的 Lottie 动画已准备就绪。";
@@ -1019,7 +1035,9 @@
 "error" = "错误";
 "group moved right to fit" = "组已右移以适应";
 "lowercase" = "小写";
-"or use your own Anthropic key" = "或使用你自己的 Anthropic 密钥";
+"or add your own Anthropic key" = "或添加你自己的 Anthropic 密钥";
+"or add your own OpenAI key" = "或添加你自己的 OpenAI 密钥";
 "result" = "结果";
-"using API key" = "使用 API key";
+"using Anthropic API key" = "正在使用 Anthropic API key";
+"using OpenAI API key" = "正在使用 OpenAI API key";
 "you@example.com — so we can reply" = "you@example.com，以便我们回复";

--- a/Sources/PalmierPro/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Activity unavailable" = "活動無法使用";
 "Add Range to Chat" = "將範圍加入對話";
 "Add Text" = "加入文字";
+"Add an Anthropic API key or credits to use this model." = "加入 Anthropic API key 或積分以使用此模型。";
+"Add an OpenAI API key or credits to use this model." = "加入 OpenAI API key 或積分以使用此模型。";
 "Add an email above to enable a reply" = "在上方加入電子郵件以接收回覆";
 "Add captions" = "加入字幕";
 "Add credits" = "加入積分";
@@ -158,6 +160,7 @@
 "Change to Match" = "更改以匹配";
 "Changes take effect after restarting Palmier Pro." = "更改將在重新啓動 Palmier Pro 後生效。";
 "Changing the ratio preserves the shorter edge." = "更改比例時會保留較短邊。";
+"Chat" = "對話";
 "Chat history" = "對話歷史";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "與 Agent 對話。它可以產生內容、編輯片段、整理素材等。登入即可開始，也可以使用自己的 Anthropic API key。";
 "Check for Updates…" = "檢查更新…";
@@ -405,6 +408,7 @@
 "Generation in progress" = "正在產生";
 "Generation panel" = "產生面板";
 "Get Anthropic API key" = "取得 Anthropic API key";
+"Get OpenAI API key" = "取得 OpenAI API key";
 "Get a notification when a generation finishes." = "在產生完成時接收通知。";
 "Getting the search model ready." = "正在準備搜尋模型。";
 "Glow" = "輝光";
@@ -418,6 +422,8 @@
 "Height" = "高度";
 "Help" = "幫助";
 "Hide keyframe timeline" = "隱藏關鍵影格時間軸";
+"Hide reasoning" = "隱藏推理過程";
+"High" = "高";
 "Highlight" = "高光";
 "Highlight Block" = "高亮色塊";
 "Highlights" = "亮部";
@@ -442,6 +448,7 @@
 "Indexing %lld/%lld" = "正在索引 %lld/%lld";
 "Input" = "輸入";
 "Inspector" = "檢查器";
+"Inspector Panel" = "檢查器面板";
 "Install" = "安裝";
 "Install in Claude Desktop" = "安裝到 Claude Desktop";
 "Install in Cursor" = "安裝到 Cursor";
@@ -504,6 +511,7 @@
 "Local runs with Apple's SpeechAnalyzer." = "本機轉錄使用 Apple SpeechAnalyzer。";
 "Local runs with Apple's SpeechAnalyzer. Cloud uses credits and a more accurate model with more capabilities." = "本機轉錄使用 Apple SpeechAnalyzer。雲端會使用積分，並提供更準確、功能更多的模型。";
 "Log in for 250 free credits" = "登入即可獲得 250 免費積分";
+"Low" = "低";
 "Luma" = "亮度";
 "Luminosity" = "明度";
 "Lyrics (optional). [Verse] and [Chorus] tags supported." = "歌詞（可選）。支援 [Verse] 和 [Chorus] 標籤。";
@@ -526,6 +534,7 @@
 "Match Timeline" = "匹配時間軸";
 "Match mouth movement to replacement audio" = "讓嘴部動作與替換音訊匹配";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "匹配不同片段中的聲音，並先轉錄時間軸上尚未轉錄的片段（使用積分）。轉錄和聲音指紋會被快取，因此再次運行速度很快。";
+"Max" = "最高";
 "Max plan" = "Max 方案";
 "Max words" = "最多字詞數";
 "Maximize Focused Panel" = "最大化聚焦面板";
@@ -539,6 +548,7 @@
 "Medium" = "中";
 "Mic" = "麥克風";
 "Midpoint" = "中點";
+"Minimal" = "最低";
 "Minimum Pause" = "最短停頓";
 "Mixed" = "混合";
 "Mode" = "模式";
@@ -617,6 +627,7 @@
 "Open Skills to browse community playbooks, create your own, or add them to other agents." = "打開“技能”以瀏覽社群操作手冊、建立自己的技能，或將其加入其他 Agent。";
 "Open Timeline" = "打開時間軸";
 "Open the AI Edit tab to upscale, prompt-edit, create video from a frame, or generate music, SFX, cleanup, and dubbing from the clip." = "打開「AI 編輯」標籤頁即可放大解析度、用提示詞編輯、從影格建立影片，或從片段產生音樂、音效、清理人聲和配音。";
+"OpenAI API Key" = "OpenAI API key";
 "Opening Google" = "正在打開 Google";
 "Opening Google…" = "正在打開 Google…";
 "Open…" = "打開…";
@@ -671,6 +682,7 @@
 "Range" = "範圍";
 "Razor (C)" = "剃刀 (C)";
 "Razor Tool" = "剃刀工具";
+"Reasoning effort" = "推理強度";
 "Redetect Beats" = "重新偵測節拍";
 "Redo" = "重做";
 "Redo (⇧⌘Z)" = "重做 (⇧⌘Z)";
@@ -764,7 +776,6 @@
 "Select Forward on All Tracks" = "選擇所有軌道上的後續片段";
 "Select Forward on Track" = "選擇軌道上的後續片段";
 "Select Range" = "選擇範圍";
-"Select a range" = "選擇範圍";
 "Select a single clip to enable" = "選擇單個片段以啓用";
 "Select media files or folders to import" = "選擇要匯入的媒體檔案或資料夾";
 "Selected" = "已選擇";
@@ -794,6 +805,7 @@
 "Show in Finder" = "在“Finder”中顯示";
 "Show keyframe timeline" = "顯示關鍵影格時間軸";
 "Show notifications" = "顯示通知";
+"Show reasoning" = "顯示推理過程";
 "Side by Side" = "並排";
 "Sign In" = "登入";
 "Sign in" = "登入";
@@ -801,6 +813,7 @@
 "Sign in to receive 250 free credits for AI chat and generation." = "登入即可獲得 250 個免費積分，用於 AI 聊天與產生。";
 "Sign in to subscribe and use AI generation." = "登入以訂閱並使用 AI 產生。";
 "Sign in to use AI" = "登入以使用 AI";
+"Sign in to use AI chat." = "登入以使用 AI 對話。";
 "Sign in to use Cloud transcription." = "登入以使用雲端轉錄。";
 "Sign in to use Cloud." = "登入以使用雲端。";
 "Sign in with Google" = "使用 Google 登入";
@@ -848,11 +861,13 @@
 "Stopped" = "已停止";
 "Storage" = "儲存空間";
 "Streaming through your Anthropic API key (BYOK)" = "正在透過你的 Anthropic API key 流式傳輸 (BYOK)";
+"Streaming through your OpenAI API key (BYOK)" = "正在透過你的 OpenAI API key 流式傳輸 (BYOK)";
 "Strikethrough" = "刪除線";
 "Student" = "學生";
 "Style" = "樣式";
 "Style instructions (optional). e.g., warm and slow, British accent." = "樣式說明（可選），例如溫暖舒緩、英式口音。";
 "Subscribe" = "訂閱";
+"Subscribe or add your own API key to use this model." = "訂閱或加入你自己的 API key 以使用此模型。";
 "Subscription" = "訂閱";
 "Swap Media" = "替換媒體";
 "Swap the clip's media when generation completes. Speed, volume, trim, and transform are preserved." = "產生完成後替換片段的媒體。速度、音量、修剪和變換將保留。";
@@ -880,10 +895,10 @@
 "The clip you're adding has different settings than the current project." = "要加入的片段與目前專案的設定不同。";
 "The export" = "匯出任務";
 "The project will be moved to the Trash." = "專案將被移到垃圾桶。";
+"The selected model refused this request. Revise the prompt and try again." = "所選模型拒絕了此要求。請修改提示詞後再試一次。";
 "The selected projects will be moved to the Trash." = "所選專案將被移到垃圾桶。";
 "The timeline settings changed. Close this sheet and try again." = "時間軸設定已更改。請關閉此表單後重試。";
 "Theme" = "主題";
-"This is the timeline ruler. Shift+drag on the ruler to select a range to render. You can pick any slot to AI edit or generate music that fits that range." = "這是時間軸標尺。按住 Shift 在標尺上拖移以選擇算繪範圍。你可以選擇任意區段進行 AI 編輯，或產生適合該範圍的音樂。";
 "This is where all your footage and assets live." = "你的所有素材和資源都位於此處。";
 "This is your preview panel to play a selected media or the whole timeline." = "這是預覽面板，用於播放所選媒體或整個時間軸。";
 "This model cannot cap the output at 60 FPS." = "此模型無法將輸出限制為 60 FPS。";
@@ -997,6 +1012,7 @@
 "Word Slide" = "字詞滑入";
 "Working on %@" = "正在處理 %@";
 "Workspace layout" = "工作區配置";
+"X High" = "極高";
 "You're all set" = "一切就緒";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "你的 Lottie 動畫已準備就緒。";
@@ -1019,7 +1035,9 @@
 "error" = "錯誤";
 "group moved right to fit" = "組已右移以適應";
 "lowercase" = "小寫";
-"or use your own Anthropic key" = "或使用你自己的 Anthropic 金鑰";
+"or add your own Anthropic key" = "或加入你自己的 Anthropic 金鑰";
+"or add your own OpenAI key" = "或加入你自己的 OpenAI 金鑰";
 "result" = "結果";
-"using API key" = "使用 API key";
+"using Anthropic API key" = "正在使用 Anthropic API key";
+"using OpenAI API key" = "正在使用 OpenAI API key";
 "you@example.com — so we can reply" = "you@example.com，以便我們回覆";


### PR DESCRIPTION
## Summary
- Complete all 14 non-English catalogs for the Agent reasoning and OpenAI chat copy introduced on the base branch.
- Localize the new Inspector Panel label across every supported language.
- Remove obsolete API-key and ruler-tour keys from each catalog.

Depends on [#468](https://github.com/palmier-io/palmier-pro/pull/468).

## Approach
- Keep the feature PR scoped to production code and the generated English source inventory.
- Layer complete language catalogs in this stacked PR so `--require-complete` validation can run without pulling unrelated translation work into the base review.
- Preserve OpenAI, Anthropic, API, and BYOK terminology while following each catalog's existing tone.

## Design
- This PR changes localization resources only; it has no runtime layout or behavior changes beyond translated copy from the base PR.

## Testing
- [x] `scripts/localization/sync.sh --require-complete` — passed for all supported catalogs.
- [x] `git diff --check` — passed.
- [ ] Native-speaker visual review for every locale has not been completed.
- [ ] Full `swift test` was not run because this stack changes localization resources only.

## Change statistics
- Code logic: +0 / -0
- Localization: +308 / -56
- Tests: +0 / -0
- Total: +308 / -56

Made with [Cursor](https://cursor.com)