### PR TITLE
[feat] Preview community skills before install

### DIFF
--- a/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
@@ -37,7 +37,6 @@ final class SkillCatalog {
 
     static func bodyURL(path: String) -> URL? { URL(string: "\(base)/\(path)") }
 
-    /// Fetches SKILL.md body; rejects skills missing the same required frontmatter as install.
     static func fetchBody(path: String) async throws -> String {
         try await fetchBody(from: bodyURL(path: path))
     }

--- a/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 /// One entry in the published catalog.json. `sha` is a content hash of the SKILL.md
 /// and is the version anchor: a changed sha means an update is available.
@@ -8,6 +9,25 @@ struct SkillCatalogEntry: Codable, Identifiable, Sendable {
     let description: String
     let sha: String
     let path: String
+
+    var version: SkillCatalogVersion {
+        SkillCatalogVersion(path: path, sha: sha)
+    }
+}
+
+struct SkillCatalogVersion: Hashable, Sendable {
+    let path: String
+    let sha: String
+}
+
+struct SkillCatalogDocument: Sendable {
+    let version: SkillCatalogVersion
+    let data: Data
+    let body: String
+
+    func matches(_ entry: SkillCatalogEntry) -> Bool {
+        version == entry.version
+    }
 }
 
 /// Fetches the community skill catalog from the palmier-skills repo (raw GitHub CDN)
@@ -37,20 +57,34 @@ final class SkillCatalog {
 
     static func bodyURL(path: String) -> URL? { URL(string: "\(base)/\(path)") }
 
-    static func fetchBody(path: String) async throws -> String {
-        try await fetchBody(from: bodyURL(path: path))
+    static func fetchDocument(for entry: SkillCatalogEntry) async throws -> SkillCatalogDocument {
+        try await fetchDocument(from: bodyURL(path: entry.path), entry: entry)
     }
 
-    static func fetchBody(from url: URL?) async throws -> String {
+    static func fetchDocument(
+        from url: URL?,
+        entry: SkillCatalogEntry
+    ) async throws -> SkillCatalogDocument {
         guard let url else { throw URLError(.badURL) }
         let data = try await fetch(url)
+        guard contentSHA(data) == entry.sha else {
+            throw URLError(.cannotParseResponse)
+        }
         guard let text = String(data: data, encoding: .utf8) else {
             throw URLError(.cannotDecodeContentData)
         }
         guard let parsed = SkillFrontmatter.requiredFields(text) else {
             throw URLError(.cannotParseResponse)
         }
-        return parsed.body
+        return SkillCatalogDocument(
+            version: entry.version,
+            data: data,
+            body: parsed.body
+        )
+    }
+
+    nonisolated static func contentSHA(_ data: Data) -> String {
+        String(SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined().prefix(12))
     }
 
     private func loadCache() {

--- a/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillCatalog.swift
@@ -37,6 +37,23 @@ final class SkillCatalog {
 
     static func bodyURL(path: String) -> URL? { URL(string: "\(base)/\(path)") }
 
+    /// Fetches SKILL.md body; rejects skills missing the same required frontmatter as install.
+    static func fetchBody(path: String) async throws -> String {
+        try await fetchBody(from: bodyURL(path: path))
+    }
+
+    static func fetchBody(from url: URL?) async throws -> String {
+        guard let url else { throw URLError(.badURL) }
+        let data = try await fetch(url)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw URLError(.cannotDecodeContentData)
+        }
+        guard let parsed = SkillFrontmatter.requiredFields(text) else {
+            throw URLError(.cannotParseResponse)
+        }
+        return parsed.body
+    }
+
     private func loadCache() {
         guard let data = try? Data(contentsOf: Self.cacheURL),
               let decoded = try? JSONDecoder().decode([SkillCatalogEntry].self, from: data)

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import AppKit
-import CryptoKit
 
 /// External coding agents that read the same SKILL.md format from their own folders.
 enum SkillExternalAgent: String, CaseIterable, Sendable {
@@ -92,7 +91,7 @@ final class SkillStore {
         return ParsedSkill(
             skill: Skill(id: id, name: parsed.name, description: parsed.description, path: path),
             body: parsed.body,
-            sha: sha12(Data(text.utf8))
+            sha: SkillCatalog.contentSHA(Data(text.utf8))
         )
     }
 
@@ -121,24 +120,37 @@ final class SkillStore {
 
     @discardableResult
     func install(_ entry: SkillCatalogEntry) async -> Bool {
-        guard let url = SkillCatalog.bodyURL(path: entry.path) else { return false }
-        guard let dir = Self.skillDirectory(for: entry.id) else {
-            Log.agent.error("install skill \(entry.id) rejected: invalid id")
+        do {
+            let document = try await SkillCatalog.fetchDocument(for: entry)
+            guard !Task.isCancelled else { return false }
+            return install(entry, document: document)
+        } catch {
+            Log.agent.error("install skill \(entry.id) failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    @discardableResult
+    func install(_ entry: SkillCatalogEntry, document: SkillCatalogDocument) -> Bool {
+        guard document.matches(entry),
+              SkillCatalog.contentSHA(document.data) == entry.sha,
+              let dir = Self.skillDirectory(for: entry.id)
+        else {
+            Log.agent.error("install skill \(entry.id) rejected: catalog content mismatch")
+            return false
+        }
+        guard let text = String(data: document.data, encoding: .utf8) else {
+            Log.agent.error("install skill \(entry.id) rejected: invalid UTF-8")
+            return false
+        }
+        let md = dir.appendingPathComponent("SKILL.md")
+        guard Self.parseSkill(id: entry.id, path: md, text: text) != nil else {
+            Log.agent.error("install skill \(entry.id) rejected: missing name or description frontmatter")
             return false
         }
         do {
-            let data = try await SkillCatalog.fetch(url)
-            guard let text = String(data: data, encoding: .utf8) else {
-                Log.agent.error("install skill \(entry.id) rejected: invalid UTF-8")
-                return false
-            }
-            let md = dir.appendingPathComponent("SKILL.md")
-            guard Self.parseSkill(id: entry.id, path: md, text: text) != nil else {
-                Log.agent.error("install skill \(entry.id) rejected: missing name or description frontmatter")
-                return false
-            }
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try data.write(to: md)
+            try document.data.write(to: md)
             reload()
             guard skills.contains(where: { $0.id == entry.id }) else {
                 try? FileManager.default.removeItem(at: dir)
@@ -172,10 +184,6 @@ final class SkillStore {
         let root = directory.standardizedFileURL.path
         let path = url.standardizedFileURL.path
         return path == root || path.hasPrefix(root + "/")
-    }
-
-    nonisolated private static func sha12(_ data: Data) -> String {
-        String(SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined().prefix(12))
     }
 
     private static func loadLedger() -> [String: String] {

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -18,12 +18,18 @@ struct SkillDetailSheet: View {
     @State private var copyToast: CopyToast?
     @State private var showingSaveError = false
     @State private var failedExit: ExitAction?
-    @State private var remoteBody: String?
-    @State private var bodyLoadFailed = false
+    @State private var remoteDocument: SkillCatalogDocument?
+    @State private var remoteLoadError: RemoteLoadError?
+    @State private var failedInstallVersion: SkillCatalogVersion?
     @FocusState private var titleFocused: Bool
 
     private enum ExitAction {
         case close, preview
+    }
+
+    private struct RemoteLoadError {
+        let version: SkillCatalogVersion
+        let message: String
     }
 
     private struct CopyToast: Equatable {
@@ -141,16 +147,23 @@ struct SkillDetailSheet: View {
 
             ScrollView {
                 Group {
-                    if let remoteBody {
-                        viewContent(description: entry.description, instructions: remoteBody)
-                    } else if bodyLoadFailed {
-                        SkillEmptyState(
-                            systemName: "exclamationmark.triangle",
-                            title: L10n.string("Skill unavailable."),
-                            message: entry.description,
-                            actionTitle: L10n.string("Try Again"),
-                            action: { Task { await loadRemoteBody(entry) } }
-                        )
+                    if let document = remoteDocument(for: entry) {
+                        viewContent(description: entry.description, instructions: document.body)
+                    } else if let message = remoteLoadError(for: entry) {
+                        VStack(spacing: AppTheme.Spacing.smMd) {
+                            Text(verbatim: message)
+                                .font(.system(size: AppTheme.FontSize.sm))
+                                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                                .multilineTextAlignment(.center)
+                            Button(L10n.string("Try Again")) {
+                                Task { await loadRemoteDocument(entry) }
+                            }
+                            .buttonStyle(.capsule(
+                                .secondary,
+                                fill: AnyShapeStyle(AppTheme.Background.raisedColor)
+                            ))
+                        }
+                        .frame(maxWidth: .infinity)
                     } else {
                         ProgressView()
                             .controlSize(.small)
@@ -170,8 +183,8 @@ struct SkillDetailSheet: View {
         .frame(width: AppTheme.Settings.skillDetailWidth)
         .frame(minHeight: AppTheme.Settings.skillDetailMinHeight)
         .background(AppTheme.Background.prominentColor)
-        .task(id: "\(entry.path)\0\(entry.sha)") {
-            await loadRemoteBody(entry)
+        .task(id: entry.version) {
+            await loadRemoteDocument(entry)
         }
     }
 
@@ -193,14 +206,20 @@ struct SkillDetailSheet: View {
 
                 Spacer(minLength: AppTheme.Spacing.md)
 
+                if failedInstallVersion == entry.version {
+                    Text(L10n.string("Failed"))
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(AppTheme.Status.errorColor)
+                }
+
                 if isInstalling {
                     ProgressView()
                         .controlSize(.small)
                         .accessibilityLabel(L10n.string("Working on \(entry.name)"))
                 } else {
-                    Button(L10n.string("Install")) { install(entry) }
+                    Button(L10n.string("Install")) { installPreview() }
                         .buttonStyle(.capsule(.prominent))
-                        .disabled(remoteBody == nil)
+                        .disabled(remoteDocument(for: entry) == nil)
                 }
             }
         }
@@ -353,34 +372,61 @@ struct SkillDetailSheet: View {
         }
     }
 
-    private func install(_ entry: SkillCatalogEntry) {
-        guard !isInstalling else { return }
+    private func installPreview() {
+        guard !isInstalling,
+              let entry = resolvedCatalogEntry,
+              let document = remoteDocument(for: entry)
+        else { return }
+        failedInstallVersion = nil
         isInstalling = true
         Task {
-            _ = await store.install(entry)
+            guard isCurrentPreview(entry) else {
+                isInstalling = false
+                return
+            }
+            let installed = store.install(entry, document: document)
+            if !installed, isCurrentPreview(entry) {
+                failedInstallVersion = entry.version
+            }
             isInstalling = false
         }
     }
 
-    private func loadRemoteBody(_ entry: SkillCatalogEntry) async {
-        bodyLoadFailed = false
-        remoteBody = nil
+    private func loadRemoteDocument(_ entry: SkillCatalogEntry) async {
+        let version = entry.version
+        if isCurrentPreview(entry) {
+            remoteLoadError = nil
+            remoteDocument = nil
+        }
         do {
-            let body = try await SkillCatalog.fetchBody(path: entry.path)
+            let document = try await SkillCatalog.fetchDocument(for: entry)
             guard !Task.isCancelled, isCurrentPreview(entry) else { return }
-            remoteBody = body
+            remoteDocument = document
         } catch is CancellationError {
             return
         } catch {
             guard !Task.isCancelled, isCurrentPreview(entry) else { return }
-            bodyLoadFailed = true
+            remoteLoadError = RemoteLoadError(
+                version: version,
+                message: error.localizedDescription
+            )
             Log.agent.error("skill preview load failed (\(entry.id)): \(error.localizedDescription)")
         }
     }
 
+    private func remoteDocument(for entry: SkillCatalogEntry) -> SkillCatalogDocument? {
+        guard let remoteDocument, remoteDocument.matches(entry) else { return nil }
+        return remoteDocument
+    }
+
+    private func remoteLoadError(for entry: SkillCatalogEntry) -> String? {
+        guard remoteLoadError?.version == entry.version else { return nil }
+        return remoteLoadError?.message
+    }
+
     private func isCurrentPreview(_ entry: SkillCatalogEntry) -> Bool {
         guard let current = resolvedCatalogEntry else { return false }
-        return current.path == entry.path && current.sha == entry.sha
+        return current.version == entry.version
     }
 
     @discardableResult

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SkillDetailSheet: View {
     let skillID: String
+    var catalogEntry: SkillCatalogEntry? = nil
 
     @Bindable private var store = SkillStore.shared
     @Bindable private var catalog = SkillCatalog.shared
@@ -11,11 +12,14 @@ struct SkillDetailSheet: View {
     @State private var originalDraft = ""
     @State private var confirmingDelete = false
     @State private var isUpdating = false
+    @State private var isInstalling = false
     @State private var editingTitle = false
     @State private var draftTitle = ""
     @State private var copyToast: CopyToast?
     @State private var showingSaveError = false
     @State private var failedExit: ExitAction?
+    @State private var remoteBody: String?
+    @State private var bodyLoadFailed = false
     @FocusState private var titleFocused: Bool
 
     private enum ExitAction {
@@ -35,6 +39,10 @@ struct SkillDetailSheet: View {
         store.skills.first { $0.id == skillID }
     }
 
+    private var resolvedCatalogEntry: SkillCatalogEntry? {
+        catalog.entry(id: skillID) ?? catalogEntry
+    }
+
     private var deleteTitle: String {
         guard let skill else { return L10n.string("Delete skill?") }
         return L10n.string("Delete \u{201C}\(skill.name)\u{201D}?")
@@ -44,6 +52,8 @@ struct SkillDetailSheet: View {
         Group {
             if let skill {
                 content(skill)
+            } else if let entry = resolvedCatalogEntry {
+                previewContent(entry)
             } else {
                 Text(L10n.string("Skill unavailable."))
                     .font(.system(size: AppTheme.FontSize.sm))
@@ -84,8 +94,11 @@ struct SkillDetailSheet: View {
                 editContent
             } else {
                 ScrollView {
-                    viewContent(skill)
-                        .padding(AppTheme.Spacing.xlXxl)
+                    viewContent(
+                        description: skill.description,
+                        instructions: store.body(for: skill.id) ?? ""
+                    )
+                    .padding(AppTheme.Spacing.xlXxl)
                 }
                 .scrollEdgeEffectStyle(.soft, for: .top)
                 .themedSurface(AppTheme.Background.raisedColor, cornerRadius: AppTheme.Radius.md)
@@ -119,6 +132,82 @@ struct SkillDetailSheet: View {
         } message: { skill in
             Text(L10n.string("This permanently removes \(displayPath(skill))."))
         }
+    }
+
+    /// Same layout as `content`, for an uninstalled catalog entry: no edit
+    /// controls, Install in the header, instructions fetched from the catalog.
+    private func previewContent(_ entry: SkillCatalogEntry) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
+            previewHeader(entry)
+            Divider().overlay(AppTheme.Border.subtleColor)
+
+            ScrollView {
+                Group {
+                    if let remoteBody {
+                        viewContent(description: entry.description, instructions: remoteBody)
+                    } else if bodyLoadFailed {
+                        SkillEmptyState(
+                            systemName: "exclamationmark.triangle",
+                            title: L10n.string("Skill unavailable."),
+                            message: entry.description,
+                            actionTitle: L10n.string("Try Again"),
+                            action: { Task { await loadRemoteBody(entry) } }
+                        )
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(maxWidth: .infinity)
+                            .accessibilityLabel(L10n.string("Loading community skills"))
+                    }
+                }
+                .padding(AppTheme.Spacing.xlXxl)
+            }
+            .scrollEdgeEffectStyle(.soft, for: .top)
+            .themedSurface(AppTheme.Background.raisedColor, cornerRadius: AppTheme.Radius.md)
+            .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md, style: .continuous))
+            .padding(.horizontal, AppTheme.Spacing.xlXxl)
+            .padding(.top, AppTheme.Spacing.mdLg)
+            .padding(.bottom, AppTheme.Spacing.xlXxl)
+        }
+        .frame(width: AppTheme.Settings.skillDetailWidth)
+        .frame(minHeight: AppTheme.Settings.skillDetailMinHeight)
+        .background(AppTheme.Background.prominentColor)
+        .task(id: "\(entry.path)\0\(entry.sha)") {
+            await loadRemoteBody(entry)
+        }
+    }
+
+    private func previewHeader(_ entry: SkillCatalogEntry) -> some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            HStack(spacing: AppTheme.Spacing.md) {
+                Text(entry.name)
+                    .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.regular))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .lineLimit(1)
+                Spacer(minLength: AppTheme.Spacing.md)
+                closeButton
+            }
+
+            HStack(spacing: AppTheme.Spacing.smMd) {
+                Text(L10n.string("Available"))
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+
+                Spacer(minLength: AppTheme.Spacing.md)
+
+                if isInstalling {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel(L10n.string("Working on \(entry.name)"))
+                } else {
+                    Button(L10n.string("Install")) { install(entry) }
+                        .buttonStyle(.capsule(.prominent))
+                        .disabled(remoteBody == nil)
+                }
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.xlXxl)
+        .padding(.vertical, AppTheme.Spacing.mdLg)
     }
 
     private func header(_ skill: Skill) -> some View {
@@ -266,6 +355,36 @@ struct SkillDetailSheet: View {
         }
     }
 
+    private func install(_ entry: SkillCatalogEntry) {
+        guard !isInstalling else { return }
+        isInstalling = true
+        Task {
+            _ = await store.install(entry)
+            isInstalling = false
+        }
+    }
+
+    private func loadRemoteBody(_ entry: SkillCatalogEntry) async {
+        bodyLoadFailed = false
+        remoteBody = nil
+        do {
+            let body = try await SkillCatalog.fetchBody(path: entry.path)
+            guard !Task.isCancelled, isCurrentPreview(entry) else { return }
+            remoteBody = body
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled, isCurrentPreview(entry) else { return }
+            bodyLoadFailed = true
+            Log.agent.error("skill preview load failed (\(entry.id)): \(error.localizedDescription)")
+        }
+    }
+
+    private func isCurrentPreview(_ entry: SkillCatalogEntry) -> Bool {
+        guard let current = resolvedCatalogEntry else { return false }
+        return current.path == entry.path && current.sha == entry.sha
+    }
+
     @discardableResult
     private func commitDraftIfDirty(onFailure exit: ExitAction? = nil) -> Bool {
         guard draft != originalDraft else { return true }
@@ -322,13 +441,13 @@ struct SkillDetailSheet: View {
             .replacingOccurrences(of: NSHomeDirectory(), with: "~")
     }
 
-    private func viewContent(_ skill: Skill) -> some View {
+    private func viewContent(description: String, instructions: String) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.xl) {
             VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
                 Text(L10n.string("Description"))
                     .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.regular))
                     .foregroundStyle(AppTheme.Text.primaryColor)
-                Text(skill.description)
+                Text(description)
                     .font(.system(size: AppTheme.FontSize.smMd))
                     .foregroundStyle(AppTheme.Text.secondaryColor)
                     .fixedSize(horizontal: false, vertical: true)
@@ -341,7 +460,7 @@ struct SkillDetailSheet: View {
                     .font(.system(size: AppTheme.FontSize.smMd, weight: AppTheme.FontWeight.regular))
                     .foregroundStyle(AppTheme.Text.primaryColor)
                 MarkdownText(
-                    text: store.body(for: skill.id) ?? "",
+                    text: instructions,
                     proseFont: .system(size: AppTheme.FontSize.smMd),
                     blockSpacing: AppTheme.Spacing.sm
                 )

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -134,8 +134,6 @@ struct SkillDetailSheet: View {
         }
     }
 
-    /// Same layout as `content`, for an uninstalled catalog entry: no edit
-    /// controls, Install in the header, instructions fetched from the catalog.
     private func previewContent(_ entry: SkillCatalogEntry) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
             previewHeader(entry)

--- a/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
@@ -22,6 +22,7 @@ struct SkillsPane: View {
 
     private struct PresentedSkill: Identifiable {
         let id: String
+        var catalogEntry: SkillCatalogEntry?
     }
 
     private var installedSkills: [Skill] {
@@ -54,7 +55,7 @@ struct SkillsPane: View {
             Task { await catalog.refresh() }
         }
         .sheet(item: $presentedSkill) { item in
-            SkillDetailSheet(skillID: item.id)
+            SkillDetailSheet(skillID: item.id, catalogEntry: item.catalogEntry)
         }
     }
 
@@ -268,8 +269,12 @@ struct SkillsPane: View {
                 : state == .update ? L10n.string("Update") : L10n.string("Open"),
             primaryAction: skill == nil,
             working: working.contains(entry.id),
-            summaryAction: skill.map { installedSkill in
-                { present(installedSkill.id) }
+            summaryAction: {
+                if skill != nil {
+                    present(entry.id)
+                } else {
+                    present(entry)
+                }
             },
             action: {
                 if let skill {
@@ -319,5 +324,9 @@ struct SkillsPane: View {
 
     private func present(_ id: String) {
         presentedSkill = PresentedSkill(id: id)
+    }
+
+    private func present(_ entry: SkillCatalogEntry) {
+        presentedSkill = PresentedSkill(id: entry.id, catalogEntry: entry)
     }
 }

--- a/Tests/PalmierProTests/Agent/SkillCatalogBodyTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillCatalogBodyTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("Skill catalog body")
 struct SkillCatalogBodyTests {
-    @Test func fetchBodyStripsFrontmatterFromLocalFile() async throws {
+    @Test func fetchDocumentStripsFrontmatterFromLocalFile() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("palmier-skills-preview-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -22,29 +22,40 @@ struct SkillCatalogBodyTests {
             """
         let url = root.appendingPathComponent("SKILL.md")
         try markdown.write(to: url, atomically: true, encoding: .utf8)
+        let data = Data(markdown.utf8)
 
-        let body = try await SkillCatalog.fetchBody(from: url)
-        #expect(body.contains("## Steps"))
-        #expect(body.contains("Install when ready."))
-        #expect(!body.contains("name: Demo Skill"))
-        #expect(!body.hasPrefix("---"))
+        let document = try await SkillCatalog.fetchDocument(
+            from: url,
+            entry: entry(path: "skills/demo/SKILL.md", sha: SkillCatalog.contentSHA(data))
+        )
+
+        #expect(document.body.contains("## Steps"))
+        #expect(document.body.contains("Install when ready."))
+        #expect(!document.body.contains("name: Demo Skill"))
+        #expect(!document.body.hasPrefix("---"))
     }
 
-    @Test func fetchBodyRejectsMissingFile() async {
+    @Test func fetchDocumentRejectsMissingFile() async {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("palmier-skills-missing-\(UUID().uuidString).md")
         await #expect(throws: (any Error).self) {
-            _ = try await SkillCatalog.fetchBody(from: url)
+            _ = try await SkillCatalog.fetchDocument(
+                from: url,
+                entry: entry(path: "skills/demo/SKILL.md", sha: "missing")
+            )
         }
     }
 
-    @Test func fetchBodyRejectsNilURL() async {
+    @Test func fetchDocumentRejectsNilURL() async {
         await #expect(throws: URLError.self) {
-            _ = try await SkillCatalog.fetchBody(from: nil)
+            _ = try await SkillCatalog.fetchDocument(
+                from: nil,
+                entry: entry(path: "skills/demo/SKILL.md", sha: "missing")
+            )
         }
     }
 
-    @Test func fetchBodyRejectsMissingRequiredFrontmatter() async throws {
+    @Test func fetchDocumentRejectsMissingRequiredFrontmatter() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("palmier-skills-invalid-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -59,9 +70,70 @@ struct SkillCatalogBodyTests {
             """
         let url = root.appendingPathComponent("SKILL.md")
         try markdown.write(to: url, atomically: true, encoding: .utf8)
+        let data = Data(markdown.utf8)
 
         await #expect(throws: URLError.self) {
-            _ = try await SkillCatalog.fetchBody(from: url)
+            _ = try await SkillCatalog.fetchDocument(
+                from: url,
+                entry: entry(path: "skills/demo/SKILL.md", sha: SkillCatalog.contentSHA(data))
+            )
         }
+    }
+
+    @Test func fetchedDocumentMatchesOnlyItsCatalogVersion() async throws {
+        let markdown = """
+            ---
+            name: Demo Skill
+            description: Preview before install.
+            ---
+
+            ## Steps
+            Read the skill.
+            """
+        let data = Data(markdown.utf8)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skills-document-\(UUID().uuidString).md")
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let entry = entry(path: "skills/demo/SKILL.md", sha: SkillCatalog.contentSHA(data))
+
+        let document = try await SkillCatalog.fetchDocument(from: url, entry: entry)
+
+        #expect(document.matches(entry))
+        #expect(!document.matches(self.entry(path: "skills/demo-v2/SKILL.md", sha: entry.sha)))
+        #expect(!document.matches(self.entry(path: entry.path, sha: "new-version")))
+        #expect(document.body.contains("Read the skill."))
+    }
+
+    @Test func fetchDocumentRejectsContentThatDoesNotMatchCatalogSHA() async throws {
+        let markdown = """
+            ---
+            name: Demo Skill
+            description: Preview before install.
+            ---
+
+            Body
+            """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skills-mismatch-\(UUID().uuidString).md")
+        try markdown.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: URLError.self) {
+            _ = try await SkillCatalog.fetchDocument(
+                from: url,
+                entry: entry(path: "skills/demo/SKILL.md", sha: "stale-sha")
+            )
+        }
+    }
+
+    private func entry(path: String, sha: String) -> SkillCatalogEntry {
+        SkillCatalogEntry(
+            id: "demo",
+            name: "Demo Skill",
+            description: "Preview before install.",
+            sha: sha,
+            path: path
+        )
     }
 }

--- a/Tests/PalmierProTests/Agent/SkillCatalogBodyTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillCatalogBodyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Skill catalog body")
+struct SkillCatalogBodyTests {
+    @Test func fetchBodyStripsFrontmatterFromLocalFile() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skills-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdown = """
+            ---
+            name: Demo Skill
+            description: Preview before install.
+            ---
+
+            ## Steps
+            1. Read the skill.
+            2. Install when ready.
+            """
+        let url = root.appendingPathComponent("SKILL.md")
+        try markdown.write(to: url, atomically: true, encoding: .utf8)
+
+        let body = try await SkillCatalog.fetchBody(from: url)
+        #expect(body.contains("## Steps"))
+        #expect(body.contains("Install when ready."))
+        #expect(!body.contains("name: Demo Skill"))
+        #expect(!body.hasPrefix("---"))
+    }
+
+    @Test func fetchBodyRejectsMissingFile() async {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skills-missing-\(UUID().uuidString).md")
+        await #expect(throws: (any Error).self) {
+            _ = try await SkillCatalog.fetchBody(from: url)
+        }
+    }
+
+    @Test func fetchBodyRejectsNilURL() async {
+        await #expect(throws: URLError.self) {
+            _ = try await SkillCatalog.fetchBody(from: nil)
+        }
+    }
+
+    @Test func fetchBodyRejectsMissingRequiredFrontmatter() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skills-invalid-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdown = """
+            ---
+            description: Missing name field.
+            ---
+
+            Body text that must not preview.
+            """
+        let url = root.appendingPathComponent("SKILL.md")
+        try markdown.write(to: url, atomically: true, encoding: .utf8)
+
+        await #expect(throws: URLError.self) {
+            _ = try await SkillCatalog.fetchBody(from: url)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Community skills in Settings → Skills could only be installed blind — clicking an uninstalled skill's name did nothing. Now it opens the existing skill detail sheet in a read-only preview with **Install** in the header, so you can read the instructions before installing.

## Approach

- `SkillDetailSheet` gains an optional `catalogEntry`. When the skill isn't installed, it renders the same layout and `viewContent` document as the installed view, minus all edit/rename/delete/external-agent controls, with an Available status and a prominent Install button.
- The preview fetches the remote SKILL.md via `SkillCatalog.fetchBody`, which applies the same required-frontmatter validation as install; Install stays disabled until a valid body loads.
- Stale-load safety: results are discarded if the active catalog entry's path/sha changed after the fetch (catalog refresh, Try Again). The live catalog entry is preferred over the presentation snapshot so install always uses the current sha/path.
- After Install succeeds, the skill appears in `SkillStore` and the sheet becomes the normal installed detail view.
- Row-level Install in the community list is unchanged.

## Testing

- `swift build` — passes
- `swift test --filter SkillCatalogBodyTests` — 4 tests pass (frontmatter stripping, missing file, nil URL, missing required frontmatter)

Manual UI verification:
1. Settings → Skills → Community → click a skill name → preview opens with description + rendered instructions, Install at top.
2. Install from the preview → sheet switches to the installed detail view (Edit, external agents).
3. Row Install still installs directly without a preview.
4. Offline / bad catalog path → "Skill unavailable." with Try Again.
5. Escape/close dismisses without installing.

## Change statistics

- Code logic: +153/−8 (`SkillDetailSheet`, `SkillsPane`, `SkillCatalog`)
- Tests: +67 (`SkillCatalogBodyTests`)

Made with [Cursor](https://cursor.com)