### PR TITLE
[fix] Preserve text visuals across preview rebuilds

### DIFF
--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -28,6 +28,7 @@ final class VideoEngine {
     private var playbackEndObserver: NSObjectProtocol?
     private(set) var rebuildTask: Task<Void, Never>?
     private var rebuildGeneration = 0
+    private var visualRefreshGeneration = 0
     private(set) var sourcePreviewTask: Task<Void, Never>?
     private var sourcePreviewGeneration = 0
     private var sourceTrackStart: CMTime = .zero
@@ -285,9 +286,15 @@ final class VideoEngine {
         let missingMediaRefs: Set<String>
     }
 
+    private typealias CompositionVisuals = (
+        audioMix: AVMutableAudioMix,
+        videoComposition: AVVideoComposition
+    )
+
     func rebuild(visualsCurrent: Bool = false) {
         guard let editor, editor.activePreviewTab == .timeline else { return }
         let generation = invalidateRebuild()
+        let startingVisualRefreshGeneration = visualRefreshGeneration
 
         let mediaURLs = editor.mediaResolver.expectedURLMap()
         let missingMediaRefs = editor.missingMediaRefs
@@ -341,15 +348,35 @@ final class VideoEngine {
                 return
             }
 
-            guard generation == rebuildGeneration else { return }
-            rebuildTask = nil
-            guard !Task.isCancelled else { return }
+            guard generation == rebuildGeneration,
+                  !Task.isCancelled,
+                  editor.activePreviewTab == .timeline,
+                  editor.timeline.id == timelineId else { return }
 
+            let useCurrentVisuals = startingVisualRefreshGeneration != visualRefreshGeneration
+            let appliedTimelineResolver = useCurrentVisuals ? editor.timelineResolver() : resolveTimeline
+            let correctiveVisuals = useCurrentVisuals
+                ? CompositionBuilder.buildVisuals(
+                    timeline: editor.timeline,
+                    trackMappings: result.trackMappings,
+                    clipNaturalSizes: result.clipNaturalSizes,
+                    clipTransforms: result.clipTransforms,
+                    resolveTimeline: appliedTimelineResolver,
+                    compositionDuration: result.composition.duration,
+                    renderSize: CGSize(width: editor.timeline.width, height: editor.timeline.height)
+                )
+                : nil
+
+            rebuildTask = nil
             if result.offlineMediaRefs.isEmpty && result.unprocessableMediaRefs.isEmpty {
                 compositionCache[timelineId] = (inputs, result)
             }
             compositionCache = compositionCache.filter { editor.openTimelineIds.contains($0.key) }
-            apply(result, editor: editor)
+            apply(
+                result,
+                editor: editor,
+                visuals: correctiveVisuals
+            )
         }
     }
 
@@ -367,7 +394,11 @@ final class VideoEngine {
         compositionCache.removeValue(forKey: timelineId)
     }
 
