### PR TITLE
[ui/fix] Add reliable caption length limits

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -854,7 +854,12 @@ enum ToolDefinitions {
                         ],
                     ],
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
-                    "maxWords": ["type": "integer", "description": "Max words per caption."],
+                    "maxWords": ["type": "integer", "minimum": 1, "description": "Max words per caption."],
+                    "maxCharacters": [
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Max characters per caption, including spaces and punctuation. A single word may exceed this limit.",
+                    ],
                     "maximumGapSeconds": [
                         "type": "number",
                         "minimum": CaptionGapSettings.maximumGapRange.lowerBound,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -3,8 +3,8 @@ import Foundation
 
 extension ToolExecutor {
     private static let addCaptionsAllowedKeys: Set<String> = Set([
-        "style", "transform", "censorProfanity", "language", "animation", "highlightColor", "maxWords", "trackIndex",
-        "maximumGapSeconds",
+        "style", "transform", "censorProfanity", "language", "animation", "highlightColor", "maxWords",
+        "maxCharacters", "trackIndex", "maximumGapSeconds",
     ])
 
     func addCaptions(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -23,11 +23,8 @@ extension ToolExecutor {
 
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "add_captions") ?? TextAnimation()
 
-        var maxWords: Int?
-        if let n = args.int("maxWords") {
-            guard n >= 1 else { throw ToolError("add_captions: maxWords must be >= 1 (got \(n))") }
-            maxWords = n
-        }
+        let maxWords = try captionLimit("maxWords", from: args)
+        let maxCharacters = try captionLimit("maxCharacters", from: args)
 
         let gapSettings: CaptionGapSettings
         if let rawMaximumGap = args["maximumGapSeconds"] {
@@ -64,6 +61,7 @@ extension ToolExecutor {
         request.censorProfanity = args.bool("censorProfanity") ?? false
         request.locale = context.preferredLocale
         request.maxWords = maxWords
+        request.maxCharacters = maxCharacters
         request.gapSettings = gapSettings
         request.animation = animation
 
@@ -75,5 +73,13 @@ extension ToolExecutor {
         })
         guard !ids.isEmpty else { throw ToolError("No speech detected to caption.") }
         return mutationResult(editor, since: snapshot)
+    }
+
+    private func captionLimit(_ key: String, from args: [String: Any]) throws -> Int? {
+        guard args.keys.contains(key) else { return nil }
+        guard let value = exactJSONInt(args[key]), value >= 1 else {
+            throw ToolError("add_captions: \(key) must be an integer >= 1.")
+        }
+        return value
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -11,6 +11,7 @@ extension EditorViewModel {
         var censorProfanity: Bool = false
         var locale: Locale? = nil
         var maxWords: Int? = nil
+        var maxCharacters: Int? = nil
         var gapSettings: CaptionGapSettings = .default
         var provider: TranscriptionProvider = .local
         /// Animation applied to every generated caption clip (timed from the transcript).
@@ -217,6 +218,7 @@ extension EditorViewModel {
             center: request.center,
             textCase: request.textCase,
             maxWords: request.maxWords,
+            maxCharacters: request.maxCharacters,
             gapSettings: request.gapSettings,
             animation: animation
         )

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -682,7 +682,7 @@ extension EditorViewModel {
 
     struct TextClipSpec: Sendable {
         let trackIndex: Int
-        let startFrame: Int
+        var startFrame: Int
         var durationFrames: Int
         let content: String
         let style: TextStyle

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -22,25 +22,23 @@ enum CaptionBuilder {
         words: [TranscriptionWord] = [],
         fits: (String) -> Bool,
         maxWords: Int? = nil,
-        minDuration: Double
+        maxCharacters: Int? = nil
     ) -> [Phrase] {
-        // Only phrases that fit visually and within the word cap are accepted; else, keep splitting.
-        let pieces: [String]
-        if let limit = maxWords {
-            let cap = max(1, limit)
-            pieces = split(segment.text, fits: { fits($0) && wordCount($0) <= cap })
-        } else {
-            pieces = split(segment.text, fits: fits)
+        let wordCap = maxWords.map { max(1, $0) }
+        let characterCap = maxCharacters.map { max(1, $0) }
+        let pieces = split(segment.text) { text in
+            fits(text)
+                && (wordCap.map { wordCount(text) <= $0 } ?? true)
+                && (characterCap.map { text.count <= $0 } ?? true)
         }
-        let timed = time(pieces, segment: segment, words: words)
-        return enforceMinDuration(timed, minDuration: minDuration)
+        return time(pieces, segment: segment, words: words)
     }
 
     static func phrases(
         fromTimedWords words: [TranscriptionWord],
         fits: (String) -> Bool,
         maxWords: Int? = nil,
-        minDuration: Double
+        maxCharacters: Int? = nil
     ) -> [Phrase] {
         let timed = words.filter { $0.start != nil && $0.end != nil }
         guard let first = timed.first, let last = timed.last, let start = first.start, let end = last.end, end > start else { return [] }
@@ -51,7 +49,7 @@ enum CaptionBuilder {
             words: timed,
             fits: fits,
             maxWords: maxWords,
-            minDuration: minDuration
+            maxCharacters: maxCharacters
         )
     }
 
@@ -149,21 +147,6 @@ enum CaptionBuilder {
             t += dur
         }
         return phrases
-    }
-
-    /// Give each phrase a floor duration without moving later phrases off their first word.
-    private static func enforceMinDuration(_ phrases: [Phrase], minDuration: Double) -> [Phrase] {
-        var out = phrases
-        for i in out.indices {
-            let targetEnd = max(out[i].end, out[i].start + minDuration)
-            if i + 1 < out.count {
-                out[i].end = min(targetEnd, out[i + 1].start)
-                if out[i].end < out[i].start { out[i].end = out[i].start }
-            } else {
-                out[i].end = targetEnd
-            }
-        }
-        return out
     }
 
     static func specs(

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionBuilder.swift
@@ -26,6 +26,7 @@ enum CaptionBuilder {
     ) -> [Phrase] {
         let wordCap = maxWords.map { max(1, $0) }
         let characterCap = maxCharacters.map { max(1, $0) }
+        // Visual, word, and character limits must all accept a phrase.
         let pieces = split(segment.text) { text in
             fits(text)
                 && (wordCap.map { wordCount(text) <= $0 } ?? true)

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -177,16 +177,23 @@ enum CaptionSpecBuilder {
         _ spec: inout EditorViewModel.TextClipSpec,
         to startFrame: Int
     ) {
+        let wordOffsetFrames = positiveDistance(from: spec.startFrame, to: startFrame) ?? 0
         let originalEnd = endFrame(of: spec)
         spec.startFrame = startFrame
-        spec.durationFrames = originalEnd.flatMap {
+        let durationFrames = originalEnd.flatMap {
             positiveDistance(from: startFrame, to: $0)
         } ?? 1
+        spec = resized(
+            spec,
+            durationFrames: durationFrames,
+            wordOffsetFrames: wordOffsetFrames
+        )
     }
 
     private static func resized(
         _ spec: EditorViewModel.TextClipSpec,
         durationFrames: Int,
+        wordOffsetFrames: Int = 0,
         extendWordCycle: Bool = false
     ) -> EditorViewModel.TextClipSpec {
         var resized = spec
@@ -194,8 +201,10 @@ enum CaptionSpecBuilder {
         guard let originalWords = resized.words else { return resized }
 
         var words = originalWords.compactMap { word -> WordTiming? in
-            let start = min(max(0, word.startFrame), durationFrames)
-            let end = min(max(start, word.endFrame), durationFrames)
+            let shiftedStart = word.startFrame.subtractingReportingOverflow(wordOffsetFrames)
+            let shiftedEnd = word.endFrame.subtractingReportingOverflow(wordOffsetFrames)
+            let start = min(max(0, shiftedStart.overflow ? 0 : shiftedStart.partialValue), durationFrames)
+            let end = min(max(start, shiftedEnd.overflow ? 0 : shiftedEnd.partialValue), durationFrames)
             return end > start
                 ? WordTiming(text: word.text, startFrame: start, endFrame: end)
                 : nil

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -16,6 +16,7 @@ enum CaptionSpecBuilder {
         let center: CGPoint
         let textCase: EditorViewModel.CaptionCase
         let maxWords: Int?
+        let maxCharacters: Int?
         let gapSettings: CaptionGapSettings
         let animation: TextAnimation?
     }
@@ -33,7 +34,7 @@ enum CaptionSpecBuilder {
                 result: target.result,
                 fps: input.fps,
                 maxWords: input.maxWords,
-                minDuration: AppTheme.Caption.minDisplayDuration,
+                maxCharacters: input.maxCharacters,
                 fits: { text in
                     if Task.isCancelled { return true }
                     return lineFits(

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -77,71 +77,136 @@ enum CaptionSpecBuilder {
             ))
             try Task.checkCancellation()
         }
-        return closingShortGaps(
+        return adjustedCaptionTiming(
             in: specs,
             settings: input.gapSettings,
             fps: input.fps
         )
     }
 
-    private static func closingShortGaps(
+    private struct TimedCaption {
+        var spec: EditorViewModel.TextClipSpec
+        let originalDurationFrames: Int
+    }
+
+    private static func adjustedCaptionTiming(
         in specs: [EditorViewModel.TextClipSpec],
         settings: CaptionGapSettings,
         fps: Int
     ) -> [EditorViewModel.TextClipSpec] {
+        let orderedIndices = specs.indices.sorted {
+            let lhsStart = specs[$0].startFrame
+            let rhsStart = specs[$1].startFrame
+            return lhsStart == rhsStart ? $0 < $1 : lhsStart < rhsStart
+        }
+        var captions = orderedIndices.map {
+            TimedCaption(spec: specs[$0], originalDurationFrames: specs[$0].durationFrames)
+        }
         let maximumGapFrames = settings.maximumGapFrames(fps: fps)
-        guard maximumGapFrames > 0, !specs.isEmpty else { return specs }
 
-        var adjusted = specs
-        let ordered = adjusted.indices.sorted {
-            let lhs = adjusted[$0].startFrame
-            let rhs = adjusted[$1].startFrame
-            return lhs == rhs ? $0 < $1 : lhs < rhs
-        }
-        guard let firstIndex = ordered.first else { return adjusted }
-        var coverageIndex = firstIndex
-        let (firstEnd, firstEndOverflow) = adjusted[firstIndex].startFrame.addingReportingOverflow(
-            adjusted[firstIndex].durationFrames
-        )
-        var coverageEnd = firstEndOverflow ? adjusted[firstIndex].startFrame : firstEnd
+        // Resolve collisions before extending captions across eligible gaps.
+        for nextIndex in captions.indices.dropFirst() {
+            let previousIndex = nextIndex - 1
+            var previous = captions[previousIndex]
+            var next = captions[nextIndex]
+            resolveOverlap(previous: &previous, next: &next)
+            captions[previousIndex] = previous
+            captions[nextIndex] = next
 
-        for nextIndex in ordered.dropFirst() {
-            let next = adjusted[nextIndex]
-            if next.startFrame > coverageEnd {
-                let (gap, gapOverflow) = next.startFrame.subtractingReportingOverflow(coverageEnd)
-                if !gapOverflow, gap <= maximumGapFrames {
-                    let overlapFrames = next.animation?.preset.needsIncomingCaptionCoverage == true ? 1 : 0
-                    let (closedEnd, endOverflow) = next.startFrame.addingReportingOverflow(
-                        overlapFrames
-                    )
-                    let previousStart = adjusted[coverageIndex].startFrame
-                    let (duration, durationOverflow) = closedEnd.subtractingReportingOverflow(
-                        previousStart
-                    )
-                    if !endOverflow, !durationOverflow, duration > 0 {
-                        var previous = adjusted[coverageIndex]
-                        previous.durationFrames = duration
-                        if previous.animation?.preset == .wordCycle,
-                           var words = previous.words,
-                           let lastIndex = words.indices.last {
-                            words[lastIndex].endFrame = duration
-                            previous.words = words
-                        }
-                        adjusted[coverageIndex] = previous
-                        coverageEnd = closedEnd
-                    }
-                }
-            }
-
-            let (nextEnd, nextEndOverflow) = next.startFrame.addingReportingOverflow(
-                next.durationFrames
-            )
-            if !nextEndOverflow, nextEnd >= coverageEnd {
-                coverageEnd = max(coverageEnd, nextEnd)
-                coverageIndex = nextIndex
+            if maximumGapFrames > 0,
+               let previousEnd = endFrame(of: captions[previousIndex].spec),
+               let gap = positiveDistance(from: previousEnd, to: captions[nextIndex].spec.startFrame),
+               gap <= maximumGapFrames,
+               let duration = positiveDistance(
+                   from: captions[previousIndex].spec.startFrame,
+                   to: captions[nextIndex].spec.startFrame
+               ) {
+                captions[previousIndex].spec = resized(
+                    captions[previousIndex].spec,
+                    durationFrames: duration,
+                    extendWordCycle: true
+                )
             }
         }
-        return adjusted
+        return captions.map(\.spec)
+    }
+
+    private static func resolveOverlap(
+        previous: inout TimedCaption,
+        next: inout TimedCaption
+    ) {
+        guard let previousEnd = endFrame(of: previous.spec),
+              next.spec.startFrame < previousEnd else { return }
+
+        if next.spec.startFrame <= previous.spec.startFrame {
+            // Preserve transcript order when starts quantize to the same frame.
+            previous.spec = resized(previous.spec, durationFrames: 1)
+            if let shiftedStart = endFrame(of: previous.spec) {
+                shiftStartPreservingEnd(&next.spec, to: shiftedStart)
+            }
+            return
+        }
+
+        let overlap = positiveDistance(from: next.spec.startFrame, to: previousEnd)
+        if overlap == 1, previous.originalDurationFrames < next.originalDurationFrames {
+            // The shorter caption owns a one-frame rounding collision.
+            shiftStartPreservingEnd(&next.spec, to: previousEnd)
+            return
+        }
+
+        // Wider overlaps end at the next caption's authoritative start.
+        if let duration = positiveDistance(
+            from: previous.spec.startFrame,
+            to: next.spec.startFrame
+        ) {
+            previous.spec = resized(previous.spec, durationFrames: duration)
+        }
+    }
+
+    private static func endFrame(of spec: EditorViewModel.TextClipSpec) -> Int? {
+        let result = spec.startFrame.addingReportingOverflow(spec.durationFrames)
+        return result.overflow ? nil : result.partialValue
+    }
+
+    private static func positiveDistance(from start: Int, to end: Int) -> Int? {
+        let result = end.subtractingReportingOverflow(start)
+        return !result.overflow && result.partialValue > 0 ? result.partialValue : nil
+    }
+
+    private static func shiftStartPreservingEnd(
+        _ spec: inout EditorViewModel.TextClipSpec,
+        to startFrame: Int
+    ) {
+        let originalEnd = endFrame(of: spec)
+        spec.startFrame = startFrame
+        spec.durationFrames = originalEnd.flatMap {
+            positiveDistance(from: startFrame, to: $0)
+        } ?? 1
+    }
+
+    private static func resized(
+        _ spec: EditorViewModel.TextClipSpec,
+        durationFrames: Int,
+        extendWordCycle: Bool = false
+    ) -> EditorViewModel.TextClipSpec {
+        var resized = spec
+        resized.durationFrames = durationFrames
+        guard let originalWords = resized.words else { return resized }
+
+        var words = originalWords.compactMap { word -> WordTiming? in
+            let start = min(max(0, word.startFrame), durationFrames)
+            let end = min(max(start, word.endFrame), durationFrames)
+            return end > start
+                ? WordTiming(text: word.text, startFrame: start, endFrame: end)
+                : nil
+        }
+        if extendWordCycle,
+           resized.animation?.preset == .wordCycle,
+           let lastIndex = words.indices.last {
+            words[lastIndex].endFrame = durationFrames
+        }
+        resized.words = words.isEmpty ? nil : words
+        return resized
     }
 
     private static func lineFits(

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -13,6 +13,7 @@ struct CaptionTab: View {
     @State private var animationHighlight: TextStyle.RGBA = TextAnimation.defaultHighlight
     @State private var censorProfanity = false
     @State private var maxWords: Int?
+    @State private var maxCharacters: Int?
     @State private var maximumGapSeconds = CaptionGapSettings.default.maximumGapSeconds
     @State private var locale: Locale?
     @State private var supportedLocales: [Locale] = []
@@ -26,6 +27,8 @@ struct CaptionTab: View {
     @State private var placementExpanded = true
 
     private static let previewText = L10n.key("Captions will look like this")
+    private static let maxWordRange = 0.0...50.0
+    private static let maxCharacterRange = 0.0...200.0
 
     private var aspect: CGFloat { CGFloat(editor.timeline.width) / CGFloat(max(1, editor.timeline.height)) }
 
@@ -183,14 +186,30 @@ struct CaptionTab: View {
                 labelHelp: L10n.string("Cap the words shown per caption. None fits each line to the box."),
                 onReset: { maxWords = nil }
             ) {
-                Menu {
-                    Button(L10n.string("None")) { maxWords = nil }
-                    ForEach(1...8, id: \.self) { n in
-                        Button(action: { maxWords = n }) { Text(verbatim: "\(n)") }
-                    }
-                } label: { EditorMenuValue(text: maxWords.map(String.init) ?? L10n.string("None"), expanded: true) }
-                .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).focusable(false)
-                .frame(maxWidth: .infinity)
+                ScrubbableNumberField(
+                    value: Double(maxWords ?? 0),
+                    range: Self.maxWordRange,
+                    dragValueAdjustment: { $0.rounded() },
+                    displayTextOverride: { $0 < 1 ? L10n.string("None") : nil },
+                    onChanged: updateMaxWords,
+                    onCommit: updateMaxWords
+                )
+                .accessibilityLabel(L10n.string("Max words"))
+            }
+            InspectorRow(
+                label: L10n.string("Max characters"),
+                labelHelp: L10n.string("Cap characters per caption, including spaces and punctuation. A single word may exceed the limit."),
+                onReset: { maxCharacters = nil }
+            ) {
+                ScrubbableNumberField(
+                    value: Double(maxCharacters ?? 0),
+                    range: Self.maxCharacterRange,
+                    dragValueAdjustment: { $0.rounded() },
+                    displayTextOverride: { $0 < 1 ? L10n.string("None") : nil },
+                    onChanged: updateMaxCharacters,
+                    onCommit: updateMaxCharacters
+                )
+                .accessibilityLabel(L10n.string("Max characters"))
             }
             InspectorRow(
                 label: L10n.string("Close gaps"),
@@ -494,6 +513,7 @@ struct CaptionTab: View {
             censorProfanity: provider == .local && censorProfanity,
             locale: locale,
             maxWords: maxWords,
+            maxCharacters: maxCharacters,
             gapSettings: CaptionGapSettings(maximumGapSeconds: maximumGapSeconds) ?? .default,
             provider: provider,
             animation: TextAnimation(preset: animationPreset, highlight: animationHighlight)
@@ -518,6 +538,16 @@ struct CaptionTab: View {
                 note = localizedCaptionError(error)
             }
         }
+    }
+
+    private func updateMaxCharacters(_ value: Double) {
+        let count = Int(value.rounded())
+        maxCharacters = count > 0 ? count : nil
+    }
+
+    private func updateMaxWords(_ value: Double) {
+        let count = Int(value.rounded())
+        maxWords = count > 0 ? count : nil
     }
 
     private func cloudUnavailableMessage(cost: Int?, provider mode: TranscriptionProvider? = nil) -> String? {

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTranscriptMapper.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTranscriptMapper.swift
@@ -29,7 +29,7 @@ enum CaptionTranscriptMapper {
         result: TranscriptionResult,
         fps: Int,
         maxWords: Int?,
-        minDuration: Double,
+        maxCharacters: Int?,
         fits: (String) -> Bool
     ) -> [CaptionBuilder.Phrase] {
         let hasWordTimings = result.words.contains { $0.start != nil && $0.end != nil }
@@ -47,7 +47,7 @@ enum CaptionTranscriptMapper {
                 visibleEnd: visibleEnd,
                 result: result,
                 maxWords: maxWords,
-                minDuration: minDuration,
+                maxCharacters: maxCharacters,
                 fits: fits
             )
         }
@@ -58,7 +58,7 @@ enum CaptionTranscriptMapper {
                 for: clipped,
                 fits: fits,
                 maxWords: maxWords,
-                minDuration: minDuration
+                maxCharacters: maxCharacters
             )
         }
     }
@@ -68,7 +68,7 @@ enum CaptionTranscriptMapper {
         visibleEnd: Double,
         result: TranscriptionResult,
         maxWords: Int?,
-        minDuration: Double,
+        maxCharacters: Int?,
         fits: (String) -> Bool
     ) -> [CaptionBuilder.Phrase] {
         let segments = result.segments.isEmpty ? [fallbackSegment(for: result)] : result.segments
@@ -109,7 +109,7 @@ enum CaptionTranscriptMapper {
                 fromTimedWords: segmentWords,
                 fits: fits,
                 maxWords: maxWords,
-                minDuration: minDuration
+                maxCharacters: maxCharacters
             ))
         }
         return phrases

--- a/Sources/PalmierPro/Models/TextAnimation.swift
+++ b/Sources/PalmierPro/Models/TextAnimation.swift
@@ -32,16 +32,6 @@ struct TextAnimation: Codable, Sendable, Equatable {
         var isPerWord: Bool { renderMode == .perWord }
         var usesHighlight: Bool { isPerWord }
 
-        var needsIncomingCaptionCoverage: Bool {
-            switch self {
-            case .fadeIn, .popIn, .slideUp, .typewriter,
-                 .wordReveal, .wordSlide, .wordPop, .wordCycle:
-                true
-            default:
-                false
-            }
-        }
-
         var displayName: String {
             switch self {
             case .none: L10n.key("Off")

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -147,6 +147,7 @@
 "Canceling" = "Canceling";
 "Cancels %@" = "Cancels %@";
 "Canvas Zoom" = "Canvas Zoom";
+"Cap characters per caption, including spaces and punctuation. A single word may exceed the limit." = "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit.";
 "Cap the words shown per caption. None fits each line to the box." = "Cap the words shown per caption. None fits each line to the box.";
 "Captions" = "Captions";
 "Captions will look like this" = "Captions will look like this";
@@ -540,6 +541,7 @@
 "Match mouth movement to replacement audio" = "Match mouth movement to replacement audio";
 "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast." = "Matches voices across clips, transcribing untranscribed timeline clips first (uses credits). Transcripts and voice fingerprints are cached, so re-runs are fast.";
 "Max" = "Max";
+"Max characters" = "Max characters";
 "Max plan" = "Max plan";
 "Max words" = "Max words";
 "Maximize Focused Panel" = "Maximize Focused Panel";

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -458,7 +458,6 @@ enum AppTheme {
         static let centerSnapThreshold: Double = 0.02
         static let defaultCenterY: CGFloat = 0.9
         static let defaultCenter = CGPoint(x: centerSnapValue, y: defaultCenterY)
-        static let minDisplayDuration: Double = 0.7
     }
 
     enum GenerationPanel {

--- a/Tests/PalmierProTests/Agent/GetTranscriptParamTests.swift
+++ b/Tests/PalmierProTests/Agent/GetTranscriptParamTests.swift
@@ -193,6 +193,27 @@ struct GetTranscriptParamTests {
         #expect(maximumGap["maximum"] as? Double == CaptionGapSettings.maximumGapRange.upperBound)
     }
 
+    @Test func addCaptionsSchemaExposesLengthLimits() throws {
+        let tool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addCaptions })
+        let properties = try #require(tool.inputSchema["properties"] as? [String: [String: Any]])
+
+        for key in ["maxWords", "maxCharacters"] {
+            #expect(properties[key]?["type"] as? String == "integer")
+            #expect(properties[key]?["minimum"] as? Int == 1)
+        }
+    }
+
+    @Test func addCaptionsRejectsInvalidMaxCharactersBeforeTranscription() async {
+        let h = ToolHarness(timeline: Fixtures.timeline())
+        let invalidValues: [Any] = [0, -1, 1.5, "10", true]
+
+        for value in invalidValues {
+            let result = await h.runRaw("add_captions", args: ["maxCharacters": value])
+            #expect(result.isError)
+            #expect(ToolHarness.textOf(result).contains("maxCharacters"))
+        }
+    }
+
     @Test func addCaptionsRejectsInvalidMaximumGapSecondsBeforeTranscription() async {
         let h = ToolHarness(timeline: Fixtures.timeline())
         let invalidValues: [Any] = [-0.1, 2.1, "0.25", true, Double.infinity]

--- a/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
@@ -38,6 +38,9 @@ struct MCPTranscriptionTrackTests {
             #expect(maximumGap["type"]?.stringValue == "number")
             #expect(maximumGap["minimum"]?.intValue == 0)
             #expect(maximumGap["maximum"]?.intValue == 2)
+            let maxCharacters = try #require(captionProperties["maxCharacters"]?.objectValue)
+            #expect(maxCharacters["type"]?.stringValue == "integer")
+            #expect(maxCharacters["minimum"]?.intValue == 1)
 
             let transcript = try await client.callTool(
                 name: "get_transcript",
@@ -59,6 +62,11 @@ struct MCPTranscriptionTrackTests {
                 arguments: ["maximumGapSeconds": .double(2.1)]
             )
             #expect(invalidGap.isError == true)
+            let invalidMaxCharacters = try await client.callTool(
+                name: "add_captions",
+                arguments: ["maxCharacters": .int(0)]
+            )
+            #expect(invalidMaxCharacters.isError == true)
         } catch {
             await server.stop()
             await client.disconnect()

--- a/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
@@ -62,6 +62,19 @@ struct CaptionBuilderTests {
         #expect(phrases.map(\.text) == ["hi,", "you"])
     }
 
+    @Test func wordAndCharacterCapsApplyTogetherWithoutDroppingText() {
+        let phrases = CaptionBuilder.phrases(
+            for: segment("a bb ccc dddd", 0, 4),
+            fits: { _ in true },
+            maxWords: 2,
+            maxCharacters: 5
+        )
+
+        #expect(phrases.allSatisfy { $0.text.split(separator: " ").count <= 2 })
+        #expect(phrases.allSatisfy { $0.text.count <= 5 })
+        #expect(phrases.map(\.text).joined(separator: " ") == "a bb ccc dddd")
+    }
+
     @Test func keepsPunctuatedTokensIntact() {
         let phrases = CaptionBuilder.phrases(for: segment("U.S. army here", 0, 6), fits: { $0.count <= 6 })
         #expect(phrases.map(\.text) == ["U.S.", "army", "here"])

--- a/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
@@ -9,59 +9,72 @@ struct CaptionBuilderTests {
     }
 
     @Test func keepsSegmentWholeWhenItFits() {
-        let phrases = CaptionBuilder.phrases(for: segment("Hello there", 1.0, 2.0), fits: { _ in true }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("Hello there", 1.0, 2.0), fits: { _ in true })
         #expect(phrases == [CaptionBuilder.Phrase(text: "Hello there", start: 1.0, end: 2.0)])
     }
 
     @Test func splitsAtSentenceBoundary() {
-        let phrases = CaptionBuilder.phrases(for: segment("One. Two.", 0, 8), fits: { $0.count <= 5 }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("One. Two.", 0, 8), fits: { $0.count <= 5 })
         #expect(phrases.map(\.text) == ["One.", "Two."])
         #expect(phrases.map(\.start) == [0.0, 4.0])
         #expect(phrases.map(\.end) == [4.0, 8.0])
     }
 
     @Test func splitsAtClauseWhenNoSentence() {
-        let phrases = CaptionBuilder.phrases(for: segment("alpha, beta", 0, 2), fits: { $0.count <= 6 }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("alpha, beta", 0, 2), fits: { $0.count <= 6 })
         #expect(phrases.map(\.text) == ["alpha,", "beta"])
     }
 
     @Test func splitsAtMidWordWhenNoPunctuation() {
-        let phrases = CaptionBuilder.phrases(for: segment("a b c d", 0, 4), fits: { $0.count <= 3 }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("a b c d", 0, 4), fits: { $0.count <= 3 })
         #expect(phrases.map(\.text) == ["a b", "c d"])
     }
 
     @Test func capsWordsPerCaption() {
         let phrases = CaptionBuilder.phrases(for: segment("one two three four five six", 0, 6),
-                                             fits: { _ in true }, maxWords: 2, minDuration: 0)
+                                             fits: { _ in true }, maxWords: 2)
         #expect(phrases.allSatisfy { $0.text.split(separator: " ").count <= 2 })
         #expect(phrases.map(\.text).joined(separator: " ") == "one two three four five six")
     }
 
     @Test func maxWordsStillPrefersSentenceBoundary() {
         let phrases = CaptionBuilder.phrases(for: segment("Hi there. How are you", 0, 6),
-                                             fits: { _ in true }, maxWords: 3, minDuration: 0)
+                                             fits: { _ in true }, maxWords: 3)
         #expect(phrases.map(\.text) == ["Hi there.", "How are you"])
     }
 
+    @Test func capsCharactersPerCaption() {
+        let phrases = CaptionBuilder.phrases(
+            for: segment("one two three four", 0, 4),
+            fits: { _ in true },
+            maxCharacters: 8
+        )
+        #expect(phrases.allSatisfy { $0.text.count <= 8 })
+        #expect(phrases.map(\.text).joined(separator: " ") == "one two three four")
+    }
+
+    @Test func characterCapIncludesSpacesAndPunctuation() {
+        let phrases = CaptionBuilder.phrases(
+            for: segment("hi, you", 0, 2),
+            fits: { _ in true },
+            maxCharacters: 6
+        )
+        #expect(phrases.map(\.text) == ["hi,", "you"])
+    }
+
     @Test func keepsPunctuatedTokensIntact() {
-        let phrases = CaptionBuilder.phrases(for: segment("U.S. army here", 0, 6), fits: { $0.count <= 6 }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("U.S. army here", 0, 6), fits: { $0.count <= 6 })
         #expect(phrases.map(\.text) == ["U.S.", "army", "here"])
     }
 
     @Test func distributesTimeByCharacterCount() {
-        let phrases = CaptionBuilder.phrases(for: segment("aaaa bb", 0, 6), fits: { $0.count <= 4 }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("aaaa bb", 0, 6), fits: { $0.count <= 4 })
         #expect(phrases.map(\.text) == ["aaaa", "bb"])
         #expect(phrases.map(\.start) == [0.0, 4.0])
         #expect(phrases.map(\.end) == [4.0, 6.0])
     }
 
-    @Test func enforcesMinimumDurationWithoutShiftingLaterPhrases() {
-        let phrases = CaptionBuilder.phrases(for: segment("aa bbbb", 0, 6), fits: { $0.count <= 4 }, minDuration: 3)
-        #expect(phrases.map(\.start) == [0.0, 2.0])
-        #expect(phrases.map(\.end) == [2.0, 6.0])
-    }
-
-    @Test func denseWordTimingsKeepNextPhraseStart() {
+    @Test func denseWordTimingsRemainExact() {
         let words = [
             TranscriptionWord(text: "Okay,", start: 1.235, end: 1.413),
             TranscriptionWord(text: "so", start: 1.430, end: 1.609),
@@ -72,12 +85,11 @@ struct CaptionBuilderTests {
         let phrases = CaptionBuilder.phrases(
             for: segment("Okay, so I've been sleeping", 1.235, 2.161),
             words: words,
-            fits: { $0 == "Okay," || $0 == "so I've been sleeping" },
-            minDuration: 0.7
+            fits: { $0 == "Okay," || $0 == "so I've been sleeping" }
         )
         #expect(phrases.map(\.text) == ["Okay,", "so I've been sleeping"])
         #expect(phrases.map(\.start) == [1.235, 1.430])
-        #expect(phrases[0].end == 1.430)
+        #expect(phrases[0].end == 1.413)
     }
 
     @Test func phrasesFromWordsUseOnlyPassedWords() {
@@ -86,15 +98,14 @@ struct CaptionBuilderTests {
                 TranscriptionWord(text: "Okay,", start: 1.0, end: 1.2),
                 TranscriptionWord(text: "go", start: 2.0, end: 2.2),
             ],
-            fits: { _ in true },
-            minDuration: 0
+            fits: { _ in true }
         )
         #expect(phrases.map(\.text) == ["Okay, go"])
         #expect(phrases[0].words.map(\.text) == ["Okay,", "go"])
     }
 
     @Test func keepsOverlongSingleWord() {
-        let phrases = CaptionBuilder.phrases(for: segment("supercalifragilistic", 0, 1), fits: { _ in false }, minDuration: 0)
+        let phrases = CaptionBuilder.phrases(for: segment("supercalifragilistic", 0, 1), fits: { _ in false })
         #expect(phrases.map(\.text) == ["supercalifragilistic"])
     }
 

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -226,7 +226,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         .wordPop,
         .wordCycle,
     ])
-    func holdsPreviousCaptionThroughTransparentAnimatedEntry(
+    func closesAnimatedCaptionGapWithoutOverlap(
         preset: TextAnimation.Preset
     ) async throws {
         let specs = try await CaptionSpecBuilder.build(input(
@@ -237,11 +237,12 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             animation: TextAnimation(preset: preset)
         ))
 
-        #expect(specs.map(\.durationFrames) == [28, 21])
-        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 28 : 21))
+        #expect(specs.map(\.durationFrames) == [27, 21])
+        #expect(specs[0].startFrame + specs[0].durationFrames == specs[1].startFrame)
+        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 27 : 21))
     }
 
-    @Test func oneFrameAnimatedCaptionOwnsTheFollowingGap() async throws {
+    @Test func oneFrameAnimatedCaptionClosesTheFollowingGapWithoutOverlap() async throws {
         let specs = try await CaptionSpecBuilder.build(input(
             targets: [
                 gapTarget(id: "one", startFrame: 0, durationFrames: 21),
@@ -251,26 +252,107 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             animation: TextAnimation(preset: .fadeIn)
         ))
 
-        #expect(specs.map(\.durationFrames) == [28, 7, 21])
+        #expect(specs.map(\.durationFrames) == [27, 6, 21])
+        #expect(specs[0].startFrame + specs[0].durationFrames == specs[1].startFrame)
+        #expect(specs[1].startFrame + specs[1].durationFrames == specs[2].startFrame)
     }
 
-    @Test func leavesOverlapsUnchanged() async throws {
-        let overlapping = try await CaptionSpecBuilder.build(input(targets: [
-            gapTarget(id: "one", startFrame: 0, durationFrames: 21),
-            gapTarget(id: "two", startFrame: 20, durationFrames: 30),
-        ]))
+    @Test func trimsOverlapsWhenGapClosingIsDisabled() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(id: "two", startFrame: 20, durationFrames: 30),
+            ],
+            maximumGapSeconds: 0
+        ))
 
-        #expect(overlapping.map(\.durationFrames) == [21, 21])
+        #expect(specs.map(\.startFrame) == [0, 20])
+        #expect(specs.map(\.durationFrames) == [20, 21])
+        #expect(specs[0].words?.last?.endFrame == 20)
     }
 
-    @Test func closesGapFromTheClipProvidingLatestCoverage() async throws {
+    @Test func trimsNestedOverlapsWithoutExtendingAcrossALongGap() async throws {
         let specs = try await CaptionSpecBuilder.build(input(targets: [
             gapTarget(id: "outer", startFrame: 0, durationFrames: 40),
             gapTarget(id: "nested", startFrame: 10, durationFrames: 5),
             gapTarget(id: "next", startFrame: 26, durationFrames: 30),
         ]))
 
-        #expect(specs.map(\.durationFrames) == [26, 5, 21])
+        #expect(specs.map(\.startFrame) == [0, 10, 26])
+        #expect(specs.map(\.durationFrames) == [10, 5, 21])
+    }
+
+    @Test func shorterPreviousCaptionOwnsOverlappingFrames() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 5),
+                gapTarget(id: "two", startFrame: 4, durationFrames: 21),
+            ],
+            maximumGapSeconds: 0
+        ))
+
+        #expect(specs.map(\.content) == ["one", "two"])
+        #expect(specs.map(\.startFrame) == [0, 5])
+        #expect(specs.map(\.durationFrames) == [5, 20])
+    }
+
+    @Test func shorterNextCaptionOwnsOverlappingFrames() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(id: "two", startFrame: 20, durationFrames: 5),
+            ],
+            maximumGapSeconds: 0
+        ))
+
+        #expect(specs.map(\.content) == ["one", "two"])
+        #expect(specs.map(\.startFrame) == [0, 20])
+        #expect(specs.map(\.durationFrames) == [20, 5])
+    }
+
+    @Test func laterCaptionWinsEqualDurationTie() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 5),
+                gapTarget(id: "two", startFrame: 4, durationFrames: 5),
+            ],
+            maximumGapSeconds: 0
+        ))
+
+        #expect(specs.map(\.startFrame) == [0, 4])
+        #expect(specs.map(\.durationFrames) == [4, 5])
+    }
+
+    @Test func sameFrameCaptionsRemainSeparateAndCapped() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "one", startFrame: 0, durationFrames: 21),
+                gapTarget(id: "two", startFrame: 0, durationFrames: 5),
+            ],
+            maximumGapSeconds: 0,
+            maxCharacters: 3
+        ))
+
+        #expect(specs.map(\.content) == ["one", "two"])
+        #expect(specs.map(\.startFrame) == [0, 1])
+        #expect(specs.map(\.durationFrames) == [1, 4])
+        #expect(specs.allSatisfy { $0.content.count <= 3 })
+    }
+
+    @Test func sameFrameCollisionChainPreservesEveryCaption() async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(id: "aaa", startFrame: 0, durationFrames: 3),
+                gapTarget(id: "bb", startFrame: 0, durationFrames: 2),
+                gapTarget(id: "c", startFrame: 0, durationFrames: 1),
+            ],
+            maximumGapSeconds: 0,
+            maxCharacters: 3
+        ))
+
+        #expect(specs.map(\.content) == ["aaa", "bb", "c"])
+        #expect(specs.map(\.startFrame) == [0, 1, 2])
+        #expect(specs.map(\.durationFrames) == [1, 1, 1])
     }
 
     @Test func captionGapSettingsValidateAndRoundDownToFrames() {

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -86,11 +86,12 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             start: startFrame,
             duration: durationFrames
         )
