### PR TITLE
[feat] Close short caption gaps

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -845,6 +845,12 @@ enum ToolDefinitions {
                     ],
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
                     "maxWords": ["type": "integer", "description": "Max words per caption."],
+                    "maximumGapSeconds": [
+                        "type": "number",
+                        "minimum": CaptionGapSettings.maximumGapRange.lowerBound,
+                        "maximum": CaptionGapSettings.maximumGapRange.upperBound,
+                        "description": "Extend each caption to close a shorter gap before the next generated caption. Default 0.25 seconds; 0 disables.",
+                    ],
                 ], textStyleProperties(detailed: false), [
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset."],
                     "highlightColor": ["type": "string", "description": "Active-word hex."],

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -4,6 +4,7 @@ import Foundation
 extension ToolExecutor {
     private static let addCaptionsAllowedKeys: Set<String> = Set([
         "style", "transform", "censorProfanity", "language", "animation", "highlightColor", "maxWords", "trackIndex",
+        "maximumGapSeconds",
     ])
 
     func addCaptions(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -28,6 +29,23 @@ extension ToolExecutor {
             maxWords = n
         }
 
+        let gapSettings: CaptionGapSettings
+        if let rawMaximumGap = args["maximumGapSeconds"] {
+            guard !isJSONBoolean(rawMaximumGap),
+                  rawMaximumGap is NSNumber || rawMaximumGap is Double || rawMaximumGap is Int,
+                  let maximumGapSeconds = args.double("maximumGapSeconds"),
+                  let parsed = CaptionGapSettings(maximumGapSeconds: maximumGapSeconds) else {
+                throw ToolError(
+                    "add_captions: maximumGapSeconds must be a finite number from "
+                    + "\(CaptionGapSettings.maximumGapRange.lowerBound) through "
+                    + "\(CaptionGapSettings.maximumGapRange.upperBound)."
+                )
+            }
+            gapSettings = parsed
+        } else {
+            gapSettings = .default
+        }
+
         let scope = try resolveTranscriptionScope(editor, args, path: "add_captions")
         let cloudRequest = scope.captionRequest(in: editor, provider: .cloud)
         let context = try await transcriptionContext(args, path: "add_captions") {
@@ -46,6 +64,7 @@ extension ToolExecutor {
         request.censorProfanity = args.bool("censorProfanity") ?? false
         request.locale = context.preferredLocale
         request.maxWords = maxWords
+        request.gapSettings = gapSettings
         request.animation = animation
 
         try await Self.validateCloudTranscriptionAccess(for: request, in: editor)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -11,6 +11,7 @@ extension EditorViewModel {
         var censorProfanity: Bool = false
         var locale: Locale? = nil
         var maxWords: Int? = nil
+        var gapSettings: CaptionGapSettings = .default
         var provider: TranscriptionProvider = .local
         /// Animation applied to every generated caption clip (timed from the transcript).
         var animation: TextAnimation = TextAnimation()
@@ -168,7 +169,12 @@ extension EditorViewModel {
         let animation: TextAnimation? = request.animation.isActive ? request.animation : nil
         let input = CaptionSpecBuilder.Input(
             targets: targets.compactMap { target in
-                results[target.clip.mediaRef].map { CaptionSpecBuilder.Target(clip: target.clip, result: $0) }
+                results[target.clip.mediaRef].map {
+                    CaptionSpecBuilder.Target(
+                        clip: target.clip,
+                        result: $0
+                    )
+                }
             },
             fps: timeline.fps,
             canvasWidth: timeline.width,
@@ -177,6 +183,7 @@ extension EditorViewModel {
             center: request.center,
             textCase: request.textCase,
             maxWords: request.maxWords,
+            gapSettings: request.gapSettings,
             animation: animation
         )
         let specs = try await CaptionSpecBuilder.build(input)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -683,7 +683,7 @@ extension EditorViewModel {
     struct TextClipSpec: Sendable {
         let trackIndex: Int
         let startFrame: Int
-        let durationFrames: Int
+        var durationFrames: Int
         let content: String
         let style: TextStyle
         /// When nil the box is auto-fit to content and centered on the canvas.

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionGapSettings.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionGapSettings.swift
@@ -1,0 +1,23 @@
+struct CaptionGapSettings: Equatable, Sendable {
+    static let maximumGapRange = 0.0...2.0
+    static let `default` = CaptionGapSettings(uncheckedMaximumGapSeconds: 0.25)
+
+    let maximumGapSeconds: Double
+
+    init?(maximumGapSeconds: Double) {
+        guard maximumGapSeconds.isFinite,
+              Self.maximumGapRange.contains(maximumGapSeconds) else { return nil }
+        self.init(uncheckedMaximumGapSeconds: maximumGapSeconds)
+    }
+
+    func maximumGapFrames(fps: Int) -> Int {
+        guard fps > 0, maximumGapSeconds > 0 else { return 0 }
+        let frames = (maximumGapSeconds * Double(fps)).rounded(.down)
+        guard frames.isFinite else { return 0 }
+        return frames >= Double(Int.max) ? Int.max : Int(frames)
+    }
+
+    private init(uncheckedMaximumGapSeconds: Double) {
+        self.maximumGapSeconds = uncheckedMaximumGapSeconds
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -135,8 +135,8 @@ enum CaptionSpecBuilder {
             let (nextEnd, nextEndOverflow) = next.startFrame.addingReportingOverflow(
                 next.durationFrames
             )
-            if !nextEndOverflow, nextEnd > coverageEnd {
-                coverageEnd = nextEnd
+            if !nextEndOverflow, nextEnd >= coverageEnd {
+                coverageEnd = max(coverageEnd, nextEnd)
                 coverageIndex = nextIndex
             }
         }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -16,6 +16,7 @@ enum CaptionSpecBuilder {
         let center: CGPoint
         let textCase: EditorViewModel.CaptionCase
         let maxWords: Int?
+        let gapSettings: CaptionGapSettings
         let animation: TextAnimation?
     }
 
@@ -75,7 +76,71 @@ enum CaptionSpecBuilder {
             ))
             try Task.checkCancellation()
         }
-        return specs
+        return closingShortGaps(
+            in: specs,
+            settings: input.gapSettings,
+            fps: input.fps
+        )
+    }
+
+    private static func closingShortGaps(
+        in specs: [EditorViewModel.TextClipSpec],
+        settings: CaptionGapSettings,
+        fps: Int
+    ) -> [EditorViewModel.TextClipSpec] {
+        let maximumGapFrames = settings.maximumGapFrames(fps: fps)
+        guard maximumGapFrames > 0, !specs.isEmpty else { return specs }
+
+        var adjusted = specs
+        let ordered = adjusted.indices.sorted {
+            let lhs = adjusted[$0].startFrame
+            let rhs = adjusted[$1].startFrame
+            return lhs == rhs ? $0 < $1 : lhs < rhs
+        }
+        guard let firstIndex = ordered.first else { return adjusted }
+        var coverageIndex = firstIndex
+        let (firstEnd, firstEndOverflow) = adjusted[firstIndex].startFrame.addingReportingOverflow(
+            adjusted[firstIndex].durationFrames
+        )
+        var coverageEnd = firstEndOverflow ? adjusted[firstIndex].startFrame : firstEnd
+
+        for nextIndex in ordered.dropFirst() {
+            let next = adjusted[nextIndex]
+            if next.startFrame > coverageEnd {
+                let (gap, gapOverflow) = next.startFrame.subtractingReportingOverflow(coverageEnd)
+                if !gapOverflow, gap <= maximumGapFrames {
+                    let overlapFrames = next.animation?.preset.needsIncomingCaptionCoverage == true ? 1 : 0
+                    let (closedEnd, endOverflow) = next.startFrame.addingReportingOverflow(
+                        overlapFrames
+                    )
+                    let previousStart = adjusted[coverageIndex].startFrame
+                    let (duration, durationOverflow) = closedEnd.subtractingReportingOverflow(
+                        previousStart
+                    )
+                    if !endOverflow, !durationOverflow, duration > 0 {
+                        var previous = adjusted[coverageIndex]
+                        previous.durationFrames = duration
+                        if previous.animation?.preset == .wordCycle,
+                           var words = previous.words,
+                           let lastIndex = words.indices.last {
+                            words[lastIndex].endFrame = duration
+                            previous.words = words
+                        }
+                        adjusted[coverageIndex] = previous
+                        coverageEnd = closedEnd
+                    }
+                }
+            }
+
+            let (nextEnd, nextEndOverflow) = next.startFrame.addingReportingOverflow(
+                next.durationFrames
+            )
+            if !nextEndOverflow, nextEnd > coverageEnd {
+                coverageEnd = nextEnd
+                coverageIndex = nextIndex
+            }
+        }
+        return adjusted
     }
 
     private static func lineFits(

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -19,6 +19,7 @@ struct CaptionTab: View {
     @State private var animationHighlight: TextStyle.RGBA = TextAnimation.defaultHighlight
     @State private var censorProfanity = false
     @State private var maxWords: Int?
+    @State private var maximumGapSeconds = CaptionGapSettings.default.maximumGapSeconds
     @State private var locale: Locale?
     @State private var supportedLocales: [Locale] = []
     @State private var isGenerating = false
@@ -196,6 +197,26 @@ struct CaptionTab: View {
                 } label: { EditorMenuValue(text: maxWords.map(String.init) ?? L10n.string("None"), expanded: true) }
                 .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).focusable(false)
                 .frame(maxWidth: .infinity)
+            }
+            InspectorRow(
+                label: L10n.string("Close gaps"),
+                labelHelp: L10n.string("Extends a caption to close gaps up to this duration."),
+                onReset: {
+                    maximumGapSeconds = CaptionGapSettings.default.maximumGapSeconds
+                }
+            ) {
+                ScrubbableNumberField(
+                    value: maximumGapSeconds,
+                    range: CaptionGapSettings.maximumGapRange,
+                    displayMultiplier: 1_000,
+                    format: "%.0f",
+                    valueSuffix: " ms",
+                    dragSensitivity: 10,
+                    dragValueAdjustment: { ($0 / 0.05).rounded() * 0.05 },
+                    onChanged: { maximumGapSeconds = $0 },
+                    onCommit: { maximumGapSeconds = $0 }
+                )
+                .accessibilityLabel(L10n.string("Close gaps"))
             }
             InspectorRow(label: L10n.string("Censor profanity"), onReset: { censorProfanity = false }) {
                 Toggle(String(), isOn: $censorProfanity)
@@ -479,6 +500,7 @@ struct CaptionTab: View {
             censorProfanity: provider == .local && censorProfanity,
             locale: locale,
             maxWords: maxWords,
+            gapSettings: CaptionGapSettings(maximumGapSeconds: maximumGapSeconds) ?? .default,
             provider: provider,
             animation: TextAnimation(preset: animationPreset, highlight: animationHighlight)
         )

--- a/Sources/PalmierPro/Models/TextAnimation.swift
+++ b/Sources/PalmierPro/Models/TextAnimation.swift
@@ -32,6 +32,16 @@ struct TextAnimation: Codable, Sendable, Equatable {
         var isPerWord: Bool { renderMode == .perWord }
         var usesHighlight: Bool { isPerWord }
 
+        var needsIncomingCaptionCoverage: Bool {
+            switch self {
+            case .fadeIn, .popIn, .slideUp, .typewriter,
+                 .wordReveal, .wordSlide, .wordPop, .wordCycle:
+                true
+            default:
+                false
+            }
+        }
+
         var displayName: String {
             switch self {
             case .none: L10n.key("Off")

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -198,6 +198,7 @@
 "Close All Tabs" = "Close All Tabs";
 "Close Other Tabs" = "Close Other Tabs";
 "Close Tab" = "Close Tab";
+"Close gaps" = "Close gaps";
 "Cloud" = "Cloud";
 "Cloud auto-detects languages, produces more accurate transcripts, can identify speakers, and uses 25 credits/hr when a transcript is not cached." = "Cloud auto-detects languages, produces more accurate transcripts, can identify speakers, and uses 25 credits/hr when a transcript is not cached.";
 "Codec" = "Codec";
@@ -347,6 +348,7 @@
 "Exporting…" = "Exporting…";
 "Export…" = "Export…";
 "Exposure" = "Exposure";
+"Extends a caption to close gaps up to this duration." = "Extends a caption to close gaps up to this duration.";
 "Extra Large" = "Extra Large";
 "Fade In" = "Fade In";
 "Fade Out" = "Fade Out";

--- a/Tests/PalmierProTests/Agent/GetTranscriptParamTests.swift
+++ b/Tests/PalmierProTests/Agent/GetTranscriptParamTests.swift
@@ -183,6 +183,27 @@ struct GetTranscriptParamTests {
         }
     }
 
+    @Test func addCaptionsSchemaExposesMaximumGapSeconds() throws {
+        let tool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addCaptions })
+        let properties = try #require(tool.inputSchema["properties"] as? [String: [String: Any]])
+        let maximumGap = try #require(properties["maximumGapSeconds"])
+
+        #expect(maximumGap["type"] as? String == "number")
+        #expect(maximumGap["minimum"] as? Double == CaptionGapSettings.maximumGapRange.lowerBound)
+        #expect(maximumGap["maximum"] as? Double == CaptionGapSettings.maximumGapRange.upperBound)
+    }
+
+    @Test func addCaptionsRejectsInvalidMaximumGapSecondsBeforeTranscription() async {
+        let h = ToolHarness(timeline: Fixtures.timeline())
+        let invalidValues: [Any] = [-0.1, 2.1, "0.25", true, Double.infinity]
+
+        for value in invalidValues {
+            let result = await h.runRaw("add_captions", args: ["maximumGapSeconds": value])
+            #expect(result.isError)
+            #expect(ToolHarness.textOf(result).contains("maximumGapSeconds"))
+        }
+    }
+
     @Test func segmentsGranularityDeclaresSegmentFormat() async throws {
         let h = ToolHarness(timeline: Fixtures.timeline())
         let json = try await h.runOK("get_transcript", args: ["granularity": "segments"]) as? [String: Any]

--- a/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
@@ -30,6 +30,14 @@ struct MCPTranscriptionTrackTests {
                 let properties = try #require(tool.inputSchema.objectValue?["properties"]?.objectValue)
                 #expect(properties["trackIndex"]?.objectValue?["type"]?.stringValue == "integer")
             }
+            let captionTool = try #require(tools.first { $0.name == "add_captions" })
+            let captionProperties = try #require(
+                captionTool.inputSchema.objectValue?["properties"]?.objectValue
+            )
+            let maximumGap = try #require(captionProperties["maximumGapSeconds"]?.objectValue)
+            #expect(maximumGap["type"]?.stringValue == "number")
+            #expect(maximumGap["minimum"]?.intValue == 0)
+            #expect(maximumGap["maximum"]?.intValue == 2)
 
             let transcript = try await client.callTool(
                 name: "get_transcript",
@@ -46,6 +54,11 @@ struct MCPTranscriptionTrackTests {
                 )
                 #expect(invalid.isError == true)
             }
+            let invalidGap = try await client.callTool(
+                name: "add_captions",
+                arguments: ["maximumGapSeconds": .double(2.1)]
+            )
+            #expect(invalidGap.isError == true)
         } catch {
             await server.stop()
             await client.disconnect()

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -73,6 +73,49 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 }
 
 @Suite struct CaptionSpecBuilderTests {
+    private func gapTarget(
+        id: String,
+        startFrame: Int,
+        durationFrames: Int
+    ) -> CaptionSpecBuilder.Target {
+        let clip = Fixtures.clip(
+            id: id,
+            mediaRef: "media-\(id)",
+            mediaType: .audio,
+            start: startFrame,
+            duration: durationFrames
+        )
+        let result = TranscriptionResult(
+            text: id,
+            language: "en",
+            words: [TranscriptionWord(text: id, start: 0, end: 0.1)],
+            segments: [TranscriptionSegment(text: id, start: 0, end: 0.2)]
+        )
+        return CaptionSpecBuilder.Target(
+            clip: clip,
+            result: result
+        )
+    }
+
+    private func input(
+        targets: [CaptionSpecBuilder.Target],
+        maximumGapSeconds: Double = CaptionGapSettings.default.maximumGapSeconds,
+        animation: TextAnimation? = nil
+    ) -> CaptionSpecBuilder.Input {
+        CaptionSpecBuilder.Input(
+            targets: targets,
+            fps: 30,
+            canvasWidth: 1920,
+            canvasHeight: 1080,
+            style: TextStyle(),
+            center: CGPoint(x: 0.5, y: 0.8),
+            textCase: .auto,
+            maxWords: nil,
+            gapSettings: CaptionGapSettings(maximumGapSeconds: maximumGapSeconds) ?? .default,
+            animation: animation
+        )
+    }
+
     @Test func buildsCaptionSpecsFromImmutableInput() async throws {
         let clip = Fixtures.clip(
             id: "source",
@@ -99,6 +142,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             center: CGPoint(x: 0.5, y: 0.8),
             textCase: .upper,
             maxWords: nil,
+            gapSettings: .default,
             animation: nil
         )
 
@@ -111,6 +155,86 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(spec.durationFrames == 30)
         #expect(spec.transform != nil)
         #expect(spec.words?.map(\.text) == ["hello", "world"])
+    }
+
+    @Test(arguments: [
+        (6, 0.25, 27),
+        (7, 0.25, 28),
+        (8, 0.25, 21),
+        (6, 0.0, 21),
+    ])
+    func closesOnlyGapsWithinTheFrameRoundedThreshold(
+        gapFrames: Int,
+        maximumGapSeconds: Double,
+        expectedFirstDuration: Int
+    ) async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(
+                    id: "two",
+                    startFrame: 21 + gapFrames,
+                    durationFrames: 30
+                ),
+            ],
+            maximumGapSeconds: maximumGapSeconds
+        ))
+
+        #expect(specs.map(\.startFrame) == [0, 21 + gapFrames])
+        #expect(specs.map(\.durationFrames) == [expectedFirstDuration, 21])
+        #expect(specs[0].words == [WordTiming(text: "one", startFrame: 0, endFrame: 3)])
+    }
+
+    @Test(arguments: [
+        TextAnimation.Preset.fadeIn,
+        .popIn,
+        .slideUp,
+        .typewriter,
+        .wordReveal,
+        .wordSlide,
+        .wordPop,
+        .wordCycle,
+    ])
+    func holdsPreviousCaptionThroughTransparentAnimatedEntry(
+        preset: TextAnimation.Preset
+    ) async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(id: "two", startFrame: 27, durationFrames: 30),
+            ],
+            animation: TextAnimation(preset: preset)
+        ))
+
+        #expect(specs.map(\.durationFrames) == [28, 21])
+        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 28 : 3))
+    }
+
+    @Test func leavesOverlapsUnchanged() async throws {
+        let overlapping = try await CaptionSpecBuilder.build(input(targets: [
+            gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+            gapTarget(id: "two", startFrame: 20, durationFrames: 30),
+        ]))
+
+        #expect(overlapping.map(\.durationFrames) == [21, 21])
+    }
+
+    @Test func closesGapFromTheClipProvidingLatestCoverage() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(targets: [
+            gapTarget(id: "outer", startFrame: 0, durationFrames: 40),
+            gapTarget(id: "nested", startFrame: 10, durationFrames: 5),
+            gapTarget(id: "next", startFrame: 26, durationFrames: 30),
+        ]))
+
+        #expect(specs.map(\.durationFrames) == [26, 5, 21])
+    }
+
+    @Test func captionGapSettingsValidateAndRoundDownToFrames() {
+        #expect(CaptionGapSettings.default.maximumGapFrames(fps: 30) == 7)
+        #expect(CaptionGapSettings(maximumGapSeconds: 0)?.maximumGapFrames(fps: 30) == 0)
+        #expect(CaptionGapSettings(maximumGapSeconds: -0.1) == nil)
+        #expect(CaptionGapSettings(maximumGapSeconds: 2.1) == nil)
+        #expect(CaptionGapSettings(maximumGapSeconds: .infinity) == nil)
     }
 }
 

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -76,7 +76,8 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
     private func gapTarget(
         id: String,
         startFrame: Int,
-        durationFrames: Int
+        durationFrames: Int,
+        hasWordTiming: Bool = true
     ) -> CaptionSpecBuilder.Target {
         let clip = Fixtures.clip(
             id: id,
@@ -88,7 +89,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         let result = TranscriptionResult(
             text: id,
             language: "en",
-            words: [TranscriptionWord(text: id, start: 0, end: 0.1)],
+            words: hasWordTiming ? [TranscriptionWord(text: id, start: 0, end: 0.1)] : [],
             segments: [TranscriptionSegment(text: id, start: 0, end: 0.2)]
         )
         return CaptionSpecBuilder.Target(
@@ -208,6 +209,19 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
         #expect(specs.map(\.durationFrames) == [28, 21])
         #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 28 : 3))
+    }
+
+    @Test func oneFrameAnimatedCaptionOwnsTheFollowingGap() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(id: "two", startFrame: 27, durationFrames: 1, hasWordTiming: false),
+                gapTarget(id: "three", startFrame: 33, durationFrames: 30),
+            ],
+            animation: TextAnimation(preset: .fadeIn)
+        ))
+
+        #expect(specs.map(\.durationFrames) == [28, 7, 21])
     }
 
     @Test func leavesOverlapsUnchanged() async throws {


### PR DESCRIPTION
## Summary

- Keep generated captions visible across brief transcript pauses instead of flashing an empty frame.
- Add a Caption tab control and `add_captions.maximumGapSeconds` parameter with a 250 ms default and 0–2 second range.
- Preserve continuity for animated captions whose first rendered frame is transparent.

## Approach

- Carry one validated `CaptionGapSettings` value through the shared caption request and off-main spec builder used by UI and Agent flows.
- Normalize the final generated caption specs in timeline-frame space, extending the clip that provides current visual coverage when the next positive gap is within the threshold.
- Treat overlapping caption specs as continuous coverage, round thresholds down to avoid exceeding the requested duration, and retain original word timings except when Word Cycle must hold its final word through the extended tail.
- Advance coverage ownership on equal end frames so one-frame animated captions cannot cause stale text to be extended later.
- Expose the same bounds and defaults through localized UI and MCP schema validation.

## Testing

Automated:
- `scripts/localization/sync.sh` — passed
- `swift test --filter CaptionSpecBuilderTests` — passed
- `swift test` — 1,368 tests in 217 suites passed on final rerun
- `swift build` — passed
- MCP discovery and invalid-threshold behavior exercised through the in-memory MCP client

Manual:
- Generated captions on a 30 fps timeline with animation Off; confirmed short gaps no longer flash after restarting the rebuilt app and regenerating captions.
- Inspected caption frame ranges through the local MCP endpoint to distinguish stale pre-feature captions from newly generated captions.

Not completed:
- Manual checks for every animation preset
- Successful `add_captions` mutation through an external MCP client with deterministic transcription media

## Change statistics

- Code logic, UI, and Agent: +157 / -5
- Tests: +174 / -2
- Localization: +2 / -0
- Total: +333 / -7