### PR TITLE
[refactor/ui] Centralize default text style; show text clips as wrapped paragraphs

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -830,7 +830,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addCaptions,
-            description: "Transcribes spoken audio and creates styled caption text clips on their own track. Pass trackIndex to caption one dialogue or multicam mic track; omit it to automatically choose the timeline track with the most speech. The app uses cloud only when the signed-in account has enough credits for the uncached request; otherwise it uses local transcription. Cloud auto-detects language. Per-word animations are timed from the transcript. Returns the caption group summary (captionGroupId, clipCount, frameRange, shared style, textPreview) — restyle it later with update_text and that captionGroupId.",
+            description: "Transcribes spoken audio and creates caption text clips on their own track. Style, animation, and transform are optional overrides: omit them ALL for the app's clean default captions (plain white Helvetica, lower-third) — do not invent fonts, colors, outlines, backgrounds, or animations the user didn't ask for. Pass trackIndex to caption one dialogue or multicam mic track; omit it to automatically choose the timeline track with the most speech. The app uses cloud only when the signed-in account has enough credits for the uncached request; otherwise it uses local transcription. Cloud auto-detects language. Per-word animations are timed from the transcript. Returns the caption group summary (captionGroupId, clipCount, frameRange, shared style, textPreview) — restyle it later with update_text and that captionGroupId.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "language": ["type": "string", "description": "BCP-47 speech language. Applies to local only; cloud auto-detects."],
@@ -846,7 +846,7 @@ enum ToolDefinitions {
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
                     "maxWords": ["type": "integer", "description": "Max words per caption."],
                 ], textStyleProperties(detailed: false), [
-                    "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset."],
+                    "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset. Omit for static captions; set only when the user asks for animation."],
                     "highlightColor": ["type": "string", "description": "Active-word hex."],
                 ])
             )
