### PR TITLE
[ui] Redesign selected media inspector

### DIFF
--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -1108,12 +1108,12 @@ struct InspectorView: View {
         let hasReferences = GenerationReferencesStrip.hasResolvableReferences(gen, in: editor.mediaAssets)
         let metadata = inputMetadataSummary(gen)
         return EditorPanelGroup(
-            L10n.string("Input"),
+            L10n.string("Generation Input"),
             contentSpacing: AppTheme.Spacing.zero,
             contentInsets: EdgeInsets(
-                top: AppTheme.Spacing.xs,
+                top: AppTheme.Spacing.xxs,
                 leading: AppTheme.Spacing.smMd,
-                bottom: AppTheme.Spacing.smMd,
+                bottom: AppTheme.Spacing.md,
                 trailing: AppTheme.Spacing.smMd
             )
         ) {
@@ -1151,6 +1151,7 @@ struct InspectorView: View {
                 .padding(.top, hasReferences ? AppTheme.Spacing.md : AppTheme.Spacing.zero)
             }
         }
+        .padding(.top, AppTheme.Spacing.xxs)
     }
 
     private func promptSection(prompt: String) -> some View {

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -61,20 +61,9 @@ struct InspectorView: View {
         }
     }
 
-    enum AssetTab: Hashable {
-        case details
-        case ai
-
-        var titleKey: String {
-            switch self {
-            case .details: L10n.key("Details")
-            case .ai: L10n.key("AI Edit")
-            }
-        }
-    }
-
     @State private var preferredTab: ClipTab = .video
-    @State private var preferredAssetTab: AssetTab = .details
+    @State private var assetInfoPresented = false
+    @State private var assetFileSize: AssetFileSize?
     @State private var transformExpanded = true
     @State private var imageAdjustmentExpanded = true
     @State var audioLevelsExpanded = true
@@ -417,15 +406,6 @@ struct InspectorView: View {
             tourAnchors: tabs.contains(.ai) ? [ClipTab.ai.titleKey: .aiEditTab] : [:]
         ) { title in
             if let tab = tabs.first(where: { $0.titleKey == title }) { preferredTab = tab }
-        }
-    }
-
-    private func assetTabBar(_ tabs: [AssetTab]) -> some View {
-        TitleTabBar(
-            titles: tabs.map(\.titleKey),
-            selected: preferredAssetTab.titleKey
-        ) { title in
-            if let tab = tabs.first(where: { $0.titleKey == title }) { preferredAssetTab = tab }
         }
     }
 
