### PR TITLE
[fix] Preserve omitted OpenAI tool arguments

### DIFF
--- a/Sources/PalmierPro/Agent/Clients/OpenAIProvider.swift
+++ b/Sources/PalmierPro/Agent/Clients/OpenAIProvider.swift
@@ -26,6 +26,7 @@ enum OpenAIRequestBody {
                     "name": $0.name,
                     "description": $0.description,
                     "parameters": $0.inputSchema,
+                    "strict": false,
                 ]
             }
         }

--- a/Tests/PalmierProTests/Agent/AgentProviderTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentProviderTests.swift
@@ -90,6 +90,7 @@ struct AgentProviderTests {
         #expect(body["max_output_tokens"] as? Int == 64_000)
         #expect(body["instructions"] as? String == "Instructions")
         #expect(tools.first?["type"] as? String == "function")
+        #expect(tools.first?["strict"] as? Bool == false)
         #expect(items.contains { $0["type"] as? String == "function_call" })
         #expect(items.contains { $0["type"] as? String == "function_call_output" })
         #expect(json.contains("data:image/png;base64,aGVsbG8="))


### PR DESCRIPTION
before: openai models keep failing at tool call because it provide all the parameters with 0/empty strings, a lot of tool calls have checks/guardrails on these things and will fail the tools.
after: if its optional, it won't provide the parameter, so behave the same way as anthropic

## Summary
- Explicitly disable strict schema normalization for OpenAI Responses API function tools.
- Preserve omission semantics for optional arguments instead of allowing placeholder empty or zero values to break tool validation.

## Approach
- Send `strict: false` on every OpenAI function tool while leaving Anthropic schemas unchanged.
- Assert the OpenAI request body preserves this provider-specific contract.

## Testing
- `swift test --filter AgentProviderTests` — passed, 14 tests in 2 suites.
- `swift build` — passed.
- Live OpenAI Responses API verification was not run.

## Change statistics
- Code logic: +1 / -0
- Tests: +1 / -0
- Total: +2 / -0

Made with [Cursor](https://cursor.com)