### PR TITLE
[perf] Batch clip removal in moveClips

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -65,10 +65,9 @@ extension EditorViewModel {
         withTimelineSwap(actionName: actionName) {
             // Pull moved clips off their source tracks first, so clearRegion on
             // the destinations never touches them.
-            for info in clipInfos {
-                if let loc = findClip(id: info.clip.id) {
-                    timeline.tracks[loc.trackIndex].clips.remove(at: loc.clipIndex)
-                }
+            let movedIds = Set(clipInfos.map(\.clip.id))
+            for trackIndex in timeline.tracks.indices {
+                timeline.tracks[trackIndex].clips.removeAll { movedIds.contains($0.id) }
             }
 
             // Trim / remove any non-moved clips blocking each destination range.


### PR DESCRIPTION
## Summary

Committing a drag of a large selection hung on mouse-up: `moveClips` pulled each moved clip off its source track with a `findClip` scan interleaved with mutations — O(selection × timeline). Dragging ~1,900 selected caption clips took multiple seconds (sampled: nearly all time under the pull-off loop).

## Approach

The pull-off phase removes all moved ids in one `removeAll` pass per track against a precomputed id set — no per-clip lookups, no interleaved invalidation, O(timeline) total. Outcome is identical: moved clips are removed wherever they live, then re-inserted at their targets by the existing placement code. This also composes with the clip-location index PR, whose per-mutation invalidation makes interleaved lookup-mutate loops especially costly.

## Testing

- `swift test` clip-mutation suites pass on this branch (42 tests), full suite green on the integration branch.
- Manual: mouse-up after dragging ~1,900 selected clips completes instantly on the 1,860-caption test project; single-clip moves, cross-track moves, and undo behave unchanged.

## Change statistics

Code: +3/-4 in `EditorViewModel+ClipMutations`.

Made with [Cursor](https://cursor.com)