### PR TITLE
[telemetry] Capture exported timeline structure

### DIFF
--- a/Sources/PalmierPro/Export/ExportQueue.swift
+++ b/Sources/PalmierPro/Export/ExportQueue.swift
@@ -109,6 +109,11 @@ final class ExportQueue {
         warnings: [String] = []
     ) throws -> ExportQueueSubmission {
         let resolver = resolver.snapshot()
+        let analyticsInput = ExportTimelineAnalyticsInput(
+            scope: .exportedTimeline(root: timeline, resolveTimeline: resolveTimeline),
+            manifest: resolver.manifestSnapshot(),
+            exportFilename: outputURL.lastPathComponent
+        )
         return try enqueue(outputURL: outputURL, projectID: projectID, source: source, warnings: warnings) { service in
             await service.export(
                 timeline: timeline,
@@ -120,7 +125,11 @@ final class ExportQueue {
                 fcpxmlTarget: fcpxmlTarget,
                 missingMediaRefs: missingMediaRefs,
                 outputURL: outputURL,
-                analyticsContext: ExportAnalyticsContext(source: source.rawValue, projectId: analyticsProjectID)
+                analyticsContext: ExportAnalyticsContext(
+                    source: source.rawValue,
+                    projectId: analyticsProjectID,
+                    timelineInput: analyticsInput
+                )
             )
         }
     }
@@ -135,13 +144,25 @@ final class ExportQueue {
         projectID: String,
         analyticsProjectID: String?
     ) throws -> ExportQueueSubmission {
-        try enqueue(outputURL: outputURL, projectID: projectID, source: source) { service in
+        let analyticsInput = ExportTimelineAnalyticsInput(
+            scope: .project(
+                timelines: projectFile.timelines,
+                rootTimelineId: projectFile.activeTimelineId
+            ),
+            manifest: manifest,
+            exportFilename: outputURL.lastPathComponent
+        )
+        return try enqueue(outputURL: outputURL, projectID: projectID, source: source) { service in
             await service.exportPalmierProject(
                 projectFile: projectFile,
                 manifest: manifest,
                 sourceProjectURL: sourceProjectURL,
                 outputURL: outputURL,
-                analyticsContext: ExportAnalyticsContext(source: source.rawValue, projectId: analyticsProjectID)
+                analyticsContext: ExportAnalyticsContext(
+                    source: source.rawValue,
+                    projectId: analyticsProjectID,
+                    timelineInput: analyticsInput
+                )
             )
         }
     }

--- a/Sources/PalmierPro/Export/ExportService.swift
+++ b/Sources/PalmierPro/Export/ExportService.swift
@@ -22,13 +22,15 @@ struct ExportRunReport {
     let unprocessableMediaRefs: Set<String>
 }
 
-struct ExportAnalyticsContext {
+struct ExportAnalyticsContext: Sendable {
     var source: String = "manual"
     var projectId: String?
+    var timelineInput: ExportTimelineAnalyticsInput?
 }
 
-private struct ExportAnalyticsRun {
-    private let basePayload: [String: Any]
+private struct ExportAnalyticsRun: Sendable {
+    private let source, projectId, mode, format, resolution: String
+    private let timelineInput: ExportTimelineAnalyticsInput?
     private let started: ContinuousClock.Instant
 
     init(
@@ -37,32 +39,42 @@ private struct ExportAnalyticsRun {
         resolution: ExportResolution?,
         context: ExportAnalyticsContext
     ) {
-        self.basePayload = [
-            "source": context.source,
-            "project_id": context.projectId ?? "unknown",
-            "mode": mode,
-            "format": format.displayName,
-            "resolution": resolution?.rawValue ?? "n/a",
-        ]
+        self.source = context.source
+        self.projectId = context.projectId ?? "unknown"
+        self.mode = mode
+        self.format = format.displayName
+        self.resolution = resolution?.rawValue ?? "n/a"
+        self.timelineInput = context.timelineInput
         self.started = ContinuousClock.now
     }
 
     init(palmierContext context: ExportAnalyticsContext) {
-        self.basePayload = [
-            "source": context.source,
-            "project_id": context.projectId ?? "unknown",
-            "mode": "palmier",
-            "format": "Palmier",
-        ]
+        self.source = context.source
+        self.projectId = context.projectId ?? "unknown"
+        self.mode = "palmier"
+        self.format = "Palmier"
+        self.resolution = "n/a"
+        self.timelineInput = context.timelineInput
         self.started = ContinuousClock.now
     }
 
     func begin() {
-        Analytics.capture(.exportStarted, properties: basePayload)
+        Analytics.capture(.exportStarted, properties: basePayload())
     }
 
     func finish() {
-        Analytics.capture(.exportFinished, properties: timedPayload())
+        let duration = Self.durationSeconds(since: started)
+        Task.detached(priority: .utility) { [self] in
+            guard Analytics.canCapture else { return }
+            var payload = basePayload()
+            payload["export_duration_seconds"] = duration
+            if let timelineInput {
+                payload.merge(ExportTimelineAnalyticsSnapshot.analyticsProperties(from: timelineInput)) {
+                    current, _ in current
+                }
+            }
+            Analytics.capture(.exportFinished, properties: payload)
+        }
     }
 
     func fail(reason: String = "other") {
@@ -72,9 +84,19 @@ private struct ExportAnalyticsRun {
     }
 
     private func timedPayload() -> [String: Any] {
-        var payload = basePayload
+        var payload = basePayload()
         payload["export_duration_seconds"] = Self.durationSeconds(since: started)
         return payload
+    }
+
+    private func basePayload() -> [String: Any] {
+        [
+            "source": source,
+            "project_id": projectId,
+            "mode": mode,
+            "format": format,
+            "resolution": resolution,
+        ]
     }
 
     private static func durationSeconds(since started: ContinuousClock.Instant) -> Double {

--- a/Sources/PalmierPro/Export/ExportTimelineAnalyticsSnapshot.swift
+++ b/Sources/PalmierPro/Export/ExportTimelineAnalyticsSnapshot.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+struct ExportTimelineAnalyticsInput: Sendable {
+    enum Scope: Sendable {
+        case exportedTimeline(root: Timeline, resolveTimeline: @Sendable (String) -> Timeline?)
+        case project(timelines: [Timeline], rootTimelineId: String?)
+    }
+
+    let scope: Scope
+    let manifest: MediaManifest
+    let exportFilename: String
+}
+
+enum ExportTimelineAnalyticsSnapshot {
+    static let schemaVersion = 2
+
+    private enum Provenance: String {
+        case imported
+        case generated = "palmier_generated"
+        case upscaled = "ai_upscaled"
+    }
+
+    private struct Usage {
+        var clipCount = 0, generatedCount = 0, upscaledCount = 0, importedCount = 0
+        var duration = 0.0, generatedDuration = 0.0
+
+        mutating func record(_ provenance: Provenance, frames: Int, fps: Int) {
+            clipCount += 1
+            let seconds = Double(max(0, frames)) / Double(max(1, fps))
+            duration += seconds
+            switch provenance {
+            case .generated:
+                generatedCount += 1
+                generatedDuration += seconds
+            case .upscaled: upscaledCount += 1
+            case .imported: importedCount += 1
+            }
+        }
+
+        var generatedRatio: Double { clipCount > 0 ? Double(generatedCount) / Double(clipCount) : 0 }
+        var generatedDurationRatio: Double { duration > 0 ? generatedDuration / duration : 0 }
+
+        var object: Analytics.Payload {
+            [
+                "clip_count": clipCount,
+                "generated_clip_count": generatedCount,
+                "upscaled_clip_count": upscaledCount,
+                "imported_clip_count": importedCount,
+                "generated_clip_ratio": generatedRatio,
+                "generated_duration_ratio": generatedDurationRatio,
+            ]
+        }
+    }
+
+    private typealias AssetRef = (id: String, provenance: Provenance)
+
+    private struct Builder {
+        let entries: [String: MediaManifestEntry]
+        var assetRefs: [String: AssetRef] = [:]
+        var assets: [Analytics.Payload] = []
+        var visual = Usage(), audio = Usage()
+
+        mutating func clip(_ clip: Clip, fps: Int, timelineIds: [String: String]) -> Analytics.Payload? {
+            guard clip.captionGroupId == nil else { return nil }
+            let nested = clip.sourceClipType == .sequence
+            let asset = nested || clip.mediaType == .text ? nil : asset(for: clip.mediaRef, fallbackType: clip.sourceClipType)
+            if let asset {
+                switch clip.mediaType {
+                case .video, .image, .lottie: visual.record(asset.provenance, frames: clip.durationFrames, fps: fps)
+                case .audio: audio.record(asset.provenance, frames: clip.durationFrames, fps: fps)
+                case .text, .sequence: break
+                }
+            }
+
+            var object: Analytics.Payload = [
+                "start_frame": clip.startFrame,
+                "duration_frames": clip.durationFrames,
+                "trim_start_frame": clip.trimStartFrame,
+                "trim_end_frame": clip.trimEndFrame,
+                "speed": clip.speed.isFinite ? clip.speed : 1,
+                "media_type": clip.mediaType.rawValue,
+                "source_clip_type": clip.sourceClipType.rawValue,
+            ]
+            if let asset { object["asset_id"] = asset.id }
+            if nested, let id = timelineIds[clip.mediaRef] { object["nested_timeline_id"] = id }
+            return object
+        }
+
+        mutating func asset(for mediaRef: String, fallbackType: ClipType) -> AssetRef {
+            if let existing = assetRefs[mediaRef] { return existing }
+            let entry = entries[mediaRef]
+            let provenance: Provenance = if let input = entry?.generationInput {
+                input.upscaleSettings == nil ? .generated : .upscaled
+            } else { .imported }
+            let ref = (id: "asset_\(assets.count)", provenance: provenance)
+            var object: Analytics.Payload = [
+                "id": ref.id,
+                "filename": entry.map(filename) ?? "unknown",
+                "media_type": (entry?.type ?? fallbackType).rawValue,
+                "provenance": provenance.rawValue,
+            ]
+            if let entry, let input = entry.generationInput {
+                object["generation_type"] = input.upscaleSettings == nil ? entry.type.rawValue : "upscale"
+                object["model"] = input.model
+            }
+            assetRefs[mediaRef] = ref
+            assets.append(object)
+            return ref
+        }
+    }
+
+    static func analyticsProperties(from input: ExportTimelineAnalyticsInput) -> Analytics.Payload {
+        let scope: String, rootId: String?, timelines: [Timeline]
+        switch input.scope {
+        case .exportedTimeline(let root, let resolve):
+            scope = "exported_timeline"
+            rootId = root.id
+            timelines = [root] + root.reachableTimelines(resolve: resolve)
+        case .project(let projectTimelines, let requestedRoot):
+            scope = "project"
+            timelines = projectTimelines
+            let ids = Set(projectTimelines.map(\.id))
+            rootId = requestedRoot.flatMap { ids.contains($0) ? $0 : nil } ?? projectTimelines.first?.id
+        }
+
+        var timelineIds: [String: String] = [:]
+        for timeline in timelines where timelineIds[timeline.id] == nil {
+            timelineIds[timeline.id] = "timeline_\(timelineIds.count)"
+        }
+        var entries: [String: MediaManifestEntry] = [:]
+        for entry in input.manifest.entries where entries[entry.id] == nil { entries[entry.id] = entry }
+
+        var builder = Builder(entries: entries)
+        var trackCount = 0, clipCount = 0, captionGroupCount = 0, captionClipCount = 0
+        let timelineObjects: [Analytics.Payload] = timelines.compactMap { timeline in
+            guard let id = timelineIds[timeline.id] else { return nil }
+            let tracks: [Analytics.Payload] = timeline.tracks.enumerated().map { index, track in
+                let clips = track.clips.compactMap {
+                    builder.clip($0, fps: timeline.fps, timelineIds: timelineIds)
+                }
+                let captions = captionGroups(track.clips)
+                trackCount += 1
+                clipCount += clips.count
+                captionGroupCount += captions.count
+                captionClipCount += captions.reduce(0) { $0 + ($1["caption_count"] as? Int ?? 0) }
+                return [
+                    "index": index,
+                    "type": track.type.rawValue,
+                    "muted": track.muted,
+                    "hidden": track.hidden,
+                    "sync_locked": track.syncLocked,
+                    "clips": clips,
+                    "caption_groups": captions,
+                ]
+            }
+            return [
+                "id": id,
+                "is_root": timeline.id == rootId,
+                "fps": timeline.fps,
+                "width": timeline.width,
+                "height": timeline.height,
+                "duration_frames": timeline.totalFrames,
+                "tracks": tracks,
+            ]
+        }
+
+        let summary: Analytics.Payload = [
+            "timeline_count": timelineObjects.count,
+            "track_count": trackCount,
+            "clip_count": clipCount,
+            "caption_group_count": captionGroupCount,
+            "caption_clip_count": captionClipCount,
+            "visual": builder.visual.object,
+            "audio": builder.audio.object,
+        ]
+        let exportFilename = sanitizedFilename(input.exportFilename)
+        var object: Analytics.Payload = [
+            "schema_version": schemaVersion,
+            "scope": scope,
+            "export_filename": exportFilename,
+            "summary": summary,
+            "assets": builder.assets,
+            "timelines": timelineObjects,
+        ]
+        if let rootId, let alias = timelineIds[rootId] { object["root_timeline_id"] = alias }
+        return [
+            "export_filename": exportFilename,
+            "timeline_snapshot_schema": schemaVersion,
+            "timeline_count": timelineObjects.count,
+            "track_count": trackCount,
+            "clip_count": clipCount,
+            "caption_group_count": captionGroupCount,
+            "caption_clip_count": captionClipCount,
+            "visual_clip_count": builder.visual.clipCount,
+            "generated_visual_clip_count": builder.visual.generatedCount,
+            "upscaled_visual_clip_count": builder.visual.upscaledCount,
+            "imported_visual_clip_count": builder.visual.importedCount,
+            "generated_visual_clip_ratio": builder.visual.generatedRatio,
+            "generated_visual_duration_ratio": builder.visual.generatedDurationRatio,
+            "timeline_snapshot": object,
+        ]
+    }
+
+    private static func captionGroups(_ clips: [Clip]) -> [Analytics.Payload] {
+        var order: [String] = []
+        var groups: [String: (start: Int, end: Int, count: Int)] = [:]
+        for clip in clips {
+            guard let id = clip.captionGroupId else { continue }
+            if let group = groups[id] {
+                groups[id] = (min(group.start, clip.startFrame), max(group.end, clip.endFrame), group.count + 1)
+            } else {
+                order.append(id)
+                groups[id] = (clip.startFrame, clip.endFrame, 1)
+            }
+        }
+        return order.compactMap { groups[$0] }.map {
+            [
+                "start_frame": $0.start,
+                "duration_frames": max(0, $0.end - $0.start),
+                "caption_count": $0.count,
+            ]
+        }
+    }
+
+    private static func filename(_ entry: MediaManifestEntry) -> String {
+        switch entry.source {
+        case .external(let path): sanitizedFilename(path)
+        case .project(let path): sanitizedFilename(path)
+        }
+    }
+
+    private static func sanitizedFilename(_ filename: String) -> String {
+        let basename = URL(fileURLWithPath: filename).lastPathComponent
+        let cleaned = basename.components(separatedBy: .controlCharacters).joined()
+        return cleaned.isEmpty ? "unknown" : String(cleaned.prefix(255))
+    }
+}

--- a/Sources/PalmierPro/Models/MediaResolver.swift
+++ b/Sources/PalmierPro/Models/MediaResolver.swift
@@ -30,6 +30,10 @@ final class MediaResolver: @unchecked Sendable {
         return MediaResolver(manifest: { manifest }, projectURL: { projectURL })
     }
 
+    func manifestSnapshot() -> MediaManifest {
+        manifest()
+    }
+
     static func expectedURLMap(entries: [MediaManifestEntry], projectURL: URL?) -> [String: URL] {
         var seenIds: Set<String> = []
         var urls: [String: URL] = [:]

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -84,6 +84,14 @@ enum Analytics {
     nonisolated(unsafe) private static var activeProjectMarks: Set<String> = []
     private static let lock = NSLock()
 
+    static var canCapture: Bool {
+        #if PRODUCTION_TELEMETRY
+        didStart && isEnabled
+        #else
+        false
+        #endif
+    }
+
     static func start() {
         #if PRODUCTION_TELEMETRY
         guard !didStart else { return }
@@ -129,7 +137,7 @@ enum Analytics {
     @discardableResult
     static func capture(_ event: Event, properties: Payload = [:]) -> Bool {
         #if PRODUCTION_TELEMETRY
-        guard didStart, isEnabled else { return false }
+        guard canCapture else { return false }
         let properties = cleanedPayload(properties)
         guard let data = try? JSONSerialization.data(withJSONObject: properties) else { return false }
         captureQueue.async {
@@ -211,12 +219,20 @@ enum Analytics {
     private static var allowedCapturePropertyKeys: Set<String> {
         Set([
             "active_day",
+            "caption_clip_count",
+            "caption_group_count",
+            "clip_count",
             "client_info",
             "error_message",
             "export_duration_seconds",
+            "export_filename",
             "failure_reason",
             "format",
+            "generated_visual_clip_count",
+            "generated_visual_clip_ratio",
+            "generated_visual_duration_ratio",
             "generation_type",
+            "imported_visual_clip_count",
             "interests",
             "mode",
             "model",
@@ -229,28 +245,28 @@ enum Analytics {
             "starter_prompt",
             "status",
             "survey_version",
+            "timeline_count",
             "timeline_changed",
+            "timeline_snapshot",
+            "timeline_snapshot_schema",
+            "track_count",
             "tool_name",
             "tool_duration_seconds",
+            "upscaled_visual_clip_count",
             "video_types",
+            "visual_clip_count",
         ])
     }
 
-    private static func clean(_ value: Any) -> Any? {
+    static func clean(_ value: Any) -> Any? {
         switch value {
         case let value as String:
             return value
-        case let value as Bool:
-            return value
-        case let value as Int:
-            return value
-        case let value as Double:
-            guard value.isFinite else { return nil }
-            return value
-        case let value as Float:
-            guard value.isFinite else { return nil }
-            return Double(value)
         case let value as NSNumber:
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                return value.boolValue
+            }
+            guard value.doubleValue.isFinite else { return nil }
             return value
         case let value as [String: Any]:
             var out: [String: Any] = [:]

--- a/Tests/PalmierProTests/Export/ExportTimelineAnalyticsSnapshotTests.swift
+++ b/Tests/PalmierProTests/Export/ExportTimelineAnalyticsSnapshotTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Export timeline analytics snapshot")
+struct ExportTimelineAnalyticsSnapshotTests {
+    @Test func stripsPrivateContentAndGroupsCaptions() throws {
+        var generated = generationInput()
+        generated.prompt = "SECRET_PROMPT"
+        generated.resultURLs = ["https://example.com/private"]
+        var manifest = MediaManifest()
+        manifest.entries = [
+            entry("SECRET_MEDIA", "/Users/private/Movies/interview.mov", generation: generated),
+        ]
+
+        let media = Fixtures.clip(id: "SECRET_CLIP", mediaRef: "SECRET_MEDIA", start: 0, duration: 30)
+        var title = Fixtures.clip(mediaRef: "title", mediaType: .text, start: 0, duration: 30)
+        title.textContent = "SECRET_TITLE"
+        var firstCaption = Fixtures.clip(mediaRef: "c1", mediaType: .text, start: 5, duration: 5)
+        firstCaption.captionGroupId = "SECRET_GROUP"
+        firstCaption.textContent = "SECRET_CAPTION_1"
+        var secondCaption = Fixtures.clip(mediaRef: "c2", mediaType: .text, start: 15, duration: 10)
+        secondCaption.captionGroupId = "SECRET_GROUP"
+        var timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [media, title, firstCaption, secondCaption]),
+        ])
+        timeline.id = "SECRET_TIMELINE"
+
+        let input = makeInput(.exportedTimeline(root: timeline, resolveTimeline: { _ in nil }), manifest)
+        let snapshot = try object(input)
+        let json = String(decoding: try JSONSerialization.data(withJSONObject: snapshot, options: [.sortedKeys]),
+                          as: UTF8.self)
+        let track = try tracks(snapshot)[0]
+        let captions = try array(track, "caption_groups")
+
+        #expect(json.contains("\"filename\":\"interview.mov\""))
+        #expect((try array(track, "clips")).count == 2)
+        #expect(captions.count == 1)
+        #expect(captions[0]["caption_count"] as? Int == 2)
+        for secret in ["/Users", "private", "SECRET_", "example.com"] {
+            #expect(!json.contains(secret))
+        }
+    }
+
+    @Test func reportsRatiosAndDeduplicatesNestedTimelines() throws {
+        var manifest = MediaManifest()
+        manifest.entries = [
+            entry("generated", "generated.mp4", generation: generationInput()),
+            entry("imported", "imported.mov"),
+            entry("upscaled", "upscaled.mp4", generation: generationInput(upscale: UpscaleSettings())),
+        ]
+        var child = Fixtures.timeline()
+        child.id = "child"
+        var firstNest = Fixtures.clip(mediaRef: child.id, mediaType: .video, start: 120, duration: 10)
+        firstNest.sourceClipType = .sequence
+        var secondNest = firstNest
+        secondNest.startFrame = 130
+        var root = Fixtures.timeline(fps: 30, tracks: [Fixtures.videoTrack(clips: [
+            Fixtures.clip(mediaRef: "generated", start: 0, duration: 60),
+            Fixtures.clip(mediaRef: "imported", start: 60, duration: 30),
+            Fixtures.clip(mediaRef: "upscaled", start: 90, duration: 30),
+            firstNest, secondNest,
+        ])])
+        root.id = "root"
+        let frozenChild = child
+        let childId = child.id
+
+        let input = makeInput(
+            .exportedTimeline(root: root, resolveTimeline: { $0 == childId ? frozenChild : nil }), manifest
+        )
+        let properties = ExportTimelineAnalyticsSnapshot.analyticsProperties(from: input)
+        let snapshot = try object(input)
+        let rootClips = try array(try tracks(snapshot)[0], "clips")
+
+        #expect((try array(snapshot, "timelines")).count == 2)
+        #expect(rootClips.suffix(2).compactMap { $0["nested_timeline_id"] as? String }
+            == ["timeline_1", "timeline_1"])
+        #expect(properties["generated_visual_clip_count"] as? Int == 1)
+        #expect(properties["imported_visual_clip_count"] as? Int == 1)
+        #expect(properties["upscaled_visual_clip_count"] as? Int == 1)
+        #expect(abs((properties["generated_visual_clip_ratio"] as? Double ?? 0) - 1.0 / 3.0) < 0.000_001)
+        #expect(properties["generated_visual_duration_ratio"] as? Double == 0.5)
+        let project = try object(makeInput(.project(timelines: [root, child], rootTimelineId: child.id), manifest))
+        #expect(project["scope"] as? String == "project")
+        #expect(project["root_timeline_id"] as? String == "timeline_1")
+        #expect((try array(project, "timelines")).count == 2)
+    }
+
+    @Test func analyticsCleaningPreservesZeroAndOneAsNumbers() throws {
+        let numbers = [0 as Any, 1 as Any, 0.0 as Any, 1.0 as Any]
+            .compactMap { Analytics.clean($0) as? NSNumber }
+        #expect(numbers.count == 4)
+        #expect(numbers.allSatisfy { CFGetTypeID($0) != CFBooleanGetTypeID() })
+        let boolean = try #require(Analytics.clean(true) as? NSNumber)
+        #expect(CFGetTypeID(boolean) == CFBooleanGetTypeID())
+    }
+
+    private func makeInput(_ scope: ExportTimelineAnalyticsInput.Scope,
+                           _ manifest: MediaManifest = .init()) -> ExportTimelineAnalyticsInput {
+        ExportTimelineAnalyticsInput(scope: scope, manifest: manifest, exportFilename: "/private/export.mp4")
+    }
+
+    private func object(_ input: ExportTimelineAnalyticsInput) throws -> Analytics.Payload {
+        try #require(ExportTimelineAnalyticsSnapshot.analyticsProperties(from: input)["timeline_snapshot"]
+            as? Analytics.Payload)
+    }
+
+    private func array(_ object: Analytics.Payload, _ key: String) throws -> [Analytics.Payload] {
+        try #require(object[key] as? [Analytics.Payload])
+    }
+
+    private func tracks(_ snapshot: Analytics.Payload) throws -> [Analytics.Payload] {
+        let timeline = try #require(array(snapshot, "timelines").first)
+        return try array(timeline, "tracks")
+    }
+
+    private func entry(_ id: String, _ filename: String, generation: GenerationInput? = nil) -> MediaManifestEntry {
+        MediaManifestEntry(
+            id: id, name: "PRIVATE_NAME", type: .video,
+            source: .external(absolutePath: filename), duration: 10, generationInput: generation
+        )
+    }
+
+    private func generationInput(upscale: UpscaleSettings? = nil) -> GenerationInput {
+        GenerationInput(
+            prompt: "generated", model: "model", duration: 5,
+            aspectRatio: "16:9", resolution: nil, upscaleSettings: upscale
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Attach a privacy-safe structural timeline snapshot to successful export events so exported projects can be analyzed by editing pattern.
- Report generated, imported, and upscaled visual usage alongside caption-group, track, and clip counts.
- Preserve basename-only filenames while excluding paths, URLs, prompts, text, captions, and internal IDs.

## Approach
- Freeze the exported timeline or Palmier project plus its media manifest when the export enters the queue.
- Build the allowlisted JSON only after a successful export, on a detached utility task, and add it to the existing `export finished` event without introducing new events.
- Collapse caption clips into range summaries, use synthetic timeline and asset IDs, and gate all work on production PostHog readiness.
- Preserve numeric zero/one values as numbers when cleaning nested PostHog payloads.

## Testing
- [x] `swift test` — 1,358 tests passed after rebasing onto `origin/main`.
- [x] `swift build --traits ProductionTelemetry`.
- [x] Optimized production benchmark: 10,000 visual clips plus 2,000 captions averaged 43.6 ms off-main; payload size was 1.64 MB.
- [x] Live export verification in PostHog: schema v2 snapshot received at 1.3 KB with no paths or URLs.

## Change statistics
- Production logic: +334 / -34 lines.
- Tests: +130 / -0 lines.
- Total: +464 / -34 lines across 6 files.

Made with [Cursor](https://cursor.com)