### PR TITLE
[fix] Expand caption outlines outward instead of into the fill

### DIFF
--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -125,11 +125,13 @@ enum TextFrameRenderer {
         let key = signature(content, style, transform, renderSize)
         if let cached = cache.object(forKey: key) { return cached }
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
-        let frame = TextLayout.frame(
-            for: NSAttributedString(string: content, attributes: style.attributes(size: fontSize)),
-            in: boxes.text
+        let frame = drawText(
+            ctx,
+            content: content,
+            style: style,
+            fontSize: fontSize,
+            box: boxes.text
         )
-        CTFrameDraw(frame, ctx)
         drawOverlines(ctx, frame: frame, style: style, fontSize: fontSize)
         guard let image = finish(ctx) else { return nil }
         cache.setObject(image, forKey: key)
@@ -167,8 +169,11 @@ enum TextFrameRenderer {
                                       fontSize: CGFloat, anim: TextAnimation, frame: Int, renderSize: CGSize) -> CIImage? {
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
 
-        let attr = NSAttributedString(string: content, attributes: style.attributes(size: fontSize))
-        let ctFrame = TextLayout.frame(for: attr, in: boxes.text)
+        let layoutAttrs = style.attributes(size: fontSize, outlinePass: .fill)
+        let ctFrame = TextLayout.frame(
+            for: NSAttributedString(string: content, attributes: layoutAttrs),
+            in: boxes.text
+        )
         let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
         var origins = [CGPoint](repeating: .zero, count: lines.count)
         CTFrameGetLineOrigins(ctFrame, CFRange(location: 0, length: 0), &origins)
@@ -177,9 +182,13 @@ enum TextFrameRenderer {
         let tokens = words(in: content)
         let timings = tokenTimings(tokens, clip.wordTimings, duration: clip.durationFrames)
         let rel = frame - clip.startFrame
-        let baseAttrs = style.attributes(size: fontSize)
-        let font = baseAttrs[.font] as? NSFont
+        let fillAttrs = layoutAttrs
+        let undercoatAttrs = style.drawsGlyphOutline
+            ? style.attributes(size: fontSize, outlinePass: .undercoat)
+            : nil
+        let font = fillAttrs[.font] as? NSFont
 
+        var placements: [WordPlacement] = []
         for (li, line) in lines.enumerated() {
             let lineRange = CTLineGetStringRange(line)
             for (ti, tok) in tokens.enumerated() {
@@ -190,33 +199,84 @@ enum TextFrameRenderer {
 
                 let startOff = CTLineGetOffsetForStringIndex(line, tok.range.location, nil)
                 let endOff = CTLineGetOffsetForStringIndex(line, tok.range.location + tok.range.length, nil)
-                let penX = frameBounds.minX + origins[li].x + startOff
-                let penY = frameBounds.minY + origins[li].y
-                let wWidth = endOff - startOff
-
-                var attrs = baseAttrs
-                attrs[.foregroundColor] = st.color.nsColor
-                let wordLine = CTLineCreateWithAttributedString(
-                    NSAttributedString(string: tok.text, attributes: attrs) as CFAttributedString)
-
-                ctx.saveGState()
-                ctx.setAlpha(CGFloat(st.opacity))
-                let cx = penX + wWidth / 2, cy = penY + fontSize * 0.35
-                ctx.translateBy(x: 0, y: -st.dy * fontSize)
-                ctx.translateBy(x: cx, y: cy)
-                ctx.scaleBy(x: st.scale, y: st.scale)
-                ctx.translateBy(x: -cx, y: -cy)
-                if let bg = st.bgColor, bg.a > 0.001 {
-                    drawWordBackground(ctx, color: bg, penX: penX, penY: penY,
-                                       width: wWidth, fontSize: fontSize, font: font)
-                }
-                ctx.textPosition = CGPoint(x: penX, y: penY)
-                CTLineDraw(wordLine, ctx)
-                if style.isOverlined, let font { drawOverline(ctx, x: penX, y: penY, width: wWidth, font: font, color: st.color) }
-                ctx.restoreGState()
+                var wordFillAttrs = fillAttrs
+                wordFillAttrs[.foregroundColor] = st.color.nsColor
+                placements.append(WordPlacement(
+                    state: st,
+                    penX: frameBounds.minX + origins[li].x + startOff,
+                    penY: frameBounds.minY + origins[li].y,
+                    width: endOff - startOff,
+                    fillLine: CTLineCreateWithAttributedString(
+                        NSAttributedString(string: tok.text, attributes: wordFillAttrs) as CFAttributedString),
+                    undercoatLine: undercoatAttrs.map {
+                        CTLineCreateWithAttributedString(
+                            NSAttributedString(string: tok.text, attributes: $0) as CFAttributedString)
+                    }
+                ))
             }
         }
+
+        drawWordPlacements(ctx, placements, style: style, fontSize: fontSize, font: font)
         return finish(ctx)
+    }
+
+    private struct WordPlacement {
+        let state: TextAnimator.WordState
+        let penX: CGFloat
+        let penY: CGFloat
+        let width: CGFloat
+        let fillLine: CTLine
+        let undercoatLine: CTLine?
+    }
+
+    /// Backgrounds, then undercoats, then fills, so no word's outline paints over a neighbor's fill.
+    private static func drawWordPlacements(_ ctx: CGContext, _ placements: [WordPlacement],
+                                           style: TextStyle, fontSize: CGFloat, font: NSFont?) {
+        guard !placements.isEmpty else { return }
+
+        func withWordState(_ p: WordPlacement, _ draw: () -> Void) {
+            ctx.saveGState()
+            ctx.setAlpha(CGFloat(p.state.opacity))
+            let cx = p.penX + p.width / 2, cy = p.penY + fontSize * 0.35
+            ctx.translateBy(x: 0, y: -p.state.dy * fontSize)
+            ctx.translateBy(x: cx, y: cy)
+            ctx.scaleBy(x: p.state.scale, y: p.state.scale)
+            ctx.translateBy(x: -cx, y: -cy)
+            draw()
+            ctx.restoreGState()
+        }
+
+        func drawFillAndOverline(_ p: WordPlacement) {
+            ctx.textPosition = CGPoint(x: p.penX, y: p.penY)
+            CTLineDraw(p.fillLine, ctx)
+            if style.isOverlined, let font {
+                drawOverline(ctx, x: p.penX, y: p.penY, width: p.width, font: font, color: p.state.color)
+            }
+        }
+
+        // One layer applies the context shadow once to the assembled block.
+        ctx.beginTransparencyLayer(auxiliaryInfo: nil)
+        for p in placements where p.state.bgColor.map({ $0.a > 0.001 }) == true {
+            withWordState(p) {
+                drawWordBackground(ctx, color: p.state.bgColor!, penX: p.penX, penY: p.penY,
+                                   width: p.width, fontSize: fontSize, font: font)
+            }
+        }
+        if placements.contains(where: { $0.undercoatLine != nil }) {
+            drawUndercoat(ctx) {
+                for p in placements {
+                    guard let undercoat = p.undercoatLine else { continue }
+                    withWordState(p) {
+                        ctx.textPosition = CGPoint(x: p.penX, y: p.penY)
+                        CTLineDraw(undercoat, ctx)
+                    }
+                }
+            }
+        }
+        for p in placements {
+            withWordState(p) { drawFillAndOverline(p) }
+        }
+        ctx.endTransparencyLayer()
     }
 
     /// Rounded highlight block behind a word.
@@ -280,15 +340,15 @@ enum TextFrameRenderer {
         if rel <= doneAt + holdFrames, (rel / 15) % 2 == 0 { visible += "|" }
         guard !visible.isEmpty else { return finish(ctx) }
         // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
-        var attrs = style.attributes(size: fontSize)
-        attrs[.paragraphStyle] = style.paragraphStyle(size: fontSize, alignment: .left)
-        let fullText = NSAttributedString(string: content, attributes: attrs)
-        let textFrame = TextLayout.frame(
-            for: NSAttributedString(string: visible, attributes: attrs),
-            in: boxes.text,
-            verticallySizedFor: fullText
+        let textFrame = drawText(
+            ctx,
+            content: visible,
+            style: style,
+            fontSize: fontSize,
+            box: boxes.text,
+            alignment: .left,
+            verticallySizedFor: content
         )
-        CTFrameDraw(textFrame, ctx)
         drawOverlines(ctx, frame: textFrame, style: style, fontSize: fontSize)
         return finish(ctx)
     }
@@ -468,6 +528,51 @@ enum TextFrameRenderer {
     }
 
     // MARK: - Shared drawing
+
+    /// Draws fill, or a 2× stroke undercoat then fill so the outline expands outward.
+    @discardableResult
+    private static func drawText(
+        _ ctx: CGContext,
+        content: String,
+        style: TextStyle,
+        fontSize: CGFloat,
+        box: CGRect,
+        alignment: NSTextAlignment? = nil,
+        verticallySizedFor sizingContent: String? = nil
+    ) -> CTFrame {
+        func attributed(_ pass: TextStyle.OutlinePass, string: String) -> NSAttributedString {
+            var attrs = style.attributes(size: fontSize, outlinePass: pass)
+            if let alignment {
+                attrs[.paragraphStyle] = style.paragraphStyle(size: fontSize, alignment: alignment)
+            }
+            return NSAttributedString(string: string, attributes: attrs)
+        }
+
+        let fill = attributed(.fill, string: content)
+        let sizing = sizingContent.map { attributed(.fill, string: $0) }
+        let fillFrame = TextLayout.frame(for: fill, in: box, verticallySizedFor: sizing)
+
+        guard style.drawsGlyphOutline else {
+            CTFrameDraw(fillFrame, ctx)
+            return fillFrame
+        }
+
+        let undercoat = attributed(.undercoat, string: content)
+        let undercoatFrame = TextLayout.frame(for: undercoat, in: box, verticallySizedFor: sizing)
+        ctx.beginTransparencyLayer(auxiliaryInfo: nil)
+        drawUndercoat(ctx) { CTFrameDraw(undercoatFrame, ctx) }
+        CTFrameDraw(fillFrame, ctx)
+        ctx.endTransparencyLayer()
+        return fillFrame
+    }
+
+    /// Core Text strokes honor context join state; round joins prevent miter spikes on pointed glyphs.
+    private static func drawUndercoat(_ ctx: CGContext, _ draw: () -> Void) {
+        ctx.saveGState()
+        ctx.setLineJoin(.round)
+        draw()
+        ctx.restoreGState()
+    }
 
     private static func drawBox(_ ctx: CGContext, style: TextStyle, box: CGRect, renderSize: CGSize) {
         guard style.background.enabled else { return }

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -169,9 +169,9 @@ enum TextFrameRenderer {
                                       fontSize: CGFloat, anim: TextAnimation, frame: Int, renderSize: CGSize) -> CIImage? {
         guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
 
-        let layoutAttrs = style.attributes(size: fontSize, outlinePass: .fill)
+        let fillAttrs = style.attributes(size: fontSize)
         let ctFrame = TextLayout.frame(
-            for: NSAttributedString(string: content, attributes: layoutAttrs),
+            for: NSAttributedString(string: content, attributes: fillAttrs),
             in: boxes.text
         )
         let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
@@ -182,9 +182,8 @@ enum TextFrameRenderer {
         let tokens = words(in: content)
         let timings = tokenTimings(tokens, clip.wordTimings, duration: clip.durationFrames)
         let rel = frame - clip.startFrame
-        let fillAttrs = layoutAttrs
         let undercoatAttrs = style.drawsGlyphOutline
-            ? style.attributes(size: fontSize, outlinePass: .undercoat)
+            ? style.outlineUndercoatAttributes(size: fontSize)
             : nil
         let font = fillAttrs[.font] as? NSFont
 
@@ -529,7 +528,7 @@ enum TextFrameRenderer {
 
     // MARK: - Shared drawing
 
-    /// Draws fill, or a 2× stroke undercoat then fill so the outline expands outward.
+    /// Outlined text draws undercoat then fill in one layer so the context shadow applies once.
     @discardableResult
     private static func drawText(
         _ ctx: CGContext,
@@ -540,25 +539,28 @@ enum TextFrameRenderer {
         alignment: NSTextAlignment? = nil,
         verticallySizedFor sizingContent: String? = nil
     ) -> CTFrame {
-        func attributed(_ pass: TextStyle.OutlinePass, string: String) -> NSAttributedString {
-            var attrs = style.attributes(size: fontSize, outlinePass: pass)
+        func attributed(_ attrs: [NSAttributedString.Key: Any], _ string: String) -> NSAttributedString {
+            var attrs = attrs
             if let alignment {
                 attrs[.paragraphStyle] = style.paragraphStyle(size: fontSize, alignment: alignment)
             }
             return NSAttributedString(string: string, attributes: attrs)
         }
 
-        let fill = attributed(.fill, string: content)
-        let sizing = sizingContent.map { attributed(.fill, string: $0) }
-        let fillFrame = TextLayout.frame(for: fill, in: box, verticallySizedFor: sizing)
+        let fillAttrs = style.attributes(size: fontSize)
+        let sizing = sizingContent.map { attributed(fillAttrs, $0) }
+        let fillFrame = TextLayout.frame(for: attributed(fillAttrs, content), in: box, verticallySizedFor: sizing)
 
         guard style.drawsGlyphOutline else {
             CTFrameDraw(fillFrame, ctx)
             return fillFrame
         }
 
-        let undercoat = attributed(.undercoat, string: content)
-        let undercoatFrame = TextLayout.frame(for: undercoat, in: box, verticallySizedFor: sizing)
+        let undercoatFrame = TextLayout.frame(
+            for: attributed(style.outlineUndercoatAttributes(size: fontSize), content),
+            in: box,
+            verticallySizedFor: sizing
+        )
         ctx.beginTransparencyLayer(auxiliaryInfo: nil)
         drawUndercoat(ctx) { CTFrameDraw(undercoatFrame, ctx) }
         CTFrameDraw(fillFrame, ctx)

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -309,30 +309,56 @@ extension TextStyle {
         fontCase.apply(to: text)
     }
 
+    /// Stroke is centered on the glyph path; render `.undercoat` then `.fill` so the outline expands outward.
+    enum OutlinePass: Sendable {
+        case fill
+        case undercoat
+    }
+
+    var drawsGlyphOutline: Bool {
+        border.enabled && border.width > 0
+    }
+
     /// `includeColor: false` for bounding measurement (color doesn't affect size).
-    func attributes(size: CGFloat, includeColor: Bool = true) -> [NSAttributedString.Key: Any] {
+    func attributes(
+        size: CGFloat,
+        includeColor: Bool = true,
+        outlinePass: OutlinePass = .fill
+    ) -> [NSAttributedString.Key: Any] {
         var attrs: [NSAttributedString.Key: Any] = [
             .font: resolvedFont(size: size),
             .paragraphStyle: paragraphStyle(size: size),
             .kern: tracking * Double(size) / max(1, fontSize * fontScale),
         ]
-        if isUnderlined { attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue }
-        if isStruckThrough { attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue }
-        if includeColor { attrs[.foregroundColor] = nsColor }
-        if border.enabled {
-            attrs[.strokeWidth] = NSNumber(value: glyphBorderStrokePercentage)
-            if includeColor { attrs[.strokeColor] = border.color.nsColor }
+        switch outlinePass {
+        case .fill:
+            if isUnderlined { attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue }
+            if isStruckThrough { attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue }
+            if includeColor { attrs[.foregroundColor] = nsColor }
+        case .undercoat:
+            guard drawsGlyphOutline else {
+                if includeColor { attrs[.foregroundColor] = nsColor }
+                break
+            }
+            // Positive = stroke only; 2× so the outer half equals `border.width` after fill covers the inside.
+            attrs[.strokeWidth] = NSNumber(value: glyphOutlineUndercoatStrokePercentage)
+            if includeColor {
+                let stroke = border.color.nsColor
+                attrs[.strokeColor] = stroke
+                attrs[.foregroundColor] = stroke
+            }
         }
         return attrs
     }
 
     func glyphBorderPadding(fontSize: CGFloat) -> CGFloat {
-        ceil(fontSize * CGFloat(abs(glyphBorderStrokePercentage)) / 100)
+        let unscaledFontSize = max(1, self.fontSize * fontScale)
+        return ceil(fontSize * CGFloat(max(0, border.width)) / CGFloat(unscaledFontSize))
     }
 
-    private var glyphBorderStrokePercentage: Double {
+    private var glyphOutlineUndercoatStrokePercentage: Double {
         let unscaledFontSize = max(1, fontSize * fontScale)
-        return -100 * max(0, border.width) / unscaledFontSize
+        return 200 * max(0, border.width) / unscaledFontSize
     }
 
     private static func font(_ font: NSFont, size: CGFloat, bold: Bool, italic: Bool) -> NSFont {

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -309,56 +309,42 @@ extension TextStyle {
         fontCase.apply(to: text)
     }
 
-    /// Stroke is centered on the glyph path; render `.undercoat` then `.fill` so the outline expands outward.
-    enum OutlinePass: Sendable {
-        case fill
-        case undercoat
-    }
-
+    /// Two-pass outlines need an opaque fill; translucent fills would show the undercoat through them.
     var drawsGlyphOutline: Bool {
-        border.enabled && border.width > 0
+        border.enabled && border.width > 0 && color.a >= 1
     }
 
     /// `includeColor: false` for bounding measurement (color doesn't affect size).
-    func attributes(
-        size: CGFloat,
-        includeColor: Bool = true,
-        outlinePass: OutlinePass = .fill
-    ) -> [NSAttributedString.Key: Any] {
-        var attrs: [NSAttributedString.Key: Any] = [
-            .font: resolvedFont(size: size),
-            .paragraphStyle: paragraphStyle(size: size),
-            .kern: tracking * Double(size) / max(1, fontSize * fontScale),
-        ]
-        switch outlinePass {
-        case .fill:
-            if isUnderlined { attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue }
-            if isStruckThrough { attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue }
-            if includeColor { attrs[.foregroundColor] = nsColor }
-        case .undercoat:
-            guard drawsGlyphOutline else {
-                if includeColor { attrs[.foregroundColor] = nsColor }
-                break
-            }
-            // Positive = stroke only; 2× so the outer half equals `border.width` after fill covers the inside.
-            attrs[.strokeWidth] = NSNumber(value: glyphOutlineUndercoatStrokePercentage)
-            if includeColor {
-                let stroke = border.color.nsColor
-                attrs[.strokeColor] = stroke
-                attrs[.foregroundColor] = stroke
-            }
+    func attributes(size: CGFloat, includeColor: Bool = true) -> [NSAttributedString.Key: Any] {
+        var attrs = baseAttributes(size: size)
+        if isUnderlined { attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue }
+        if isStruckThrough { attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue }
+        if includeColor { attrs[.foregroundColor] = nsColor }
+        if border.enabled, border.width > 0, !drawsGlyphOutline {
+            attrs[.strokeWidth] = NSNumber(value: -100 * max(0, border.width) / max(1, fontSize * fontScale))
+            if includeColor { attrs[.strokeColor] = border.color.nsColor }
         }
         return attrs
     }
 
-    func glyphBorderPadding(fontSize: CGFloat) -> CGFloat {
-        let unscaledFontSize = max(1, self.fontSize * fontScale)
-        return ceil(fontSize * CGFloat(max(0, border.width)) / CGFloat(unscaledFontSize))
+    /// Stroke-only undercoat at 2× width; the fill drawn on top covers the inner half, leaving `border.width` outward.
+    func outlineUndercoatAttributes(size: CGFloat) -> [NSAttributedString.Key: Any] {
+        var attrs = baseAttributes(size: size)
+        attrs[.strokeWidth] = NSNumber(value: 200 * max(0, border.width) / max(1, fontSize * fontScale))
+        attrs[.strokeColor] = border.color.nsColor
+        return attrs
     }
 
-    private var glyphOutlineUndercoatStrokePercentage: Double {
-        let unscaledFontSize = max(1, fontSize * fontScale)
-        return 200 * max(0, border.width) / unscaledFontSize
+    func glyphBorderPadding(fontSize: CGFloat) -> CGFloat {
+        ceil(fontSize * CGFloat(max(0, border.width)) / CGFloat(max(1, self.fontSize * fontScale)))
+    }
+
+    private func baseAttributes(size: CGFloat) -> [NSAttributedString.Key: Any] {
+        [
+            .font: resolvedFont(size: size),
+            .paragraphStyle: paragraphStyle(size: size),
+            .kern: tracking * Double(size) / max(1, fontSize * fontScale),
+        ]
     }
 
     private static func font(_ font: NSFont, size: CGFloat, bold: Bool, italic: Bool) -> NSFont {

--- a/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
@@ -99,6 +99,23 @@ struct TextAnimationRenderTests {
         #expect(actualPixels == expectedPixels)
     }
 
+    @Test func laterWordOutlinesDoNotPaintOverEarlierFills() {
+        var animated = clip(TextAnimation(preset: .wordReveal, perWordFrames: 4, highlight: .init(r: 1, g: 1, b: 1, a: 1)))
+        animated.textStyle?.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 40)
+        animated.textStyle?.tracking = -6
+        var expected = animated
+        expected.textAnimation = nil
+
+        // Steady frame: all words revealed, no motion — per-word must match static stacking.
+        let animatedWhite = brightCount(pixels(animated, frame: 85))
+        let staticWhite = brightCount(pixels(expected, frame: 85))
+        #expect(staticWhite > 500, "expected a visible white fill baseline")
+        #expect(
+            animatedWhite >= staticWhite * 97 / 100,
+            "later words' outlines must not cover earlier fills (\(animatedWhite) vs \(staticWhite) white pixels)"
+        )
+    }
+
     @Test func tokenTimingsSplitAlignedTranscriptSpan() {
         let tokens = [
             (range: NSRange(location: 0, length: 3), text: "New"),

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -168,111 +168,81 @@ struct TextFrameRendererTests {
         #expect(edgeRed < 50, "border should not render a rectangular clip box")
     }
 
+    private func outlineTestPixels(_ content: String, fontSize: Double, box: Transform,
+                                   outlineWidth: Double?, fillAlpha: Double = 1, size: CGSize) -> [UInt8] {
+        var style = TextStyle()
+        style.fontName = "Helvetica-Bold"
+        style.fontSize = fontSize
+        style.color = .init(r: 1, g: 1, b: 1, a: fillAlpha)
+        style.shadow.enabled = false
+        if let outlineWidth {
+            style.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: outlineWidth)
+        }
+        let clip = textClip(content: content, style: style, transform: box)
+        return rawPixels(TextFrameRenderer.image(clip: clip, frame: 0, renderSize: size)!, size: size)
+    }
+
     @Test func glyphOutlineExpandsOutwardWithoutEatingFill() throws {
         let size = CGSize(width: 640, height: 360)
-        var base = TextStyle()
-        base.fontName = "Helvetica-Bold"
-        base.fontSize = 240
-        base.color = .init(r: 1, g: 1, b: 1, a: 1)
-        base.shadow.enabled = false
         let box = Transform(topLeft: (0.15, 0.15), width: 0.7, height: 0.7)
-
-        let plainPixels = rawPixels(
-            TextFrameRenderer.image(
-                clip: textClip(content: "O", style: base, transform: box),
-                frame: 0,
-                renderSize: size
-            )!,
-            size: size
-        )
-        var outlined = base
-        outlined.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 24)
-        let outlinedPixels = rawPixels(
-            TextFrameRenderer.image(
-                clip: textClip(content: "O", style: outlined, transform: box),
-                frame: 0,
-                renderSize: size
-            )!,
-            size: size
-        )
+        let plain = outlineTestPixels("O", fontSize: 240, box: box, outlineWidth: nil, size: size)
+        let outlined = outlineTestPixels("O", fontSize: 240, box: box, outlineWidth: 24, size: size)
 
         func whiteFillCount(_ pixels: [UInt8]) -> Int {
-            var count = 0
-            for i in stride(from: 0, to: pixels.count, by: 4) {
-                if pixels[i] > 200, pixels[i + 1] > 200, pixels[i + 2] > 200, pixels[i + 3] > 200 {
-                    count += 1
-                }
+            stride(from: 0, to: pixels.count, by: 4).count {
+                pixels[$0] > 200 && pixels[$0 + 1] > 200 && pixels[$0 + 2] > 200 && pixels[$0 + 3] > 200
             }
-            return count
         }
 
-        let plainWhite = whiteFillCount(plainPixels)
-        let outlinedWhite = whiteFillCount(outlinedPixels)
+        let plainWhite = whiteFillCount(plain)
+        let outlinedWhite = whiteFillCount(outlined)
         #expect(plainWhite > 100, "expected a solid white glyph fill")
         #expect(
             outlinedWhite >= plainWhite * 9 / 10,
             "outline must not eat into the fill (\(outlinedWhite) vs \(plainWhite) white pixels)"
         )
 
-        let plainBounds = try #require(alphaBounds(plainPixels, size: size))
-        let outlinedBounds = try #require(alphaBounds(outlinedPixels, size: size))
+        let plainBounds = try #require(alphaBounds(plain, size: size))
+        let outlinedBounds = try #require(alphaBounds(outlined, size: size))
         #expect(outlinedBounds.width > plainBounds.width + 8)
         #expect(outlinedBounds.height > plainBounds.height + 8)
     }
 
+    @Test func hollowFillKeepsCenteredSingleWidthOutline() throws {
+        let size = CGSize(width: 640, height: 360)
+        let box = Transform(topLeft: (0.15, 0.15), width: 0.7, height: 0.7)
+        let outlineWidth = 24.0
+        let plainBounds = try #require(alphaBounds(
+            outlineTestPixels("O", fontSize: 240, box: box, outlineWidth: nil, size: size), size: size))
+        let hollow = outlineTestPixels("O", fontSize: 240, box: box, outlineWidth: outlineWidth, fillAlpha: 0, size: size)
+        let hollowBounds = try #require(alphaBounds(hollow, size: size))
+
+        let redCount = stride(from: 0, to: hollow.count, by: 4).count {
+            hollow[$0] > 160 && hollow[$0 + 1] < 80 && hollow[$0 + 2] < 80 && hollow[$0 + 3] > 100
+        }
+        #expect(redCount > 500, "hollow text should still render a visible outline")
+
+        // Centered stroke extends width/2 outward; the doubled undercoat would extend the full width.
+        let maxGrowth = CGFloat(outlineWidth) / 2 * size.height / TextLayout.referenceCanvasHeight + 3
+        #expect(hollowBounds.maxX <= plainBounds.maxX + maxGrowth)
+        #expect(hollowBounds.minX >= plainBounds.minX - maxGrowth)
+    }
+
     @Test func thickOutlineOnPointedGlyphsStaysWithinDeclaredPadding() throws {
         let size = CGSize(width: 640, height: 360)
-        var base = TextStyle()
-        base.fontName = "Helvetica-Bold"
-        base.fontSize = 500
-        base.color = .init(r: 1, g: 1, b: 1, a: 1)
-        base.shadow.enabled = false
         let box = Transform(topLeft: (0.05, 0.05), width: 0.9, height: 0.9)
-
+        let outlineWidth = 30.0
         let plainBounds = try #require(alphaBounds(
-            rawPixels(
-                TextFrameRenderer.image(
-                    clip: textClip(content: "VW", style: base, transform: box),
-                    frame: 0,
-                    renderSize: size
-                )!,
-                size: size
-            ),
-            size: size
-        ))
-        var outlined = base
-        outlined.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 30)
+            outlineTestPixels("VW", fontSize: 500, box: box, outlineWidth: nil, size: size), size: size))
         let outlinedBounds = try #require(alphaBounds(
-            rawPixels(
-                TextFrameRenderer.image(
-                    clip: textClip(content: "VW", style: outlined, transform: box),
-                    frame: 0,
-                    renderSize: size
-                )!,
-                size: size
-            ),
-            size: size
-        ))
+            outlineTestPixels("VW", fontSize: 500, box: box, outlineWidth: outlineWidth, size: size), size: size))
 
         // Round joins keep corners inside width + antialias slack; miter spikes shoot far past it.
-        let scale = size.height / TextLayout.referenceCanvasHeight
-        let maxGrowth = CGFloat(outlined.border.width) * scale + 3
+        let maxGrowth = CGFloat(outlineWidth) * size.height / TextLayout.referenceCanvasHeight + 3
         #expect(outlinedBounds.minX >= plainBounds.minX - maxGrowth)
         #expect(outlinedBounds.maxX <= plainBounds.maxX + maxGrowth)
         #expect(outlinedBounds.minY >= plainBounds.minY - maxGrowth)
         #expect(outlinedBounds.maxY <= plainBounds.maxY + maxGrowth)
-    }
-
-    @Test func glyphOutlineUndercoatUsesDoubledPositiveStroke() {
-        var style = TextStyle()
-        style.fontSize = 100
-        style.border = .init(enabled: true, width: 5)
-        let undercoat = style.attributes(size: 100, outlinePass: .undercoat)
-        let fill = style.attributes(size: 100, outlinePass: .fill)
-
-        #expect((undercoat[.strokeWidth] as? NSNumber)?.doubleValue == 10)
-        #expect(fill[.strokeWidth] == nil)
-        #expect(style.glyphBorderPadding(fontSize: 100) == 5)
     }
 
     @Test func backgroundRendersRoundedFillAndIndependentOutline() {

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -168,6 +168,113 @@ struct TextFrameRendererTests {
         #expect(edgeRed < 50, "border should not render a rectangular clip box")
     }
 
+    @Test func glyphOutlineExpandsOutwardWithoutEatingFill() throws {
+        let size = CGSize(width: 640, height: 360)
+        var base = TextStyle()
+        base.fontName = "Helvetica-Bold"
+        base.fontSize = 240
+        base.color = .init(r: 1, g: 1, b: 1, a: 1)
+        base.shadow.enabled = false
+        let box = Transform(topLeft: (0.15, 0.15), width: 0.7, height: 0.7)
+
+        let plainPixels = rawPixels(
+            TextFrameRenderer.image(
+                clip: textClip(content: "O", style: base, transform: box),
+                frame: 0,
+                renderSize: size
+            )!,
+            size: size
+        )
+        var outlined = base
+        outlined.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 24)
+        let outlinedPixels = rawPixels(
+            TextFrameRenderer.image(
+                clip: textClip(content: "O", style: outlined, transform: box),
+                frame: 0,
+                renderSize: size
+            )!,
+            size: size
+        )
+
+        func whiteFillCount(_ pixels: [UInt8]) -> Int {
+            var count = 0
+            for i in stride(from: 0, to: pixels.count, by: 4) {
+                if pixels[i] > 200, pixels[i + 1] > 200, pixels[i + 2] > 200, pixels[i + 3] > 200 {
+                    count += 1
+                }
+            }
+            return count
+        }
+
+        let plainWhite = whiteFillCount(plainPixels)
+        let outlinedWhite = whiteFillCount(outlinedPixels)
+        #expect(plainWhite > 100, "expected a solid white glyph fill")
+        #expect(
+            outlinedWhite >= plainWhite * 9 / 10,
+            "outline must not eat into the fill (\(outlinedWhite) vs \(plainWhite) white pixels)"
+        )
+
+        let plainBounds = try #require(alphaBounds(plainPixels, size: size))
+        let outlinedBounds = try #require(alphaBounds(outlinedPixels, size: size))
+        #expect(outlinedBounds.width > plainBounds.width + 8)
+        #expect(outlinedBounds.height > plainBounds.height + 8)
+    }
+
+    @Test func thickOutlineOnPointedGlyphsStaysWithinDeclaredPadding() throws {
+        let size = CGSize(width: 640, height: 360)
+        var base = TextStyle()
+        base.fontName = "Helvetica-Bold"
+        base.fontSize = 500
+        base.color = .init(r: 1, g: 1, b: 1, a: 1)
+        base.shadow.enabled = false
+        let box = Transform(topLeft: (0.05, 0.05), width: 0.9, height: 0.9)
+
+        let plainBounds = try #require(alphaBounds(
+            rawPixels(
+                TextFrameRenderer.image(
+                    clip: textClip(content: "VW", style: base, transform: box),
+                    frame: 0,
+                    renderSize: size
+                )!,
+                size: size
+            ),
+            size: size
+        ))
+        var outlined = base
+        outlined.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 30)
+        let outlinedBounds = try #require(alphaBounds(
+            rawPixels(
+                TextFrameRenderer.image(
+                    clip: textClip(content: "VW", style: outlined, transform: box),
+                    frame: 0,
+                    renderSize: size
+                )!,
+                size: size
+            ),
+            size: size
+        ))
+
+        // Round joins keep corners inside width + antialias slack; miter spikes shoot far past it.
+        let scale = size.height / TextLayout.referenceCanvasHeight
+        let maxGrowth = CGFloat(outlined.border.width) * scale + 3
+        #expect(outlinedBounds.minX >= plainBounds.minX - maxGrowth)
+        #expect(outlinedBounds.maxX <= plainBounds.maxX + maxGrowth)
+        #expect(outlinedBounds.minY >= plainBounds.minY - maxGrowth)
+        #expect(outlinedBounds.maxY <= plainBounds.maxY + maxGrowth)
+    }
+
+    @Test func glyphOutlineUndercoatUsesDoubledPositiveStroke() {
+        var style = TextStyle()
+        style.fontSize = 100
+        style.border = .init(enabled: true, width: 5)
+        let undercoat = style.attributes(size: 100, outlinePass: .undercoat)
+        let fill = style.attributes(size: 100, outlinePass: .fill)
+
+        #expect((undercoat[.strokeWidth] as? NSNumber)?.doubleValue == 10)
+        #expect(fill[.strokeWidth] == nil)
+        #expect(style.glyphBorderPadding(fontSize: 100) == 5)
+    }
+
     @Test func backgroundRendersRoundedFillAndIndependentOutline() {
         let size = CGSize(width: 640, height: 360)
         var style = TextStyle()


### PR DESCRIPTION
Before:
<img width="872" height="458" alt="Screenshot 2026-08-03 at 10 17 35 AM" src="https://github.com/user-attachments/assets/0cf54edd-12ba-4ac7-9ee3-0d81745fb431" />

After
<img width="915" height="390" alt="Screenshot 2026-08-03 at 10 17 54 AM" src="https://github.com/user-attachments/assets/3e49b958-4e83-4938-8a6c-5ef7ce58bb4f" />


## Summary

Caption/text outline width was centered on the glyph path, so increasing it ate into the letterforms. Outlines now grow outward while the fill keeps its full weight. Also fixes two related rendering defects found while testing: miter spikes on pointed glyphs at thick widths, and later words' outlines painting over earlier words' fills in per-word caption animations.

## Approach

Core Text has no outer-stroke mode — `strokeWidth` strokes are always centered on the glyph path. The renderer therefore draws outlined text in two passes: a stroke-only undercoat at 2× the requested width, then the fill on top. The visible outer half equals the requested width; the fill restores the interior.

- `TextStyle` exposes `outlineUndercoatAttributes(size:)` alongside the existing fill `attributes(size:)`, both built from a shared base, so there is one source of truth for outline math.
- Both passes draw inside one transparency layer so the context shadow applies once to the combined silhouette.
- The undercoat draws with a round line join (`drawUndercoat`) — Core Text strokes honor context join state, verified empirically. Under the default miter join, thick outlines on pointed glyphs (V, W, 4) threw spikes up to ~45 canvas points past the declared outline width, escaping the measured text box.
- The per-word animation path now collects `WordPlacement`s and draws in ordered passes — all highlight backgrounds, then all undercoats, then all fills/overlines — so no word's outline can cover a neighbor's letters. Static and typewriter paths get the same guarantee from whole-frame draw order.
- Translucent fills (`color.a < 1`, including hollow text) keep the original centered single-pass stroke: an outward undercoat would show through a non-opaque fill (Bugbot finding, addressed).

Layout is unchanged: `glyphBorderPadding` still resolves to exactly `border.width` at the outer extent, so text-box auto-fit and clip placement do not move. FCPXML export is untouched.

## Testing

`swift build` and the five affected suites all pass (36 tests): TextFrameRenderer, TextFrameRenderer — animation, Compositor — text layer, text clip layout, and export glyph rendering.

New regression tests, each verified to fail against the pre-fix renderer:

- `glyphOutlineExpandsOutwardWithoutEatingFill` — outlined glyph keeps ≥90% of the plain fill pixels and its alpha bounds grow outward
- `thickOutlineOnPointedGlyphsStaysWithinDeclaredPadding` — fails with miter-spike overshoot when the round join is removed
- `laterWordOutlinesDoNotPaintOverEarlierFills` — steady frame of a per-word animation preserves the static render's fill coverage
- `hollowFillKeepsCenteredSingleWidthOutline` — fails with doubled outline width when the opaque-fill gate is removed

Bugbot reviewed the branch twice: one finding (translucent-fill bleed-through), fixed; second pass clean.

Manual UI verification (performed): outline width sweep on captions looks correct — fill preserved, outline grows outward, thick outlines have clean rounded corners, multi-word animated captions no longer show neighbor overlap.

## Change statistics

- Code logic: +170 / −51 (`TextFrameRenderer.swift`, `TextStyle.swift`)
- Tests: +94 (two rendering suites)

Made with [Cursor](https://cursor.com)