### PR TITLE
[perf] Tight bounded text raster cache and animated caption frame reuse

### DIFF
--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -329,6 +329,9 @@ enum FrameRenderer {
             .unpremultiplyingAlpha() else { return nil }
 
         if let effects = clip.effects, !effects.isEmpty {
+            // Effects expect the full frame; a filter may map transparent pixels to visible ones.
+            let renderRect = CGRect(origin: .zero, size: renderSize)
+            image = image.composited(over: CIImage(color: .clear).cropped(to: renderRect))
             let offset = frame - clip.startFrame
             for effect in effects where effect.enabled {
                 guard let descriptor = EffectRegistry.descriptor(id: effect.type) else { continue }

--- a/Sources/PalmierPro/Compositing/TextAnimator.swift
+++ b/Sources/PalmierPro/Compositing/TextAnimator.swift
@@ -10,7 +10,7 @@ enum TextAnimator {
         static let identity = ClipState()
     }
 
-    struct WordState: Equatable {
+    struct WordState: Equatable, Hashable {
         var opacity: Float = 1
         var scale: CGFloat = 1
         var dy: CGFloat = 0

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -94,7 +94,7 @@ enum TextFrameRenderer {
                 .insetBy(dx: -stroke, dy: -stroke)
             rect = rect.union(offset)
         }
-        if style.drawsGlyphOutline {
+        if style.border.enabled, style.border.width > 0 {
             let pad = style.glyphBorderPadding(fontSize: fontSize)
             rect = rect.insetBy(dx: -pad, dy: -pad)
         }

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -1,11 +1,20 @@
 import AppKit
 import CoreImage
 import CoreText
+import os
 
 /// Renders a text clip as a CIImage using CoreText on the compositor queue
 enum TextFrameRenderer {
     // NSCache is internally thread-safe; the compositor queue and main thread both hit it.
-    nonisolated(unsafe) private static let cache = NSCache<NSString, CIImage>()
+    nonisolated(unsafe) private static let cache: NSCache<NSString, CIImage> = {
+        let cache = NSCache<NSString, CIImage>()
+        cache.totalCostLimit = 256 * 1024 * 1024
+        cache.countLimit = 2048
+        return cache
+    }()
+
+    /// Test seam: called with the clip content each time a raster is actually drawn (cache miss).
+    static let onRasterize = OSAllocatedUnfairLock<(@Sendable (String) -> Void)?>(initialState: nil)
 
     static func image(clip: Clip, frame: Int, renderSize: CGSize) -> CIImage? {
         guard renderSize.width >= 1, renderSize.height >= 1 else { return nil }
@@ -17,24 +26,30 @@ enum TextFrameRenderer {
         let boxes = layoutBoxes(style: style, box: box, renderSize: renderSize)
         let fontSize = CGFloat(style.fontSize) * (renderSize.height / TextLayout.referenceCanvasHeight)
         let anim = clip.textAnimation
+        let wordMotion = anim?.isActive == true && anim?.preset.renderMode != .entrance
+        let raster = rasterBounds(style: style, boxes: boxes, fontSize: fontSize,
+                                  renderSize: renderSize, coversWordMotion: wordMotion)
 
         if let anim, anim.isActive {
             switch anim.preset.renderMode {
             case .perWord:
-                return renderPerWord(clip: clip, content: content, style: style, boxes: boxes,
+                return renderPerWord(clip: clip, content: content, style: style, boxes: boxes, raster: raster,
                                      fontSize: fontSize, anim: anim, frame: frame, renderSize: renderSize)
             case .typewriter:
-                return renderTypewriter(clip: clip, content: content, style: style, boxes: boxes,
+                return renderTypewriter(clip: clip, content: content, style: style, boxes: boxes, raster: raster,
                                         fontSize: fontSize, frame: frame, renderSize: renderSize)
             case .entrance:
                 break
             }
         }
 
-        // Static base is frame-independent → cache it. Entrance reuses it under a transform.
-        guard let base = cachedStatic(content: content, style: style, transform: transform,
-                                      boxes: boxes,
-                                      fontSize: fontSize, renderSize: renderSize) else { return nil }
+        // Static text is frame-independent; entrance animation reuses it under a CI transform.
+        let base = cachedImage(content: content, style: style, boxes: boxes, raster: raster,
+                               renderSize: renderSize) { ctx in
+            let textFrame = drawText(ctx, content: content, style: style, fontSize: fontSize, box: boxes.text)
+            drawOverlines(ctx, frame: textFrame, style: style, fontSize: fontSize)
+        }
+        guard let base else { return nil }
         guard let anim, anim.isActive else { return base }
         return applyEntrance(base, TextAnimator.clipEntry(anim, rel: frame - clip.startFrame),
                              box: box, renderSize: renderSize)
@@ -67,10 +82,63 @@ enum TextFrameRenderer {
         return LayoutBoxes(text: text, background: box)
     }
 
-    /// A render-sized context with the box fill and shadow already applied.
-    private static func beginContext(style: TextStyle, backgroundBox: CGRect, renderSize: CGSize) -> CGContext? {
-        guard let ctx = CGContext(
-            data: nil, width: Int(renderSize.width.rounded()), height: Int(renderSize.height.rounded()),
+    private static func rasterBounds(style: TextStyle, boxes: LayoutBoxes, fontSize: CGFloat,
+                                     renderSize: CGSize, coversWordMotion: Bool) -> CGRect {
+        let scale = renderSize.height / TextLayout.referenceCanvasHeight
+        var rect = boxes.text.union(boxes.background)
+        if style.background.enabled {
+            let stroke = CGFloat(max(0, style.background.outlineWidth)) * scale / 2
+            let offset = boxes.background
+                .offsetBy(dx: CGFloat(style.background.offsetX) * scale,
+                          dy: -CGFloat(style.background.offsetY) * scale)
+                .insetBy(dx: -stroke, dy: -stroke)
+            rect = rect.union(offset)
+        }
+        if style.drawsGlyphOutline {
+            let pad = style.glyphBorderPadding(fontSize: fontSize)
+            rect = rect.insetBy(dx: -pad, dy: -pad)
+        }
+        if coversWordMotion {
+            rect = rect.insetBy(dx: -fontSize, dy: -fontSize)
+        }
+        if style.shadow.enabled {
+            let blur = max(0, CGFloat(style.shadow.blur) * scale)
+            let dx = CGFloat(style.shadow.offsetX) * scale
+            let dy = -CGFloat(style.shadow.offsetY) * scale
+            rect = CGRect(x: rect.minX + min(0, dx) - blur, y: rect.minY + min(0, dy) - blur,
+                          width: rect.width + abs(dx) + blur * 2, height: rect.height + abs(dy) + blur * 2)
+        }
+        return rect.insetBy(dx: -2, dy: -2).integral
+    }
+
+    private static func placed(_ image: CIImage, _ raster: CGRect) -> CIImage {
+        image.transformed(by: CGAffineTransform(translationX: raster.minX, y: raster.minY))
+    }
+
+    private static func cachedImage(content: String, style: TextStyle, boxes: LayoutBoxes,
+                                    raster: CGRect, renderSize: CGSize, state: Int? = nil,
+                                    draw: (CGContext) -> Void) -> CIImage? {
+        let key = signature(content, style, boxes: boxes, raster: raster, renderSize: renderSize, state: state)
+        if let cached = cache.object(forKey: key) { return placed(cached, raster) }
+        onRasterize.withLock { $0 }?(content)
+        guard let ctx = beginContext(style: style, backgroundBox: boxes.background, raster: raster,
+                                     renderSize: renderSize) else { return nil }
+        draw(ctx)
+        guard let image = finish(ctx) else { return nil }
+        cache.setObject(image, forKey: key, cost: Int(raster.width * raster.height) * 4)
+        return placed(image, raster)
+    }
+
+    private static func stateHash<Value: Hashable>(_ value: Value) -> Int {
+        var h = Hasher()
+        h.combine(value)
+        return h.finalize()
+    }
+
+    private static func beginContext(style: TextStyle, backgroundBox: CGRect, raster: CGRect,
+                                     renderSize: CGSize) -> CGContext? {
+        guard raster.width >= 1, raster.height >= 1, let ctx = CGContext(
+            data: nil, width: Int(raster.width), height: Int(raster.height),
             bitsPerComponent: 8, bytesPerRow: 0, space: CGColorSpace(name: CGColorSpace.sRGB)!,
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ) else { return nil }
@@ -80,6 +148,7 @@ enum TextFrameRenderer {
         ctx.setShouldSmoothFonts(true)
         ctx.setAllowsFontSubpixelPositioning(true)
         ctx.setShouldSubpixelPositionFonts(true)
+        ctx.translateBy(x: -raster.minX, y: -raster.minY)
         drawBox(ctx, style: style, box: backgroundBox, renderSize: renderSize)
         applyShadow(ctx, style: style, renderSize: renderSize)
         return ctx
@@ -117,27 +186,6 @@ enum TextFrameRenderer {
         ctx.strokeLineSegments(between: [CGPoint(x: x, y: top), CGPoint(x: x + width, y: top)])
     }
 
-    // MARK: - Static
-
-    private static func cachedStatic(content: String, style: TextStyle, transform: Transform,
-                                     boxes: LayoutBoxes,
-                                     fontSize: CGFloat, renderSize: CGSize) -> CIImage? {
-        let key = signature(content, style, transform, renderSize)
-        if let cached = cache.object(forKey: key) { return cached }
-        guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
-        let frame = drawText(
-            ctx,
-            content: content,
-            style: style,
-            fontSize: fontSize,
-            box: boxes.text
-        )
-        drawOverlines(ctx, frame: frame, style: style, fontSize: fontSize)
-        guard let image = finish(ctx) else { return nil }
-        cache.setObject(image, forKey: key)
-        return image
-    }
-
     // MARK: - Entrance (whole-clip)
 
     private static func applyEntrance(_ base: CIImage, _ st: TextAnimator.ClipState,
@@ -165,13 +213,35 @@ enum TextFrameRenderer {
 
     // MARK: - Per-word
 
-    private static func renderPerWord(clip: Clip, content: String, style: TextStyle, boxes: LayoutBoxes,
-                                      fontSize: CGFloat, anim: TextAnimation, frame: Int, renderSize: CGSize) -> CIImage? {
-        guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
+    /// Lays out each word's position in the raster; `nil` if the word doesn't appear on any line.
+    private struct PerWordLayout {
+        struct TokenPen { let x: CGFloat; let y: CGFloat; let width: CGFloat }
 
-        let fillAttrs = style.attributes(size: fontSize)
+        let tokens: [(range: NSRange, text: String)]
+        let timings: [WordTiming]
+        let pens: [TokenPen?]
+    }
+
+    private final class Cached<Value> {
+        let value: Value; init(_ value: Value) { self.value = value }
+    }
+
+    nonisolated(unsafe) private static let layoutCache: NSCache<NSString, Cached<PerWordLayout>> = {
+        let cache = NSCache<NSString, Cached<PerWordLayout>>()
+        cache.countLimit = 512
+        return cache
+    }()
+
+    private static func perWordLayout(clip: Clip, content: String, style: TextStyle, boxes: LayoutBoxes,
+                                      raster: CGRect, fontSize: CGFloat, renderSize: CGSize) -> PerWordLayout {
+        var h = Hasher()
+        h.combine(clip.wordTimings); h.combine(clip.durationFrames)
+        let key = signature(content, style, boxes: boxes, raster: raster, renderSize: renderSize,
+                            state: h.finalize())
+        if let cached = layoutCache.object(forKey: key) { return cached.value }
+
         let ctFrame = TextLayout.frame(
-            for: NSAttributedString(string: content, attributes: fillAttrs),
+            for: NSAttributedString(string: content, attributes: style.attributes(size: fontSize)),
             in: boxes.text
         )
         let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
@@ -181,42 +251,67 @@ enum TextFrameRenderer {
 
         let tokens = words(in: content)
         let timings = tokenTimings(tokens, clip.wordTimings, duration: clip.durationFrames)
-        let rel = frame - clip.startFrame
-        let undercoatAttrs = style.drawsGlyphOutline
-            ? style.outlineUndercoatAttributes(size: fontSize)
-            : nil
-        let font = fillAttrs[.font] as? NSFont
-
-        var placements: [WordPlacement] = []
+        var pens = [PerWordLayout.TokenPen?](repeating: nil, count: tokens.count)
         for (li, line) in lines.enumerated() {
             let lineRange = CTLineGetStringRange(line)
             for (ti, tok) in tokens.enumerated() {
                 guard tok.range.location >= lineRange.location,
                       tok.range.location < lineRange.location + lineRange.length else { continue }
-                let st = TextAnimator.wordState(anim, word: timings[ti], rel: rel, base: style.color)
-                guard st.opacity > 0 else { continue }
-
                 let startOff = CTLineGetOffsetForStringIndex(line, tok.range.location, nil)
                 let endOff = CTLineGetOffsetForStringIndex(line, tok.range.location + tok.range.length, nil)
+                pens[ti] = PerWordLayout.TokenPen(
+                    x: frameBounds.minX + origins[li].x + startOff - raster.minX,
+                    y: frameBounds.minY + origins[li].y - raster.minY,
+                    width: endOff - startOff
+                )
+            }
+        }
+
+        let layout = PerWordLayout(tokens: tokens, timings: timings, pens: pens)
+        layoutCache.setObject(Cached(layout), forKey: key)
+        return layout
+    }
+
+    private static func renderPerWord(clip: Clip, content: String, style: TextStyle, boxes: LayoutBoxes,
+                                      raster: CGRect, fontSize: CGFloat, anim: TextAnimation, frame: Int,
+                                      renderSize: CGSize) -> CIImage? {
+        let layout = perWordLayout(clip: clip, content: content, style: style, boxes: boxes,
+                                   raster: raster, fontSize: fontSize, renderSize: renderSize)
+        let rel = frame - clip.startFrame
+        let states = layout.timings.map { TextAnimator.wordState(anim, word: $0, rel: rel, base: style.color) }
+
+        // The output depends on the frame only through the word states.
+        return cachedImage(content: content, style: style, boxes: boxes, raster: raster,
+                           renderSize: renderSize, state: stateHash(states)) { ctx in
+            let fillAttrs = style.attributes(size: fontSize)
+            let undercoatAttrs = style.drawsGlyphOutline
+                ? style.outlineUndercoatAttributes(size: fontSize)
+                : nil
+            let font = fillAttrs[.font] as? NSFont
+
+            var placements: [WordPlacement] = []
+            for (ti, pen) in layout.pens.enumerated() {
+                guard let pen else { continue }
+                let st = states[ti]
+                guard st.opacity > 0 else { continue }
                 var wordFillAttrs = fillAttrs
                 wordFillAttrs[.foregroundColor] = st.color.nsColor
                 placements.append(WordPlacement(
                     state: st,
-                    penX: frameBounds.minX + origins[li].x + startOff,
-                    penY: frameBounds.minY + origins[li].y,
-                    width: endOff - startOff,
+                    penX: pen.x + raster.minX,
+                    penY: pen.y + raster.minY,
+                    width: pen.width,
                     fillLine: CTLineCreateWithAttributedString(
-                        NSAttributedString(string: tok.text, attributes: wordFillAttrs) as CFAttributedString),
+                        NSAttributedString(string: layout.tokens[ti].text, attributes: wordFillAttrs) as CFAttributedString),
                     undercoatLine: undercoatAttrs.map {
                         CTLineCreateWithAttributedString(
-                            NSAttributedString(string: tok.text, attributes: $0) as CFAttributedString)
+                            NSAttributedString(string: layout.tokens[ti].text, attributes: $0) as CFAttributedString)
                     }
                 ))
             }
-        }
 
-        drawWordPlacements(ctx, placements, style: style, fontSize: fontSize, font: font)
-        return finish(ctx)
+            drawWordPlacements(ctx, placements, style: style, fontSize: fontSize, font: font)
+        }
     }
 
     private struct WordPlacement {
@@ -296,9 +391,8 @@ enum TextFrameRenderer {
     // MARK: - Typewriter (whole-clip character reveal)
 
     private static func renderTypewriter(clip: Clip, content: String, style: TextStyle, boxes: LayoutBoxes,
-                                         fontSize: CGFloat, frame: Int, renderSize: CGSize) -> CIImage? {
+                                         raster: CGRect, fontSize: CGFloat, frame: Int, renderSize: CGSize) -> CIImage? {
         let holdFrames = 18
-        guard let ctx = beginContext(style: style, backgroundBox: boxes.background, renderSize: renderSize) else { return nil }
         let rel = frame - clip.startFrame
         let ns = content as NSString
 
@@ -337,19 +431,23 @@ enum TextFrameRenderer {
         // Caret blinks (~0.5s) until shortly after the last word finishes.
         let doneAt = timings.last?.endFrame ?? clip.durationFrames
         if rel <= doneAt + holdFrames, (rel / 15) % 2 == 0 { visible += "|" }
-        guard !visible.isEmpty else { return finish(ctx) }
-        // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
-        let textFrame = drawText(
-            ctx,
-            content: visible,
-            style: style,
-            fontSize: fontSize,
-            box: boxes.text,
-            alignment: .left,
-            verticallySizedFor: content
-        )
-        drawOverlines(ctx, frame: textFrame, style: style, fontSize: fontSize)
-        return finish(ctx)
+
+        // The output depends on the frame only through the visible substring.
+        return cachedImage(content: content, style: style, boxes: boxes, raster: raster,
+                           renderSize: renderSize, state: stateHash(visible)) { ctx in
+            guard !visible.isEmpty else { return }
+            // Left-anchor so the text reveals rightward in place rather than re-centering as it grows.
+            let textFrame = drawText(
+                ctx,
+                content: visible,
+                style: style,
+                fontSize: fontSize,
+                box: boxes.text,
+                alignment: .left,
+                verticallySizedFor: content
+            )
+            drawOverlines(ctx, frame: textFrame, style: style, fontSize: fontSize)
+        }
     }
 
     /// Returns one timing per token, aligning transcript spans when token counts differ.
@@ -622,11 +720,18 @@ enum TextFrameRenderer {
         CGColor(srgbRed: CGFloat(c.r), green: CGFloat(c.g), blue: CGFloat(c.b), alpha: CGFloat(c.a))
     }
 
-    private static func signature(_ content: String, _ s: TextStyle, _ t: Transform, _ size: CGSize) -> NSString {
+    private static func signature(_ content: String, _ s: TextStyle, boxes: LayoutBoxes, raster: CGRect,
+                                  renderSize: CGSize, state: Int? = nil) -> NSString {
+        func quantized(_ v: CGFloat) -> Int { Int((v * 64).rounded()) }
         var h = Hasher()
         h.combine(content); h.combine(s)
-        h.combine(t.centerX); h.combine(t.centerY); h.combine(t.width); h.combine(t.height)
-        h.combine(size)
+        h.combine(quantized(boxes.text.minX - raster.minX)); h.combine(quantized(boxes.text.minY - raster.minY))
+        h.combine(quantized(boxes.text.width)); h.combine(quantized(boxes.text.height))
+        h.combine(quantized(boxes.background.minX - raster.minX)); h.combine(quantized(boxes.background.minY - raster.minY))
+        h.combine(quantized(boxes.background.width)); h.combine(quantized(boxes.background.height))
+        h.combine(raster.width); h.combine(raster.height)
+        h.combine(renderSize)
+        if let state { h.combine(state) }
         return String(h.finalize()) as NSString
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -48,8 +48,7 @@ extension EditorViewModel {
         }
     }
 
-    /// Text clips sharing this clip's caption group (so animation applies once for the whole
-    /// caption track), or just the clip itself when it isn't part of a caption.
+    /// Returns text clip ids in the clip's caption group, or the clip's id if none.
     func captionGroupTextClipIds(for clipId: String) -> [String] {
         guard let clip = clipFor(id: clipId), let group = clip.captionGroupId else { return [clipId] }
         let ids = captionGroupTextClipIds(groupId: group)
@@ -60,6 +59,41 @@ extension EditorViewModel {
     func captionGroupTextClipIds(groupId: String) -> [String] {
         timeline.tracks.flatMap(\.clips)
             .filter { $0.captionGroupId == groupId && $0.mediaType == .text }.map(\.id)
+    }
+
+    /// For each clip id, returns all text clip ids in its caption group, or just the id itself if no group.
+    /// Fast for large selections (O(timeline) instead of O(selection × timeline)).
+    func captionGroupTextClipIds(expanding clipIds: [String]) -> [String] {
+        let requested = Set(clipIds)
+        var groupByRequestedId: [String: String] = [:]
+        for track in timeline.tracks {
+            for clip in track.clips where requested.contains(clip.id) {
+                if let group = clip.captionGroupId { groupByRequestedId[clip.id] = group }
+            }
+        }
+        let groups = Set(groupByRequestedId.values)
+
+        var seen = Set<String>()
+        var result: [String] = []
+        var groupsWithText = Set<String>()
+        for track in timeline.tracks {
+            for clip in track.clips {
+                let included: Bool
+                if let group = clip.captionGroupId, groups.contains(group) {
+                    included = clip.mediaType == .text
+                    if included { groupsWithText.insert(group) }
+                } else {
+                    included = requested.contains(clip.id)
+                }
+                if included, seen.insert(clip.id).inserted { result.append(clip.id) }
+            }
+        }
+
+        for id in clipIds where !seen.contains(id) {
+            if let group = groupByRequestedId[id], groupsWithText.contains(group) { continue }
+            if seen.insert(id).inserted { result.append(id) }
+        }
+        return result
     }
 
     func captionCanTranscribe(_ clip: Clip) -> Bool {

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -170,9 +170,7 @@ struct TextAnimateTab: View {
 
     private var clip: Clip { clips[0] }
     private var targetIds: [String] {
-        var seen = Set<String>()
-        return clips.flatMap { editor.captionGroupTextClipIds(for: $0.id) }
-            .filter { seen.insert($0).inserted }
+        editor.captionGroupTextClipIds(expanding: clips.map(\.id))
     }
 
     var body: some View {

--- a/Sources/PalmierPro/Models/TextAnimation.swift
+++ b/Sources/PalmierPro/Models/TextAnimation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct WordTiming: Codable, Sendable, Equatable {
+struct WordTiming: Codable, Sendable, Equatable, Hashable {
     var text: String
     var startFrame: Int
     var endFrame: Int

--- a/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
@@ -96,6 +96,37 @@ struct TextRasterCacheTests {
         #expect(count == 1, "typewriter hold frames must reuse the raster, got \(count)")
     }
 
+    @Test func translucentFillBorderPadsRasterBeyondTextBox() throws {
+        // A border with a translucent fill strokes in a single pass (not drawsGlyphOutline);
+        // the raster must still pad for it or edge strokes clip.
+        var c = clip(content: uniqueContent("HHH"))
+        var style = TextStyle(fontSize: 48)
+        style.color.a = 0.5
+        style.alignment = .left
+        style.border = .init(enabled: true, color: .init(r: 1, g: 0, b: 0, a: 1), width: 40)
+        c.textStyle = style
+        c.transform = Transform(centerX: 0.5, centerY: 0.5, width: 0.5, height: 0.25)
+
+        let image = try #require(TextFrameRenderer.image(clip: c, frame: 0, renderSize: size))
+        let boxMinX = 0.25 * size.width
+        #expect(image.extent.minX <= boxMinX - 10,
+                "raster must pad for single-pass border strokes, got \(image.extent)")
+
+        let ctx = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
+        let bg = CIImage(color: .black).cropped(to: CGRect(origin: .zero, size: size))
+        let w = Int(size.width), h = Int(size.height)
+        var px = [UInt8](repeating: 0, count: w * h * 4)
+        ctx.render(image.unpremultiplyingAlpha().composited(over: bg), toBitmap: &px, rowBytes: w * 4,
+                   bounds: CGRect(origin: .zero, size: size), format: .RGBA8, colorSpace: nil)
+        var strokePixelsOutsideBox = 0
+        for y in 0..<h {
+            for x in (Int(boxMinX) - 7)..<(Int(boxMinX) - 2) where px[(y * w + x) * 4] > 100 {
+                strokePixelsOutsideBox += 1
+            }
+        }
+        #expect(strokePixelsOutsideBox > 0, "border stroke left of the text box must survive the raster crop")
+    }
+
     @Test func reusedRasterCompositesAtTheClipPosition() throws {
         let ctx = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
         var c = clip(content: uniqueContent("MOVE"))

--- a/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
@@ -1,0 +1,131 @@
+import CoreImage
+import Foundation
+import os
+import Testing
+@testable import PalmierPro
+
+/// Serialized: the suite owns the rasterize hook, and counts are filtered by each
+/// test's unique content so concurrent rasters from other suites don't interfere.
+@Suite("TextFrameRenderer — raster cache", .serialized)
+struct TextRasterCacheTests {
+    private let size = CGSize(width: 640, height: 360)
+
+    private func clip(content: String, anim: TextAnimation? = nil) -> Clip {
+        var c = Clip(mediaRef: "", startFrame: 0, durationFrames: 90)
+        c.mediaType = .text
+        c.textContent = content
+        var style = TextStyle()
+        style.fontScale = 1.6
+        c.textStyle = style
+        c.transform = Transform(centerX: 0.5, centerY: 0.5, width: 0.5, height: 0.25)
+        c.textAnimation = anim
+        return c
+    }
+
+    /// Rasterizations of `content` performed inside `body`.
+    private func rasterCount(of content: String, _ body: () -> Void) -> Int {
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        TextFrameRenderer.onRasterize.withLock { hook in
+            hook = { rasterized in
+                if rasterized == content { counter.withLock { $0 += 1 } }
+            }
+        }
+        defer { TextFrameRenderer.onRasterize.withLock { $0 = nil } }
+        body()
+        return counter.withLock { $0 }
+    }
+
+    private func uniqueContent(_ base: String) -> String {
+        "\(base) \(UUID().uuidString.prefix(8))"
+    }
+
+    @Test func staticRasterCoversContentNotTheFullFrame() throws {
+        let c = clip(content: uniqueContent("Tight"))
+        let image = TextFrameRenderer.image(clip: c, frame: 0, renderSize: size)
+        let extent = try #require(image?.extent)
+        #expect(CGRect(origin: .zero, size: size).insetBy(dx: -64, dy: -64).contains(extent))
+        #expect(extent.width * extent.height < size.width * size.height / 2,
+                "raster should be caption-sized, got \(extent) in \(size)")
+    }
+
+    @Test func staticFramesAndWholePixelMovesReuseOneRaster() {
+        var c = clip(content: uniqueContent("Static"))
+        let count = rasterCount(of: c.textContent!) {
+            _ = TextFrameRenderer.image(clip: c, frame: 0, renderSize: size)
+            _ = TextFrameRenderer.image(clip: c, frame: 30, renderSize: size)
+            c.transform.centerX += 0.0078125   // 5 px
+            c.transform.centerY += 0.125       // 45 px
+            _ = TextFrameRenderer.image(clip: c, frame: 0, renderSize: size)
+        }
+        #expect(count == 1, "expected one raster for static frames and whole-pixel moves, got \(count)")
+    }
+
+    @Test func entranceAnimationSharesOneBaseRaster() {
+        let c = clip(content: uniqueContent("Entrance"), anim: TextAnimation(preset: .fadeIn))
+        let count = rasterCount(of: c.textContent!) {
+            for frame in 0..<8 {
+                _ = TextFrameRenderer.image(clip: c, frame: frame, renderSize: size)
+            }
+        }
+        #expect(count == 1, "entrance frames must reuse the static base, got \(count) rasters")
+    }
+
+    @Test func perWordSteadyFramesReuseRasterAndRampsDoNot() {
+        // Five tokens over 90 frames → ramps start at 0, 18, 36, 54, 72 and settle after 6 frames.
+        let c = clip(content: "ONE TWO THREE \(uniqueContent("FOUR"))",
+                     anim: TextAnimation(preset: .wordReveal, perWordFrames: 6))
+        let steady = rasterCount(of: c.textContent!) {
+            _ = TextFrameRenderer.image(clip: c, frame: 8, renderSize: size)
+            _ = TextFrameRenderer.image(clip: c, frame: 14, renderSize: size)
+        }
+        #expect(steady == 1, "steady per-word frames must reuse the raster, got \(steady)")
+
+        let ramping = rasterCount(of: c.textContent!) {
+            _ = TextFrameRenderer.image(clip: c, frame: 20, renderSize: size)
+            _ = TextFrameRenderer.image(clip: c, frame: 21, renderSize: size)
+        }
+        #expect(ramping == 2, "distinct ramp states must re-raster, got \(ramping)")
+    }
+
+    @Test func typewriterHoldFramesReuseRaster() {
+        let c = clip(content: uniqueContent("Aa Bb"), anim: TextAnimation(preset: .typewriter))
+        let count = rasterCount(of: c.textContent!) {
+            _ = TextFrameRenderer.image(clip: c, frame: 80, renderSize: size)  // held, same caret phase
+            _ = TextFrameRenderer.image(clip: c, frame: 82, renderSize: size)
+        }
+        #expect(count == 1, "typewriter hold frames must reuse the raster, got \(count)")
+    }
+
+    @Test func reusedRasterCompositesAtTheClipPosition() throws {
+        let ctx = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
+        var c = clip(content: uniqueContent("MOVE"))
+        c.transform = Transform(centerX: 0.25, centerY: 0.5, width: 0.5, height: 0.25)
+
+        func brightestColumnStart(_ clip: Clip) -> Int? {
+            guard let text = TextFrameRenderer.image(clip: clip, frame: 0, renderSize: size) else { return nil }
+            let bg = CIImage(color: .black).cropped(to: CGRect(origin: .zero, size: size))
+            let w = Int(size.width), h = Int(size.height)
+            var px = [UInt8](repeating: 0, count: w * h * 4)
+            ctx.render(text.composited(over: bg), toBitmap: &px, rowBytes: w * 4,
+                       bounds: CGRect(origin: .zero, size: size), format: .RGBA8, colorSpace: nil)
+            for x in 0..<w {
+                for y in 0..<h where px[(y * w + x) * 4] > 128 { return x }
+            }
+            return nil
+        }
+
+        var count = 0
+        var before: Int?
+        var after: Int?
+        count = rasterCount(of: c.textContent!) {
+            before = brightestColumnStart(c)
+            c.transform.centerX += 0.25   // 160 px, whole-pixel move → raster reused
+            after = brightestColumnStart(c)
+        }
+        let beforeX = try #require(before)
+        let afterX = try #require(after)
+        #expect(count == 1, "whole-pixel move must reuse the raster, got \(count)")
+        #expect(afterX == beforeX + 160,
+                "reused raster must composite at the moved position: \(beforeX) → \(afterX)")
+    }
+}

--- a/Tests/PalmierProTests/Timeline/CaptionGroupExpansionTests.swift
+++ b/Tests/PalmierProTests/Timeline/CaptionGroupExpansionTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorViewModel — caption group expansion")
+@MainActor
+struct CaptionGroupExpansionTests {
+
+    private func textClip(_ id: String, group: String? = nil, start: Int) -> Clip {
+        var c = Fixtures.clip(id: id, mediaRef: "text", mediaType: .text, start: start, duration: 10)
+        c.captionGroupId = group
+        c.textContent = id
+        return c
+    }
+
+    private func editor() -> EditorViewModel {
+        let e = EditorViewModel()
+        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 0, duration: 100)
+        audio.captionGroupId = "g1"
+        e.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                textClip("a1", group: "g1", start: 0),
+                textClip("a2", group: "g1", start: 10),
+                textClip("b1", group: "g2", start: 20),
+                textClip("solo", start: 30),
+            ]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+        return e
+    }
+
+    @Test func batchExpansionMatchesPerClipExpansion() {
+        let e = editor()
+        let ids = ["a1", "b1", "solo", "missing"]
+        var seen = Set<String>()
+        let perClip = ids.flatMap { e.captionGroupTextClipIds(for: $0) }
+            .filter { seen.insert($0).inserted }
+        let batch = e.captionGroupTextClipIds(expanding: ids)
+        #expect(Set(batch) == Set(perClip))
+        #expect(batch.count == perClip.count)
+    }
+
+    @Test func batchExpansionCoversWholeGroupAndDeduplicates() {
+        let e = editor()
+        let batch = e.captionGroupTextClipIds(expanding: ["a1", "a2", "a1"])
+        #expect(batch == ["a1", "a2"])
+    }
+
+    @Test func groupedNonTextClipExpandsToGroupTextClipsOnly() {
+        let e = editor()
+        #expect(e.captionGroupTextClipIds(expanding: ["audio"]) == ["a1", "a2"])
+    }
+
+    @Test func ungroupedAndUnknownClipsFallBackToThemselves() {
+        let e = editor()
+        #expect(e.captionGroupTextClipIds(expanding: ["solo"]) == ["solo"])
+        #expect(e.captionGroupTextClipIds(expanding: ["missing"]) == ["missing"])
+    }
+}


### PR DESCRIPTION
## Summary

Caption-dense timelines (thousands of text clips) hit three scaling problems in the shared preview/export compositor and one main-thread hang in the UI:

1. Every text clip rasterized a full render-size bitmap (~8 MB at 1080p) into an `NSCache` with no limits, and position keyframes defeated the cache entirely (one miss plus one dead entry per frame).
2. Per-word and typewriter captions bypassed caching and re-rasterized a full-frame bitmap with fresh CoreText layout on every output frame, serialized on the single compositor queue — the dominant cost when exporting animated captions.
3. Selecting many text clips and changing their animation hung the main thread for seconds: the caption-group expansion was O(selection × timeline) with large `Clip` struct copies (~7M copies for an 1,860-clip selection).

## Approach

**Tight rasters (`TextFrameRenderer`).** `rasterBounds` computes an integral render-space rect bounding everything a caption can draw — text/background boxes, background offset and stroke, glyph outline padding, per-word motion headroom, and shadow reach. The `CGContext` is created at that size with its CTM shifted by the rect origin, so all existing drawing code keeps render-space coordinates and produces pixels byte-identical to the old full-frame raster cropped to the rect (proven by the pre-existing exact pixel-equality typewriter tests). `placed()` translates the cached raster back as a lossless whole-pixel CI transform.

**One cache flow.** All render paths go through a single `cachedImage(...)` helper: key → hit → raster → store (costed in bytes against a 256 MB budget) → place. The key covers content, style, and box geometry *relative* to the raster origin; absolute position enters only through the subpixel remainder, quantized to 1/64 px to absorb float noise. Whole-pixel moves and identical captions at different positions reuse one raster.

**Animated frame reuse.** A per-word frame's pixels depend on the frame number only through the discrete word states (constant between animation ramps), and a typewriter frame's only through its visible substring — so the key appends a hash of that state and steady frames are cache hits. Frame-independent per-word layout (CoreText layout, tokenization, transcript timing alignment, raster-relative pen positions) is cached separately (`perWordLayout`), so ramp-frame misses only redraw.

**FrameRenderer.** Text images are now sub-frame extents; the only semantic guard needed is padding back to full frame before clip effects run (a filter may map transparent pixels to visible ones). The footage-fill stencil is unaffected because CI samples outside an extent as transparent black — the same value the old full-frame raster held there.

**Caption group expansion (`EditorViewModel+Captions`).** New batch `captionGroupTextClipIds(expanding:)` resolves an entire selection in two timeline passes with the same semantics as the per-clip form (grouped clips expand to their group's text clips; ungrouped/unknown clips fall back to themselves; deduplicated). `TextAnimateTab` uses it.

Residual risks accepted: the cache key remains a 64-bit hash without equality verification on hit (same as before; collision odds ~1e-13 at the 2048-entry cap), and captions combining position keyframes with per-word animation still miss per frame (correct, evicted by the budget, ~9x cheaper per miss than before).

## Testing

- `swift test`: full suite passes (1,382 tests / 219 suites).
- New `TextRasterCacheTests` (6 tests, serialized, via an `onRasterize` cache-miss hook): tight extents, one raster across static frames and whole-pixel moves, entrance sharing one base raster, per-word steady-frame reuse vs. ramp re-raster, typewriter hold reuse, and correct composite position for a reused raster.
- New `CaptionGroupExpansionTests` (4 tests): batch/per-clip equivalence, whole-group coverage with dedupe, grouped non-text expansion, ungrouped/unknown fallback.
- Real-project measurement (`heavybit.palmier`: 1,860 captions, 1080p, 41 min; export-pass harness, old vs new on identical data):
  - Static, all 1,860 captions / 71,600 frames: 0.24 s → 0.22 s; footprint +62 MB → +75 MB (parity — old NSCache already reused static rasters; the new cache adds a deterministic bound).
  - `wordPop`, 300 captions / 11,570 frames: **12.4 s → 0.75 s (16.5x)**; footprint +207 MB, held by the 256 MB budget.
  - Raster size at 1080p: 7.91 MB full-frame → 0.89 MB tight (~9x).
- Manual verification (user-confirmed): select-all → change animation now responds immediately (previously a multi-second hang; `sample` traces before/after). Preview/scrub of the 1,860-caption project behaves correctly. Remaining manual checks suggested: a short export spot-check with animated + heavily-styled captions.

## Change statistics

- Renderer logic: +186/−73 (`TextFrameRenderer`), +3 (`FrameRenderer`), +2/−2 (`Hashable` conformances).
- Editor logic: +37/−1 (`EditorViewModel+Captions`), +1/−4 (`TextTab`).
- Tests: +181 across two new suites.

Made with [Cursor](https://cursor.com)