-    private func apply(_ result: CompositionResult, editor: EditorViewModel) {
+    private func apply(
+        _ result: CompositionResult,
+        editor: EditorViewModel,
+        visuals: CompositionVisuals? = nil
+    ) {
         trackMappings = result.trackMappings
         clipNaturalSizes = result.clipNaturalSizes
         clipTransforms = result.clipTransforms
@@ -375,9 +406,13 @@ final class VideoEngine {
         editor.offlineMediaRefs = result.offlineMediaRefs
         editor.unprocessableMediaRefs = result.unprocessableMediaRefs
 
+        let appliedVisuals = visuals ?? (
+            audioMix: result.audioMix,
+            videoComposition: result.videoComposition
+        )
         let item = AVPlayerItem(asset: result.composition)
-        item.audioMix = result.audioMix
-        item.videoComposition = result.videoComposition
+        item.audioMix = appliedVisuals.audioMix
+        item.videoComposition = appliedVisuals.videoComposition
         replacePlayerItem(item, reason: "rebuild")
 
         seek(to: editor.currentFrame, mode: .exact)
@@ -385,6 +420,7 @@ final class VideoEngine {
     }
 
     func refreshVisuals() {
+        visualRefreshGeneration &+= 1
         guard let editor, editor.activePreviewTab == .timeline,
               let currentItem = player.currentItem,
               !trackMappings.isEmpty else {

--- a/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
@@ -137,6 +137,17 @@ struct TextClipPlaybackTests {
         #expect(playerBackground.enabled == editorBackground.enabled)
         #expect(playerBackground.paddingX == editorBackground.paddingX)
         #expect(playerBackground.paddingY == editorBackground.paddingY)
+
+        engine.player.replaceCurrentItem(with: AVPlayerItem(asset: AVMutableComposition()))
+        engine.rebuild()
+        #expect(engine.rebuildTask == nil)
+
+        let cacheHitPlayerClip = try self.playerClip(id: text.id, engine: engine)
+        let cacheHitBackground = try #require(cacheHitPlayerClip.textStyle).background
+        #expect(cacheHitPlayerClip.textFillMode == editorClip.textFillMode)
+        #expect(cacheHitBackground.enabled == editorBackground.enabled)
+        #expect(cacheHitBackground.paddingX == editorBackground.paddingX)
+        #expect(cacheHitBackground.paddingY == editorBackground.paddingY)
     }
 
     private func playerClip(id: String, engine: VideoEngine) throws -> Clip {

--- a/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextClipPlaybackTests.swift
@@ -76,4 +76,74 @@ struct TextClipPlaybackTests {
             instruction.layers.contains { $0.clip.id == addedClipId }
         })
     }
+
+    @Test func rebuildCompletionPreservesNewerTextVisuals() async throws {
+        var text = Fixtures.clip(
+            id: "race-text",
+            mediaRef: "",
+            mediaType: .text,
+            start: 0,
+            duration: 60
+        )
+        text.textContent = "RACE"
+        text.textStyle = TextStyle()
+
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(
+            fps: 30,
+            tracks: [Fixtures.videoTrack(clips: [text])]
+        )
+        editor.timeline.width = 64
+        editor.timeline.height = 64
+
+        let engine = VideoEngine(editor: editor)
+        editor.videoEngine = engine
+        let executor = ToolExecutor(editor: editor)
+        defer {
+            engine.teardown()
+            editor.videoEngine = nil
+        }
+
+        engine.rebuild()
+        try await #require(engine.rebuildTask).value
+
+        editor.timeline.tracks[0].clips[0].durationFrames = 61
+        engine.rebuild()
+        let rebuildTask = try #require(engine.rebuildTask)
+
+        let updateResult = try executor.updateText(editor, [
+            "clipIds": [text.id],
+            "fillMode": "footage",
+            "style": [
+                "background": [
+                    "enabled": true,
+                    "padding": ["x": 37.0, "y": 19.0],
+                ],
+            ],
+        ])
+        #expect(updateResult.isError == false)
+
+        await rebuildTask.value
+
+        let editorClip = try #require(editor.clipFor(id: text.id))
+        let playerClip = try playerClip(id: text.id, engine: engine)
+        let editorBackground = try #require(editorClip.textStyle).background
+        let playerBackground = try #require(playerClip.textStyle).background
+        #expect(editorClip.textFillMode == .footage)
+        #expect(editorBackground.enabled)
+        #expect(editorBackground.paddingX == 37)
+        #expect(editorBackground.paddingY == 19)
+        #expect(playerClip.textFillMode == editorClip.textFillMode)
+        #expect(playerBackground.enabled == editorBackground.enabled)
+        #expect(playerBackground.paddingX == editorBackground.paddingX)
+        #expect(playerBackground.paddingY == editorBackground.paddingY)
+    }
+
+    private func playerClip(id: String, engine: VideoEngine) throws -> Clip {
+        let videoComposition = try #require(engine.player.currentItem?.videoComposition)
+        let instructions = videoComposition.instructions.compactMap { $0 as? CompositorInstruction }
+        return try #require(
+            instructions.lazy.flatMap(\.layers).first(where: { $0.clip.id == id })?.clip
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Prevent an asynchronous preview rebuild from overwriting newer text styling applied through `update_text` or the inspector.
- Keep footage fill, background, and layout-affecting text changes visible without requiring a follow-up inspector adjustment.
- Preserve the caption-only rebuild cache path added on `main` while fixing cache-miss rebuild completion.

## Approach

- Track a visual refresh generation alongside the existing full-rebuild generation.
- When a cache-miss rebuild completes, verify cancellation, active timeline identity, and preview-tab state.
- If visuals changed after the rebuild snapshot, regenerate visual instructions once from the current timeline using the completed structural mappings.
- Install one player item and perform one seek; the correction is bounded and cannot retry indefinitely.
- Keep cache-hit behavior unchanged: text-only edits continue to reuse the existing composition and refresh visuals directly.

A full rebuild restart was rejected because it measured about 3.1 seconds on the 3,367-clip `heavybit` project. An asynchronous retry loop was also rejected because continuous edits could prevent convergence. The bounded corrective visual pass measured approximately 21–24 ms on that project and runs only when a visual edit overlaps a cache-miss rebuild.

## Testing

- [x] `swift test --filter TextClipPlaybackTests` — 2 tests passed.
- [x] Cache-hit reapply regression — replacing the current item and rebuilding from cache preserves current fill and background visuals.
- [x] `swift test` — 1,415 tests passed in 224 suites on rerun; the first run hit an unrelated `FrameSamplerTests` flake that passed alone.
- [x] `swift build` — passed.
- [x] Release MCP reproduction on the bounded implementation: on a 100-clip isolated project, start a full rebuild and immediately change text from a red background to a green background with 120×60 padding; the green result appeared without inspector interaction.
- [x] Unfixed release control: the same request returned success while the preview remained stale; a second one-point padding adjustment made the style appear.
- [ ] Repeat the release MCP smoke after rebasing onto the current caption-cache implementation before marking ready.

## Change statistics

- Code logic: +43 / −7
- Tests: +81 / −0
- Total: +124 / −7