### PR TITLE
[agent] Add clip media source swapping

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -31,6 +31,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case removeClips = "remove_clips"
     case splitClips = "split_clips"
     case rippleDeleteRanges = "ripple_delete_ranges"
+    case swapClipMedia = "swap_clip_media"
     case setClipProperties = "set_clip_properties"
     case setKeyframes = "set_keyframes"
     case applyLayout = "apply_layout"
@@ -482,6 +483,15 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: ["ranges"]
+            )
+        ),
+        AgentTool(
+            name: .swapClipMedia,
+            description: "Replace a clip's source with another library asset while preserving its edit, timing, framing, effects, and keyframes. Linked video/audio clips that share the source are updated together. The replacement must have the same source type, contain audio when a linked audio clip needs it, and cover the current source range; extra tail remains available for trimming. Text, nested timeline, and multicam clips are refused; use change_cam for multicam.",
+            inputSchema: objectSchema(
+                properties: ["clipId": ["type": "string", "description": "Clip ID from get_timeline."],
+                             "mediaRef": ["type": "string", "description": "Replacement asset ID from get_media."]],
+                required: ["clipId", "mediaRef"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -520,6 +520,25 @@ extension ToolExecutor {
         return mutationResult(editor, since: snapshot, touched: allMoves.map(\.clipId))
     }
 
+    // MARK: swap_clip_media
+
+    func swapClipMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["clipId", "mediaRef"], path: "swap_clip_media")
+        let clipId = try args.requireString("clipId")
+        let replacement = try asset(args.requireString("mediaRef"), editor: editor, label: "Replacement media")
+        let snapshot = timelineSnapshot(editor)
+        let plan = try editor.swapClipMedia(clipId: clipId, replacement: replacement)
+
+        return mutationResult(
+            editor,
+            since: snapshot,
+            touched: plan.changed ? plan.affectedClipIds : [],
+            extra: ["changed": plan.changed, "clipId": plan.clipId,
+                    "oldMediaRef": plan.oldMediaRef, "mediaRef": plan.newMediaRef,
+                    "affectedClipIds": plan.affectedClipIds]
+        )
+    }
+
     // MARK: set_clip_properties
 
     func setClipProperties(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -299,6 +299,7 @@ final class ToolExecutor {
         case .manageTracks:     return try manageTracks(editor, args)
         case .moveClips:        return try moveClips(editor, args)
         case .applyLayout:      return try applyLayout(editor, args)
+        case .swapClipMedia:    return try swapClipMedia(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -639,7 +639,7 @@ extension EditorViewModel {
         pendingReplacements.remove(clipId)
     }
 
-    private func linkedClipIdsSharingMedia(anchor: String) -> Set<String> {
+    func linkedClipIdsSharingMedia(anchor: String) -> Set<String> {
         guard let loc = findClip(id: anchor) else { return [anchor] }
         let clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
         var ids: Set<String> = [anchor]
@@ -656,7 +656,10 @@ extension EditorViewModel {
 
     /// Replace the source asset a clip points at, preserving states. 
     /// Registered as a single undo step.
-    func replaceClipMediaRef(clipId: String, newAssetId: String, resetTrim: Bool = false) {
+    func replaceClipMediaRef(
+        clipId: String, newAssetId: String, resetTrim: Bool = false,
+        trimEndFrames: [String: Int] = [:]
+    ) {
         guard let loc = findClip(id: clipId) else { return }
         let oldMediaRef = timeline.tracks[loc.trackIndex].clips[loc.clipIndex].mediaRef
         guard oldMediaRef != newAssetId else { return }
@@ -664,34 +667,16 @@ extension EditorViewModel {
             prepareMediaVisuals(for: asset)
         }
 
-        let targetIds = linkedClipIdsSharingMedia(anchor: clipId)
-
-        var oldTrims: [String: (start: Int, end: Int)] = [:]
-        for id in targetIds {
-            if let l = findClip(id: id) {
-                if resetTrim {
-                    let c = timeline.tracks[l.trackIndex].clips[l.clipIndex]
-                    oldTrims[id] = (c.trimStartFrame, c.trimEndFrame)
-                    timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = 0
-                    timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = 0
-                }
-                timeline.tracks[l.trackIndex].clips[l.clipIndex].mediaRef = newAssetId
+        commitClipProperties(clipIds: linkedClipIdsSharingMedia(anchor: clipId).sorted(),
+                             actionName: "Replace Clip Source") { clip in
+            clip.mediaRef = newAssetId
+            if resetTrim {
+                clip.trimStartFrame = 0
+                clip.trimEndFrame = 0
+            } else if let trimEndFrame = trimEndFrames[clip.id] {
+                clip.trimEndFrame = trimEndFrame
             }
         }
-
-        registerTimelineUndo("Replace Clip Source") { vm in
-            for id in targetIds {
-                if let l = vm.findClip(id: id) {
-                    vm.timeline.tracks[l.trackIndex].clips[l.clipIndex].mediaRef = oldMediaRef
-                    if let old = oldTrims[id] {
-                        vm.timeline.tracks[l.trackIndex].clips[l.clipIndex].trimStartFrame = old.start
-                        vm.timeline.tracks[l.trackIndex].clips[l.clipIndex].trimEndFrame = old.end
-                    }
-                }
-            }
-            vm.notifyTimelineChanged()
-        }
-        notifyTimelineChanged()
     }
 
     // MARK: - Playhead-relative operations

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaSwap.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaSwap.swift
@@ -48,8 +48,10 @@ extension EditorViewModel {
             cancelMediaSwap()
             return
         }
-        guard (try? swapClipMedia(clipId: clip.id, replacement: asset)) != nil else {
-            mediaPanelToast = MediaPanelToast(message: L10n.string("Can't swap this clip. Required media type: \(clip.sourceClipType.localizedTrackLabel)."))
+        do {
+            try swapClipMedia(clipId: clip.id, replacement: asset)
+        } catch {
+            mediaPanelToast = MediaPanelToast(message: L10n.string("This source can’t replace the clip."))
             return
         }
         cancelMediaSwap()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaSwap.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaSwap.swift
@@ -1,40 +1,121 @@
 import Foundation
 
+struct ClipMediaSwapPlan {
+    let clipId, oldMediaRef, newMediaRef: String
+    let affectedClipIds: [String]
+    var changed: Bool { oldMediaRef != newMediaRef }
+}
+
+struct ClipMediaSwapError: LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
+}
+
 // Armed swap session: pick a replacement source from the media panel for a clip, preserving its state.
 extension EditorViewModel {
     var pendingSwapClip: Clip? {
-        guard let id = pendingSwapClipId, let loc = findClip(id: id) else { return nil }
-        return timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        pendingSwapClipId.flatMap { clipFor(id: $0) }
     }
 
     var pendingSwapClipName: String? {
-        guard let clip = pendingSwapClip else { return nil }
-        return mediaAssets.first { $0.id == clip.mediaRef }?.name
+        pendingSwapClip.flatMap { clip in mediaAssets.first { $0.id == clip.mediaRef }?.name }
     }
 
     func beginMediaSwap(clipId: String) {
-        guard findClip(id: clipId) != nil else { return }
+        guard let ids = try? mediaSwapTargetClipIds(for: clipId) else { return }
+        pendingSwapTargetClipIds = ids
         pendingSwapClipId = clipId
         showMediaPanelMediaTab()
     }
 
     func cancelMediaSwap() {
         pendingSwapClipId = nil
+        pendingSwapTargetClipIds = []
     }
 
     func isAssetCompatibleWithPendingSwap(_ asset: MediaAsset) -> Bool {
-        guard let clip = pendingSwapClip else { return false }
-        return clip.mediaType == asset.type
+        guard let clipId = pendingSwapClipId else { return false }
+        return (try? swapClipMedia(
+            clipId: clipId,
+            replacement: asset,
+            targetClipIds: pendingSwapTargetClipIds,
+            commit: false
+        )) != nil
     }
 
     func completeMediaSwap(with asset: MediaAsset) {
-        guard let clip = pendingSwapClip else { pendingSwapClipId = nil; return }
-        guard clip.mediaType == asset.type else {
-            mediaPanelToast = MediaPanelToast(message: L10n.string("Can't swap this clip. Required media type: \(clip.mediaType.localizedTrackLabel)."))
+        guard let clip = pendingSwapClip else {
+            cancelMediaSwap()
             return
         }
-        pendingSwapClipId = nil
-        guard asset.id != clip.mediaRef else { return }
-        replaceClipMediaRef(clipId: clip.id, newAssetId: asset.id)
+        guard (try? swapClipMedia(clipId: clip.id, replacement: asset)) != nil else {
+            mediaPanelToast = MediaPanelToast(message: L10n.string("Can't swap this clip. Required media type: \(clip.sourceClipType.localizedTrackLabel)."))
+            return
+        }
+        cancelMediaSwap()
+    }
+
+    @discardableResult
+    func swapClipMedia(
+        clipId: String,
+        replacement: MediaAsset,
+        targetClipIds: [String]? = nil,
+        commit: Bool = true
+    ) throws -> ClipMediaSwapPlan {
+        guard let anchor = clipFor(id: clipId) else { throw ClipMediaSwapError(message: "Clip not found: \(clipId)") }
+        let ids = try targetClipIds ?? mediaSwapTargetClipIds(for: clipId)
+        let targets = ids.compactMap { clipFor(id: $0) }
+        guard targets.count == ids.count else { throw ClipMediaSwapError(message: "Linked clip not found.") }
+        guard targets.allSatisfy({ $0.sourceClipType == replacement.type }) else { throw ClipMediaSwapError(message: "Replacement must match the clip's source type.") }
+
+        let plan = ClipMediaSwapPlan(
+            clipId: clipId, oldMediaRef: anchor.mediaRef, newMediaRef: replacement.id,
+            affectedClipIds: ids
+        )
+        guard plan.changed else { return plan }
+        if replacement.type == .video, !replacement.hasAudio,
+           targets.contains(where: { $0.mediaType == .audio }) {
+            throw ClipMediaSwapError(message: "Replacement video has no audio for the linked clip.")
+        }
+
+        var trimEndFrames: [String: Int] = [:]
+        if replacement.type != .image {
+            let rawAvailable = (replacement.resolvedDuration * Double(timeline.fps)).rounded(.down)
+            guard let available = Int(exactly: rawAvailable), available > 0 else {
+                throw ClipMediaSwapError(message: "Replacement media has no valid duration.")
+            }
+            for clip in targets {
+                let rawConsumed = (Double(clip.durationFrames) * clip.speed).rounded()
+                guard let consumed = Int(exactly: rawConsumed), consumed >= 0 else {
+                    throw ClipMediaSwapError(message: "Clip has invalid source timing.")
+                }
+                let (required, overflow) = clip.trimStartFrame.addingReportingOverflow(consumed)
+                guard !overflow, required >= 0, required <= available else {
+                    throw ClipMediaSwapError(message: "Replacement media is too short for the clip's source range.")
+                }
+                trimEndFrames[clip.id] = available - required
+            }
+        }
+
+        if commit {
+            replaceClipMediaRef(
+                clipId: plan.clipId,
+                newAssetId: plan.newMediaRef,
+                trimEndFrames: trimEndFrames
+            )
+        }
+        return plan
+    }
+
+    private func mediaSwapTargetClipIds(for clipId: String) throws -> [String] {
+        guard let clip = clipFor(id: clipId) else { throw ClipMediaSwapError(message: "Clip not found: \(clipId)") }
+        guard clip.mediaType != .text,
+              clip.sourceClipType != .text,
+              clip.sourceClipType != .sequence else {
+            throw ClipMediaSwapError(message: "This clip does not support media source swapping.")
+        }
+        let ids = linkedClipIdsSharingMedia(anchor: clipId).sorted()
+        guard !ids.contains(where: { clipFor(id: $0)?.multicamGroupId != nil }) else { throw ClipMediaSwapError(message: "Use change_cam for multicam clips.") }
+        return ids
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -95,6 +95,7 @@ extension EditorViewModel {
         selectedGap = nil
         selectedTimelineRange = nil
         pendingSwapClipId = nil
+        pendingSwapTargetClipIds = []
         dragBefore = [:]
         preDragTimeline = nil
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -114,6 +114,7 @@ final class EditorViewModel {
     var selectedFolderIds: Set<String> = []
     var selectedTimelineIds: Set<String> = []
     var pendingSwapClipId: String?
+    @ObservationIgnored var pendingSwapTargetClipIds: [String] = []
     var clipClipboard: [ClipClipboardEntry] = []
     var zoomScale: Double = Defaults.pixelsPerFrame
     var canvasZoom: CGFloat = 1.0 {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -32,7 +32,10 @@ final class EditorViewModel {
     // MARK: - Persisted state (synced with VideoProject)
 
     var timelines: [Timeline] {
-        didSet { timelineRenderRevision &+= 1 }
+        didSet {
+            timelineRenderRevision &+= 1
+            if pendingSwapClipId != nil { cancelMediaSwap() }
+        }
     }
     var activeTimelineId: String
     var openTimelineIds: [String]

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -138,7 +138,6 @@
 "Can't import \"%@\" — unsupported file type." = "Can't import \"%@\" — unsupported file type.";
 "Can't paste \"%@\" here — it would nest this timeline inside itself." = "Can't paste \"%@\" here — it would nest this timeline inside itself.";
 "Can't relink \"%@\". Required media type: %@. Selected media type: %@." = "Can't relink \"%@\". Required media type: %@. Selected media type: %@.";
-"Can't swap this clip. Required media type: %@." = "Can't swap this clip. Required media type: %@.";
 "Can't unlock sync on a multicam track — \"%@\" stays aligned through it." = "Can't unlock sync on a multicam track — \"%@\" stays aligned through it.";
 "Cancel" = "Cancel";
 "Cancel Export" = "Cancel Export";
@@ -905,6 +904,7 @@
 "This is your preview panel to play a selected media or the whole timeline." = "This is your preview panel to play a selected media or the whole timeline.";
 "This model cannot cap the output at 60 FPS." = "This model cannot cap the output at 60 FPS.";
 "This permanently removes %@." = "This permanently removes %@.";
+"This source can’t replace the clip." = "This source can’t replace the clip.";
 "Three-Stack" = "Three-Stack";
 "Three-Up" = "Three-Up";
 "Threshold" = "Threshold";

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1144,7 +1144,8 @@ final class TimelineView: NSView {
 
         // Media
         var mediaItems: [NSMenuItem] = []
-        if clip.mediaType != .text, clip.sourceClipType != .sequence, singleLinkGroup {
+        if clip.mediaType != .text, clip.sourceClipType != .sequence,
+           clip.multicamGroupId == nil, singleLinkGroup {
             let swapItem = NSMenuItem(title: L10n.string("Swap Media"), action: #selector(performSwapMedia(_:)), keyEquivalent: "")
             swapItem.target = self
             swapItem.representedObject = clip.id

--- a/Tests/PalmierProTests/Agent/SwapClipMediaToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SwapClipMediaToolTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import PalmierPro
+
+@Suite("MCP clip media swap")
+@MainActor
+struct SwapClipMediaToolTests {
+    @Test func validatesSwapsReadsBackAndUndoes() async throws {
+        let (oldMedia, newMedia) = ("old-media", "new-media")
+
+        var video = Fixtures.clip(id: "video-clip", mediaRef: oldMedia, start: 12, duration: 30,
+                                  trimStart: 10, trimEnd: 20, speed: 1.5, volume: 0.7)
+        video.linkGroupId = "linked"
+        video.transform = Transform(centerX: 0.4, centerY: 0.6, width: 0.7, height: 0.8, rotation: 15)
+        video.opacityTrack = KeyframeTrack(keyframes: [Keyframe(frame: 5, value: 0.8)])
+        video.effects = [Effect(type: "blur")]
+        var audio = Fixtures.clip(id: "audio-clip", mediaRef: oldMedia, mediaType: .audio, start: 12,
+                                  duration: 30, trimStart: 10, trimEnd: 20, speed: 1.5, volume: 0.25)
+        audio.sourceClipType = .video
+        audio.linkGroupId = "linked"
+
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [video]), Fixtures.audioTrack(clips: [audio]),
+        ]))
+        harness.addAsset(id: newMedia, duration: 4, hasAudio: true)
+        harness.addAsset(id: "short-media", duration: 1, hasAudio: true)
+        harness.addAsset(id: "silent-media", duration: 4)
+        harness.addAsset(id: "image-media", type: .image)
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        let server = Server(
+            name: "palmier-pro-test", version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "clip-media-swap-test", version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            let tool = try #require(tools.first { $0.name == "swap_clip_media" })
+            #expect(try #require(tool.inputSchema.objectValue?["required"]?.arrayValue)
+                .compactMap(\.stringValue) == ["clipId", "mediaRef"])
+
+            for mediaRef in ["short-media", "silent-media", "image-media"] {
+                #expect((try await callSwap(client, clipId: video.id, mediaRef: mediaRef)).isError == true)
+            }
+            #expect(harness.editor.clipFor(id: video.id) == video)
+            #expect(harness.editor.clipFor(id: audio.id) == audio)
+            #expect(!undoManager.canUndo)
+
+            let swap = try await callSwap(client, clipId: video.id, mediaRef: newMedia)
+            let receipt = try json(swap)
+            #expect(receipt["changed"] as? Bool == true)
+            #expect(Set(receipt["affectedClipIds"] as? [String] ?? []) == Set([video.id, audio.id]))
+
+            var expectedVideo = video
+            expectedVideo.mediaRef = newMedia
+            expectedVideo.trimEndFrame = 65
+            var expectedAudio = audio
+            expectedAudio.mediaRef = newMedia
+            expectedAudio.trimEndFrame = 65
+            #expect(harness.editor.clipFor(id: video.id) == expectedVideo)
+            #expect(harness.editor.clipFor(id: audio.id) == expectedAudio)
+            #expect(try await timelineMediaRef(client: client, clipId: video.id) == newMedia)
+
+            let noOp = try await callSwap(client, clipId: video.id, mediaRef: newMedia)
+            #expect(try json(noOp)["changed"] as? Bool == false)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: video.id) == video)
+            #expect(harness.editor.clipFor(id: audio.id) == audio)
+            undoManager.redo()
+            #expect(harness.editor.clipFor(id: video.id) == expectedVideo)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
+    private func callSwap(_ client: Client, clipId: String, mediaRef: String) async throws
+        -> (content: [Tool.Content], isError: Bool?) {
+        try await client.callTool(name: "swap_clip_media", arguments: [
+            "clipId": .string(clipId),
+            "mediaRef": .string(mediaRef),
+        ])
+    }
+
+    private func timelineMediaRef(client: Client, clipId: String) async throws -> String {
+        let payload = try json(try await client.callTool(name: "get_timeline"))
+        let tracks = try #require(payload["tracks"] as? [[String: Any]])
+        let clips = tracks.flatMap { $0["clips"] as? [[String: Any]] ?? [] }
+        return try #require(clips.first { $0["id"] as? String == clipId }?["mediaRef"] as? String)
+    }
+
+    private func json(_ result: (content: [Tool.Content], isError: Bool?)) throws -> [String: Any] {
+        guard case .text(let text, _, _) = result.content.first else { throw CocoaError(.coderReadCorrupt) }
+        return try #require(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+}

--- a/Tests/PalmierProTests/Agent/SwapClipMediaToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SwapClipMediaToolTests.swift
@@ -86,6 +86,17 @@ struct SwapClipMediaToolTests {
         await client.disconnect()
     }
 
+    @Test func timelineMutationCancelsPendingSwap() {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 30)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+
+        harness.editor.beginMediaSwap(clipId: clip.id)
+        harness.editor.timeline.tracks[0].clips[0].linkGroupId = "changed"
+
+        #expect(harness.editor.pendingSwapClipId == nil)
+        #expect(harness.editor.pendingSwapTargetClipIds.isEmpty)
+    }
+
     private func callSwap(_ client: Client, clipId: String, mediaRef: String) async throws
         -> (content: [Tool.Content], isError: Bool?) {
         try await client.callTool(name: "swap_clip_media", arguments: [


### PR DESCRIPTION
## Summary
- Add `swap_clip_media` so the Agent can replace a clip's library source without recreating the clip or losing its edit state.
- Preserve linked video/audio behavior, source bounds, effects, keyframes, framing, and undo/redo.
- Reject incompatible, too-short, text, nested-timeline, and multicam replacements before mutation.

## Approach
- Route the Agent and existing media-picker flow through one `EditorViewModel` source-swap operation.
- Resolve linked clips once, validate the full target set, and recompute trailing trim availability from the replacement duration while preserving the visible source range.
- Cancel armed picker swaps when the timeline changes so cached eligibility cannot become stale.
- Reuse clip-state swap undo registration and return a structured mutation receipt with old/new media references and affected clip IDs.

## Testing
- `swift test` — passed: 1,416 tests in 225 suites.
- `swift build` — passed.
- `scripts/localization/sync.sh` — passed.
- MCP end-to-end coverage verifies discovery, invalid replacements, linked A/V mutation, independent timeline readback, no-op behavior, undo, and redo.
- Manual UI verification not completed: verify media-picker dimming, linked replacement, preview refresh, Escape, invalid-source feedback, and undo/redo.

## Change statistics
- Agent tool and schema: +30 / -0
- Editor domain and UI: +119 / -45
- Localization: +1 / -1
- Tests: +119 / -0
- Total: +269 / -46

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline mutations affect linked clips and trim math; mistakes could desync A/V or corrupt edits, though validation gates most bad swaps and tests cover the MCP path.
> 
> **Overview**
> Adds **`swap_clip_media`** so the Agent (and MCP clients) can point a clip at a different library asset while keeping edit state—timing, effects, keyframes, transform, and linked A/V behavior.
> 
> **`EditorViewModel.swapClipMedia`** centralizes validation and mutation for both the new tool and the existing **Swap Media** UI: it resolves linked clips that share the source, rejects text/nested-timeline/multicam and incompatible or too-short replacements, recomputes trailing trim from the replacement duration, and commits via refactored **`replaceClipMediaRef`** (optional per-clip `trimEndFrames`, `commitClipProperties` undo). Pending swap sessions track target clip IDs, use dry-run validation for media-panel dimming, cancel on timeline edits, and hide **Swap Media** on multicam clips.
> 
> MCP tests cover tool discovery, failed swaps, linked mutation, readback, no-op, undo, and redo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2311d703dd353eaadf78a3344d0883d7b61f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->