@@ -1149,7 +1149,7 @@ enum ToolDefinitions {
         let properties: [String: [String: Any]] = [
             "style": [
                 "type": "object",
-                "description": "Partial text-style patch. Omit properties to keep defaults or existing values.",
+                "description": "Partial text-style patch. Omitted properties keep existing values (updates) or the app's default style (new text and captions). Set only what the user asked for; omit the whole object when they didn't specify a look.",
                 "properties": [
                     "fontName": ["type": "string", "description": "Font PostScript name."],
                     "fontSize": ["type": "number", "minimum": 12, "maximum": 300, "description": "Font size in canvas points."],
@@ -1224,7 +1224,7 @@ enum ToolDefinitions {
         ]
         guard !detailed, var style = properties["style"] else { return properties }
         style = schemaWithoutDescriptions(style)
-        style["description"] = "Same partial style patch as update_text."
+        style["description"] = "Same partial style patch as update_text. Omit entirely unless the user asked for specific styling; omitted = app default style."
         return ["style": style]
     }
 

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -10,7 +10,7 @@ extension ToolExecutor {
         try validateUnknownKeys(args, allowed: Self.addCaptionsAllowedKeys, path: "add_captions")
 
         let stylePatch = try parseTextStylePatch(args, path: "add_captions")
-        var style = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
+        var style = TextStyle.caption
         if let stylePatch { Self.applyTextStylePatch(stylePatch, to: &style) }
 
         var center = AppTheme.Caption.defaultCenter

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -5,7 +5,7 @@ extension EditorViewModel {
     struct CaptionRequest {
         var sourceClipIds: [String] = []
         var autoDetect: Bool = false
-        var style: TextStyle = TextStyle()
+        var style: TextStyle = .caption
         var center: CGPoint = AppTheme.Caption.defaultCenter
         var textCase: CaptionCase = .auto
         var censorProfanity: Bool = false

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionPresetGallery.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionPresetGallery.swift
@@ -90,8 +90,6 @@ private struct CaptionPresetCell: View {
 
     private var previewClip: Clip {
         var style = TextStyle()
-        style.color = .init(r: 1, g: 1, b: 1, a: 1)
-        style.shadow.enabled = false
         style.fontSize = 300   // fraction of render height; large so the sample reads in a small cell
         let transform = Transform(centerX: 0.5, centerY: 0.5, width: 0.92, height: 0.55)
         return CaptionPreviewRender.clip(content: Self.sample, style: style, transform: transform, preset: preset, highlight: highlight)

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionPresetGallery.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionPresetGallery.swift
@@ -89,8 +89,7 @@ private struct CaptionPresetCell: View {
     }
 
     private var previewClip: Clip {
-        var style = TextStyle()
-        style.fontSize = 300   // fraction of render height; large so the sample reads in a small cell
+        let style = TextStyle(fontSize: 300)
         let transform = Transform(centerX: 0.5, centerY: 0.5, width: 0.92, height: 0.55)
         return CaptionPreviewRender.clip(content: Self.sample, style: style, transform: transform, preset: preset, highlight: highlight)
     }

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -4,14 +4,8 @@ struct CaptionTab: View {
     @Environment(EditorViewModel.self) var editor
     @Bindable private var account = AccountService.shared
 
-    @State private var style: TextStyle = CaptionTab.defaultStyle
+    @State private var style: TextStyle = .caption
     @State private var center = AppTheme.Caption.defaultCenter
-
-    private static var defaultStyle: TextStyle {
-        var s = TextStyle(fontSize: AppTheme.Caption.defaultFontSize)
-        s.shadow.enabled = false
-        return s
-    }
     @State private var selectedTrackId: String?
     @State private var selectedClipTargets: [String] = []
     @State private var provider: TranscriptionProvider = .cloud
@@ -301,8 +295,8 @@ struct CaptionTab: View {
 
     private var styleSection: some View {
         TextStyleControls(
-            selection: TextStyleSelection(styles: [style], fallback: Self.defaultStyle),
-            defaults: Self.defaultStyle,
+            selection: TextStyleSelection(styles: [style], fallback: .caption),
+            defaults: .caption,
             styleExpanded: $styleExpanded,
             groupsExpandedByDefault: false,
             actions: styleActions

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct TextStyle: Codable, Sendable, Equatable, Hashable {
     static let axisScaleRange = 0.1...10.0
 
-    var fontName: String = "Helvetica-Bold"
+    var fontName: String = "Helvetica"
     var fontSize: Double = 96
     var fontScale: Double = 1.0
     var widthScale: Double = 1.0
@@ -13,7 +13,7 @@ struct TextStyle: Codable, Sendable, Equatable, Hashable {
     var tracking: Double = 0
     var lineSpacing: Double = 0
     var fontCase: FontCase = .mixed
-    var isBold: Bool = true
+    var isBold: Bool = false
     var isItalic: Bool = false
     var isUnderlined: Bool = false
     var isStruckThrough: Bool = false
@@ -60,7 +60,7 @@ struct TextStyle: Codable, Sendable, Equatable, Hashable {
     }
 
     struct Shadow: Codable, Sendable, Equatable, Hashable {
-        var enabled: Bool = true
+        var enabled: Bool = false
         /// Alpha doubles as opacity; layer.shadowOpacity stays at 1.
         var color: RGBA = RGBA(r: 0, g: 0, b: 0, a: 0.6)
         /// Canvas points; scaled at render time.
@@ -154,31 +154,36 @@ struct TextStyle: Codable, Sendable, Equatable, Hashable {
 }
 
 extension TextStyle {
+    static var caption: TextStyle { TextStyle(fontSize: AppTheme.Caption.defaultFontSize) }
+}
+
+extension TextStyle {
     /// Missing-key-tolerant decode — older files pick up defaults for fields added later.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        let fontName = (try? c.decode(String.self, forKey: .fontName)) ?? "Helvetica-Bold"
-        let fontSize = (try? c.decode(Double.self, forKey: .fontSize)) ?? 96
+        let defaults = TextStyle()
+        let fontName = (try? c.decode(String.self, forKey: .fontName)) ?? defaults.fontName
+        let fontSize = (try? c.decode(Double.self, forKey: .fontSize)) ?? defaults.fontSize
         let inferredTraits = Self.symbolicTraits(fontName: fontName, size: CGFloat(fontSize))
         self.init(
             fontName: fontName,
             fontSize: fontSize,
-            fontScale: (try? c.decode(Double.self, forKey: .fontScale)) ?? 1.0,
-            widthScale: (try? c.decode(Double.self, forKey: .widthScale)) ?? 1.0,
-            heightScale: (try? c.decode(Double.self, forKey: .heightScale)) ?? 1.0,
-            tracking: (try? c.decode(Double.self, forKey: .tracking)) ?? 0,
-            lineSpacing: (try? c.decode(Double.self, forKey: .lineSpacing)) ?? 0,
-            fontCase: (try? c.decode(FontCase.self, forKey: .fontCase)) ?? .mixed,
+            fontScale: (try? c.decode(Double.self, forKey: .fontScale)) ?? defaults.fontScale,
+            widthScale: (try? c.decode(Double.self, forKey: .widthScale)) ?? defaults.widthScale,
+            heightScale: (try? c.decode(Double.self, forKey: .heightScale)) ?? defaults.heightScale,
+            tracking: (try? c.decode(Double.self, forKey: .tracking)) ?? defaults.tracking,
+            lineSpacing: (try? c.decode(Double.self, forKey: .lineSpacing)) ?? defaults.lineSpacing,
+            fontCase: (try? c.decode(FontCase.self, forKey: .fontCase)) ?? defaults.fontCase,
             isBold: (try? c.decode(Bool.self, forKey: .isBold)) ?? inferredTraits.contains(.traitBold),
             isItalic: (try? c.decode(Bool.self, forKey: .isItalic)) ?? inferredTraits.contains(.traitItalic),
-            isUnderlined: (try? c.decode(Bool.self, forKey: .isUnderlined)) ?? false,
-            isStruckThrough: (try? c.decode(Bool.self, forKey: .isStruckThrough)) ?? false,
-            isOverlined: (try? c.decode(Bool.self, forKey: .isOverlined)) ?? false,
-            color: (try? c.decode(RGBA.self, forKey: .color)) ?? RGBA(),
-            alignment: (try? c.decode(Alignment.self, forKey: .alignment)) ?? .center,
-            shadow: (try? c.decode(Shadow.self, forKey: .shadow)) ?? Shadow(),
-            background: (try? c.decode(Background.self, forKey: .background)) ?? Background(),
-            border: (try? c.decode(Outline.self, forKey: .border)) ?? Outline()
+            isUnderlined: (try? c.decode(Bool.self, forKey: .isUnderlined)) ?? defaults.isUnderlined,
+            isStruckThrough: (try? c.decode(Bool.self, forKey: .isStruckThrough)) ?? defaults.isStruckThrough,
+            isOverlined: (try? c.decode(Bool.self, forKey: .isOverlined)) ?? defaults.isOverlined,
+            color: (try? c.decode(RGBA.self, forKey: .color)) ?? defaults.color,
+            alignment: (try? c.decode(Alignment.self, forKey: .alignment)) ?? defaults.alignment,
+            shadow: (try? c.decode(Shadow.self, forKey: .shadow)) ?? defaults.shadow,
+            background: (try? c.decode(Background.self, forKey: .background)) ?? defaults.background,
+            border: (try? c.decode(Outline.self, forKey: .border)) ?? defaults.border
         )
     }
 }

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -185,8 +185,12 @@ enum ClipRenderer {
         let showLabel = showsLabel(isSelected: isSelected, in: rect)
 
         if showLabel {
-            drawLabelBar(clip: clip, type: type, in: labelRect, clipRect: rect, context: context,
-                         displayName: displayName, badge: multicamAngleLabel, fps: fps)
+            if type == .text {
+                drawTextParagraph(clip: clip, displayName: displayName, in: rect)
+            } else {
+                drawLabelBar(clip: clip, type: type, in: labelRect, clipRect: rect, context: context,
+                             displayName: displayName, badge: multicamAngleLabel, fps: fps)
+            }
         } else if multicamAngleLabel != nil, rect.width >= AppTheme.ComponentSize.timelineClipBorderMinWidth {
             let d = AppTheme.ComponentSize.timelineDotSize
             let inset = AppTheme.Spacing.xxs
@@ -826,6 +830,20 @@ enum ClipRenderer {
         str.draw(at: NSPoint(x: rect.minX + padH, y: rect.minY + padV))
         context.restoreGState()
         return rect
+    }
+
+    private static func drawTextParagraph(clip: Clip, displayName: String?, in rect: NSRect) {
+        let content = clip.textContent?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let text = content.isEmpty ? (displayName ?? "") : content
+        guard !text.isEmpty else { return }
+
+        let drawRect = rect.insetBy(dx: AppTheme.Spacing.sm, dy: AppTheme.Spacing.xxs)
+        guard !drawRect.isEmpty else { return }
+
+        NSAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs, weight: .medium),
+            .foregroundColor: clip.sourceClipType.themeForegroundColor,
+        ]).draw(with: drawRect, options: [.usesLineFragmentOrigin], context: nil)
     }
 
     private static func drawLabelBar(clip: Clip, type: ClipType, in labelRect: NSRect, clipRect: NSRect, context: CGContext, displayName: String? = nil, badge: String? = nil, fps: Int) {

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -128,6 +128,8 @@ enum ClipRenderer {
             drawWaveform(samples: samples, deadAirRanges: deadAirRanges(),
                          speakerMask: speakerColors.isEmpty ? nil : cache?.speakerMask(for: clip.mediaRef),
                          clip: clip, type: colorType, in: audioRect, context: context)
+        } else if type == .text, showsLabel(isSelected: isSelected, in: rect) {
+            drawTextParagraph(clip: clip, displayName: displayName, in: rect)
         }
 
         let showsFadeControls = showsFadeControls(isSelected: isSelected, isHovered: isHovered, in: rect)
@@ -184,13 +186,9 @@ enum ClipRenderer {
         let showDetailChrome = rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth
         let showLabel = showsLabel(isSelected: isSelected, in: rect)
 
-        if showLabel {
-            if type == .text {
-                drawTextParagraph(clip: clip, displayName: displayName, in: rect)
-            } else {
-                drawLabelBar(clip: clip, type: type, in: labelRect, clipRect: rect, context: context,
-                             displayName: displayName, badge: multicamAngleLabel, fps: fps)
-            }
+        if showLabel, type != .text {
+            drawLabelBar(clip: clip, type: type, in: labelRect, clipRect: rect, context: context,
+                         displayName: displayName, badge: multicamAngleLabel, fps: fps)
         } else if multicamAngleLabel != nil, rect.width >= AppTheme.ComponentSize.timelineClipBorderMinWidth {
             let d = AppTheme.ComponentSize.timelineDotSize
             let inset = AppTheme.Spacing.xxs

--- a/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
+++ b/Tests/PalmierProTests/Export/FCPXMLExporterTests.swift
@@ -772,6 +772,7 @@ struct FCPXMLExporterTests {
         text.textContent = "Caption"
         var style = TextStyle()
         style.fontName = "Helvetica-Bold"
+        style.isBold = true
         text.textStyle = style
         let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [text])])
 

--- a/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextFrameRendererTests.swift
@@ -281,6 +281,7 @@ struct TextFrameRendererTests {
         var style = TextStyle()
         style.tracking = 18
         style.lineSpacing = 24
+        style.shadow.enabled = true
         style.shadow.offsetX = 15
         style.shadow.offsetY = -9
         style.shadow.blur = 10
@@ -307,6 +308,7 @@ struct TextFrameRendererTests {
 
     @Test func verticalShadowOffsetExpandsMeasuredHeight() {
         var centered = TextStyle()
+        centered.shadow.enabled = true
         centered.shadow.offsetX = 0
         centered.shadow.offsetY = 0
         var shifted = centered


### PR DESCRIPTION
## Summary

Two related caption/text polish changes:

1. **Centralize the default text style.** `TextStyle()`'s memberwise defaults are now the single source of the app's default look: Helvetica regular, white, no outline, no shadow, no background (animation already defaulted to none). Previously the default was Helvetica-Bold with a shadow, and the Captions tab, the `add_captions` agent tool, and the preset gallery each re-derived their own variants — which had drifted: agent-generated captions carried a shadow while UI-generated captions did not.
2. **Timeline text clips render their content as a paragraph.** Text clips no longer show the name + duration label bar; the clip's text draws as a word-wrapped multi-line paragraph across the clip, preserving explicit line breaks, so captions read as prose on the timeline.

## Approach

- `TextStyle`'s memberwise defaults own the default style. The missing-key-tolerant decoder now falls back to a `TextStyle()` instance instead of repeating literals, so the defaults exist in exactly one place. Saved projects encode every field, so existing projects are unaffected; only pre-shadow-era files missing keys would pick up the new defaults.
- A shared `TextStyle.caption` (caption font size on top of the default) replaces the duplicated setup in `CaptionTab`, `ToolExecutor+Captions`, and `CaptionRequest`.
- Tool schema descriptions now state that omitted style/animation means the app default and tell the agent not to invent styling the user didn't ask for. The old `add_captions` description ("creates styled caption text clips") was inviting the model to improvise fonts, colors, and animations on a bare "add captions" prompt. No parameter names or enum values changed, so the tool contract remains stable.
- In `ClipRenderer`, text clips (`mediaType == .text`) skip `drawLabelBar` and use a new `drawTextParagraph` that draws `clip.textContent` with `.usesLineFragmentOrigin` (which word-wraps and clips to the rect), using the same font and track foreground color as other clip labels. Other clip types keep the existing label bar, multicam chips, and link underline. The existing width threshold still hides text on very narrow clips.

## Testing

- `swift build` — passes.
- `swift test` (full suite, 1360 tests / 217 suites) — passes on the text-style commit.
- Focused suites re-run after the renderer change: `TextFrameRendererTests`, `ProjectRoundTripTests`, `ClipRendererPerformanceTests` (35 tests) plus tool schema/executor/MCP suites — pass.
- Tests that intentionally relied on the old defaults were updated to set them explicitly (shadow-measurement tests enable the shadow; an FCPXML font-face test sets `isBold`).
- Manual UI verification still needed: caption/text clips on the timeline show wrapped text with no duration; Captions tab and Text inspector show Helvetica regular with decorations off; a bare "add captions" agent prompt produces default-styled captions.

## Change statistics

- Code: ~+55/−40 across `Models`, `MediaPanel`, `Agent/Tools`, `Editor`, `Timeline`.
- Tests: +3 lines (explicit defaults in existing tests).

Made with [Cursor](https://cursor.com)