### PR TITLE
[fix] Avoid timeline symbol snapshot crash

### DIFF
--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -6,7 +6,7 @@ enum TimelineHeaderSymbol {
         tint: NSColor,
         configuration: NSImage.SymbolConfiguration
     ) -> NSImage? {
-        let colorConfiguration = NSImage.SymbolConfiguration(paletteColors: [tint])
+        let colorConfiguration = NSImage.SymbolConfiguration(paletteColors: [tint, tint, tint])
         return NSImage(systemSymbolName: name, accessibilityDescription: nil)?
             .withSymbolConfiguration(configuration.applying(colorConfiguration))
     }

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -1,5 +1,17 @@
 import AppKit
 
+enum TimelineHeaderSymbol {
+    static func image(
+        named name: String,
+        tint: NSColor,
+        configuration: NSImage.SymbolConfiguration
+    ) -> NSImage? {
+        let colorConfiguration = NSImage.SymbolConfiguration(paletteColors: [tint])
+        return NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(configuration.applying(colorConfiguration))
+    }
+}
+
 /// Fixed track header column drawn to the left of the scrollable timeline.
 final class TimelineHeaderView: NSView {
     unowned var editor: EditorViewModel
@@ -77,7 +89,12 @@ final class TimelineHeaderView: NSView {
             // Drag handle (reorder grip)
             let gripX = stripWidth + 6
             let gripRect = NSRect(x: gripX, y: y + (h - iconSize) / 2, width: iconSize, height: iconSize)
-            drawSymbol("line.3.horizontal", in: gripRect, tint: AppTheme.Text.secondary.withAlphaComponent(0.4), config: iconConfig, context: ctx)
+            drawSymbol(
+                "line.3.horizontal",
+                in: gripRect,
+                tint: AppTheme.Text.secondary.withAlphaComponent(0.4),
+                config: iconConfig
+            )
             dragHandleRects[i] = gripRect.insetBy(dx: -4, dy: -4)
 
             // Track label
@@ -91,17 +108,17 @@ final class TimelineHeaderView: NSView {
             let syncX = rightmostX - iconSize - 4
 
             syncLockButtonRects[i] = drawToggleIcon(
-                x: syncX, y: iconY, size: iconSize, config: iconConfig, context: ctx,
+                x: syncX, y: iconY, size: iconSize, config: iconConfig,
                 active: track.syncLocked, onSymbol: "link", offSymbol: "personalhotspot.slash"
             )
             if track.type == .audio {
                 muteButtonRects[i] = drawToggleIcon(
-                    x: rightmostX, y: iconY, size: iconSize, config: iconConfig, context: ctx,
+                    x: rightmostX, y: iconY, size: iconSize, config: iconConfig,
                     active: !track.muted, onSymbol: "speaker.wave.2.fill", offSymbol: "speaker.slash.fill"
                 )
             } else {
                 hideButtonRects[i] = drawToggleIcon(
-                    x: rightmostX, y: iconY, size: iconSize, config: iconConfig, context: ctx,
+                    x: rightmostX, y: iconY, size: iconSize, config: iconConfig,
                     active: !track.hidden, onSymbol: "eye", offSymbol: "eye.slash"
                 )
             }
@@ -128,27 +145,25 @@ final class TimelineHeaderView: NSView {
     /// Draw a toggleable SF Symbol button; returns the hit-test rect (padded).
     private func drawToggleIcon(
         x: CGFloat, y: CGFloat, size: CGFloat,
-        config: NSImage.SymbolConfiguration, context: CGContext,
+        config: NSImage.SymbolConfiguration,
         active: Bool, onSymbol: String, offSymbol: String
     ) -> NSRect {
         let rect = NSRect(x: x, y: y, width: size, height: size)
         let tint = active ? AppTheme.Text.secondary : AppTheme.Text.secondary.withAlphaComponent(0.3)
-        drawSymbol(active ? onSymbol : offSymbol, in: rect, tint: tint, config: config, context: context)
+        drawSymbol(active ? onSymbol : offSymbol, in: rect, tint: tint, config: config)
         return rect.insetBy(dx: -4, dy: -4)
     }
 
-    private func drawSymbol(_ name: String, in rect: NSRect, tint: NSColor, config: NSImage.SymbolConfiguration, context: CGContext) {
-        guard let img = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
-            .withSymbolConfiguration(config) else { return }
+    private func drawSymbol(
+        _ name: String,
+        in rect: NSRect,
+        tint: NSColor,
+        config: NSImage.SymbolConfiguration
+    ) {
+        guard let img = TimelineHeaderSymbol.image(named: name, tint: tint, configuration: config) else { return }
         let symbolSize = img.size
         let drawRect = NSRect(x: rect.midX - symbolSize.width / 2, y: rect.midY - symbolSize.height / 2, width: symbolSize.width, height: symbolSize.height)
-        let tinted = NSImage(size: drawRect.size, flipped: true) { drawRect in
-            tint.set()
-            img.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1.0)
-            drawRect.fill(using: .sourceAtop)
-            return true
-        }
-        tinted.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        img.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1.0)
     }
 
     private func updateAppearanceColors() {

--- a/Tests/PalmierProTests/Timeline/TimelineHeaderSymbolTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineHeaderSymbolTests.swift
@@ -1,0 +1,49 @@
+import AppKit
+import Testing
+@testable import PalmierPro
+
+@Suite("Timeline header symbols")
+@MainActor
+struct TimelineHeaderSymbolTests {
+    @Test(arguments: [
+        "line.3.horizontal",
+        "link",
+        "personalhotspot.slash",
+        "speaker.wave.2.fill",
+        "speaker.slash.fill",
+        "eye",
+        "eye.slash",
+    ])
+    func rendersDirectSymbolRepresentation(_ name: String) throws {
+        let configuration = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        let image = try #require(TimelineHeaderSymbol.image(
+            named: name,
+            tint: .systemBlue.withAlphaComponent(0.4),
+            configuration: configuration
+        ))
+        #expect(!image.representations.contains { $0 is NSCustomImageRep })
+
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 32,
+            pixelsHigh: 32,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = context
+        image.draw(in: NSRect(x: 8, y: 8, width: 16, height: 16))
+        context.flushGraphics()
+
+        let data = try #require(bitmap.bitmapData)
+        let bytes = UnsafeBufferPointer(start: data, count: bitmap.bytesPerRow * bitmap.pixelsHigh)
+        #expect(bytes.contains { $0 != 0 })
+    }
+}

--- a/Tests/PalmierProTests/Timeline/TimelineHeaderSymbolTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineHeaderSymbolTests.swift
@@ -16,11 +16,16 @@ struct TimelineHeaderSymbolTests {
     ])
     func rendersDirectSymbolRepresentation(_ name: String) throws {
         let configuration = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        let tint = NSColor.systemBlue.withAlphaComponent(0.4)
         let image = try #require(TimelineHeaderSymbol.image(
             named: name,
-            tint: .systemBlue.withAlphaComponent(0.4),
+            tint: tint,
             configuration: configuration
         ))