@@ -1033,69 +1013,70 @@ struct InspectorView: View {
 
     // MARK: - Media Asset Inspector
 
-    @ViewBuilder
     private func mediaAssetInspectorContent(_ asset: MediaAsset) -> some View {
-        if asset.type.isVisual && !AccountService.shared.isMisconfigured {
-            VStack(spacing: 0) {
-                assetTabBar([.details, .ai])
-                if preferredAssetTab == .ai {
-                    AIEditTab(asset: asset)
-                } else {
-                    assetDetailsContent(asset)
+        VStack(spacing: AppTheme.Spacing.zero) {
+            assetInspectorHeader(asset)
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
+                    if let gen = asset.generationInput {
+                        inputSection(gen)
+                    }
+                    AIEditTab(asset: asset, usesOwnScrollView: false)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-        } else {
-            assetDetailsContent(asset)
         }
     }
 
-    @ViewBuilder
-    private func assetDetailsContent(_ asset: MediaAsset) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-                assetIdentityHeader(asset)
-                    .padding(.horizontal, AppTheme.Spacing.lg)
-                    .padding(.bottom, AppTheme.Spacing.xl)
-
-                fileSection(asset)
-
-                if let gen = asset.generationInput {
-                    if GenerationReferencesStrip.hasResolvableReferences(gen, in: editor.mediaAssets) {
-                        metadataSection(title: L10n.string("References")) {
-                            GenerationReferencesStrip(generationInput: gen)
-                        }
-                    }
-
-                    metadataSection(title: L10n.string("Generated")) {
-                        plainMetadataRow(label: L10n.string("Model"), value: ModelRegistry.displayName(for: gen.model))
-                        if !gen.aspectRatio.isEmpty {
-                            plainMetadataRow(
-                                label: L10n.string("Aspect Ratio"),
-                                value: ImageModelConfig.aspectRatioDisplayLabel(gen.aspectRatio)
-                            )
-                        }
-                        if let resolution = gen.resolution {
-                            plainMetadataRow(label: L10n.string("Resolution"), value: resolution)
-                        }
-                        if gen.duration > 0 {
-                            plainMetadataRow(label: L10n.string("Duration"), value: "\(gen.duration)s")
-                        }
-                    }
-
-                    if !gen.prompt.isEmpty {
-                        promptSection(prompt: gen.prompt)
-                            .padding(.horizontal, AppTheme.Spacing.lg)
-                    }
-                }
+    private func assetInspectorHeader(_ asset: MediaAsset) -> some View {
+        let infoLabel = assetInfoPresented ? L10n.string("Hide Info") : L10n.string("Show Info")
+        return HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: asset.type.sfSymbolName)
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                .accessibilityHidden(true)
+            Text(verbatim: asset.name)
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.regular))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(Text(verbatim: asset.name))
+            Spacer(minLength: AppTheme.Spacing.xs)
+            Button {
+                assetInfoPresented.toggle()
+            } label: {
+                Image(systemName: assetInfoPresented ? "info.circle.fill" : "info.circle")
+                    .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(assetInfoPresented ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
+                    .frame(width: AppTheme.IconSize.lg, height: AppTheme.IconSize.lg)
             }
-            .padding(.top, AppTheme.Spacing.xs)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .buttonStyle(.plain)
+            .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+            .help(infoLabel)
+            .accessibilityLabel(infoLabel)
+            .popover(isPresented: $assetInfoPresented, arrowEdge: .top) {
+                assetFileInfoContent(asset)
+                    .frame(width: AppTheme.EditorPanel.defaultWidth)
+            }
         }
+        .padding(.horizontal, AppTheme.Spacing.smMd)
+        .panelHeaderBar()
     }
 
-    @ViewBuilder
+    private func assetFileInfoContent(_ asset: MediaAsset) -> some View {
+        fileSection(asset)
+            .task(id: asset.url) {
+                let url = asset.url
+                assetFileSize = nil
+                let formattedSize = await Self.formattedFileSize(for: url)
+                guard !Task.isCancelled, asset.url == url else { return }
+                assetFileSize = formattedSize.map { AssetFileSize(url: url, formattedValue: $0) }
+            }
+    }
+
     private func fileSection(_ asset: MediaAsset) -> some View {
-        metadataSection(title: L10n.string("File")) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
             plainMetadataRow(label: L10n.string("Type"), value: asset.type.localizedTrackLabel)
             if asset.type != .audio, let width = asset.sourceWidth, let height = asset.sourceHeight {
                 plainMetadataRow(label: L10n.string("Dimensions"), value: "\(width) × \(height)")
@@ -1109,8 +1090,8 @@ struct InspectorView: View {
             if asset.duration > 0 && asset.type != .image {
                 plainMetadataRow(label: L10n.string("Duration"), value: formatDuration(asset.duration))
             }
-            if let fileSize = fileSize(for: asset.url) {
-                plainMetadataRow(label: L10n.string("Size"), value: fileSize)
+            if let fileSize = assetFileSize, fileSize.url == asset.url {
+                plainMetadataRow(label: L10n.string("Size"), value: fileSize.formattedValue)
             }
             plainMetadataRow(
                 label: L10n.string("Path"),
@@ -1118,50 +1099,90 @@ struct InspectorView: View {
                 truncate: .middle
             )
         }
+        .padding(.horizontal, AppTheme.Spacing.smMd)
+        .padding(.vertical, AppTheme.Spacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func assetIdentityHeader(_ asset: MediaAsset) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: AppTheme.Spacing.sm) {
-            Text(asset.name)
-                .font(.system(size: AppTheme.FontSize.lg, weight: .semibold))
-                .foregroundStyle(AppTheme.Text.primaryColor)
-                .lineLimit(2)
-                .textSelection(.enabled)
-            if asset.generationInput != nil {
-                aiBadge
+    private func inputSection(_ gen: GenerationInput) -> some View {
+        let hasReferences = GenerationReferencesStrip.hasResolvableReferences(gen, in: editor.mediaAssets)
+        let metadata = inputMetadataSummary(gen)
+        return EditorPanelGroup(
+            L10n.string("Input"),
+            contentSpacing: AppTheme.Spacing.zero,
+            contentInsets: EdgeInsets(
+                top: AppTheme.Spacing.xs,
+                leading: AppTheme.Spacing.smMd,
+                bottom: AppTheme.Spacing.smMd,
+                trailing: AppTheme.Spacing.smMd
+            )
+        ) {
+            if hasReferences {
+                GenerationReferencesStrip(generationInput: gen)
             }
-            Spacer(minLength: 0)
+            if !gen.prompt.isEmpty || !metadata.isEmpty {
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
+                    if !gen.prompt.isEmpty {
+                        promptSection(prompt: gen.prompt)
+                    }
+                    if !gen.prompt.isEmpty, !metadata.isEmpty {
+                        Rectangle()
+                            .fill(AppTheme.Border.subtleColor)
+                            .frame(height: AppTheme.BorderWidth.hairline)
+                    }
+                    if !metadata.isEmpty {
+                        Text(verbatim: metadata)
+                            .font(.system(size: AppTheme.FontSize.xs))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .textSelection(.enabled)
+                            .help(Text(verbatim: metadata))
+                    }
+                }
+                .padding(.horizontal, AppTheme.Spacing.smMd)
+                .padding(.vertical, AppTheme.Spacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .themedSurface(
+                    AppTheme.Background.raisedColor,
+                    cornerRadius: AppTheme.Radius.sm,
+                    borderWidth: AppTheme.BorderWidth.hairline
+                )
+                .padding(.top, hasReferences ? AppTheme.Spacing.md : AppTheme.Spacing.zero)
+            }
         }
     }
 
-    private var aiBadge: some View {
-        Text(verbatim: "AI")
-            .font(.system(size: AppTheme.FontSize.xxs, weight: .bold))
-            .tracking(AppTheme.Tracking.wide)
-            .foregroundStyle(AppTheme.aiGradient)
-            .padding(.horizontal, AppTheme.Spacing.sm)
-            .padding(.vertical, AppTheme.Spacing.xxs)
-            .overlay(
-                RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
-                    .strokeBorder(AppTheme.Interaction.fill(AppTheme.Opacity.muted), lineWidth: AppTheme.BorderWidth.hairline)
-            )
-    }
-
     private func promptSection(prompt: String) -> some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
             HStack(spacing: AppTheme.Spacing.sm) {
                 Text(L10n.string("Prompt"))
-                    .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.medium))
-                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
                 Spacer()
                 PromptCopyButton(text: prompt)
             }
-            Text(prompt)
+            Text(verbatim: prompt)
                 .font(.system(size: AppTheme.FontSize.sm))
+                .lineSpacing(AppTheme.Spacing.xxs)
                 .foregroundStyle(AppTheme.Text.secondaryColor)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private func inputMetadataSummary(_ gen: GenerationInput) -> String {
+        var values = [ModelRegistry.displayName(for: gen.model)]
+        if !gen.aspectRatio.isEmpty {
+            values.append(ImageModelConfig.aspectRatioDisplayLabel(gen.aspectRatio))
+        }
+        if let resolution = gen.resolution, !resolution.isEmpty {
+            values.append(resolution)
+        }
+        if gen.duration > 0 {
+            values.append("\(gen.duration)s")
+        }
+        return values.joined(separator: " · ")
     }
 
     // MARK: - Helpers
@@ -1172,10 +1193,17 @@ struct InspectorView: View {
         return editor.mediaAssets.first { $0.id == id }
     }
 
+    private struct AssetFileSize {
+        let url: URL
+        let formattedValue: String
+    }
 
-    private func fileSize(for url: URL) -> String? {
+    @concurrent
+    private static func formattedFileSize(for url: URL) async -> String? {
+        guard !Task.isCancelled else { return nil }
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
               let bytes = attrs[.size] as? Int64 else { return nil }
+        guard !Task.isCancelled else { return nil }
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
         return formatter.string(fromByteCount: bytes)

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -4,6 +4,7 @@ struct AIEditTab: View {
     let asset: MediaAsset
     /// Clip id from the timeline.
     let clipId: String?
+    let usesOwnScrollView: Bool
     @Environment(EditorViewModel.self) private var editor
     @Bindable private var account = AccountService.shared
     @State private var replaceClipSource: Bool = false
@@ -11,123 +12,133 @@ struct AIEditTab: View {
     @State private var placeAudioOnTimeline: Bool = true
     @State private var aiEnhanceExpanded: Bool = true
     @State private var aiAudioExpanded: Bool = true
+    @State private var createVideoOptionsPresented = false
 
-    init(asset: MediaAsset, clipId: String? = nil) {
+    init(asset: MediaAsset, clipId: String? = nil, usesOwnScrollView: Bool = true) {
         self.asset = asset
         self.clipId = clipId
+        self.usesOwnScrollView = usesOwnScrollView
     }
 
+    @ViewBuilder
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-                if trimmedClipAvailable {
-                    trimmedClipToggle
-                        .padding(AppTheme.Spacing.smMd)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(AppTheme.Background.surfaceColor)
-                        .overlay(alignment: .bottom) {
-                            Rectangle()
-                                .fill(AppTheme.Border.primaryColor)
-                                .frame(height: AppTheme.BorderWidth.thin)
-                        }
-                }
-
-                if isVisualClipContext {
-                    EditorPanelGroup(L10n.string("AI Enhance"), isExpanded: $aiEnhanceExpanded, contentSpacing: AppTheme.Spacing.smMd) {
-                        if clipId != nil { replaceToggle }
-                        actionRow(
-                            action: .upscale,
-                            icon: "sparkles.rectangle.stack",
-                            title: L10n.string("Upscale"),
-                            description: L10n.string("Enhance resolution or frame rate with AI")
-                        )
-                        actionRow(
-                            action: .edit,
-                            icon: "wand.and.stars",
-                            title: L10n.string("Edit"),
-                            description: L10n.string("Transform with a prompt or motion reference")
-                        )
-                        actionRow(
-                            action: .rerun,
-                            icon: "arrow.clockwise",
-                            title: L10n.string("Rerun"),
-                            description: L10n.string("Regenerate with the same parameters"),
-                            detail: rerunCost
-                        )
-                        if asset.type == .video, let model = VideoModelConfig.lipSync {
-                            actionRow(
-                                action: .lipSync,
-                                icon: "mouth",
-                                title: L10n.string("Lip Sync"),
-                                description: L10n.string("Match mouth movement to replacement audio"),
-                                detail: model.sourceDurationLimitLabel.map { L10n.string("Up to \($0)") },
-                                triggerTitle: L10n.string("Choose Audio")
-                            )
-                        }
-                        if asset.type == .video {
-                            actionRow(
-                                action: .reframe,
-                                icon: "aspectratio",
-                                title: L10n.string("Reframe"),
-                                description: L10n.string("Change aspect ratio and extend the frame with AI"),
-                                detail: VideoModelConfig.reframe?.reframeDurationLimitLabel
-                                    .map { L10n.string("Up to \($0)") }
-                            )
-                        }
-                        if asset.type == .image {
-                            actionRow(
-                                action: .createVideo,
-                                icon: "video.badge.plus",
-                                title: L10n.string("Create Video"),
-                                description: L10n.string("Use as first frame or reference")
-                            )
-                        }
-                    }
-                }
-
-                if asset.type == .video || asset.type == .audio {
-                    EditorPanelGroup(L10n.string("AI Audio"), isExpanded: $aiAudioExpanded, contentSpacing: AppTheme.Spacing.smMd) {
-                        if showsAudioOutputOptions {
-                            audioPlacementToggle
-                        }
-                        if asset.type == .audio {
-                            actionRow(
-                                action: .rerun,
-                                icon: "arrow.clockwise",
-                                title: L10n.string("Rerun"),
-                                description: L10n.string("Regenerate with the same parameters"),
-                                detail: rerunCost
-                            )
-                        }
-                        if clipId != nil {
-                            audioTransformActionRow(kind: .cleanup)
-                            audioTransformActionRow(kind: .dubbing)
-                        }
-                        if isVisualClipContext, asset.type == .video {
-                            videoAudioActionRow(kind: .music)
-                            videoAudioActionRow(kind: .sfx)
-                        }
-                    }
-                }
+        if usesOwnScrollView {
+            ScrollView {
+                panelContent
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            panelContent
         }
     }
 
-    private var showsAudioOutputOptions: Bool {
-        (asset.type == .video || asset.type == .audio) && clipId != nil
+    private var panelContent: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
+            if trimmedClipAvailable {
+                trimmedClipToggle
+                    .padding(AppTheme.Spacing.smMd)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(AppTheme.Background.surfaceColor)
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(AppTheme.Border.primaryColor)
+                            .frame(height: AppTheme.BorderWidth.thin)
+                    }
+            }
+
+            if isVisualClipContext {
+                EditorPanelGroup(L10n.string("AI Enhance"), isExpanded: $aiEnhanceExpanded, contentSpacing: AppTheme.Spacing.smMd) {
+                    if clipId != nil { replaceToggle }
+                    visualActionGrid
+                }
+            }
+
+            if asset.type == .video || asset.type == .audio {
+                EditorPanelGroup(L10n.string("AI Audio"), isExpanded: $aiAudioExpanded, contentSpacing: AppTheme.Spacing.smMd) {
+                    if clipId != nil {
+                        audioPlacementToggle
+                    }
+                    audioActionGrid
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var actionGridColumns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: AppTheme.Spacing.sm),
+            GridItem(.flexible(), spacing: AppTheme.Spacing.sm),
+        ]
+    }
+
+    private var visualActionGrid: some View {
+        LazyVGrid(columns: actionGridColumns, spacing: AppTheme.Spacing.sm) {
+            actionTile(
+                action: .upscale,
+                icon: "sparkles.rectangle.stack",
+                title: L10n.string("Upscale"),
+                description: L10n.string("Enhance resolution or frame rate with AI")
+            )
+            actionTile(
+                action: .edit,
+                icon: "wand.and.stars",
+                title: L10n.string("Edit"),
+                description: L10n.string("Transform with a prompt or motion reference")
+            )
+            actionTile(
+                action: .rerun,
+                icon: "arrow.clockwise",
+                title: L10n.string("Rerun"),
+                description: L10n.string("Regenerate with the same parameters")
+            )
+            if asset.type == .video, VideoModelConfig.lipSync != nil {
+                actionTile(
+                    action: .lipSync,
+                    icon: "mouth",
+                    title: L10n.string("Lip Sync"),
+                    description: L10n.string("Match mouth movement to replacement audio")
+                )
+            }
+            if asset.type == .video {
+                actionTile(
+                    action: .reframe,
+                    icon: "aspectratio",
+                    title: L10n.string("Reframe"),
+                    description: L10n.string("Change aspect ratio and extend the frame with AI")
+                )
+            }
+            if asset.type == .image {
+                actionTile(
+                    action: .createVideo,
+                    icon: "video.badge.plus",
+                    title: L10n.string("Create Video"),
+                    description: L10n.string("Use as first frame or reference")
+                )
+            }
+        }
+    }
+
+    private var audioActionGrid: some View {
+        LazyVGrid(columns: actionGridColumns, spacing: AppTheme.Spacing.sm) {
+            if asset.type == .audio {
+                actionTile(
+                    action: .rerun,
+                    icon: "arrow.clockwise",
+                    title: L10n.string("Rerun"),
+                    description: L10n.string("Regenerate with the same parameters")
+                )
+            }
+            audioTransformActionTile(kind: .cleanup)
+            audioTransformActionTile(kind: .dubbing)
+            if isVisualClipContext, asset.type == .video {
+                videoAudioActionTile(kind: .music)
+                videoAudioActionTile(kind: .sfx)
+            }
+        }
     }
 
     private var isVisualClipContext: Bool {
         timelineClip?.mediaType.isVisual ?? asset.type.isVisual
-    }
-
-    private var rerunCost: String? {
-        guard let gen = asset.generationInput,
-              let cost = CostEstimator.cost(for: gen) else {
-            return nil
-        }
-        return CostEstimator.localizedDescription(cost)
     }
 
     // MARK: - Replace toggle
@@ -205,16 +216,15 @@ struct AIEditTab: View {
         trimmedSourceIfEnabled()?.durationSeconds
     }
 
-    // MARK: - Action row
+    // MARK: - Action tiles
 
     @ViewBuilder
-    private func actionRow(
+    private func actionTile(
         action: EditAction,
         icon: String,
         title: String,
         description: String,
-        detail: String? = nil,
-        triggerTitle: String? = nil
+        detail: String? = nil
     ) -> some View {
         let availability = action.availability(
             for: asset,
@@ -225,132 +235,173 @@ struct AIEditTab: View {
         let disabledReason = aiDisabledReason
             ?? (paidBlocked ? L10n.string("Requires a paid plan") : availability.reason)
 
-        descriptiveActionRow(
-            icon: icon,
-            title: title,
-            description: description,
-            detail: detail,
-            isEnabled: isEnabled,
-            disabledReason: disabledReason
-        ) {
-            actionTrigger(action: action, title: triggerTitle ?? title, isEnabled: isEnabled)
+        switch action {
+        case .createVideo:
+            actionTileSurface(
+                description: description,
+                isEnabled: isEnabled,
+                disabledReason: disabledReason
+            ) {
+                actionButton(
+                    icon: icon,
+                    title: title,
+                    detail: detail,
+                    isEnabled: isEnabled,
+                    showsMenuIndicator: true
+                ) {
+                    createVideoOptionsPresented = true
+                }
+                .popover(isPresented: $createVideoOptionsPresented, arrowEdge: .bottom) {
+                    createVideoOptions
+                }
+            }
+        case .upscale, .lipSync, .reframe, .edit, .generateMusic, .generateSFX, .rerun:
+            actionTileSurface(
+                description: description,
+                isEnabled: isEnabled,
+                disabledReason: disabledReason
+            ) {
+                actionButton(
+                    icon: icon,
+                    title: title,
+                    detail: detail,
+                    isEnabled: isEnabled
+                ) {
+                    present(action)
+                }
+            }
         }
     }
 
-    private func videoAudioActionRow(kind: VideoToAudioEditKind) -> some View {
-        actionRow(
+    private func videoAudioActionTile(kind: VideoToAudioEditKind) -> some View {
+        actionTile(
             action: kind.action,
             icon: kind.iconName,
             title: L10n.string(key: kind.title),
-            description: L10n.string(key: kind.description),
-            triggerTitle: L10n.string("Generate")
+            description: L10n.string(key: kind.description)
         )
     }
 
-    @ViewBuilder
-    private func audioTransformActionRow(kind: AudioTransformEditKind) -> some View {
-        let model = kind.model
+    private func audioTransformActionTile(kind: AudioTransformEditKind) -> some View {
         let availability = kind.availability(
             for: asset,
             effectiveDurationOverride: effectiveDurationForAvailability
         )
-        let paidBlocked = model?.paidOnly == true && !account.isPaid
+        let paidBlocked = kind.model?.paidOnly == true && !account.isPaid
         let isEnabled = availability.isAvailable && !paidBlocked && aiDisabledReason == nil
         let disabledReason = aiDisabledReason
             ?? (paidBlocked ? L10n.string("Requires a paid plan") : availability.reason)
 
-        descriptiveActionRow(
-            icon: kind.iconName,
-            title: L10n.string(key: kind.title),
+        return actionTileSurface(
             description: L10n.string(key: kind.description),
             isEnabled: isEnabled,
             disabledReason: disabledReason
         ) {
-            Button(L10n.string("Generate")) {
+            actionButton(
+                icon: kind.iconName,
+                title: L10n.string(key: kind.title),
+                isEnabled: isEnabled
+            ) {
                 presentAudioTransform(kind)
             }
-            .buttonStyle(.capsule(.secondary))
-            .controlSize(.small)
-            .disabled(!isEnabled)
         }
     }
 
-    private func descriptiveActionRow<Trailing: View>(
-        icon: String,
-        title: String,
+    private func actionTileSurface<Content: View>(
         description: String,
-        detail: String? = nil,
         isEnabled: Bool,
         disabledReason: String?,
-        @ViewBuilder trailing: () -> Trailing
+        @ViewBuilder content: () -> Content
     ) -> some View {
-        HStack(alignment: .center, spacing: AppTheme.Spacing.sm) {
-            Image(systemName: icon)
-                .font(.system(size: AppTheme.FontSize.md))
-                .foregroundStyle(isEnabled ? AppTheme.Text.secondaryColor : AppTheme.Text.mutedColor)
-                .frame(width: AppTheme.Spacing.lgXl, alignment: .center)
-            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
-                Text(L10n.string(key: title))
-                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+        content()
+            .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+            .themedSurface(
+                AppTheme.Background.raisedColor,
+                cornerRadius: AppTheme.Radius.sm,
+                borderWidth: AppTheme.BorderWidth.hairline
+            )
+            .disabled(!isEnabled)
+            .help(disabledReason ?? description)
+            .accessibilityHint(disabledReason ?? description)
+    }
+
+    private func actionButton(
+        icon: String,
+        title: String,
+        detail: String? = nil,
+        isEnabled: Bool,
+        showsMenuIndicator: Bool = false,
+        perform: @escaping () -> Void
+    ) -> some View {
+        Button(action: perform) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.medium))
+                    .foregroundStyle(isEnabled ? AppTheme.Text.secondaryColor : AppTheme.Text.mutedColor)
+                    .frame(width: AppTheme.IconSize.xs, alignment: .center)
+                Text(verbatim: title)
+                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
                     .foregroundStyle(isEnabled ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
-                if let disabledReason {
-                    Text(disabledReason)
-                        .font(.system(size: AppTheme.FontSize.xs))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
-                        .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+                Spacer(minLength: AppTheme.Spacing.xs)
+                if isEnabled, let detail {
+                    Text(verbatim: detail)
+                        .font(.system(size: AppTheme.FontSize.xxs))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .lineLimit(1)
+                }
+                if showsMenuIndicator {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.semibold))
+                        .foregroundStyle(isEnabled ? AppTheme.Text.tertiaryColor : AppTheme.Text.mutedColor)
                 }
             }
-            Spacer(minLength: AppTheme.Spacing.xs)
-            if isEnabled, let detail {
-                Text(detail)
-                    .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
-                    .lineLimit(1)
-            }
-            trailing()
-                .accessibilityHint(disabledReason ?? description)
+            .padding(.horizontal, AppTheme.Spacing.smMd)
+            .padding(.vertical, AppTheme.Spacing.smMd)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(
+                RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
+            )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .buttonStyle(.plain)
     }
 
     private func presentAudioTransform(_ kind: AudioTransformEditKind) {
-        guard let clipId else { return }
-        editor.beginAIAudioTransform(
-            clipId: clipId,
-            kind: kind,
-            useTrimmedClip: useTrimmedClip,
-            placeOnTimeline: placeAudioOnTimeline
-        )
+        if let clipId {
+            editor.beginAIAudioTransform(
+                clipId: clipId,
+                kind: kind,
+                useTrimmedClip: useTrimmedClip,
+                placeOnTimeline: placeAudioOnTimeline
+            )
+        } else if let stored = EditSubmitter.audioTransformSeed(for: asset, kind: kind) {
+            editor.seedGenerationPanel(asset: asset, stored: stored)
+        }
     }
 
-    @ViewBuilder
-    private func actionTrigger(action: EditAction, title: String, isEnabled: Bool) -> some View {
-        switch action {
-        case .upscale:
-            Button(title) {
-                present(action)
-            }
-            .buttonStyle(.capsule(.secondary))
-            .controlSize(.small)
-            .disabled(!isEnabled)
-        case .createVideo:
-            Menu(title) {
-                Button(L10n.string("Set as first frame")) { sendToVideo(asReference: false) }
-                Button(L10n.string("Set as reference")) { sendToVideo(asReference: true) }
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .controlSize(.small)
-            .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
-            .disabled(!isEnabled)
-        case .lipSync, .reframe, .edit, .generateMusic, .generateSFX, .rerun:
-            Button(title) {
-                present(action)
-            }
-            .buttonStyle(.capsule(.secondary))
-            .controlSize(.small)
-            .disabled(!isEnabled)
+    private var createVideoOptions: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
+            createVideoOption(L10n.string("Set as first frame"), asReference: false)
+            createVideoOption(L10n.string("Set as reference"), asReference: true)
         }
+        .padding(.vertical, AppTheme.Spacing.xs)
+    }
+
+    private func createVideoOption(_ title: String, asReference: Bool) -> some View {
+        Button {
+            createVideoOptionsPresented = false
+            sendToVideo(asReference: asReference)
+        } label: {
+            Text(verbatim: title)
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.primaryColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.vertical, AppTheme.Spacing.sm)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
     }
 
     private func sendToVideo(asReference: Bool) {

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -46,14 +46,24 @@ struct AIEditTab: View {
             }
 
             if isVisualClipContext {
-                EditorPanelGroup(L10n.string("AI Enhance"), isExpanded: $aiEnhanceExpanded, contentSpacing: AppTheme.Spacing.smMd) {
+                EditorPanelGroup(
+                    L10n.string("AI Enhance"),
+                    isExpanded: $aiEnhanceExpanded,
+                    contentSpacing: AppTheme.Spacing.smMd,
+                    contentInsets: actionGroupInsets
+                ) {
                     if clipId != nil { replaceToggle }
                     visualActionGrid
                 }
             }
 
             if asset.type == .video || asset.type == .audio {
-                EditorPanelGroup(L10n.string("AI Audio"), isExpanded: $aiAudioExpanded, contentSpacing: AppTheme.Spacing.smMd) {
+                EditorPanelGroup(
+                    L10n.string("AI Audio"),
+                    isExpanded: $aiAudioExpanded,
+                    contentSpacing: AppTheme.Spacing.smMd,
+                    contentInsets: actionGroupInsets
+                ) {
                     if clipId != nil {
                         audioPlacementToggle
                     }
@@ -62,6 +72,15 @@ struct AIEditTab: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var actionGroupInsets: EdgeInsets {
+        EdgeInsets(
+            top: AppTheme.Spacing.zero,
+            leading: AppTheme.Spacing.smMd,
+            bottom: AppTheme.Spacing.smMd,
+            trailing: AppTheme.Spacing.smMd
+        )
     }
 
     private var actionGridColumns: [GridItem] {

--- a/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/AIEditTab.swift
@@ -55,6 +55,7 @@ struct AIEditTab: View {
                     if clipId != nil { replaceToggle }
                     visualActionGrid
                 }
+                .padding(.top, AppTheme.Spacing.xxs)
             }
 
             if asset.type == .video || asset.type == .audio {
@@ -69,6 +70,7 @@ struct AIEditTab: View {
                     }
                     audioActionGrid
                 }
+                .padding(.top, AppTheme.Spacing.xxs)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -76,9 +78,9 @@ struct AIEditTab: View {
 
     private var actionGroupInsets: EdgeInsets {
         EdgeInsets(
-            top: AppTheme.Spacing.zero,
+            top: AppTheme.Spacing.xxs,
             leading: AppTheme.Spacing.smMd,
-            bottom: AppTheme.Spacing.smMd,
+            bottom: AppTheme.Spacing.md,
             trailing: AppTheme.Spacing.smMd
         )
     }
@@ -357,7 +359,11 @@ struct AIEditTab: View {
                 Image(systemName: icon)
                     .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.medium))
                     .foregroundStyle(isEnabled ? AppTheme.Text.secondaryColor : AppTheme.Text.mutedColor)
-                    .frame(width: AppTheme.IconSize.xs, alignment: .center)
+                    .frame(
+                        width: AppTheme.IconSize.xs,
+                        height: AppTheme.IconSize.xs,
+                        alignment: .center
+                    )
                 Text(verbatim: title)
                     .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
                     .foregroundStyle(isEnabled ? AppTheme.Text.primaryColor : AppTheme.Text.mutedColor)
@@ -376,7 +382,7 @@ struct AIEditTab: View {
                 }
             }
             .padding(.horizontal, AppTheme.Spacing.smMd)
-            .padding(.vertical, AppTheme.Spacing.smMd)
+            .padding(.vertical, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -227,8 +227,8 @@ struct AssetThumbnailView: View {
     }
 
     private var durationBadge: some View {
-        Text(formatDuration(asset.duration))
-            .font(.system(size: AppTheme.FontSize.xxs, weight: .medium))
+        Text(verbatim: formatMediaTileDuration(asset.duration))
+            .font(.system(size: AppTheme.FontSize.micro, weight: .medium))
             .monospacedDigit()
             .tileBadge()
     }
@@ -262,13 +262,6 @@ struct AssetThumbnailView: View {
                 .foregroundStyle(AppTheme.MediaOverlay.secondaryColor)
         }
         .help(L10n.string("Palmier couldn't load this source file. It may be missing, on an ejected drive, or unreadable."))
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let total = Int(seconds)
-        let m = total / 60
-        let s = total % 60
-        return String(format: "%02d:%02d", m, s)
     }
 
     private var isSelected: Bool {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -40,7 +40,7 @@ extension MediaTab {
 
 extension MediaTab {
     func gridDimensions(width: CGFloat) -> GridDimensions {
-        let spacing = AppTheme.Spacing.xl
+        let spacing = AppTheme.Spacing.md
         let outerPadding: CGFloat = AppTheme.Spacing.md * 2
         let usable = max(0, width - outerPadding)
         let cols = max(1, Int(floor((usable + spacing) / (thumbnailSize + spacing))))
@@ -90,7 +90,6 @@ extension MediaTab {
         cols: Int,
         tileWidth: CGFloat,
         spacing: CGFloat,
-        topPadding: CGFloat,
         @ViewBuilder cellView: @escaping (Cell) -> Content
     ) -> some View where Cell.ID == String {
         ScrollViewReader { proxy in
@@ -103,8 +102,8 @@ extension MediaTab {
                             .id(cell.id)
                     }
                 }
-                .padding(AppTheme.Spacing.md)
-                .padding(.top, topPadding)
+                .padding(.horizontal, AppTheme.Spacing.md)
+                .padding(.bottom, AppTheme.Spacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .coordinateSpace(name: "mediaGrid")
@@ -139,8 +138,7 @@ extension MediaTab {
                 orderedIds: layout.orderedIds,
                 cols: layout.cols,
                 tileWidth: layout.tileWidth,
-                spacing: layout.spacing,
-                topPadding: AppTheme.Spacing.sm
+                spacing: layout.spacing
             ) { cell in
                 cellView(for: cell)
             }
@@ -162,8 +160,7 @@ extension MediaTab {
                 orderedIds: orderedIds,
                 cols: dims.cols,
                 tileWidth: dims.tileWidth,
-                spacing: dims.spacing,
-                topPadding: AppTheme.Spacing.sm
+                spacing: dims.spacing
             ) { cell in
                 cellView(for: cell)
             }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -281,14 +281,14 @@ struct MediaTab: View {
     // MARK: - Toolbar
 
     private var toolbar: some View {
-        VStack(spacing: AppTheme.Spacing.xs) {
+        VStack(spacing: AppTheme.Spacing.xxs) {
             actionsRow
             searchControlsRow
             contextBar
         }
         .padding(.horizontal, AppTheme.Spacing.sm)
         .padding(.top, AppTheme.Spacing.sm)
-        .padding(.bottom, AppTheme.Spacing.xs)
+        .padding(.bottom, AppTheme.Spacing.sm)
         .background(AppTheme.Background.surfaceColor)
     }
 

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTileScaffold.swift
@@ -95,3 +95,22 @@ extension View {
             .padding(AppTheme.Spacing.xs)
     }
 }
+
+func formatMediaTileDuration(_ seconds: Double) -> String {
+    guard seconds.isFinite, seconds > 0 else { return "0s" }
+    let total = max(1, Int(seconds.rounded()))
+    let hours = total / 3600
+    let minutes = (total % 3600) / 60
+    let remainingSeconds = total % 60
+    if hours > 0 {
+        return "\(hours):\(mediaTileTwoDigits(minutes)):\(mediaTileTwoDigits(remainingSeconds))"
+    }
+    if minutes > 0 {
+        return "\(minutes):\(mediaTileTwoDigits(remainingSeconds))"
+    }
+    return "\(remainingSeconds)s"
+}
+
+private func mediaTileTwoDigits(_ value: Int) -> String {
+    value < 10 ? "0\(value)" : "\(value)"
+}

--- a/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/TimelineTileView.swift
@@ -78,8 +78,10 @@ struct TimelineTileView: View {
             Spacer()
             HStack {
                 Spacer()
-                Text(formatTimecode(frame: timeline.totalFrames, fps: timeline.fps))
-                    .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.medium))
+                Text(verbatim: formatMediaTileDuration(
+                    Double(timeline.totalFrames) / Double(max(timeline.fps, 1))
+                ))
+                    .font(.system(size: AppTheme.FontSize.micro, weight: AppTheme.FontWeight.medium))
                     .monospacedDigit()
                     .tileBadge()
             }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -403,6 +403,7 @@
 "Generate · 1 credit" = "Generate · 1 credit";
 "Generating…" = "Generating…";
 "Generation Failed" = "Generation Failed";
+"Generation Input" = "Generation Input";
 "Generation complete" = "Generation complete";
 "Generation in progress" = "Generation in progress";
 "Generation panel" = "Generation panel";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -164,7 +164,6 @@
 "Chat history" = "Chat history";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key.";
 "Check for Updates…" = "Check for Updates…";
-"Choose Audio" = "Choose Audio";
 "Choose a .cube LUT file" = "Choose a .cube LUT file";
 "Choose a crop aspect" = "Choose a crop aspect";
 "Choose animation clip color" = "Choose animation clip color";
@@ -286,7 +285,6 @@
 "Designer" = "Designer";
 "Destination" = "Destination";
 "Detail" = "Detail";
-"Details" = "Details";
 "Detect Beats" = "Detect Beats";
 "Detected %lld beats at %lld BPM." = "Detected %lld beats at %lld BPM.";
 "Detected %lld beats." = "Detected %lld beats.";
@@ -403,7 +401,6 @@
 "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame." = "Generate video, image, or audio with different models and settings. Drag assets from the media panel above into the reference frame.";
 "Generate · %lld credits" = "Generate · %lld credits";
 "Generate · 1 credit" = "Generate · 1 credit";
-"Generated" = "Generated";
 "Generating…" = "Generating…";
 "Generation Failed" = "Generation Failed";
 "Generation complete" = "Generation complete";
@@ -423,6 +420,7 @@
 "Hard Light" = "Hard Light";
 "Height" = "Height";
 "Help" = "Help";
+"Hide Info" = "Hide Info";
 "Hide keyframe timeline" = "Hide keyframe timeline";
 "Hide reasoning" = "Hide reasoning";
 "High" = "High";
@@ -804,6 +802,7 @@
 "Sharpen" = "Sharpen";
 "Short-form and social" = "Short-form and social";
 "Shortcuts" = "Shortcuts";
+"Show Info" = "Show Info";
 "Show in Finder" = "Show in Finder";
 "Show keyframe timeline" = "Show keyframe timeline";
 "Show notifications" = "Show notifications";
@@ -947,7 +946,6 @@
 "Ungroup Multicam" = "Ungroup Multicam";
 "Unlink" = "Unlink";
 "Untitled" = "Untitled";
-"Up to %@" = "Up to %@";
 "Update" = "Update";
 "Update available" = "Update available";
 "Updating %@" = "Updating %@";

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -474,7 +474,7 @@ enum AppTheme {
 
     enum MediaPanel {
         static let tabRailWidth: CGFloat = IconSize.lg + Spacing.sm * 2
-        static let contextRowHeight: CGFloat = IconSize.md
+        static let contextRowHeight: CGFloat = IconSize.smMd
     }
 
     enum Export {


### PR DESCRIPTION
<img width="1859" height="1046" alt="Screenshot 2026-08-04 at 11 56 44 AM" src="https://github.com/user-attachments/assets/ca12efe5-fef2-40c2-a746-13a11c3de1e5" />

## Summary
- Prioritize AI editing actions when media assets are selected instead of opening a separate Details tab.
- Keep generation inputs visible in a compact provenance card and move secondary file metadata into an Info popover.
- Expose asset-level audio transforms and replace duplicated action rows with consistent, fully clickable action tiles.

## Approach
- Use a compact media identity header with a type icon, truncated asset name, and Info popover.
- Present references, prompt, and generation parameters together under Input while preserving copy and reference-navigation behavior.
- Reuse the clip-aware `AIEditTab` without a nested scroll container and share action-tile styling across video and audio operations.
- Balance action-group insets so dividers, headings, and controls use a consistent visual rhythm.
- Load file size on a concurrent executor and reject cancelled or stale URL results before updating inspector state.
- Keep Create Video as a standard action tile with an attached options popover so its appearance and hit target match other actions.

## Testing
- `swift build` — passed.
- `swift test --filter Inspector` — 2 tests passed.
- `scripts/localization/sync.sh` — passed.
- Manual UI verification during iteration covered generated image/video Input layouts, the Info popover, AI action grids, Create Video options, and full-tile hit targets.
- Manual verification of a selected audio asset remains.

## Change statistics
- Code logic: +389 / -291
- Localization inventory: +2 / -4
- Tests: +0 / -0
- Total: +391 / -295

Made with [Cursor](https://cursor.com)