### PR TITLE
[telemetry] Capture active hang context

### DIFF
--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -219,12 +219,14 @@ final class AppState {
     }
 
     func createProjectInteractively() {
+        Telemetry.beginOperation("save_panel", data: ["flow": "project_create"])
         let panel = NSSavePanel()
         panel.allowedContentTypes = [Self.projectContentType]
         panel.nameFieldStringValue = Project.defaultProjectName
         panel.directoryURL = Project.storageDirectory
         panel.title = L10n.string("New Project")
         panel.begin { [self] response in
+            Telemetry.endOperation("save_panel")
             guard response == .OK, let url = panel.url else { return }
             let doc = instantiateProject(at: url)
             doc.save(to: url, ofType: VideoProject.typeIdentifier, for: .saveOperation) { error in
@@ -350,6 +352,7 @@ final class AppState {
     }
 
     func openProjectFromPanel() {
+        Telemetry.beginOperation("open_panel", data: ["flow": "project_open"])
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [Self.projectContentType]
         panel.canChooseDirectories = false
@@ -357,6 +360,7 @@ final class AppState {
         panel.allowsMultipleSelection = false
         panel.title = L10n.string("Open Project")
         panel.begin { response in
+            Telemetry.endOperation("open_panel")
             guard response == .OK, let url = panel.url else { return }
             AppState.shared.openProject(at: url)
         }

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -653,6 +653,7 @@ struct ExportView: View {
         if destination == .palmierProject { startPalmierExport(); return }
         submissionError = nil
         let format = exportFormat
+        Telemetry.beginOperation("save_panel", data: ["flow": "video_export", "format": format.fileExtension])
         let panel = NSSavePanel()
         let contentType: UTType = switch format {
         case .xml:
@@ -668,6 +669,7 @@ struct ExportView: View {
         panel.nameFieldStringValue = "\(exportTimeline.name).\(format.fileExtension)"
 
         panel.begin { response in
+            Telemetry.endOperation("save_panel")
             guard response == .OK, let url = panel.url else { return }
             do {
                 try exportQueue.enqueueVideo(
@@ -692,12 +694,14 @@ struct ExportView: View {
 
     private func startPalmierExport() {
         submissionError = nil
+        Telemetry.beginOperation("save_panel", data: ["flow": "project_export"])
         let panel = NSSavePanel()
         panel.allowedContentTypes = [UTType(Project.typeIdentifier) ?? .package]
         let base = editor.projectURL?.deletingPathExtension().lastPathComponent ?? Project.defaultProjectName
         panel.nameFieldStringValue = "\(base).\(Project.fileExtension)"
 
         panel.begin { response in
+            Telemetry.endOperation("save_panel")
             guard response == .OK, let url = panel.url else { return }
             do {
                 try exportQueue.enqueuePalmierProject(

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -406,6 +406,11 @@ class VideoProject: NSDocument {
             if let oldURL, let newURL = newValue,
                oldURL.standardizedFileURL != newURL.standardizedFileURL {
                 MainActor.assumeIsolated {
+                    Telemetry.beginOperation("project_url_rebase", data: [
+                        "media_count": editorViewModel.mediaAssets.count,
+                        "registry_count": ProjectRegistry.shared.entries.count,
+                    ])
+                    defer { Telemetry.endOperation("project_url_rebase") }
                     ProjectRegistry.shared.updateURL(from: oldURL, to: newURL)
                     editorViewModel.rebaseProjectURL(from: oldURL, to: newURL)
                 }

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -98,6 +98,18 @@ enum Telemetry {
         #endif
     }
 
+    static func beginOperation(_ name: String, data: Payload = [:]) {
+        var data = data
+        data["name"] = name
+        setExtra(value: data, key: "active_operation")
+        breadcrumb("operation begin", category: "operation", data: data)
+    }
+
+    static func endOperation(_ name: String) {
+        breadcrumb("operation end", category: "operation", data: ["name": name])
+        setExtra(value: nil, key: "active_operation")
+    }
+
     static func logWarning(_ message: String, category: String, data: Payload? = nil) {
         breadcrumb(message, category: category, level: .warning, data: data)
     }


### PR DESCRIPTION
## Summary
- Capture a bounded active-operation scope and matching breadcrumbs for app-hang events.
- Annotate project panel, export panel, and project URL rebase workflows without sending paths, filenames, or user content.

## Approach
- Store only the current operation name plus safe dimensions on the Sentry scope, then clear it when the operation completes.
- Emit begin/end breadcrumbs so an App Hang can distinguish an in-progress operation from stale context.
- Scope instrumentation to infrequent user actions; it does not run in the audio-meter refresh path.

## Testing
- `swift build` — passed.
- `swift test --filter VideoProjectWriteUnblockTests` — passed (4 tests).
- `swift test --filter ExportQueueTests` — passed (5 tests).
- Manual production telemetry verification is pending a release: exercise project/export panels and Save As, then inspect App Hang event extras and breadcrumbs.

## Change statistics
- Code logic: +25 / -0
- Tests: +0 / -0

Made with [Cursor](https://cursor.com)