### PR TITLE
[feat] Show matching timelines in media search

### DIFF
--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Grids.swift
@@ -413,7 +413,7 @@ extension MediaTab {
         }
     }
 
-    fileprivate func timelineTile(_ timeline: Timeline) -> some View {
+    func timelineTile(_ timeline: Timeline) -> some View {
         TimelineTileView(
             timeline: timeline,
             posterImage: timelinePoster(timeline),
@@ -442,7 +442,7 @@ extension MediaTab {
     }
 
     /// First visual clip's cached asset thumbnail — no dedicated timeline render.
-    fileprivate func timelinePoster(_ timeline: Timeline) -> NSImage? {
+    func timelinePoster(_ timeline: Timeline) -> NSImage? {
         for track in timeline.tracks where track.type == .video {
             for clip in track.clips where clip.mediaType == .video || clip.mediaType == .image {
                 if let thumb = editor.mediaAssets.first(where: { $0.id == clip.mediaRef })?.thumbnail {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab+Search.swift
@@ -8,9 +8,11 @@ extension MediaTab {
 
     var searchResults: some View {
         let nameMatches = sortAndFilter(editor.mediaAssets)
-        let orderedAssetIds = Self.searchOrderedAssetIds(
+        let timelineMatches = searchFilteredTimelines(editor.timelines)
+        let orderedItemIds = Self.searchOrderedItemIds(
             momentAssetIds: visualHits.map(\.assetID),
             spokenAssetIds: spokenHits.map(\.assetID),
+            timelineItemIds: timelineMatches.map { MediaPanelItemKey.timeline($0.id) },
             fileAssetIds: nameMatches.map(\.id),
             collapsedSectionTitles: collapsedSearchSections
         )
@@ -31,11 +33,20 @@ extension MediaTab {
                         .padding(.bottom, AppTheme.Spacing.sm)
                     }
                 }
+                if !timelineMatches.isEmpty {
+                    momentHeader(L10n.key("Timelines"), icon: "film.stack", count: timelineMatches.count)
+                    resultsGrid {
+                        ForEach(timelineMatches) { timeline in
+                            timelineTile(timeline)
+                                .id(MediaPanelItemKey.timeline(timeline.id))
+                        }
+                    }
+                }
                 if !nameMatches.isEmpty {
                     momentHeader(L10n.key("Files"), icon: "doc", count: nameMatches.count)
                     resultsGrid { ForEach(nameMatches) { fileCard($0) } }
                 }
-                if visualHits.isEmpty, spokenHits.isEmpty, nameMatches.isEmpty {
+                if visualHits.isEmpty, spokenHits.isEmpty, timelineMatches.isEmpty, nameMatches.isEmpty {
                     Text(L10n.string("No matches for “\(trimmedSearchQuery)”"))
                         .font(.system(size: AppTheme.FontSize.sm))
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
@@ -46,19 +57,21 @@ extension MediaTab {
             .padding(.top, AppTheme.Spacing.sm)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .onAppear { publishGridState(orderedIds: orderedAssetIds, columnCount: 1) }
-        .onChange(of: orderedAssetIds) { _, ids in publishOrderedIds(ids) }
+        .onAppear { publishGridState(orderedIds: orderedItemIds, columnCount: 1) }
+        .onChange(of: orderedItemIds) { _, ids in publishOrderedIds(ids) }
     }
 
-    static func searchOrderedAssetIds(
+    static func searchOrderedItemIds(
         momentAssetIds: [String],
         spokenAssetIds: [String],
+        timelineItemIds: [String],
         fileAssetIds: [String],
         collapsedSectionTitles: Set<String>
     ) -> [String] {
         let sections = [
             collapsedSectionTitles.contains(L10n.key("Moments")) ? [] : momentAssetIds,
             collapsedSectionTitles.contains(L10n.key("Spoken")) ? [] : spokenAssetIds,
+            timelineItemIds,
             fileAssetIds,
         ]
         var seen: Set<String> = []

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -515,7 +515,11 @@ struct MediaTab: View {
     }
 
     func searchFilteredTimelines(_ timelines: [Timeline]) -> [Timeline] {
-        let q = searchQuery.trimmingCharacters(in: .whitespaces)
+        Self.timelinesMatchingName(timelines, query: searchQuery)
+    }
+
+    static func timelinesMatchingName(_ timelines: [Timeline], query: String) -> [Timeline] {
+        let q = query.trimmingCharacters(in: .whitespaces)
         guard !q.isEmpty else { return timelines }
         return timelines.filter { $0.name.localizedCaseInsensitiveContains(q) }
     }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -912,6 +912,7 @@
 "Timeline" = "Timeline";
 "Timeline Format" = "Timeline Format";
 "Timeline colors" = "Timeline colors";
+"Timelines" = "Timelines";
 "Tint" = "Tint";
 "Tints waveforms by speaker. Voices are matched across clips using cloud transcripts." = "Tints waveforms by speaker. Voices are matched across clips using cloud transcripts.";
 "Toggle Agent Panel" = "Toggle Agent Panel";

--- a/Tests/PalmierProTests/Media/MediaPanelTests.swift
+++ b/Tests/PalmierProTests/Media/MediaPanelTests.swift
@@ -632,14 +632,32 @@ struct MediaPanelInteractionTests {
     }
 
     @Test func orderIncludesVisibleSectionsAndDeduplicatesAssets() {
-        let ids = MediaTab.searchOrderedAssetIds(
+        let timelineKey = MediaPanelItemKey.timeline("tl-1")
+        let ids = MediaTab.searchOrderedItemIds(
             momentAssetIds: ["moment", "shared"],
             spokenAssetIds: ["spoken", "shared"],
+            timelineItemIds: [timelineKey],
             fileAssetIds: ["file", "shared"],
             collapsedSectionTitles: ["Spoken"]
         )
 
-        #expect(ids == ["moment", "shared", "file"])
+        #expect(ids == ["moment", "shared", timelineKey, "file"])
+    }
+
+    @Test func timelinesMatchingNameFiltersCaseInsensitively() {
+        let interview = Timeline(name: "Interview Cut")
+        let broll = Timeline(name: "B-Roll")
+        let coldOpen = Timeline(name: "Cold Open")
+
+        let matches = MediaTab.timelinesMatchingName(
+            [interview, broll, coldOpen],
+            query: " cut "
+        )
+
+        #expect(matches.map(\.id) == [interview.id])
+        #expect(MediaTab.timelinesMatchingName([interview, broll], query: "B-ROLL").map(\.id) == [broll.id])
+        #expect(MediaTab.timelinesMatchingName([interview], query: "   ").map(\.id) == [interview.id])
+        #expect(MediaTab.timelinesMatchingName([interview, broll], query: "missing").isEmpty)
     }
 
     @Test func creationSelectsAndRevealsFolderAndRestoresSelectionOnUndo() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Media panel search previously switched to Moments / Spoken / Files and never listed timelines, even though name filtering already existed for grid modes. Typing a timeline name in the search bar now returns matching timelines.

## Approach

- Reuse `searchFilteredTimelines` (via a shared `timelinesMatchingName` helper) so search uses the same case-insensitive name match as folder/flat grids.
- Add a **Timelines** section in `searchResults`, placed after Spoken and before Files, rendering the existing `TimelineTileView` for open / rename / duplicate / delete.
- Include timeline panel item keys in search keyboard/selection ordering.
- Empty state only shows when Moments, Spoken, Timelines, and Files are all empty.

## Testing

**Automated (written, not run here):**
- `MediaTab.timelinesMatchingName` — case-insensitive match, whitespace-only query returns all, no-match empty
- `MediaTab.searchOrderedItemIds` — timelines appear between Spoken and Files; collapsed Spoken still omitted

This environment is Linux without Swift/toolchain, so `swift build`, `swift test`, and `scripts/localization/sync.sh` were not run. CI should cover build/tests; run locally if needed:

```bash
swift test --filter MediaPanelInteractionTests
swift build
```

**Manual UI:**
1. Open a project with multiple named timelines (and optionally media whose names overlap).
2. In the media panel search bar, type part of a timeline name.
3. Expect a Timelines section with matching tiles; open / rename / select should work as in the grid.
4. Confirm Moments / Spoken / Files still appear when they match.
5. Clear search and confirm normal folder/flat/grouped browsing is unchanged.
6. Search for a string that matches only a timeline — empty Moments/Spoken/Files should not show “No matches”.

## Change statistics

- Code logic: ~+35 / −8 across MediaTab search/grids
- Tests: ~+20 / −2
- Localization: +1 English key (`Timelines`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc55026c-5075-42d2-9eed-631b54f704f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc55026c-5075-42d2-9eed-631b54f704f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

