### PR TITLE
[fix] Preserve drag access on narrow timeline clips

### DIFF
--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -49,6 +49,14 @@ enum ClipRenderer {
         rect.width < AppTheme.ComponentSize.timelineClipBorderMinWidth
     }
 
+    static func supportsPrecisionControls(atWidth width: CGFloat) -> Bool {
+        width >= AppTheme.ComponentSize.timelineClipControlsMinWidth
+    }
+
+    static func supportsPrecisionControls(in rect: NSRect) -> Bool {
+        supportsPrecisionControls(atWidth: rect.width)
+    }
+
     static func showsLabel(isSelected: Bool, in rect: NSRect) -> Bool {
         let minimumWidth = isSelected
             ? AppTheme.ComponentSize.timelineClipDetailMinWidth
@@ -57,8 +65,8 @@ enum ClipRenderer {
     }
 
     static func showsFadeControls(isSelected: Bool, isHovered: Bool, in rect: NSRect) -> Bool {
-        guard !usesCompactRendering(in: rect) else { return false }
-        return isHovered || (isSelected && rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth)
+        guard supportsPrecisionControls(in: rect) else { return false }
+        return isHovered || isSelected
     }
 
     static func showsVolumeKeyframes(isSelected: Bool, isHovered: Bool, in rect: NSRect) -> Bool {

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -20,7 +20,7 @@ final class TimelineInputController {
         case end
     }
 
-    private enum TrimEdge {
+    enum TrimEdge: Equatable {
         case left
         case right
     }
@@ -162,8 +162,8 @@ final class TimelineInputController {
 
         if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
             let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
-            view.setHoveredClipId(clip.id)
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
+            view.setHoveredClipId(ClipRenderer.supportsPrecisionControls(in: rect) ? clip.id : nil)
             let isShift = event.modifierFlags.contains(.shift)
             let isOption = event.modifierFlags.contains(.option)
             // Linked behavior is always on; Option is the per-drag override.
@@ -740,8 +740,8 @@ final class TimelineInputController {
 
         if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
             let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
-            view.setHoveredClipId(clip.id)
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
+            view.setHoveredClipId(ClipRenderer.supportsPrecisionControls(in: rect) ? clip.id : nil)
             let localX = point.x - rect.minX
             if let trimEdge = Self.trimEdge(localX: localX, clipWidth: rect.width) {
                 Self.trimCursor(for: trimEdge).set()
@@ -770,7 +770,8 @@ final class TimelineInputController {
         NSCursor.arrow.set()
     }
 
-    private static func trimEdge(localX: CGFloat, clipWidth: CGFloat) -> TrimEdge? {
+    static func trimEdge(localX: CGFloat, clipWidth: CGFloat) -> TrimEdge? {
+        guard ClipRenderer.supportsPrecisionControls(atWidth: clipWidth) else { return nil }
         if localX <= Trim.handleWidth { return .left }
         if localX >= clipWidth - Trim.handleWidth { return .right }
         return nil
@@ -962,6 +963,7 @@ final class TimelineInputController {
 
     /// Returns true if a kf was added.
     private func addVolumeKeyframeOnClick(at point: NSPoint, clip: Clip, clipRect: NSRect) -> Bool {
+        guard ClipRenderer.supportsPrecisionControls(in: clipRect) else { return false }
         guard clip.durationFrames > 0 else { return false }
         let body = ClipRenderer.clipBodyRect(in: clipRect)
         guard body.contains(point) else { return false }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -167,8 +167,21 @@ final class TimelineView: NSView {
 
     func setHoveredClipId(_ clipId: String?) {
         guard hoveredClipId != clipId else { return }
+        let previousClipId = hoveredClipId
         hoveredClipId = clipId
-        needsDisplay = true
+
+        let padding = AppTheme.BorderWidth.thick
+        var requiresFullRedraw = false
+        for id in [previousClipId, clipId].compactMap({ $0 }) {
+            guard let rect = clipDisplayRects[id] else {
+                requiresFullRedraw = true
+                continue
+            }
+            setNeedsDisplay(rect.insetBy(dx: -padding, dy: -padding))
+        }
+        if requiresFullRedraw {
+            needsDisplay = true
+        }
     }
 
     @discardableResult

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -394,6 +394,7 @@ enum AppTheme {
         static let projectSearchWidth: CGFloat = 260
         static let timelineClipBorderMinWidth: CGFloat = 8
         static let timelineClipDetailMinWidth: CGFloat = 32
+        static let timelineClipControlsMinWidth: CGFloat = 48
         static let timelineTabRenameWidth: CGFloat = 120
         static let timelineClipLabelMinWidth: CGFloat = 56
         static let timelineBadgePadH: CGFloat = 4

--- a/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipRendererPerformanceTests.swift
@@ -4,17 +4,35 @@ import Testing
 
 @Suite struct ClipRendererPerformanceTests {
     @Test func volumeKeyframesUseTheSameVisibilityRulesAsRendering() {
-        let compactRect = CGRect(x: 0, y: 0, width: 0.5, height: 64)
-        let detailRect = CGRect(
+        let narrowRect = CGRect(
             x: 0,
             y: 0,
-            width: AppTheme.ComponentSize.timelineClipDetailMinWidth,
+            width: AppTheme.ComponentSize.timelineClipControlsMinWidth - AppTheme.BorderWidth.hairline,
+            height: 64
+        )
+        let controlsRect = CGRect(
+            x: 0,
+            y: 0,
+            width: AppTheme.ComponentSize.timelineClipControlsMinWidth,
             height: 64
         )
 
-        #expect(!ClipRenderer.showsVolumeKeyframes(isSelected: true, isHovered: true, in: compactRect))
-        #expect(!ClipRenderer.showsVolumeKeyframes(isSelected: false, isHovered: true, in: detailRect))
-        #expect(ClipRenderer.showsVolumeKeyframes(isSelected: true, isHovered: false, in: detailRect))
+        #expect(!ClipRenderer.showsFadeControls(isSelected: true, isHovered: true, in: narrowRect))
+        #expect(!ClipRenderer.showsVolumeKeyframes(isSelected: true, isHovered: true, in: narrowRect))
+        #expect(ClipRenderer.showsFadeControls(isSelected: false, isHovered: true, in: controlsRect))
+        #expect(!ClipRenderer.showsVolumeKeyframes(isSelected: false, isHovered: true, in: controlsRect))
+        #expect(ClipRenderer.showsVolumeKeyframes(isSelected: true, isHovered: false, in: controlsRect))
+    }
+
+    @Test @MainActor func narrowClipsUseTheirWholeWidthForMoveDragging() {
+        let narrowWidth = AppTheme.ComponentSize.timelineClipControlsMinWidth - AppTheme.BorderWidth.hairline
+        let controlsWidth = AppTheme.ComponentSize.timelineClipControlsMinWidth
+
+        #expect(TimelineInputController.trimEdge(localX: 0, clipWidth: narrowWidth) == nil)
+        #expect(TimelineInputController.trimEdge(localX: narrowWidth, clipWidth: narrowWidth) == nil)
+        #expect(TimelineInputController.trimEdge(localX: 0, clipWidth: controlsWidth) == .left)
+        #expect(TimelineInputController.trimEdge(localX: controlsWidth, clipWidth: controlsWidth) == .right)
+        #expect(TimelineInputController.trimEdge(localX: controlsWidth / 2, clipWidth: controlsWidth) == nil)
     }
 
     @Test func compactSelectedClipsRenderWithinInteractionBudget() throws {


### PR DESCRIPTION
## Summary
- Hide and disable trim, fade, and volume-keyframe controls when a timeline clip is too narrow to leave a usable drag target.
- Let narrow selected clips fall through to the existing multi-clip move path so bulk dragging remains reachable when zoomed out.
- Reduce hover rendering by invalidating only clips whose hover chrome changes.

## Approach
- Introduce a shared 48-point precision-control threshold used by both rendering and hit testing.
- Keep fade curves visible, but suppress their handles and related hit regions below the threshold.
- Preserve existing move, selection expansion, linked-clip, snapping, and undo behavior.

## Testing
- `swift test --filter ClipRendererPerformanceTests` — passed, 4 tests.
- `swift build` — passed.
- Manual UI verification not completed: zoom below and above the threshold, drag a multi-selection from a narrow clip, and confirm trim/fade controls return when zoomed in.

## Change statistics
- Code logic: +31 / -7
- Tests: +24 / -6
- Total: +55 / -13

Made with [Cursor](https://cursor.com)