### PR TITLE
[ui] Make default timeline panel a bit taller

### DIFF
--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -22,7 +22,7 @@ enum Layout {
 
     // Timeline
     static let timelineMinHeight: CGFloat = 100
-    static let timelineDefaultHeightFraction: CGFloat = 0.275
+    static let timelineDefaultHeightFraction: CGFloat = 0.35
     static let trackHeight: CGFloat = TrackSize.defaultHeight
     static let rulerHeight: CGFloat = 24
     static let trackHeaderWidth: CGFloat = 100

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -22,7 +22,7 @@ enum Layout {
 
     // Timeline
     static let timelineMinHeight: CGFloat = 100
-    static let timelineDefaultHeightFraction: CGFloat = 0.25
+    static let timelineDefaultHeightFraction: CGFloat = 0.275
     static let trackHeight: CGFloat = TrackSize.defaultHeight
     static let rulerHeight: CGFloat = 24
     static let trackHeaderWidth: CGFloat = 100


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bumps the default timeline panel height fraction from `0.25` to `0.35`  so new editor windows open with a slightly larger timeline.

## Approach
Changed the single source of truth: `Layout.timelineDefaultHeightFraction` in `Constants.swift`. This is used when positioning the vertical split for unsaved windows in `EditorView`. Saved window layouts are unaffected.

## Testing
- Not run: `swift build` / UI verification (Linux cloud environment; macOS-only app).
- Manual UI: open a new project window and confirm the timeline occupies a bit more vertical space than before; resize and reopen a saved window to confirm restored layout is unchanged.

## Change statistics
- Code logic: +1 / −1
- Tests: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ed2dae0-6cd4-4726-a6a9-c808408decb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ed2dae0-6cd4-4726-a6a9-c808408decb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