+        let captionDuration = min(0.7, Double(durationFrames) / 30)
         let result = TranscriptionResult(
             text: id,
             language: "en",
-            words: hasWordTiming ? [TranscriptionWord(text: id, start: 0, end: 0.1)] : [],
-            segments: [TranscriptionSegment(text: id, start: 0, end: 0.2)]
+            words: hasWordTiming ? [TranscriptionWord(text: id, start: 0, end: captionDuration)] : [],
+            segments: [TranscriptionSegment(text: id, start: 0, end: captionDuration)]
         )
         return CaptionSpecBuilder.Target(
             clip: clip,
@@ -101,6 +102,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
     private func input(
         targets: [CaptionSpecBuilder.Target],
         maximumGapSeconds: Double = CaptionGapSettings.default.maximumGapSeconds,
+        maxCharacters: Int? = nil,
         animation: TextAnimation? = nil
     ) -> CaptionSpecBuilder.Input {
         CaptionSpecBuilder.Input(
@@ -112,6 +114,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             center: CGPoint(x: 0.5, y: 0.8),
             textCase: .auto,
             maxWords: nil,
+            maxCharacters: maxCharacters,
             gapSettings: CaptionGapSettings(maximumGapSeconds: maximumGapSeconds) ?? .default,
             animation: animation
         )
@@ -143,6 +146,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             center: CGPoint(x: 0.5, y: 0.8),
             textCase: .upper,
             maxWords: nil,
+            maxCharacters: nil,
             gapSettings: .default,
             animation: nil
         )
@@ -156,6 +160,32 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(spec.durationFrames == 30)
         #expect(spec.transform != nil)
         #expect(spec.words?.map(\.text) == ["hello", "world"])
+    }
+
+    @Test func appliesCharacterCapWhenBuildingCaptionSpecs() async throws {
+        let clip = Fixtures.clip(
+            mediaRef: "media",
+            mediaType: .audio,
+            start: 0,
+            duration: 90
+        )
+        let result = TranscriptionResult(
+            text: "one two three",
+            language: "en",
+            words: [
+                TranscriptionWord(text: "one", start: 0, end: 0.2),
+                TranscriptionWord(text: "two", start: 0.3, end: 0.5),
+                TranscriptionWord(text: "three", start: 0.6, end: 0.8),
+            ],
+            segments: [TranscriptionSegment(text: "one two three", start: 0, end: 0.8)]
+        )
+
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [.init(clip: clip, result: result)],
+            maxCharacters: 7
+        ))
+
+        #expect(specs.map(\.content) == ["one", "two", "three"])
     }
 
     @Test(arguments: [
@@ -183,7 +213,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
         #expect(specs.map(\.startFrame) == [0, 21 + gapFrames])
         #expect(specs.map(\.durationFrames) == [expectedFirstDuration, 21])
-        #expect(specs[0].words == [WordTiming(text: "one", startFrame: 0, endFrame: 3)])
+        #expect(specs[0].words == [WordTiming(text: "one", startFrame: 0, endFrame: 21)])
     }
 
     @Test(arguments: [
@@ -208,7 +238,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         ))
 
         #expect(specs.map(\.durationFrames) == [28, 21])
-        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 28 : 3))
+        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 28 : 21))
     }
 
     @Test func oneFrameAnimatedCaptionOwnsTheFollowingGap() async throws {
@@ -371,6 +401,41 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
 @MainActor
 @Suite struct CaptionProjectionTests {
+    @Test(arguments: [true, false])
+    func preservesShortTimingsAcrossTranscriptSegments(hasWordTimings: Bool) {
+        let clip = Fixtures.clip(
+            mediaRef: "media",
+            mediaType: .audio,
+            start: 0,
+            duration: 60
+        )
+        let result = TranscriptionResult(
+            text: "Sophie? Hi,",
+            language: "en",
+            words: hasWordTimings ? [
+                TranscriptionWord(text: "Sophie?", start: 0, end: 0.2),
+                TranscriptionWord(text: "Hi,", start: 0.3, end: 0.5),
+            ] : [],
+            segments: [
+                TranscriptionSegment(text: "Sophie?", start: 0, end: 0.2),
+                TranscriptionSegment(text: "Hi,", start: 0.3, end: 0.5),
+            ]
+        )
+
+        let phrases = CaptionTranscriptMapper.phrases(
+            for: clip,
+            result: result,
+            fps: 30,
+            maxWords: nil,
+            maxCharacters: 4,
+            fits: { _ in true }
+        )
+
+        #expect(phrases.map(\.text) == ["Sophie?", "Hi,"])
+        #expect(phrases.map(\.start) == [0, 0.3])
+        #expect(phrases.map(\.end) == [0.2, 0.5])
+    }
+
     @Test func phrasesIgnoreWordsOutsideCurrentClipFragments() {
         let first = Fixtures.clip(id: "first", mediaRef: "media-1", mediaType: .audio, start: 0, duration: 30, trimStart: 0)
         let second = Fixtures.clip(id: "second", mediaRef: "media-1", mediaType: .audio, start: 30, duration: 30, trimStart: 60)
@@ -386,10 +451,12 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         )
 
         let firstPhrases = CaptionTranscriptMapper.phrases(
-            for: first, result: result, fps: 30, maxWords: nil, minDuration: 0, fits: { _ in true }
+            for: first, result: result, fps: 30, maxWords: nil, maxCharacters: nil,
+            fits: { _ in true }
         )
         let secondPhrases = CaptionTranscriptMapper.phrases(
-            for: second, result: result, fps: 30, maxWords: nil, minDuration: 0, fits: { _ in true }
+            for: second, result: result, fps: 30, maxWords: nil, maxCharacters: nil,
+            fits: { _ in true }
         )
 
         #expect(firstPhrases.map(\.text) == ["keep"])

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -294,6 +294,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(specs.map(\.content) == ["one", "two"])
         #expect(specs.map(\.startFrame) == [0, 5])
         #expect(specs.map(\.durationFrames) == [5, 20])
+        #expect(specs[1].words == [WordTiming(text: "two", startFrame: 0, endFrame: 20)])
     }
 
     @Test func shorterNextCaptionOwnsOverlappingFrames() async throws {
@@ -337,6 +338,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(specs.map(\.startFrame) == [0, 1])
         #expect(specs.map(\.durationFrames) == [1, 4])
         #expect(specs.allSatisfy { $0.content.count <= 3 })
+        #expect(specs[1].words == [WordTiming(text: "two", startFrame: 0, endFrame: 4)])
     }
 
     @Test func sameFrameCollisionChainPreservesEveryCaption() async throws {


### PR DESCRIPTION
## Summary
- Add scrubbable maximum-word and maximum-character controls to caption generation.
- Apply visual, word, and character limits together without dropping transcript text.
- Prevent generated caption clips from overlapping after timestamp-to-frame conversion.
- Expose `maxCharacters` through the `add_captions` Agent tool.

## Approach
- Keep text splitting in `CaptionBuilder`; an accepted phrase must satisfy every enabled limit, while a single indivisible word may exceed the character cap.
- Preserve transcript timing instead of applying the previous hidden 0.7-second display floor. The existing Close gaps setting remains the only duration extension policy.
- Normalize adjacent caption frame ranges after spec creation. Wider overlaps end at the next caption start; one-frame rounding collisions favor the shorter caption; same-frame starts preserve transcript order with one-frame placement.
- Rebase clip-relative word timings when a collision moves a caption start, then clamp timings to the resulting duration.
- Keep word-animation timing inside resized clip bounds and remove the obsolete animation-specific overlap policy.
- Validate Agent length limits as positive integers before transcription and verify discovery through the MCP boundary.

Merging same-frame captions was rejected because it silently violates configured length limits. Dropping one caption loses transcript text, while retaining overlap renders both captions simultaneously.

## Testing
- `swift test --filter '(CaptionBuilderTests|CaptionSpecBuilderTests|TextAnimationRenderTests)'` — passed.
- `swift test --filter '(GetTranscriptParamTests|MCPTranscriptionTrackTests)'` — passed.
- `swift test` — passed after rebasing onto `origin/main` and after the review fix.
- `swift build` — passed after rebasing onto `origin/main` and after the review fix.
- Manual app verification: regenerated captions with length limits and confirmed words remained present without overlapping clips.

## Change statistics
- Core caption logic: +147 / -97
- Caption UI: +38 / -8
- Agent tool logic: +19 / -8
- Localization inventory: +2 / -0
- Tests: +243 / -39
- Total: +449 / -152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core caption generation timing and splitting behavior across UI, agent tools, and timeline placement; well-tested but affects how all generated captions appear on the timeline.
> 
> **Overview**
> Adds **max characters** alongside max words for caption generation, with scrubbable controls in the Captions panel and a new `maxCharacters` parameter on the **`add_captions`** agent tool (validated as integers ≥ 1).
> 
> **Caption splitting** now requires each phrase to satisfy visual fit, word cap, and character cap together; transcript text is not dropped. The hidden **0.7s minimum display duration** is removed so phrase timing follows the transcript; **Close gaps** remains the only duration-extension policy.
> 
> **Post-build timing** in `CaptionSpecBuilder` resolves frame-quantization overlaps (trim, shift, same-frame ordering) before optional gap closing, with word timings adjusted inside resized clips. Animation-specific “incoming coverage” overlap behavior is removed.
> 
> Tests cover character caps, overlap resolution, agent/MCP schema, and updated gap-closing expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94534b8059a71510ab147315237ea4984e97645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->