### PR TITLE
[fix] Remove audio meter accessibility polling

### DIFF
--- a/Sources/PalmierPro/Audio/AudioMeterView.swift
+++ b/Sources/PalmierPro/Audio/AudioMeterView.swift
@@ -119,34 +119,12 @@ struct AudioMeterView: View {
 
 private struct AudioMeterAccessibilityRepresentation: View {
     let meter: AudioMeterHub
-    @State private var description = L10n.string(
-        "Left \(Int(AudioMeterChannelState.floorDb)) dBFS, right \(Int(AudioMeterChannelState.floorDb)) dBFS"
-    )
 
     var body: some View {
         Text(L10n.string("Master Audio Meter"))
-            .accessibilityValue(description)
             .accessibilityAction(named: L10n.string("Reset Clipping Indicators")) {
                 meter.resetClipping()
             }
-            .task { await updateDescription() }
-    }
-
-    private func updateDescription() async {
-        let clock = ContinuousClock()
-        while !Task.isCancelled {
-            let value = value(for: meter.display())
-            if description != value { description = value }
-            do {
-                try await clock.sleep(for: AppTheme.AudioMeter.accessibilityRefreshInterval)
-            } catch {
-                return
-            }
-        }
-    }
-
-    private func value(for display: StereoAudioMeterDisplay) -> String {
-        L10n.string("Left \(Int(display.left.levelDb.rounded())) dBFS, right \(Int(display.right.levelDb.rounded())) dBFS")
     }
 }
 

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -485,7 +485,6 @@
 "Large" = "Large";
 "Last Frame" = "Last Frame";
 "Layout" = "Layout";
-"Left %lld dBFS, right %lld dBFS" = "Left %lld dBFS, right %lld dBFS";
 "Length of the generated music. It's placed at the playhead, or at the marked range start." = "Length of the generated music. It's placed at the playhead, or at the marked range start.";
 "Let Agent create captions for you. Choose a predefined task, or ask Agent in the chat." = "Let Agent create captions for you. Choose a predefined task, or ask Agent in the chat.";
 "Let Agent generate music for you. Choose a starter, or ask Agent in the chat." = "Let Agent generate music for you. Choose a starter, or ask Agent in the chat.";

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -125,7 +125,6 @@ enum AppTheme {
         static let panelWidth: CGFloat = 32
         static let barWidth: CGFloat = 8
         static let refreshInterval: Double = 1.0 / 30.0
-        static let accessibilityRefreshInterval: Duration = .milliseconds(250)
         static let rulerStepDb: Float = 6
         static let rulerMajorStepDb: Float = 12
         static let yellowThresholdDb: Float = -20


### PR DESCRIPTION
## Summary
- Remove the recurring main-thread accessibility task that localized live audio-meter dB readings every 250 ms.
- Preserve the static “Master Audio Meter” label and “Reset Clipping Indicators” accessibility action.
- Eliminate the code path sampled by the `PALMIER-PRO-1GH` production hang cluster now that live spoken meter levels are not a product requirement.

## Approach
- Remove the dynamic accessibility value and polling task from `AudioMeterAccessibilityRepresentation`.
- Remove the now-unused accessibility refresh interval from `AppTheme` and sync the generated English localization inventory.
- Keep the visual meter, accessibility identity, and reset behavior unchanged.

## Testing
- `scripts/localization/sync.sh` — passed; generated inventory committed.
- `swift test --filter AudioMeterTests` — 6 tests passed.
- `swift build` — passed.
- `swift test` — 1,427 tests passed.
- Temporary debug microbenchmark: the original path took 1.003 seconds for 100,000 idle refreshes; the final implementation schedules no recurring accessibility refreshes.
- Manual VoiceOver verification remains: confirm the meter is announced and the reset action works.

## Change statistics
- Code logic: +0 / -23
- Localization inventory: +0 / -1
- Tests: +0 / -0
- Total: +0 / -24