### PR TITLE
[feat] Use MiniMax H3 with a video reference for Edit → Reframe

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AIEdit.swift
@@ -39,13 +39,14 @@ extension EditorViewModel {
     }
 
     func beginAIReframe(clipId: String) {
-        guard let (clip, asset) = aiEditClipAsset(clipId), clip.mediaType == .video,
-              let stored = EditSubmitter.reframeSeed(for: asset) else { return }
+        guard let (clip, asset) = aiEditClipAsset(clipId), clip.mediaType == .video else { return }
+        let trim = aiEditTrimmedSource(clipId: clipId)
+        guard let stored = EditSubmitter.reframeSeed(for: asset, trimmedSource: trim) else { return }
         seedGenerationPanel(
             asset: asset,
             stored: stored,
             replacementClipId: clipId,
-            trimmedSource: aiEditTrimmedSource(clipId: clipId)
+            trimmedSource: trim
         )
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AITransition.swift
@@ -3,19 +3,8 @@ import Foundation
 extension EditorViewModel {
     static let maxTransitionSeconds: Double = 15
 
-    static let defaultTransitionPrompt = """
-        Create a seamless transition between the first frame and the last frame, one continuous \
-        take. No weird movements, effects, or artifacts. Natural and consistent motion that makes \
-        sense. No music, just appropriate SFX.
-        """
-
     func transitionGapSeconds(lengthFrames: Int) -> Double {
         Double(lengthFrames) / Double(max(1, timeline.fps))
-    }
-
-    static func nearestSupportedDuration(seconds: Double, in durations: [Int]) -> Int {
-        durations.min { abs(Double($0) - seconds) < abs(Double($1) - seconds) }
-            ?? max(1, Int(seconds.rounded()))
     }
 
     func aiTransitionAvailability(for gap: GapSelection) -> (model: VideoModelConfig?, refusal: String?) {
@@ -26,7 +15,7 @@ extension EditorViewModel {
             return (nil, "Transitions are limited to \(Int(Self.maxTransitionSeconds)) seconds. This gap is \(String(format: "%.1f", seconds)) seconds.")
         }
         guard aiEditAllowed else { return (nil, "Sign in to generate.") }
-        let model = VideoModelConfig.allModels.first { !$0.requiresSourceVideo && $0.supportsFirstFrame && $0.supportsLastFrame }
+        let model = VideoModelConfig.firstAndLastFrame
         return (model, model == nil ? "No video model supports first and last frames." : nil)
     }
 
@@ -38,10 +27,7 @@ extension EditorViewModel {
             gapStartFrame: gap.range.start,
             gapLengthFrames: gap.range.length
         )
-        let duration = Self.nearestSupportedDuration(
-            seconds: transitionGapSeconds(lengthFrames: placement.gapLengthFrames),
-            in: model.durations
-        )
+        let gapSeconds = transitionGapSeconds(lengthFrames: placement.gapLengthFrames)
         cancelPendingTransitionSeed()
         transitionSeedTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -61,12 +47,12 @@ extension EditorViewModel {
                 )
                 try Task.checkCancellation()
                 guard transitionSeedIsCurrent(placement) else { return }
-                var stored = GenerationInput(
-                    prompt: Self.defaultTransitionPrompt, model: model.id,
-                    duration: duration,
-                    aspectRatio: "", resolution: nil
+                let stored = EditSubmitter.transitionSeed(
+                    model: model,
+                    firstFrame: first.asset,
+                    lastFrame: last.asset,
+                    gapSeconds: gapSeconds
                 )
-                stored.imageURLAssetIds = [first.asset.id, last.asset.id]
                 seedGenerationPanel(asset: first.asset, stored: stored, transitionPlacement: placement)
             } catch is CancellationError {
             } catch {

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -40,6 +40,14 @@ struct VideoModelConfig: Identifiable, Sendable {
         Self.nearestSupportedDuration(seconds: seconds, in: durations)
     }
 
+    /// Smallest supported duration that fully covers `seconds`, so generated
+    /// media is never shorter than the clip span it replaces.
+    func supportedDuration(covering seconds: Double) -> Int {
+        durations.filter { Double($0) >= seconds }.min()
+            ?? durations.max()
+            ?? max(1, Int(seconds.rounded(.up)))
+    }
+
     var preferredHighResolution: String? {
         if let resolutions, resolutions.contains("2K") { return "2K" }
         if let resolutions, resolutions.contains("1080p") { return "1080p" }

--- a/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
+++ b/Sources/PalmierPro/Generation/Catalog/VideoModelConfig.swift
@@ -15,7 +15,63 @@ struct VideoModelConfig: Identifiable, Sendable {
 
     @MainActor
     static var reframe: VideoModelConfig? {
-        allModels.first(where: { $0.id.contains("reframe") })
+        allModels.first(where: isReframeModel)
+    }
+
+    @MainActor
+    static var firstAndLastFrame: VideoModelConfig? {
+        allModels.first { !$0.requiresSourceVideo && $0.supportsFirstFrame && $0.supportsLastFrame }
+    }
+
+    static func isReframeModel(_ model: VideoModelConfig) -> Bool {
+        guard model.supportsPrompt,
+              !model.requiresSourceVideo,
+              model.maxReferenceVideos > 0 else { return false }
+        let id = model.id.lowercased()
+        return id.contains("minimax-h3") || id.contains("hailuo-03")
+    }
+
+    static func nearestSupportedDuration(seconds: Double, in durations: [Int]) -> Int {
+        durations.min { abs(Double($0) - seconds) < abs(Double($1) - seconds) }
+            ?? max(1, Int(seconds.rounded()))
+    }
+
+    func nearestSupportedDuration(for seconds: Double) -> Int {
+        Self.nearestSupportedDuration(seconds: seconds, in: durations)
+    }
+
+    var preferredHighResolution: String? {
+        if let resolutions, resolutions.contains("2K") { return "2K" }
+        if let resolutions, resolutions.contains("1080p") { return "1080p" }
+        return resolutions?.first
+    }
+
+    var reframeDurationLimitLabel: String? {
+        if let maximum = maxCombinedVideoRefSeconds,
+           maximum.isFinite, maximum > 0,
+           let seconds = Int(exactly: maximum.rounded()) {
+            return Self.durationLimitLabel(seconds: seconds)
+        }
+        return durations.max().map(Self.durationLimitLabel)
+    }
+
+    func validateReframeDuration(_ duration: Double) -> String? {
+        guard duration.isFinite, duration > 0 else {
+            return "Loading video metadata…"
+        }
+        let maximum = maxCombinedVideoRefSeconds
+            ?? durations.max().map(Double.init)
+        guard let maximum, duration > maximum,
+              let limit = reframeDurationLimitLabel else { return nil }
+        return "\(displayName) supports source videos up to \(limit). Trim the clip to continue."
+    }
+
+    private static func durationLimitLabel(seconds: Int) -> String {
+        if seconds.isMultiple(of: 60) {
+            let minutes = seconds / 60
+            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
+        }
+        return seconds == 1 ? "1 second" : "\(seconds) seconds"
     }
 
     @MainActor
@@ -64,11 +120,7 @@ struct VideoModelConfig: Identifiable, Sendable {
         guard let maximum = maxSourceVideoSeconds,
               maximum.isFinite, maximum > 0,
               let seconds = Int(exactly: maximum.rounded()) else { return nil }
-        if seconds.isMultiple(of: 60) {
-            let minutes = seconds / 60
-            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
-        }
-        return seconds == 1 ? "1 second" : "\(seconds) seconds"
+        return Self.durationLimitLabel(seconds: seconds)
     }
 
     func validateSourceDuration(_ duration: Double) -> String? {

--- a/Sources/PalmierPro/Generation/Edit/EditAction.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditAction.swift
@@ -67,7 +67,7 @@ enum EditAction {
                 return .disabled(reason: L10n.string("Reframe model not available"))
             }
             let duration = effectiveDurationOverride ?? asset.resolvedDuration
-            if let error = model.validateSourceDuration(duration) {
+            if let error = model.validateReframeDuration(duration) {
                 return .disabled(reason: error)
             }
             return .available

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
@@ -1,24 +1,64 @@
 import Foundation
 
 extension EditSubmitter {
-    static func reframeSeed(for asset: MediaAsset) -> GenerationInput? {
-        guard asset.type == .video, let model = VideoModelConfig.reframe else { return nil }
+    static let reframePrompt =
+        "The exact same video as @Video1 but fill in to match the output aspect ratio. Keep movement, details, and audio the same as the original audio"
+
+    static let transitionPrompt = """
+        Create a seamless transition between the first frame and the last frame, one continuous \
+        take. No weird movements, effects, or artifacts. Natural and consistent motion that makes \
+        sense. No music, just appropriate SFX.
+        """
+
+    static func reframeSeed(
+        for asset: MediaAsset,
+        trimmedSource: TrimmedSource? = nil
+    ) -> GenerationInput? {
+        guard let model = VideoModelConfig.reframe else { return nil }
+        return reframeSeed(for: asset, model: model, trimmedSource: trimmedSource)
+    }
+
+    static func reframeSeed(
+        for asset: MediaAsset,
+        model: VideoModelConfig,
+        trimmedSource: TrimmedSource? = nil
+    ) -> GenerationInput? {
+        guard asset.type == .video,
+              VideoModelConfig.isReframeModel(model) else { return nil }
         let isPortrait: Bool
         if let width = asset.sourceWidth, let height = asset.sourceHeight {
             isPortrait = height > width
         } else {
             isPortrait = false
         }
+        let sourceSeconds = trimmedSource?.hasTrim == true
+            ? trimmedSource?.durationSeconds ?? asset.resolvedDuration
+            : asset.resolvedDuration
         var stored = GenerationInput(
-            prompt: "",
+            prompt: reframePrompt,
             model: model.id,
-            duration: 0,
+            duration: model.nearestSupportedDuration(for: sourceSeconds),
             aspectRatio: isPortrait ? "16:9" : "9:16",
-            resolution: model.resolutions?.contains("1080p") == true
-                ? "1080p"
-                : model.resolutions?.first
+            resolution: model.preferredHighResolution
         )
-        stored.imageURLAssetIds = [asset.id]
+        stored.referenceVideoAssetIds = [asset.id]
+        return stored
+    }
+
+    static func transitionSeed(
+        model: VideoModelConfig,
+        firstFrame: MediaAsset,
+        lastFrame: MediaAsset,
+        gapSeconds: Double
+    ) -> GenerationInput {
+        var stored = GenerationInput(
+            prompt: transitionPrompt,
+            model: model.id,
+            duration: model.nearestSupportedDuration(for: gapSeconds),
+            aspectRatio: "",
+            resolution: nil
+        )
+        stored.imageURLAssetIds = [firstFrame.id, lastFrame.id]
         return stored
     }
 

--- a/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
+++ b/Sources/PalmierPro/Generation/Edit/EditSubmitter+Seeds.swift
@@ -37,7 +37,7 @@ extension EditSubmitter {
         var stored = GenerationInput(
             prompt: reframePrompt,
             model: model.id,
-            duration: model.nearestSupportedDuration(for: sourceSeconds),
+            duration: model.supportedDuration(covering: sourceSeconds),
             aspectRatio: isPortrait ? "16:9" : "9:16",
             resolution: model.preferredHighResolution
         )

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -38,7 +38,7 @@ final class GenerationService {
         folderId: String? = nil,
         buildParams: @escaping ([String]) -> BackendGenerationParams,
         snapshotRefs: (@Sendable (inout GenerationInput, [String]) -> Void)? = nil,
-        preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)? = nil,
+        preprocessRef: (@Sendable (Int, MediaAsset, URL) async throws -> URL?)? = nil,
         preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)? = nil,
         fileExtension: String,
         projectURL: URL?,
@@ -147,7 +147,7 @@ final class GenerationService {
         references: [MediaAsset],
         trimmedSourceOverride: TrimmedSource?,
         preUploadedURLs: [String]?,
-        preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?,
+        preprocessRef: (@Sendable (Int, MediaAsset, URL) async throws -> URL?)?,
         preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)?
     ) async throws -> PreparedReferences {
         if let preUploadedURLs, !preUploadedURLs.isEmpty {
@@ -158,11 +158,14 @@ final class GenerationService {
         do {
             var urlsToUpload = references.map(\.url)
             let refTypes = references.map(\.type)
-            if let trim = trimmedSourceOverride, trim.hasTrim, !urlsToUpload.isEmpty {
-                Log.generation.notice("using trimmed source: frames \(trim.trimStartFrame)+\(trim.sourceFramesConsumed) of \(urlsToUpload[0].lastPathComponent)")
+            var trimmedIndex: Int?
+            if let trim = trimmedSourceOverride, trim.hasTrim,
+               let index = urlsToUpload.firstIndex(of: trim.sourceURL) {
+                Log.generation.notice("using trimmed source: frames \(trim.trimStartFrame)+\(trim.sourceFramesConsumed) of \(urlsToUpload[index].lastPathComponent)")
                 let extracted = try await VideoTrimExtractor.extract(trim)
-                urlsToUpload[0] = extracted
+                urlsToUpload[index] = extracted
                 tempFiles.append(extracted)
+                trimmedIndex = index
             }
             if let preprocessSourceVideo, let sourceURL = urlsToUpload.first,
                let processed = try await preprocessSourceVideo(sourceURL) {
@@ -170,7 +173,11 @@ final class GenerationService {
                 tempFiles.append(processed)
             }
             if let preprocessRef, !references.isEmpty {
-                let rewrites = try await preprocessedReferenceURLs(references: references, preprocessRef: preprocessRef)
+                let rewrites = try await preprocessedReferenceURLs(
+                    references: references,
+                    currentURLs: urlsToUpload,
+                    preprocessRef: preprocessRef
+                )
                 for (i, rewritten) in rewrites {
                     guard let rewritten else { continue }
                     urlsToUpload[i] = rewritten
@@ -182,7 +189,7 @@ final class GenerationService {
                 types: refTypes,
                 cacheKeys: uploadCacheKeys(
                     references: references,
-                    trimmedFirstReference: trimmedSourceOverride?.hasTrim == true,
+                    trimmedIndex: trimmedIndex,
                     hasPreprocess: preprocessRef != nil || preprocessSourceVideo != nil
                 ),
             )
@@ -195,11 +202,13 @@ final class GenerationService {
 
     private func preprocessedReferenceURLs(
         references: [MediaAsset],
-        preprocessRef: @escaping @Sendable (Int, MediaAsset) async throws -> URL?
+        currentURLs: [URL],
+        preprocessRef: @escaping @Sendable (Int, MediaAsset, URL) async throws -> URL?
     ) async throws -> [(Int, URL?)] {
         try await withThrowingTaskGroup(of: (Int, URL?).self) { group in
             for (i, asset) in references.enumerated() {
-                group.addTask { (i, try await preprocessRef(i, asset)) }
+                let currentURL = currentURLs[i]
+                group.addTask { (i, try await preprocessRef(i, asset, currentURL)) }
             }
             var results: [(Int, URL?)] = []
             for try await result in group { results.append(result) }
@@ -209,12 +218,12 @@ final class GenerationService {
 
     private func uploadCacheKeys(
         references: [MediaAsset],
-        trimmedFirstReference: Bool,
+        trimmedIndex: Int?,
         hasPreprocess: Bool
     ) -> [MediaAsset?] {
         references.enumerated().map { index, asset in
             if hasPreprocess { return nil }
-            if index == 0 && trimmedFirstReference { return nil }
+            if index == trimmedIndex { return nil }
             return asset
         }
     }

--- a/Sources/PalmierPro/Generation/Submission/AudioGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/AudioGenerationSubmission.swift
@@ -23,12 +23,12 @@ struct AudioGenerationSubmission {
         let shouldExtractAudio = !usesReferences && !references.isEmpty && model.usesSourceURL
             && (references.first?.type == .video || trimmedSourceOverride?.hasTrim == true)
         let extractionTrim = shouldExtractAudio ? trimmedSourceOverride : nil
-        let preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+        let preprocessRef: (@Sendable (Int, MediaAsset, URL) async throws -> URL?)?
         if shouldExtractAudio {
-            preprocessRef = { index, asset in
+            preprocessRef = { index, _, currentURL in
                 guard index == 0 else { return nil }
                 return try await AudioTrackExtractor.extract(
-                    sourceURL: asset.url,
+                    sourceURL: currentURL,
                     trimmedSource: extractionTrim
                 )
             }

--- a/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
+++ b/Sources/PalmierPro/Generation/Submission/VideoGenerationSubmission.swift
@@ -10,7 +10,7 @@ struct VideoGenerationSubmission {
     let folderId: String?
     let buildParams: ([String]) -> BackendGenerationParams
     let snapshotRefs: (@Sendable (inout GenerationInput, [String]) -> Void)?
-    let preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+    let preprocessRef: (@Sendable (Int, MediaAsset, URL) async throws -> URL?)?
     let preprocessSourceVideo: (@Sendable (URL) async throws -> URL?)?
 
     @MainActor
@@ -141,13 +141,14 @@ struct VideoGenerationSubmission {
             videoRefCount: videoRefCount,
             audioRefCount: audioRefCount
         )
-        let preprocessRef: (@Sendable (Int, MediaAsset) async throws -> URL?)?
+        let preprocessRef: (@Sendable (Int, MediaAsset, URL) async throws -> URL?)?
         if inputAssets.videoRefs.isEmpty {
             preprocessRef = nil
         } else {
-            preprocessRef = { _, asset in
+            // currentURL may already be a trimmed extract; downscale must chain onto it.
+            preprocessRef = { _, asset, currentURL in
                 guard asset.type == .video else { return nil }
-                return try await VideoPreprocessor.downscaleIfNeeded(url: asset.url)
+                return try await VideoPreprocessor.downscaleIfNeeded(url: currentURL)
             }
         }
 
@@ -208,15 +209,21 @@ struct VideoGenerationSubmission {
         }
 
         @MainActor
-        func validate(for model: VideoModelConfig) -> String? {
+        func validate(
+            for model: VideoModelConfig,
+            trimmedSource: TrimmedSource? = nil
+        ) -> String? {
             if model.requiresSourceVideo {
-                return validateEditReferences(for: model)
+                return validateEditReferences(for: model, trimmedSource: trimmedSource)
             }
-            return validateTextToVideoReferences(for: model)
+            return validateTextToVideoReferences(for: model, trimmedSource: trimmedSource)
         }
 
         @MainActor
-        private func validateEditReferences(for model: VideoModelConfig) -> String? {
+        private func validateEditReferences(
+            for model: VideoModelConfig,
+            trimmedSource: TrimmedSource?
+        ) -> String? {
             guard let sourceVideo else {
                 return "Model '\(model.id)' requires a source video."
             }
@@ -232,11 +239,18 @@ struct VideoGenerationSubmission {
             if model.requiresReferenceAudio && audioRefs.isEmpty {
                 return "\(model.displayName) requires an audio reference"
             }
-            return validateReferences(for: model, includingFrames: false)
+            return validateReferences(
+                for: model,
+                includingFrames: false,
+                trimmedSource: trimmedSource
+            )
         }
 
         @MainActor
-        private func validateTextToVideoReferences(for model: VideoModelConfig) -> String? {
+        private func validateTextToVideoReferences(
+            for model: VideoModelConfig,
+            trimmedSource: TrimmedSource?
+        ) -> String? {
             if sourceVideo != nil {
                 return "\(model.displayName) does not accept a source video"
             }
@@ -252,13 +266,18 @@ struct VideoGenerationSubmission {
             if model.framesAndReferencesExclusive, !frames.isEmpty, !allRefs.isEmpty {
                 return "\(model.displayName) uses frames OR references, not both. Clear one side."
             }
-            return validateReferences(for: model, includingFrames: true)
+            return validateReferences(
+                for: model,
+                includingFrames: true,
+                trimmedSource: trimmedSource
+            )
         }
 
         @MainActor
         private func validateReferences(
             for model: VideoModelConfig,
-            includingFrames: Bool
+            includingFrames: Bool,
+            trimmedSource: TrimmedSource?
         ) -> String? {
             let referenceLabel = model.requiresSourceVideo ? "reference(s)" : "references"
             if imageRefs.count > model.maxReferenceImages {
@@ -273,13 +292,22 @@ struct VideoGenerationSubmission {
             if let totalCap = model.maxTotalReferences, totalRefCount > totalCap {
                 return "\(model.displayName) accepts at most \(totalCap) references total"
             }
-            if let cap = model.maxCombinedVideoRefSeconds,
-               videoRefs.reduce(0, { $0 + $1.duration }) > cap {
-                return "Combined video reference duration exceeds \(Int(cap))s"
+            let uploadOrder = includingFrames ? textToVideoReferences : editReferences
+            if let cap = model.maxCombinedVideoRefSeconds {
+                let combined = videoRefs.reduce(0.0) {
+                    $0 + referenceDuration($1, trimmedSource: trimmedSource, uploadOrder: uploadOrder)
+                }
+                if combined > cap {
+                    return "Combined video reference duration exceeds \(Int(cap))s"
+                }
             }
-            if let cap = model.maxCombinedAudioRefSeconds,
-               audioRefs.reduce(0, { $0 + $1.duration }) > cap {
-                return "Combined audio reference duration exceeds \(Int(cap))s"
+            if let cap = model.maxCombinedAudioRefSeconds {
+                let combined = audioRefs.reduce(0.0) {
+                    $0 + referenceDuration($1, trimmedSource: trimmedSource, uploadOrder: uploadOrder)
+                }
+                if combined > cap {
+                    return "Combined audio reference duration exceeds \(Int(cap))s"
+                }
             }
             var groups: [([MediaAsset], ClipType, String)] = [
                 (imageRefs, .image, "referenceImageMediaRefs"),
@@ -290,6 +318,21 @@ struct VideoGenerationSubmission {
                 groups.insert((frames, .image, "frame references"), at: 0)
             }
             return validateTypes(groups)
+        }
+
+        /// GenerationService rewrites the first uploaded reference whose URL matches the trim.
+        @MainActor
+        private func referenceDuration(
+            _ asset: MediaAsset,
+            trimmedSource: TrimmedSource?,
+            uploadOrder: [MediaAsset]
+        ) -> Double {
+            guard let trim = trimmedSource, trim.hasTrim,
+                  trim.sourceURL == asset.url,
+                  uploadOrder.first(where: { $0.url == trim.sourceURL })?.id == asset.id else {
+                return asset.duration
+            }
+            return trim.durationSeconds
         }
 
         @MainActor

--- a/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
@@ -226,7 +226,8 @@ extension GenerationView {
                 flashDropError("\(videoModel.displayName) only accepts \(supported) references.")
                 return
             }
-            if let err = selection.validate(for: videoModel) {
+            let trim = pendingTrimmedSource(for: videoModel, inputAssets: selection)
+            if let err = selection.validate(for: videoModel, trimmedSource: trim) {
                 flashDropError(err)
                 return
             }

--- a/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+Submit.swift
@@ -171,6 +171,22 @@ extension GenerationView {
         )
     }
 
+    /// Matches GenerationService: the trim rewrites the first uploaded reference whose URL matches it.
+    func pendingTrimmedSource(
+        for model: VideoModelConfig,
+        inputAssets: VideoGenerationSubmission.InputAssets
+    ) -> TrimmedSource? {
+        guard let trim = editor.pendingEditTrimmedSource, trim.hasTrim else { return nil }
+        if model.requiresSourceVideo {
+            guard let source = inputAssets.sourceVideo ?? sourceVideo,
+                  trim.sourceURL == source.url else { return nil }
+            return trim
+        }
+        guard let match = inputAssets.textToVideoReferences.first(where: { $0.url == trim.sourceURL }),
+              match.type == .video else { return nil }
+        return trim
+    }
+
     func audioInputAssets(for model: AudioModelConfig) -> AudioGenerationSubmission.InputAssets {
         guard model.supportsReferences else { return AudioGenerationSubmission.InputAssets() }
         return AudioGenerationSubmission.InputAssets(imageRefs: refImages, audioRefs: refAudios)
@@ -180,6 +196,7 @@ extension GenerationView {
         switch selectedType {
         case .video:
             let inputAssets = videoInputAssets(for: videoModel)
+            let trimmedSource = pendingTrimmedSource(for: videoModel, inputAssets: inputAssets)
             let modelError: String?
             if videoModel.requiresSourceVideo {
                 modelError = videoModel.validateSourceDuration(effectiveSourceVideoSeconds)
@@ -191,7 +208,7 @@ extension GenerationView {
                     resolution: effectiveResolution
                 )
             }
-            return modelError ?? inputAssets.validate(for: videoModel)
+            return modelError ?? inputAssets.validate(for: videoModel, trimmedSource: trimmedSource)
         case .image:
             let quality = imageModel.qualities != nil ? selectedQuality : nil
             let imageCount = imageModel.maxImages > 1
@@ -330,13 +347,7 @@ extension GenerationView {
         case .video:
             let model = videoModel
             let inputAssets = videoInputAssets(for: model)
-            let trimmedSource: TrimmedSource? = {
-                guard model.requiresSourceVideo,
-                      let trim = editor.pendingEditTrimmedSource,
-                      let sv = sourceVideo,
-                      trim.sourceURL == sv.url else { return nil }
-                return trim
-            }()
+            let trimmedSource = pendingTrimmedSource(for: model, inputAssets: inputAssets)
             let placeholderDuration: Double
             if model.requiresSourceVideo {
                 if let trim = trimmedSource, trim.hasTrim {
@@ -344,6 +355,8 @@ extension GenerationView {
                 } else {
                     placeholderDuration = sourceVideo?.duration ?? 5
                 }
+            } else if let trim = trimmedSource, trim.hasTrim {
+                placeholderDuration = trim.durationSeconds
             } else {
                 placeholderDuration = Double(selectedDuration)
             }

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -70,7 +70,7 @@ struct AIEditTab: View {
                                 icon: "aspectratio",
                                 title: L10n.string("Reframe"),
                                 description: L10n.string("Change aspect ratio and extend the frame with AI"),
-                                detail: VideoModelConfig.reframe?.sourceDurationLimitLabel
+                                detail: VideoModelConfig.reframe?.reframeDurationLimitLabel
                                     .map { L10n.string("Up to \($0)") }
                             )
                         }
@@ -368,8 +368,9 @@ struct AIEditTab: View {
                 trimmed: trim
             )
         case .reframe:
-            guard let stored = EditSubmitter.reframeSeed(for: asset) else { return }
-            seedPanel(stored: stored, trimmed: trimmedSourceIfEnabled())
+            let trim = trimmedSourceIfEnabled()
+            guard let stored = EditSubmitter.reframeSeed(for: asset, trimmedSource: trim) else { return }
+            seedPanel(stored: stored, trimmed: trim)
         case .lipSync:
             guard let model = VideoModelConfig.lipSync,
                   let stored = EditSubmitter.lipSyncSeed(for: asset, model: model) else { return }

--- a/Tests/PalmierProTests/Generation/ReframeSeedTests.swift
+++ b/Tests/PalmierProTests/Generation/ReframeSeedTests.swift
@@ -25,7 +25,7 @@ struct ReframeSeedTests {
         #expect(seed.prompt.contains("@Video1"))
         #expect(seed.aspectRatio == "9:16")
         #expect(seed.resolution == "2K")
-        #expect(seed.duration == 8)
+        #expect(seed.duration == 9)
         #expect(seed.referenceVideoAssetIds == ["clip-1"])
         #expect(seed.imageURLAssetIds == nil)
     }
@@ -61,12 +61,14 @@ struct ReframeSeedTests {
         #expect(!VideoModelConfig.isReframeModel(model))
     }
 
-    @Test("Snaps duration to the nearest supported value")
-    func snapsDuration() throws {
+    @Test("Duration covers the source span so the replaced clip never outlives the media")
+    func durationCoversSourceSpan() throws {
         let model = try Self.minimaxH3()
-        #expect(model.nearestSupportedDuration(for: 7.6) == 8)
-        #expect(model.nearestSupportedDuration(for: 4.1) == 5)
-        #expect(model.nearestSupportedDuration(for: 20) == 15)
+        #expect(model.supportedDuration(covering: 7.6) == 8)
+        #expect(model.supportedDuration(covering: 8.5) == 9)
+        #expect(model.supportedDuration(covering: 4.1) == 5)
+        #expect(model.supportedDuration(covering: 10) == 10)
+        #expect(model.supportedDuration(covering: 20) == 15)
         #expect(model.validateReframeDuration(16) != nil)
         #expect(model.validateReframeDuration(10) == nil)
     }

--- a/Tests/PalmierProTests/Generation/ReframeSeedTests.swift
+++ b/Tests/PalmierProTests/Generation/ReframeSeedTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Reframe seed")
+@MainActor
+struct ReframeSeedTests {
+    @Test("Seeds MiniMax H3 with video reference and fill prompt")
+    func seedsVideoReferenceAndPrompt() throws {
+        let model = try Self.minimaxH3()
+        let asset = MediaAsset(
+            id: "clip-1",
+            url: URL(fileURLWithPath: "/tmp/wide.mp4"),
+            type: .video,
+            name: "Wide",
+            duration: 8.2
+        )
+        asset.sourceWidth = 1920
+        asset.sourceHeight = 1080
+
+        let seed = try #require(EditSubmitter.reframeSeed(for: asset, model: model))
+
+        #expect(seed.model == "minimax-h3")
+        #expect(seed.prompt == EditSubmitter.reframePrompt)
+        #expect(seed.prompt.contains("@Video1"))
+        #expect(seed.aspectRatio == "9:16")
+        #expect(seed.resolution == "2K")
+        #expect(seed.duration == 8)
+        #expect(seed.referenceVideoAssetIds == ["clip-1"])
+        #expect(seed.imageURLAssetIds == nil)
+    }
+
+    @Test("Portrait sources reframe to landscape")
+    func flipsPortraitToLandscape() throws {
+        let model = try Self.minimaxH3()
+        let asset = MediaAsset(
+            id: "clip-2",
+            url: URL(fileURLWithPath: "/tmp/tall.mp4"),
+            type: .video,
+            name: "Tall",
+            duration: 5
+        )
+        asset.sourceWidth = 1080
+        asset.sourceHeight = 1920
+
+        let seed = try #require(EditSubmitter.reframeSeed(for: asset, model: model))
+        #expect(seed.aspectRatio == "16:9")
+    }
+
+    @Test("Rejects models that cannot take video references")
+    func rejectsSourceOnlyModels() throws {
+        let model = try Self.sourceEditModel()
+        let asset = MediaAsset(
+            id: "clip-3",
+            url: URL(fileURLWithPath: "/tmp/clip.mp4"),
+            type: .video,
+            name: "Clip",
+            duration: 5
+        )
+        #expect(EditSubmitter.reframeSeed(for: asset, model: model) == nil)
+        #expect(!VideoModelConfig.isReframeModel(model))
+    }
+
+    @Test("Snaps duration to the nearest supported value")
+    func snapsDuration() throws {
+        let model = try Self.minimaxH3()
+        #expect(model.nearestSupportedDuration(for: 7.6) == 8)
+        #expect(model.nearestSupportedDuration(for: 4.1) == 5)
+        #expect(model.nearestSupportedDuration(for: 20) == 15)
+        #expect(model.validateReframeDuration(16) != nil)
+        #expect(model.validateReframeDuration(10) == nil)
+    }
+
+    @Test("Validates combined video-ref duration against the trimmed span")
+    func validateUsesTrimmedVideoRefDuration() throws {
+        let model = try Self.minimaxH3()
+        let url = URL(fileURLWithPath: "/tmp/long-reframe.mp4")
+        let asset = MediaAsset(
+            id: "long-1",
+            url: url,
+            type: .video,
+            name: "Long",
+            duration: 60
+        )
+        let inputs = VideoGenerationSubmission.InputAssets(videoRefs: [asset])
+        #expect(inputs.validate(for: model)?.contains("Combined video reference duration") == true)
+
+        let trim = TrimmedSource(
+            sourceURL: url,
+            trimStartFrame: 0,
+            trimEndFrame: 45 * 30,
+            sourceFramesConsumed: 10 * 30,
+            fps: 30
+        )
+        #expect(trim.durationSeconds == 10)
+        #expect(inputs.validate(for: model, trimmedSource: trim) == nil)
+    }
+
+    @Test("Applies trim to the matching video even when an image reference precedes it")
+    func validateAppliesTrimBehindImageReference() throws {
+        let model = try Self.minimaxH3()
+        let image = MediaAsset(
+            id: "img-1",
+            url: URL(fileURLWithPath: "/tmp/style.png"),
+            type: .image,
+            name: "Style"
+        )
+        let videoURL = URL(fileURLWithPath: "/tmp/long-second.mp4")
+        let video = MediaAsset(
+            id: "vid-2",
+            url: videoURL,
+            type: .video,
+            name: "Long second",
+            duration: 60
+        )
+        let inputs = VideoGenerationSubmission.InputAssets(
+            imageRefs: [image],
+            videoRefs: [video]
+        )
+        let trim = TrimmedSource(
+            sourceURL: videoURL,
+            trimStartFrame: 30,
+            trimEndFrame: 49 * 30,
+            sourceFramesConsumed: 10 * 30,
+            fps: 30
+        )
+        #expect(inputs.validate(for: model, trimmedSource: trim) == nil)
+    }
+
+    @Test("Ignores trim whose source URL matches no reference")
+    func validateIgnoresUnrelatedTrim() throws {
+        let model = try Self.minimaxH3()
+        let video = MediaAsset(
+            id: "vid-3",
+            url: URL(fileURLWithPath: "/tmp/long-third.mp4"),
+            type: .video,
+            name: "Long third",
+            duration: 60
+        )
+        let inputs = VideoGenerationSubmission.InputAssets(videoRefs: [video])
+        let trim = TrimmedSource(
+            sourceURL: URL(fileURLWithPath: "/tmp/other.mp4"),
+            trimStartFrame: 30,
+            trimEndFrame: 49 * 30,
+            sourceFramesConsumed: 10 * 30,
+            fps: 30
+        )
+        #expect(inputs.validate(for: model, trimmedSource: trim)?.contains("Combined video reference duration") == true)
+    }
+
+    private static func minimaxH3() throws -> VideoModelConfig {
+        try decodeVideoModel(#"""
+        {
+          "id": "minimax-h3",
+          "kind": "video",
+          "displayName": "MiniMax H3",
+          "providerIconKey": "minimax",
+          "allowedEndpoints": ["opaque"],
+          "responseShape": "video",
+          "uiCapabilities": {
+            "supportsPrompt": true,
+            "durations": [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            "resolutions": ["768P", "2K"],
+            "aspectRatios": ["16:9", "9:16", "1:1"],
+            "supportsFirstFrame": false,
+            "supportsLastFrame": false,
+            "maxReferenceImages": 9,
+            "maxReferenceVideos": 3,
+            "maxReferenceAudios": 3,
+            "maxTotalReferences": 12,
+            "maxCombinedVideoRefSeconds": 15,
+            "maxCombinedAudioRefSeconds": 15,
+            "framesAndReferencesExclusive": false,
+            "referenceTagNoun": "Video",
+            "requiresSourceVideo": false,
+            "maxSourceVideoSeconds": null,
+            "requiresReferenceImage": false,
+            "requiresReferenceAudio": false
+          }
+        }
+        """#)
+    }
+
+    private static func sourceEditModel() throws -> VideoModelConfig {
+        try decodeVideoModel(#"""
+        {
+          "id": "kling-reframe",
+          "kind": "video",
+          "displayName": "Legacy Reframe",
+          "allowedEndpoints": ["opaque"],
+          "responseShape": "video",
+          "uiCapabilities": {
+            "supportsPrompt": true,
+            "durations": [5, 10],
+            "resolutions": ["1080p"],
+            "aspectRatios": ["16:9", "9:16"],
+            "supportsFirstFrame": false,
+            "supportsLastFrame": false,
+            "maxReferenceImages": 0,
+            "maxReferenceVideos": 0,
+            "maxReferenceAudios": 0,
+            "maxTotalReferences": null,
+            "maxCombinedVideoRefSeconds": null,
+            "maxCombinedAudioRefSeconds": null,
+            "framesAndReferencesExclusive": false,
+            "referenceTagNoun": "Video",
+            "requiresSourceVideo": true,
+            "maxSourceVideoSeconds": 10,
+            "requiresReferenceImage": false,
+            "requiresReferenceAudio": false
+          }
+        }
+        """#)
+    }
+
+    private static func decodeVideoModel(_ json: String) throws -> VideoModelConfig {
+        let entry = try JSONDecoder().decode(CatalogEntry.self, from: Data(json.utf8))
+        guard case .video(let caps) = entry.uiCapabilities else {
+            Issue.record("Expected video capabilities")
+            throw DecodeError.wrongKind
+        }
+        return VideoModelConfig(entry: entry, caps: caps)
+    }
+
+    private enum DecodeError: Error { case wrongKind }
+}

--- a/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
+++ b/Tests/PalmierProTests/Timeline/AITransitionPlacementTests.swift
@@ -74,7 +74,7 @@ struct AITransitionPlacementTests {
         (12.0, [4, 6, 8], 8),
         (2.4, [Int](), 2),
     ]) func seedDurationSnapsToNearestSupported(seconds: Double, durations: [Int], expected: Int) {
-        #expect(EditorViewModel.nearestSupportedDuration(seconds: seconds, in: durations) == expected)
+        #expect(VideoModelConfig.nearestSupportedDuration(seconds: seconds, in: durations) == expected)
     }
 
     @Test func seedIsStaleAfterTimelineSwitchOrFilledGap() {


### PR DESCRIPTION
## Summary

Edit → Reframe now seeds the generation panel with MiniMax H3 (Hailuo-03) using the source clip as a **video reference** and a fill prompt ("The exact same video as @Video1 but fill in to match the output aspect ratio…"), instead of the legacy source-video reframe model. This produces noticeably better reframe results: motion, detail, and audio are preserved while the new aspect-ratio area is filled in.

Fixes a user-reported bug found during testing: reframing a trimmed clip (or reframing with an image reference added) failed at Generate with "Combined video reference duration exceeds 15s" even though the trimmed span was within the limit.

## Approach

**Seeding (`EditSubmitter+Seeds`, `VideoModelConfig`):**
- `VideoModelConfig.reframe` resolves via `isReframeModel` (MiniMax H3 / Hailuo-03 with prompt + video-reference support) instead of matching `"reframe"` in the ID.
- The seed sets the fill prompt, flips the aspect ratio (landscape ↔ portrait), picks the highest available resolution, and snaps duration to the nearest supported value for the (possibly trimmed) source length.
- Reframe availability validates against `maxCombinedVideoRefSeconds` (`validateReframeDuration`) rather than `maxSourceVideoSeconds`, since the clip now travels as a reference.

**Trim support on the reference path (the bug fix):**
- Reframe previously used the source-video path, which was trim-aware; the reference-video path was not. `GenerationService.prepareReferences` now applies `trimmedSourceOverride` to the first uploaded reference whose URL matches the trim (previously it blindly trimmed index 0, which broke when an image reference sorted first).
- `InputAssets.validate` accepts the pending trim and counts the trimmed duration for the matching reference, so preflight agrees with what will actually upload.
- `preprocessRef` now receives the current (possibly trimmed) URL so downscaling chains onto the trimmed extract instead of re-reading the full-length original.

**Shared prefill infrastructure (refactor):**
- Duration snapping unified into `VideoModelConfig.nearestSupportedDuration` (transitions and reframe previously had two implementations that disagreed on rounding; the more accurate raw-seconds comparison won).
- AI-transition seeding moved into `EditSubmitter.transitionSeed` next to the other seeds; model selection via a `VideoModelConfig.firstAndLastFrame` capability selector. Future prefilled workflows follow the same pattern: capability selector + seed function.

**Known follow-up:** the rule "the trim applies to the first uploaded reference matching its URL" is mirrored in three places (`GenerationService`, `pendingTrimmedSource`, `referenceDuration`). Making the trim part of the reference itself would collapse these; deferred to a follow-up PR since it touches panel seeding, submission, and undo paths beyond this change.

## Testing

- `swift build` — passes.
- `swift test --filter "ReframeSeedTests|AITransitionPlacementTests"` — 13 tests in 2 suites pass.
- New `ReframeSeedTests` cover: seed model/prompt/aspect/resolution/duration, portrait→landscape flip, rejection of source-only models, duration snapping, and regression tests for trimmed-reference validation (including the image-before-video ordering that triggered the reported bug, and an unrelated-trim no-op).
- Manual verification performed: reframe of a trimmed clip with an added image reference previously errored at Generate and now submits.

**Manual UI test plan (not yet re-verified after final cleanup commits):**
1. Select a video clip → AI Edit tab → Reframe: panel opens seeded with MiniMax H3, the fill prompt, flipped aspect ratio, and the clip as a video reference.
2. Trim a clip below 15s from a longer source, Reframe, add an image reference, Generate: no duration error; placeholder matches trimmed length.
3. AI transition in a timeline gap still seeds prompt/model/duration as before.

## Change statistics

- Code logic: 11 files, +229 / −83 (seeding ~60, trim-aware validation and upload ~120, shared-prefill refactor and cleanup ~50)
- Tests: 2 files, +227 / −1 (new `ReframeSeedTests` suite; one renamed helper reference)

Made with [Cursor](https://cursor.com)