+        let expectedConfiguration = configuration.applying(
+            NSImage.SymbolConfiguration(paletteColors: [tint, tint, tint])
+        )
+        #expect(image.symbolConfiguration == expectedConfiguration)
         #expect(!image.representations.contains { $0 is NSCustomImageRep })
 
         let bitmap = try #require(NSBitmapImageRep(


### PR DESCRIPTION
## Summary
- Prevent a main-thread AppKit crash while drawing timeline header SF Symbols.
- Preserve existing track header icon sizing, tint, active state, and hit targets.

## Approach
- Replace the block-backed tinted `NSImage` with a native SF Symbol palette configuration.
- Apply the intended monochrome tint to every palette layer, including layered speaker and visibility symbols.
- Draw the configured symbol directly, avoiding the custom image representation and AppKit snapshot/hints path in the crash stack.
- Remove unused graphics-context plumbing from the symbol helpers.
- Add parameterized rendering coverage for every timeline header symbol, asserting each uses the complete palette configuration, a direct representation, and produces bitmap content.

## Testing
- `swift build` — passed; existing dependency/compiler warnings remain.
- `swift test --filter TimelineHeaderSymbolTests` — passed, 7 symbol cases.
- `swift test` — passed, 1,360 tests in 217 suites.
- Manual UI verification not completed: inspect video and audio track headers in light and dark appearances, toggle sync/mute/visibility states, and confirm icons retain their current size, tint, alignment, and hit targets.

## Change statistics
- Code logic: +31 / -16
- Tests: +54 / -0
- Total: +85 / -16

Made with [Cursor](https://cursor.com)