### PR TITLE
[feat/telemetry] Improve skill authoring workflow

### DIFF
--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -359,6 +359,13 @@ final class SkillStore {
 
     func body(for id: String) -> String? { bodyCache[id] }
 
+    func rawContents(for skill: Skill) async -> String? {
+        let path = skill.path
+        return await Task.detached(priority: .utility) {
+            try? String(contentsOf: path, encoding: .utf8)
+        }.value
+    }
+
     /// One-line list of skills; full content loads on demand.
     var skillIndex: String {
         skills.map { "- \($0.id): \($0.description)" }.joined(separator: "\n")
@@ -421,16 +428,32 @@ final class SkillStore {
         } ?? false
     }
 
+    static let newSkillTemplate = """
+        ---
+        name: New skill
+        description: Describe in one line when the assistant should use this skill.
+        ---
+
+        ## Workflow
+        1. First step.
+        2. Second step.
+        """
+
     @discardableResult
-    func newSkill() async -> String? {
-        await serializeMutation("create skill") { [self] in
-            let id = try await Self.performFileOperation { try Self.createSkillFile() }
+    func createSkill(raw: String) async -> String? {
+        guard let parsed = SkillFrontmatter.requiredFields(raw) else { return nil }
+        guard let id = await serializeMutation("create skill", { [self] in
+            let id = try await Self.performFileOperation { try Self.createSkillFile(raw: raw) }
             await reloadInBackground()
             return id
+        }) else {
+            return nil
         }
+        Analytics.captureSkillCreated(skillName: parsed.name)
+        return id
     }
 
-    nonisolated private static func createSkillFile() throws -> String {
+    nonisolated private static func createSkillFile(raw: String) throws -> String {
         let fm = FileManager.default
         var id = "new-skill"
         var n = 2
@@ -439,18 +462,8 @@ final class SkillStore {
         }
         let dir = Self.directory.appendingPathComponent(id, isDirectory: true)
         let md = dir.appendingPathComponent("SKILL.md")
-        let template = """
-            ---
-            name: New skill
-            description: Describe in one line when the assistant should use this skill.
-            ---
-
-            ## Workflow
-            1. First step.
-            2. Second step.
-            """
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        try template.write(to: md, atomically: true, encoding: .utf8)
+        try raw.write(to: md, atomically: true, encoding: .utf8)
         return id
     }
 

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -36,6 +36,12 @@ struct SkillLedger: Equatable, Sendable {
     var suppressed: Set<String> = []
 }
 
+enum SkillOrigin: String, Sendable {
+    case community
+    case communityModified = "community_modified"
+    case local
+}
+
 private struct PersistedSkillLedger: Codable {
     static let currentVersion = 1
 
@@ -141,6 +147,17 @@ final class SkillStore {
     // MARK: Catalog install / ledger
 
     func localSha(_ skill: Skill) -> String? { shaCache[skill.id] }
+
+    func contentSHA(for id: String) -> String? { shaCache[id] }
+
+    func origin(for id: String) -> SkillOrigin {
+        Self.skillOrigin(installedSHA: ledger?.installed[id], localSHA: shaCache[id])
+    }
+
+    nonisolated static func skillOrigin(installedSHA: String?, localSHA: String?) -> SkillOrigin {
+        guard let installedSHA else { return .local }
+        return localSHA == installedSHA ? .community : .communityModified
+    }
 
     func startSkillSync() {
         guard syncTask == nil else { return }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -339,6 +339,11 @@ final class ToolExecutor {
         guard let body = SkillStore.shared.body(for: id) else {
             return .error("Unknown skill: \(id)")
         }
+        Analytics.captureSkillRead(
+            skillID: id,
+            skillSHA: SkillStore.shared.contentSHA(for: id),
+            skillOrigin: SkillStore.shared.origin(for: id).rawValue
+        )
         return .ok(body)
     }
 

--- a/Sources/PalmierPro/Settings/Skill/SkillDeleteConfirmation.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDeleteConfirmation.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+extension Skill {
+    var displayPath: String {
+        path.deletingLastPathComponent().path
+            .replacingOccurrences(of: NSHomeDirectory(), with: "~")
+    }
+}
+
+private struct SkillDeleteConfirmation: ViewModifier {
+    @Binding var skill: Skill?
+    let onDelete: (Skill) -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            title,
+            isPresented: Binding(
+                get: { skill != nil },
+                set: { if !$0 { skill = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: skill
+        ) { skill in
+            Button(L10n.string("Delete \u{201C}\(skill.name)\u{201D}"), role: .destructive) {
+                onDelete(skill)
+            }
+            Button(L10n.string("Keep Skill"), role: .cancel) {}
+        } message: { skill in
+            Text(L10n.string("This permanently removes \(skill.displayPath)."))
+        }
+    }
+
+    private var title: String {
+        guard let skill else { return L10n.string("Delete skill?") }
+        return L10n.string("Delete \u{201C}\(skill.name)\u{201D}?")
+    }
+}
+
+extension View {
+    func skillDeleteConfirmation(
+        skill: Binding<Skill?>,
+        onDelete: @escaping (Skill) -> Void
+    ) -> some View {
+        modifier(SkillDeleteConfirmation(skill: skill, onDelete: onDelete))
+    }
+}

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -169,7 +169,7 @@ struct SkillDetailSheet: View {
 
         return VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             HStack(spacing: AppTheme.Spacing.md) {
-                titleView(skill?.name ?? draftName)
+                titleView(editing ? draftName : skill?.name ?? draftName)
                 Spacer(minLength: AppTheme.Spacing.md)
                 closeButton
             }
@@ -268,6 +268,7 @@ struct SkillDetailSheet: View {
                 .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
         }
         .buttonStyle(.plain)
+        .disabled(isSaving)
         .accessibilityLabel(L10n.string("Close"))
         .help(L10n.string("Close"))
     }
@@ -374,12 +375,14 @@ struct SkillDetailSheet: View {
     }
 
     private func saveDraft() async {
+        guard !isSaving else { return }
+        isSaving = true
         await commitTitle()
         guard SkillFrontmatter.requiredFields(draft) != nil else {
+            isSaving = false
             showingSaveError = true
             return
         }
-        isSaving = true
         guard let id = await store.createSkill(raw: draft) else {
             isSaving = false
             showingSaveError = true
@@ -404,6 +407,7 @@ struct SkillDetailSheet: View {
         guard let skill, name != skill.name else { return }
         if editing {
             draft = SkillFrontmatter.replacingName(draft, name: name)
+            return
         }
         await store.rename(skill, to: name)
     }
@@ -420,6 +424,7 @@ struct SkillDetailSheet: View {
     }
 
     private func close() {
+        guard !isSaving else { return }
         if isDraft {
             dismiss()
         } else {

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -389,11 +389,12 @@ struct SkillDetailSheet: View {
             draft = SkillFrontmatter.replacingName(draft, name: name)
             return
         }
-        guard let skill, name != skill.name else { return }
+        guard let skill else { return }
         if editing {
             draft = SkillFrontmatter.replacingName(draft, name: name)
             return
         }
+        guard name != skill.name else { return }
         await store.rename(skill, to: name)
     }
 

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -1,22 +1,42 @@
 import SwiftUI
 
 struct SkillDetailSheet: View {
-    let skillID: String
+    enum Mode {
+        case draft(onSaved: (String) -> Void)
+        case existing(id: String, opensForEditing: Bool)
+    }
+
+    let mode: Mode
 
     @Bindable private var store = SkillStore.shared
     @Bindable private var catalog = SkillCatalog.shared
     @Environment(\.dismiss) private var dismiss
-    @State private var editing = false
-    @State private var draft = ""
-    @State private var originalDraft = ""
-    @State private var confirmingDelete = false
+    @State private var editing: Bool
+    @State private var draft: String
+    @State private var originalDraft: String
+    @State private var skillPendingDeletion: Skill?
     @State private var isUpdating = false
+    @State private var isSaving = false
     @State private var editingTitle = false
     @State private var draftTitle = ""
     @State private var copyToast: CopyToast?
     @State private var showingSaveError = false
     @State private var failedExit: ExitAction?
     @FocusState private var titleFocused: Bool
+
+    init(mode: Mode) {
+        self.mode = mode
+        let isDraft = if case .draft = mode { true } else { false }
+        let draft = switch mode {
+        case .draft: SkillStore.newSkillTemplate
+        case .existing: ""
+        }
+        _editing = State(initialValue: isDraft)
+        _draft = State(initialValue: draft)
+        _originalDraft = State(initialValue: draft)
+        _editingTitle = State(initialValue: isDraft)
+        _draftTitle = State(initialValue: isDraft ? SkillFrontmatter.parse(draft).fields["name"] ?? "" : "")
+    }
 
     private enum ExitAction {
         case close, preview
@@ -32,17 +52,39 @@ struct SkillDetailSheet: View {
     }
 
     private var skill: Skill? {
-        store.skills.first { $0.id == skillID }
+        guard case let .existing(id, _) = mode else { return nil }
+        return store.skills.first { $0.id == id }
     }
 
-    private var deleteTitle: String {
-        guard let skill else { return L10n.string("Delete skill?") }
-        return L10n.string("Delete \u{201C}\(skill.name)\u{201D}?")
+    private var isDraft: Bool {
+        if case .draft = mode { return true }
+        return false
+    }
+
+    private var opensForEditing: Bool {
+        guard case let .existing(_, opensForEditing) = mode else { return false }
+        return opensForEditing
+    }
+
+    private var taskID: String {
+        switch mode {
+        case .draft: "draft"
+        case let .existing(id, _): id
+        }
+    }
+
+    private var draftName: String {
+        let name = SkillFrontmatter.parse(draft).fields["name"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let name, !name.isEmpty else { return L10n.string("New skill") }
+        return name
     }
 
     var body: some View {
         Group {
-            if let skill {
+            if isDraft {
+                content(nil)
+            } else if let skill {
                 content(skill)
             } else {
                 Text(L10n.string("Skill unavailable."))
@@ -57,7 +99,15 @@ struct SkillDetailSheet: View {
                     }
             }
         }
-        .interactiveDismissDisabled((editing && draft != originalDraft) || editingTitle)
+        .interactiveDismissDisabled(isSaving || (!isDraft && (editing && draft != originalDraft || editingTitle)))
+        .task(id: taskID) {
+            if isDraft {
+                titleFocused = true
+                return
+            }
+            guard opensForEditing, let skill else { return }
+            await beginEditing(skill)
+        }
         .onExitCommand {
             if editingTitle {
                 cancelTitleEditing()
@@ -75,14 +125,13 @@ struct SkillDetailSheet: View {
         }
     }
 
-    private func content(_ skill: Skill) -> some View {
+    private func content(_ skill: Skill?) -> some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
             header(skill)
-            Divider().overlay(AppTheme.Border.subtleColor)
 
             if editing {
                 editContent
-            } else {
+            } else if let skill {
                 ScrollView {
                     viewContent(skill)
                         .padding(AppTheme.Spacing.xlXxl)
@@ -105,73 +154,108 @@ struct SkillDetailSheet: View {
             }
         }
         .animation(.easeInOut(duration: AppTheme.Anim.transition), value: copyToast)
-        .confirmationDialog(
-            deleteTitle,
-            isPresented: $confirmingDelete,
-            titleVisibility: .visible,
-            presenting: self.skill
-        ) { skill in
-            Button(L10n.string("Delete \u{201C}\(skill.name)\u{201D}"), role: .destructive) {
-                Task { if await store.delete(skill) { dismiss() } }
+        .skillDeleteConfirmation(skill: $skillPendingDeletion) { skill in
+            Task {
+                if await store.delete(skill) {
+                    dismiss()
+                }
             }
-            Button(L10n.string("Keep Skill"), role: .cancel) {}
-        } message: { skill in
-            Text(L10n.string("This permanently removes \(displayPath(skill))."))
         }
     }
 
-    private func header(_ skill: Skill) -> some View {
-        let state = SkillCommunityState.resolve(skill, store: store, catalog: catalog)
+    private func header(_ skill: Skill?) -> some View {
+        let state = skill.flatMap { SkillCommunityState.resolve($0, store: store, catalog: catalog) }
         let dirty = editing && draft != originalDraft
 
         return VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             HStack(spacing: AppTheme.Spacing.md) {
-                titleView(skill)
+                titleView(skill?.name ?? draftName)
                 Spacer(minLength: AppTheme.Spacing.md)
                 closeButton
             }
 
             HStack(spacing: AppTheme.Spacing.smMd) {
-                Text(verbatim: state.map { L10n.string(key: $0.label) } ?? L10n.string("Local"))
-                    .font(.system(size: AppTheme.FontSize.xs))
-                    .foregroundStyle(state?.color ?? AppTheme.Text.tertiaryColor)
+                if skill != nil {
+                    Text(verbatim: state.map { L10n.string(key: $0.label) } ?? L10n.string("Local"))
+                        .font(.system(size: AppTheme.FontSize.xs))
+                        .foregroundStyle(state?.color ?? AppTheme.Text.tertiaryColor)
+                }
 
                 Spacer(minLength: AppTheme.Spacing.md)
-
-                if state == .update, !editing {
-                    if isUpdating {
-                        ProgressView()
-                            .controlSize(.small)
-                            .accessibilityLabel(L10n.string("Updating \(skill.name)"))
-                    } else {
-                        Button(L10n.string("Update")) { update(skill) }
-                            .buttonStyle(.capsule(.secondary, fill: AnyShapeStyle(AppTheme.Background.raisedColor)))
-                    }
-                }
-
-                SkillExternalAgentMenu(skill: skill, store: store) { agent, url in
-                    copyToast = CopyToast(agentLabel: agent.label, url: url)
-                }
-                .disabled(editing)
-
-                if dirty {
-                    Button(L10n.string("Save Changes")) {
-                        Task { _ = await commitDraftIfDirty() }
-                    }
-                    .buttonStyle(.capsule(.prominent))
-                    .keyboardShortcut("s", modifiers: .command)
-                }
-
-                Button(editing ? L10n.string("Preview") : L10n.string("Edit")) {
-                    Task { await toggleEditing(skill) }
-                }
-                .buttonStyle(.capsule(.secondary, fill: AnyShapeStyle(AppTheme.Background.raisedColor)))
-
-                actionsMenu(skill)
+                headerControls(skill: skill, state: state, dirty: dirty)
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xlXxl)
         .padding(.vertical, AppTheme.Spacing.mdLg)
+    }
+
+    @ViewBuilder
+    private func headerControls(
+        skill: Skill?,
+        state: SkillCommunityState?,
+        dirty: Bool
+    ) -> some View {
+        if let skill {
+            existingHeaderControls(skill: skill, state: state, dirty: dirty)
+        } else {
+            draftHeaderControls
+        }
+    }
+
+    @ViewBuilder
+    private func existingHeaderControls(
+        skill: Skill,
+        state: SkillCommunityState?,
+        dirty: Bool
+    ) -> some View {
+        if state == .update, !editing {
+            if isUpdating {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(L10n.string("Updating \(skill.name)"))
+            } else {
+                Button(L10n.string("Update")) { update(skill) }
+                    .buttonStyle(.capsule(.secondary, fill: AnyShapeStyle(AppTheme.Background.raisedColor)))
+            }
+        }
+
+        SkillExternalAgentMenu(skill: skill, store: store) { agent, url in
+            copyToast = CopyToast(agentLabel: agent.label, url: url)
+        }
+        .disabled(editing)
+
+        if dirty {
+            Button(L10n.string("Save Changes")) {
+                Task {
+                    await commitTitle()
+                    _ = await commitDraftIfDirty()
+                }
+            }
+            .buttonStyle(.capsule(.prominent))
+            .keyboardShortcut("s", modifiers: .command)
+        }
+
+        Button(editing ? L10n.string("Preview") : L10n.string("Edit")) {
+            Task { await toggleEditing(skill) }
+        }
+        .buttonStyle(.capsule(.secondary, fill: AnyShapeStyle(AppTheme.Background.raisedColor)))
+
+        actionsMenu(skill)
+    }
+
+    @ViewBuilder
+    private var draftHeaderControls: some View {
+        if isSaving {
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel(L10n.string("Save"))
+        } else {
+            Button(L10n.string("Save")) {
+                Task { await saveDraft() }
+            }
+            .buttonStyle(.capsule(.prominent))
+            .keyboardShortcut("s", modifiers: .command)
+        }
     }
 
     private var closeButton: some View {
@@ -189,7 +273,7 @@ struct SkillDetailSheet: View {
     }
 
     @ViewBuilder
-    private func titleView(_ skill: Skill) -> some View {
+    private func titleView(_ title: String) -> some View {
         if editingTitle {
             TextField(L10n.string("Skill name"), text: $draftTitle)
                 .textFieldStyle(.plain)
@@ -207,27 +291,31 @@ struct SkillDetailSheet: View {
                 .onSubmit { Task { await commitTitle() } }
                 .onChange(of: titleFocused) { if !titleFocused { Task { await commitTitle() } } }
         } else {
-            Text(skill.name)
-                .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.regular))
-                .foregroundStyle(AppTheme.Text.primaryColor)
-                .lineLimit(1)
+            Button {
+                beginTitleEditing(title)
+            } label: {
+                Text(title)
+                    .font(.system(size: AppTheme.FontSize.xl, weight: AppTheme.FontWeight.regular))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(L10n.string("Rename Skill"))
+            .help(L10n.string("Rename Skill"))
         }
     }
 
     private func actionsMenu(_ skill: Skill) -> some View {
         Menu {
             Button(L10n.string("Rename Skill"), systemImage: "pencil") {
-                draftTitle = skill.name
-                editingTitle = true
-                titleFocused = true
+                beginTitleEditing(skill.name)
             }
-            .disabled(editing)
             Button(L10n.string("Show in Finder"), systemImage: "folder") {
                 store.reveal(skill.path)
             }
             Divider()
             Button(L10n.string("Delete Skill"), systemImage: "trash", role: .destructive) {
-                confirmingDelete = true
+                skillPendingDeletion = skill
             }
         } label: {
             Image(systemName: "ellipsis")
@@ -250,9 +338,16 @@ struct SkillDetailSheet: View {
             return
         }
 
+        await beginEditing(skill)
+    }
+
+    private func beginEditing(_ skill: Skill) async {
+        guard !editing else { return }
         await commitTitle()
-        draft = (try? String(contentsOf: skill.path, encoding: .utf8)) ?? ""
-        originalDraft = draft
+        let raw = await store.rawContents(for: skill) ?? ""
+        guard !Task.isCancelled, self.skill?.id == skill.id else { return }
+        draft = raw
+        originalDraft = raw
         editing = true
     }
 
@@ -278,26 +373,67 @@ struct SkillDetailSheet: View {
         return true
     }
 
+    private func saveDraft() async {
+        await commitTitle()
+        guard SkillFrontmatter.requiredFields(draft) != nil else {
+            showingSaveError = true
+            return
+        }
+        isSaving = true
+        guard let id = await store.createSkill(raw: draft) else {
+            isSaving = false
+            showingSaveError = true
+            return
+        }
+        if case let .draft(onSaved: onSaved) = mode {
+            onSaved(id)
+        } else {
+            assertionFailure("Draft save requested for an existing skill")
+        }
+    }
+
     private func commitTitle() async {
-        guard editingTitle, let skill else { return }
+        guard editingTitle else { return }
+        let name = draftTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         editingTitle = false
-        await store.rename(skill, to: draftTitle)
+        guard !name.isEmpty else { return }
+        if isDraft {
+            draft = SkillFrontmatter.replacingName(draft, name: name)
+            return
+        }
+        guard let skill, name != skill.name else { return }
+        if editing {
+            draft = SkillFrontmatter.replacingName(draft, name: name)
+        }
+        await store.rename(skill, to: name)
+    }
+
+    private func beginTitleEditing(_ title: String) {
+        draftTitle = title
+        editingTitle = true
+        titleFocused = true
     }
 
     private func cancelTitleEditing() {
         editingTitle = false
-        draftTitle = skill?.name ?? ""
+        draftTitle = skill?.name ?? draftName
     }
 
-    private func close() { Task { await finish(.close) } }
+    private func close() {
+        if isDraft {
+            dismiss()
+        } else {
+            Task { await finish(.close) }
+        }
+    }
 
     private func finish(_ action: ExitAction) async {
         guard skill != nil else {
             dismiss()
             return
         }
-        guard await commitDraftIfDirty(onFailure: action) else { return }
         await commitTitle()
+        guard await commitDraftIfDirty(onFailure: action) else { return }
         switch action {
         case .close: dismiss()
         case .preview: editing = false
@@ -312,11 +448,6 @@ struct SkillDetailSheet: View {
         case .close: dismiss()
         case .preview: editing = false
         }
-    }
-
-    private func displayPath(_ skill: Skill) -> String {
-        skill.path.deletingLastPathComponent().path
-            .replacingOccurrences(of: NSHomeDirectory(), with: "~")
     }
 
     private func viewContent(_ skill: Skill) -> some View {
@@ -358,6 +489,7 @@ struct SkillDetailSheet: View {
             .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.md))
             .padding(AppTheme.Spacing.xlXxl)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .disabled(isSaving)
     }
 
     private func copyToastBanner(_ toast: CopyToast) -> some View {

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -1,16 +1,22 @@
 import SwiftUI
 
 struct SkillDetailSheet: View {
-    enum Mode {
-        case draft(onSaved: (String) -> Void)
-        case existing(id: String, opensForEditing: Bool)
-    }
+    enum Mode: Identifiable {
+        case draft
+        case existing(id: String)
 
-    let mode: Mode
+        var id: String {
+            switch self {
+            case .draft: "draft"
+            case let .existing(id): id
+            }
+        }
+    }
 
     @Bindable private var store = SkillStore.shared
     @Bindable private var catalog = SkillCatalog.shared
     @Environment(\.dismiss) private var dismiss
+    @State private var skillID: String?
     @State private var editing: Bool
     @State private var draft: String
     @State private var originalDraft: String
@@ -25,12 +31,13 @@ struct SkillDetailSheet: View {
     @FocusState private var titleFocused: Bool
 
     init(mode: Mode) {
-        self.mode = mode
-        let isDraft = if case .draft = mode { true } else { false }
-        let draft = switch mode {
-        case .draft: SkillStore.newSkillTemplate
-        case .existing: ""
+        let skillID: String? = switch mode {
+        case .draft: nil
+        case let .existing(id): id
         }
+        let isDraft = skillID == nil
+        let draft = isDraft ? SkillStore.newSkillTemplate : ""
+        _skillID = State(initialValue: skillID)
         _editing = State(initialValue: isDraft)
         _draft = State(initialValue: draft)
         _originalDraft = State(initialValue: draft)
@@ -52,26 +59,11 @@ struct SkillDetailSheet: View {
     }
 
     private var skill: Skill? {
-        guard case let .existing(id, _) = mode else { return nil }
-        return store.skills.first { $0.id == id }
+        guard let skillID else { return nil }
+        return store.skills.first { $0.id == skillID }
     }
 
-    private var isDraft: Bool {
-        if case .draft = mode { return true }
-        return false
-    }
-
-    private var opensForEditing: Bool {
-        guard case let .existing(_, opensForEditing) = mode else { return false }
-        return opensForEditing
-    }
-
-    private var taskID: String {
-        switch mode {
-        case .draft: "draft"
-        case let .existing(id, _): id
-        }
-    }
+    private var isDraft: Bool { skillID == nil }
 
     private var draftName: String {
         let name = SkillFrontmatter.parse(draft).fields["name"]?
@@ -100,13 +92,8 @@ struct SkillDetailSheet: View {
             }
         }
         .interactiveDismissDisabled(isSaving || (!isDraft && (editing && draft != originalDraft || editingTitle)))
-        .task(id: taskID) {
-            if isDraft {
-                titleFocused = true
-                return
-            }
-            guard opensForEditing, let skill else { return }
-            await beginEditing(skill)
+        .task {
+            if isDraft { titleFocused = true }
         }
         .onExitCommand {
             if editingTitle {
@@ -388,11 +375,9 @@ struct SkillDetailSheet: View {
             showingSaveError = true
             return
         }
-        if case let .draft(onSaved: onSaved) = mode {
-            onSaved(id)
-        } else {
-            assertionFailure("Draft save requested for an existing skill")
-        }
+        skillID = id
+        originalDraft = draft
+        isSaving = false
     }
 
     private func commitTitle() async {

--- a/Sources/PalmierPro/Settings/Skill/SkillRows.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillRows.swift
@@ -72,6 +72,7 @@ struct SkillRow: View {
     let primaryAction: Bool
     let working: Bool
     var summaryAction: (() -> Void)? = nil
+    var deleteAction: (() -> Void)? = nil
     let action: () -> Void
 
     var body: some View {
@@ -91,11 +92,26 @@ struct SkillRow: View {
                         .controlSize(.small)
                         .accessibilityLabel(L10n.string("Working on \(name)"))
                 } else {
-                    Button(actionTitle, action: action)
-                        .buttonStyle(.capsule(
-                            primaryAction ? .prominent : .secondary,
-                            fill: primaryAction ? nil : AnyShapeStyle(AppTheme.Background.raisedColor)
-                        ))
+                    HStack(spacing: AppTheme.Spacing.xs) {
+                        Button(actionTitle, action: action)
+                            .buttonStyle(.capsule(
+                                primaryAction ? .prominent : .secondary,
+                                fill: primaryAction ? nil : AnyShapeStyle(AppTheme.Background.raisedColor)
+                            ))
+
+                        if let deleteAction {
+                            Button(role: .destructive, action: deleteAction) {
+                                Image(systemName: "trash")
+                                    .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+                                    .padding(AppTheme.Spacing.xs)
+                                    .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(L10n.string("Delete Skill"))
+                            .help(L10n.string("Delete Skill"))
+                        }
+                    }
                 }
             }
             .frame(width: AppTheme.Settings.skillActionWidth, alignment: .trailing)

--- a/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
@@ -5,7 +5,7 @@ struct SkillsPane: View {
     @Bindable private var catalog = SkillCatalog.shared
     @State private var collection: SkillCollection = .installed
     @State private var query = ""
-    @State private var presentedSkill: PresentedSkill?
+    @State private var presentedSkill: SkillDetailSheet.Mode?
     @State private var working: Set<String> = []
     @State private var skillPendingDeletion: Skill?
 
@@ -17,18 +17,6 @@ struct SkillsPane: View {
             switch self {
             case .installed: L10n.key("Installed")
             case .community: L10n.key("Community")
-            }
-        }
-    }
-
-    private enum PresentedSkill: Identifiable {
-        case existing(id: String, opensForEditing: Bool)
-        case new
-
-        var id: String {
-            switch self {
-            case let .existing(id, _): "existing-\(id)"
-            case .new: "new"
             }
         }
     }
@@ -61,18 +49,8 @@ struct SkillsPane: View {
         .onAppear {
             Task { await store.syncSkills() }
         }
-        .sheet(item: $presentedSkill) { item in
-            switch item {
-            case let .existing(id, opensForEditing):
-                SkillDetailSheet(mode: .existing(id: id, opensForEditing: opensForEditing))
-            case .new:
-                SkillDetailSheet(
-                    mode: .draft(onSaved: { id in
-                        collection = .installed
-                        query = ""
-                        present(id, opensForEditing: true)
-                    }))
-            }
+        .sheet(item: $presentedSkill) { mode in
+            SkillDetailSheet(mode: mode)
         }
         .skillDeleteConfirmation(skill: $skillPendingDeletion, onDelete: deleteSkill)
     }
@@ -312,7 +290,9 @@ struct SkillsPane: View {
     }
 
     private func createSkill() {
-        presentedSkill = .new
+        collection = .installed
+        query = ""
+        presentedSkill = .draft
     }
 
     private func install(_ entry: SkillCatalogEntry) {
@@ -345,7 +325,7 @@ struct SkillsPane: View {
         }
     }
 
-    private func present(_ id: String, opensForEditing: Bool = false) {
-        presentedSkill = .existing(id: id, opensForEditing: opensForEditing)
+    private func present(_ id: String) {
+        presentedSkill = .existing(id: id)
     }
 }

--- a/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillsPane.swift
@@ -7,6 +7,7 @@ struct SkillsPane: View {
     @State private var query = ""
     @State private var presentedSkill: PresentedSkill?
     @State private var working: Set<String> = []
+    @State private var skillPendingDeletion: Skill?
 
     private enum SkillCollection: String {
         case installed = "Installed"
@@ -20,8 +21,16 @@ struct SkillsPane: View {
         }
     }
 
-    private struct PresentedSkill: Identifiable {
-        let id: String
+    private enum PresentedSkill: Identifiable {
+        case existing(id: String, opensForEditing: Bool)
+        case new
+
+        var id: String {
+            switch self {
+            case let .existing(id, _): "existing-\(id)"
+            case .new: "new"
+            }
+        }
     }
 
     private var installedSkills: [Skill] {
@@ -53,8 +62,19 @@ struct SkillsPane: View {
             Task { await store.syncSkills() }
         }
         .sheet(item: $presentedSkill) { item in
-            SkillDetailSheet(skillID: item.id)
+            switch item {
+            case let .existing(id, opensForEditing):
+                SkillDetailSheet(mode: .existing(id: id, opensForEditing: opensForEditing))
+            case .new:
+                SkillDetailSheet(
+                    mode: .draft(onSaved: { id in
+                        collection = .installed
+                        query = ""
+                        present(id, opensForEditing: true)
+                    }))
+            }
         }
+        .skillDeleteConfirmation(skill: $skillPendingDeletion, onDelete: deleteSkill)
     }
 
     private var introduction: some View {
@@ -195,6 +215,7 @@ struct SkillsPane: View {
                         primaryAction: false,
                         working: working.contains(skill.id),
                         summaryAction: { present(skill.id) },
+                        deleteAction: { skillPendingDeletion = skill },
                         action: { state == .update ? update(skill) : present(skill.id) }
                     )
                 }
@@ -270,6 +291,9 @@ struct SkillsPane: View {
             summaryAction: skill.map { installedSkill in
                 { present(installedSkill.id) }
             },
+            deleteAction: skill.map { installedSkill in
+                { skillPendingDeletion = installedSkill }
+            },
             action: {
                 if let skill {
                     state == .update ? update(skill) : present(skill.id)
@@ -288,12 +312,7 @@ struct SkillsPane: View {
     }
 
     private func createSkill() {
-        Task {
-            guard let id = await store.newSkill() else { return }
-            collection = .installed
-            query = ""
-            present(id)
-        }
+        presentedSkill = .new
     }
 
     private func install(_ entry: SkillCatalogEntry) {
@@ -318,7 +337,15 @@ struct SkillsPane: View {
         }
     }
 
-    private func present(_ id: String) {
-        presentedSkill = PresentedSkill(id: id)
+    private func deleteSkill(_ skill: Skill) {
+        working.insert(skill.id)
+        Task {
+            _ = await store.delete(skill)
+            working.remove(skill.id)
+        }
+    }
+
+    private func present(_ id: String, opensForEditing: Bool = false) {
+        presentedSkill = .existing(id: id, opensForEditing: opensForEditing)
     }
 }

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -35,6 +35,12 @@ enum Analytics {
         return properties
     }
 
+    static func skillCreatedProperties(skillName: String) -> Payload {
+        var properties = originProperties()
+        properties["skill_name"] = skillName
+        return properties
+    }
+
     struct SessionActivation {
         private(set) var isActivated: Bool
 
@@ -59,6 +65,7 @@ enum Analytics {
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
         case agentToolCalled = "agent tool called"
+        case skillCreated = "skill created"
         case skillRead = "skill read"
         case agentStarterPromptClicked = "agent starter prompt clicked"
         case editorEditCommitted = "editor edit committed"
@@ -166,6 +173,11 @@ enum Analytics {
     }
 
     @discardableResult
+    static func captureSkillCreated(skillName: String) -> Bool {
+        capture(.skillCreated, properties: skillCreatedProperties(skillName: skillName))
+    }
+
+    @discardableResult
     static func captureSkillRead(skillID: String, skillSHA: String?, skillOrigin: String) -> Bool {
         capture(
             .skillRead,
@@ -269,6 +281,7 @@ enum Analytics {
             "roles",
             "session_id",
             "skill_id",
+            "skill_name",
             "skill_origin",
             "skill_sha",
             "source",

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -21,6 +21,20 @@ enum Analytics {
         return ["source": origin.source, "session_id": origin.sessionID]
     }
 
+    static func skillReadProperties(
+        skillID: String,
+        skillSHA: String?,
+        skillOrigin: String
+    ) -> Payload {
+        var properties = originProperties()
+        properties["skill_id"] = skillID
+        properties["skill_origin"] = skillOrigin
+        if let skillSHA {
+            properties["skill_sha"] = skillSHA
+        }
+        return properties
+    }
+
     struct SessionActivation {
         private(set) var isActivated: Bool
 
@@ -45,6 +59,7 @@ enum Analytics {
         case exportFailed = "export failed"
         case agentSessionStarted = "agent session started"
         case agentToolCalled = "agent tool called"
+        case skillRead = "skill read"
         case agentStarterPromptClicked = "agent starter prompt clicked"
         case editorEditCommitted = "editor edit committed"
         case generationSubmitted = "generation submitted"
@@ -150,6 +165,18 @@ enum Analytics {
         #endif
     }
 
+    @discardableResult
+    static func captureSkillRead(skillID: String, skillSHA: String?, skillOrigin: String) -> Bool {
+        capture(
+            .skillRead,
+            properties: skillReadProperties(
+                skillID: skillID,
+                skillSHA: skillSHA,
+                skillOrigin: skillOrigin
+            )
+        )
+    }
+
     static func captureProjectActive(projectId: String?, properties: Payload = [:]) {
         let day = Self.dayString(Date())
         let id = projectId ?? "unknown"
@@ -241,6 +268,9 @@ enum Analytics {
             "resolution",
             "roles",
             "session_id",
+            "skill_id",
+            "skill_origin",
+            "skill_sha",
             "source",
             "starter_prompt",
             "status",

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -417,7 +417,7 @@ enum AppTheme {
         static let skillsSearchWidth: CGFloat = 260
         static let skillRowIconFrame: CGFloat = 42
         static let skillStatusWidth: CGFloat = 124
-        static let skillActionWidth: CGFloat = 72
+        static let skillActionWidth: CGFloat = 112
         static let skillDetailWidth: CGFloat = 720
         static let skillDetailMinHeight: CGFloat = 600
         static let skillToastWidth: CGFloat = 380

--- a/Tests/PalmierProTests/Agent/SkillFrontmatterTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillFrontmatterTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import PalmierPro
 
@@ -11,5 +12,28 @@ struct SkillFrontmatterTests {
         #expect(SkillFrontmatter.requiredFields(valid) != nil)
         #expect(SkillFrontmatter.requiredFields(missingName) == nil)
         #expect(SkillFrontmatter.requiredFields(emptyDescription) == nil)
+    }
+
+    @Test func replacingNameKeepsTheDraftInstructions() {
+        let draft = "---\nname: New skill\ndescription: Edit clips.\n---\n\n## Workflow\n1. First step."
+
+        let updated = SkillFrontmatter.replacingName(draft, name: "Editing")
+
+        #expect(updated == "---\nname: Editing\ndescription: Edit clips.\n---\n\n## Workflow\n1. First step.")
+    }
+
+    @Test @MainActor func newSkillTemplateIsValidBeforeItIsSaved() {
+        let parsed = SkillFrontmatter.requiredFields(SkillStore.newSkillTemplate)
+
+        #expect(parsed?.name == "New skill")
+        #expect(parsed?.description.isEmpty == false)
+    }
+
+    @Test func displayPathUsesTheHomeDirectoryAbbreviation() {
+        let path = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".palmier/skills/captions/SKILL.md")
+        let skill = Skill(id: "captions", name: "Captions", description: "Create captions.", path: path)
+
+        #expect(skill.displayPath == "~/.palmier/skills/captions")
     }
 }

--- a/Tests/PalmierProTests/Agent/SkillUsageAnalyticsTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillUsageAnalyticsTests.swift
@@ -23,6 +23,20 @@ struct SkillUsageAnalyticsTests {
         #expect(Set(properties.keys) == ["skill_id", "skill_sha", "skill_origin", "source", "session_id"])
     }
 
+    @Test func skillCreatedPropertiesAttributeTheCreator() {
+        let origin = Analytics.Origin(source: "agent", sessionID: "session-1")
+
+        let properties = Analytics.$origin.withValue(origin) {
+            Analytics.skillCreatedProperties(skillName: "Custom workflow")
+        }
+
+        #expect(Analytics.Event.skillCreated.rawValue == "skill created")
+        #expect(properties["skill_name"] as? String == "Custom workflow")
+        #expect(properties["source"] as? String == "agent")
+        #expect(properties["session_id"] as? String == "session-1")
+        #expect(Set(properties.keys) == ["skill_name", "source", "session_id"])
+    }
+
     @Test func skillOriginDistinguishesCommunityLocalAndModifiedSkills() {
         #expect(SkillStore.skillOrigin(installedSHA: "catalog", localSHA: "catalog") == .community)
         #expect(SkillStore.skillOrigin(installedSHA: "catalog", localSHA: "local") == .communityModified)

--- a/Tests/PalmierProTests/Agent/SkillUsageAnalyticsTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillUsageAnalyticsTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Skill usage analytics")
+struct SkillUsageAnalyticsTests {
+    @Test func skillReadPropertiesIdentifyTheSkillRevisionAndOrigin() {
+        let origin = Analytics.Origin(source: "mcp", sessionID: "session-1")
+
+        let properties = Analytics.$origin.withValue(origin) {
+            Analytics.skillReadProperties(
+                skillID: "color-grade",
+                skillSHA: "a1b2c3d4e5f6",
+                skillOrigin: SkillOrigin.community.rawValue
+            )
+        }
+
+        #expect(properties["skill_id"] as? String == "color-grade")
+        #expect(properties["skill_sha"] as? String == "a1b2c3d4e5f6")
+        #expect(properties["skill_origin"] as? String == "community")
+        #expect(properties["source"] as? String == "mcp")
+        #expect(properties["session_id"] as? String == "session-1")
+        #expect(Set(properties.keys) == ["skill_id", "skill_sha", "skill_origin", "source", "session_id"])
+    }
+
+    @Test func skillOriginDistinguishesCommunityLocalAndModifiedSkills() {
+        #expect(SkillStore.skillOrigin(installedSHA: "catalog", localSHA: "catalog") == .community)
+        #expect(SkillStore.skillOrigin(installedSHA: "catalog", localSHA: "local") == .communityModified)
+        #expect(SkillStore.skillOrigin(installedSHA: nil, localSHA: "local") == .local)
+    }
+
+    @Test @MainActor func unknownSkillReadIsRejectedBeforeItCanBeTracked() {
+        let editor = EditorViewModel()
+        let executor = ToolExecutor(editor: editor)
+
+        let result = executor.readSkill(["id": UUID().uuidString])
+
+        #expect(result.isError)
+    }
+}


### PR DESCRIPTION
## Summary
- Track successful skill reads with stable IDs, cached content revisions, and community/local origin metadata.
- Create skills only after a valid first save, recording the saved skill name and creator attribution in PostHog.
- Streamline skill editing and management with title-first drafts, row deletion controls, and shared deletion confirmation UI.

## Approach
- Skill telemetry never uploads instruction bodies or filesystem paths. Read events include the cached content SHA; create events include the user-requested skill name.
- New skills stay in an in-memory draft until validation and atomic file creation succeed. The unified editor explicitly separates draft and persisted modes.
- Existing and row-level deletion share the same confirmation presentation while retaining their respective dismissal and progress behavior.

## Testing
- [x] `swift test --filter SkillFrontmatterTests`
- [x] `swift test --filter SkillUsageAnalyticsTests`
- [x] `swift build --traits ProductionTelemetry`
- [x] `swift build`
- [ ] Manual UI: discard a new draft and confirm no file exists or creation event is sent.
- [ ] Manual UI: save a new skill, edit its title, and confirm the skill remains editable and the creation event has the expected name.
- [ ] Manual UI: confirm row deletion, cancellation, progress, and the absent header/content divider.

## Change statistics
- Application logic and UI: +411 / -112
- Tests: +78 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly settings UI and optional telemetry on local skill files; agent read_skill only adds analytics after existing validation.
> 
> **Overview**
> Improves skill authoring and management while adding **PostHog telemetry** for skill reads and successful creates (metadata only: id, content SHA, community/local/modified origin, and skill name—no bodies or paths).
> 
> **Authoring:** New skills open as an in-memory **draft** in `SkillDetailSheet` (`.draft` vs `.existing`); nothing is written until **Save** validates frontmatter and calls `createSkill(raw:)`. Title editing updates frontmatter in the draft or while editing; closing a draft discards without creating a file.
> 
> **Store:** Adds `SkillOrigin`, SHA/origin helpers, `rawContents(for:)`, shared `newSkillTemplate`, and replaces immediate `newSkill()` file creation with validated `createSkill`.
> 
> **UI:** Installed/community rows get trash delete with a shared `skillDeleteConfirmation` modifier; skill list action column widens slightly. Agent `read_skill` emits read analytics on success.
> 
> **Tests:** Frontmatter/template/display path and analytics/origin coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25716e7b64c219017b5c3cc6cc4810abb96518db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->