### PR TITLE
[agent] Keep text boxes fitted to content

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -783,7 +783,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addTexts,
-            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Transform is normalized text-box center/size; center-only auto-fits, all four fields override the box. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
+            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets normalized center and rotation. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -798,8 +798,8 @@ enum ToolDefinitions {
                                 "content": ["type": "string", "description": "Text. Supports \\n."],
                                 "transform": [
                                     "type": "object",
-                                    "description": "Text box. Omit for centered auto-fit; rotation alone rotates an auto-fit box; center only auto-fits size; all four override.",
-                                    "properties": textBoxTransformProperties(),
+                                    "description": "Optional position and rotation. Set centerX and centerY together. Size always auto-fits the text.",
+                                    "properties": textTransformProperties(),
                                 ],
                             ], textStyleProperties(detailed: false), [
                                 "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Animation preset; off clears."],
@@ -815,7 +815,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .updateText,
-            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box unless transform includes box geometry; rotation alone keeps auto-fit. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
+            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box; transform can reposition or rotate it without changing its size. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "clipIds": [
@@ -827,8 +827,8 @@ enum ToolDefinitions {
                     "content": ["type": "string", "description": "Replacement text. Supports \\n."],
                     "transform": [
                         "type": "object",
-                        "description": "Partial text-box transform; omitted fields keep current values.",
-                        "properties": textBoxTransformProperties(),
+                        "description": "Partial position and rotation; omitted fields keep current values. Size remains auto-fit.",
+                        "properties": textTransformProperties(),
                     ],
                 ], textStyleProperties(detailed: true), [
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Animation preset; off clears."],
@@ -1158,12 +1158,10 @@ enum ToolDefinitions {
     static var mcpServer: [AgentTool] { all + [manageProject] }
     static var inAppAgent: [AgentTool] { all + [readSkill] }
 
-    private static func textBoxTransformProperties() -> [String: [String: Any]] {
+    private static func textTransformProperties() -> [String: [String: Any]] {
         [
             "centerX": ["type": "number", "description": "0-1 horizontal center."],
             "centerY": ["type": "number", "description": "0-1 vertical center."],
-            "width": ["type": "number", "description": "0-1 width."],
-            "height": ["type": "number", "description": "0-1 height."],
             "rotation": ["type": "number", "description": "Clockwise degrees."],
         ]
     }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -366,11 +366,9 @@ extension ToolExecutor {
         path: String
     ) throws -> Transform? {
         guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height", "rotation"], path: "\(path).transform")
+        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "rotation"], path: "\(path).transform")
         let cX = try optionalNumber(tDict, key: "centerX", path: "\(path).transform")
         let cY = try optionalNumber(tDict, key: "centerY", path: "\(path).transform")
-        let w = try optionalNumber(tDict, key: "width", path: "\(path).transform")
-        let h = try optionalNumber(tDict, key: "height", path: "\(path).transform")
         let rotation = try optionalNumber(tDict, key: "rotation", path: "\(path).transform")
 
         func autoFit(centerX: Double, centerY: Double) -> Transform {
@@ -384,30 +382,24 @@ extension ToolExecutor {
             )
         }
 
-        if cX == nil && cY == nil && w == nil && h == nil {
+        if cX == nil && cY == nil {
             guard rotation != nil else { return nil }
             return autoFit(centerX: 0.5, centerY: 0.5)
         }
         guard let cx = cX, let cy = cY else {
-            throw ToolError("\(path): transform must be either {centerX, centerY} for auto-fit, or all four of {centerX, centerY, width, height}")
-        }
-        if let ww = w, let hh = h {
-            return Transform(centerX: cx, centerY: cy, width: ww, height: hh, rotation: rotation ?? 0)
-        }
-        guard w == nil && h == nil else {
-            throw ToolError("\(path): transform must be either {centerX, centerY} for auto-fit, or all four of {centerX, centerY, width, height}")
+            throw ToolError("\(path): transform must provide both centerX and centerY")
         }
         return autoFit(centerX: cx, centerY: cy)
     }
 
     private func parseUpdateTextTransform(_ tDict: [String: Any]?, path: String) throws -> ParsedTransform? {
         guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "width", "height", "rotation"], path: "\(path).transform")
+        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "rotation"], path: "\(path).transform")
         let transform = ParsedTransform(
             centerX: try optionalNumber(tDict, key: "centerX", path: "\(path).transform"),
             centerY: try optionalNumber(tDict, key: "centerY", path: "\(path).transform"),
-            width: try optionalNumber(tDict, key: "width", path: "\(path).transform"),
-            height: try optionalNumber(tDict, key: "height", path: "\(path).transform"),
+            width: nil,
+            height: nil,
             rotation: try optionalNumber(tDict, key: "rotation", path: "\(path).transform"),
             flipHorizontal: nil,
             flipVertical: nil
@@ -596,7 +588,7 @@ extension ToolExecutor {
         }
         let snapshot = timelineSnapshot(editor)
         let actionName = clipIds.count == 1 ? "Update Text (Agent)" : "Update Texts (Agent)"
-        let shouldFitToContent = transform?.hasLayoutField != true && (hasContent || textStylePatch?.affectsLayout == true)
+        let shouldFitToContent = hasContent || textStylePatch?.affectsLayout == true
         let canvasW = Double(editor.timeline.width)
         let canvasH = Double(editor.timeline.height)
         editor.undo.perform(actionName) {
@@ -611,6 +603,9 @@ extension ToolExecutor {
                     var style = clip.textStyle ?? TextStyle()
                     Self.applyTextStylePatch(textStylePatch, to: &style)
                     clip.textStyle = style
+                }
+                if shouldFitToContent {
+                    _ = editor.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
                 }
                 if let t = transform {
                     t.apply(to: &clip)
@@ -634,9 +629,6 @@ extension ToolExecutor {
                 }
                 if let fillMode {
                     clip.textFillMode = fillMode == .footage ? .footage : nil
-                }
-                if shouldFitToContent {
-                    _ = editor.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
                 }
             }
         }

--- a/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
@@ -23,11 +23,15 @@ struct MCPStaticRotationTests {
             let entryProperties = try #require(entries["items"]?.objectValue?["properties"]?.objectValue)
             let addTransform = try #require(entryProperties["transform"]?.objectValue?["properties"]?.objectValue)
             #expect(addTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+            #expect(addTransform["width"] == nil)
+            #expect(addTransform["height"] == nil)
 
             let updateTool = try #require(tools.first { $0.name == "update_text" })
             let updateProperties = try #require(updateTool.inputSchema.objectValue?["properties"]?.objectValue)
             let updateTransform = try #require(updateProperties["transform"]?.objectValue?["properties"]?.objectValue)
             #expect(updateTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+            #expect(updateTransform["width"] == nil)
+            #expect(updateTransform["height"] == nil)
         }
     }
 
@@ -101,7 +105,7 @@ struct MCPStaticRotationTests {
         }
     }
 
-    @Test func rotationDoesNotDisableContentAutoFitThroughMCP() async throws {
+    @Test func positionAndRotationDoNotDisableContentAutoFitThroughMCP() async throws {
         let harness = ToolHarness()
         let undoManager = UndoManager()
         harness.editor.undo.attach(undoManager)
@@ -121,10 +125,16 @@ struct MCPStaticRotationTests {
             let updateResult = try await client.callTool(name: "update_text", arguments: [
                 "clipIds": .array([.string(original.id)]),
                 "content": .string("A much longer title"),
-                "transform": .object(["rotation": .double(45)]),
+                "transform": .object([
+                    "centerX": .double(0.25),
+                    "centerY": .double(0.75),
+                    "rotation": .double(45),
+                ]),
             ])
             #expect(updateResult.isError != true)
             let updated = try #require(harness.editor.clipFor(id: original.id))
+            #expect(updated.transform.centerX == 0.25)
+            #expect(updated.transform.centerY == 0.75)
             #expect(updated.transform.rotation == 45)
             #expect(updated.transform.width > original.transform.width)
 
@@ -132,6 +142,40 @@ struct MCPStaticRotationTests {
             let restored = try #require(harness.editor.clipFor(id: original.id))
             #expect(restored.textContent == "I")
             #expect(restored.transform == original.transform)
+        }
+    }
+
+    @Test func textBoxDimensionsAreRejectedWithoutMutationThroughMCP() async throws {
+        var clip = Fixtures.clip(id: "title", mediaRef: "", mediaType: .text, start: 0, duration: 60)
+        clip.textContent = "Title"
+        let original = clip
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+
+        try await withClient(harness: harness, name: "text-box-dimensions-test") { client in
+            let addResult = try await client.callTool(name: "add_texts", arguments: [
+                "entries": .array([.object([
+                    "startFrame": .int(60),
+                    "endFrame": .int(120),
+                    "content": .string("Invalid box"),
+                    "transform": .object([
+                        "centerX": .double(0.5),
+                        "centerY": .double(0.5),
+                        "width": .double(0.5),
+                    ]),
+                ])]),
+            ])
+            #expect(addResult.isError == true)
+            #expect(harness.editor.timeline.tracks.flatMap(\.clips) == [original])
+
+            let updateResult = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(clip.id)]),
+                "transform": .object(["height": .double(0.5)]),
+            ])
+            #expect(updateResult.isError == true)
+            #expect(harness.editor.clipFor(id: clip.id) == original)
+            #expect((try await client.callTool(name: "undo")).isError == true)
         }
     }
 

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1961,16 +1961,27 @@ struct ToolExecutorTextFolderTests {
 
     // MARK: - add_texts
 
-    @Test func updateTextSchemaExposesIndependentTextScale() throws {
-        let tool = try #require(ToolDefinitions.mcpServer.first { $0.name == .updateText })
-        let properties = try #require(tool.inputSchema["properties"] as? [String: [String: Any]])
-        let style = try #require(properties["style"])
+    @Test func textSchemasExposeStyleScaleWithoutBoxDimensions() throws {
+        let updateTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .updateText })
+        let updateProperties = try #require(updateTool.inputSchema["properties"] as? [String: [String: Any]])
+        let style = try #require(updateProperties["style"])
         let styleProperties = try #require(style["properties"] as? [String: [String: Any]])
 
         #expect((styleProperties["widthScale"]?["minimum"] as? NSNumber)?.doubleValue == 0.1)
         #expect((styleProperties["widthScale"]?["maximum"] as? NSNumber)?.doubleValue == 10)
         #expect((styleProperties["heightScale"]?["minimum"] as? NSNumber)?.doubleValue == 0.1)
         #expect((styleProperties["heightScale"]?["maximum"] as? NSNumber)?.doubleValue == 10)
+
+        let updateTransform = try #require(updateProperties["transform"]?["properties"] as? [String: [String: Any]])
+        #expect(Set(updateTransform.keys) == ["centerX", "centerY", "rotation"])
+
+        let addTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addTexts })
+        let addProperties = try #require(addTool.inputSchema["properties"] as? [String: [String: Any]])
+        let entries = try #require(addProperties["entries"])
+        let items = try #require(entries["items"] as? [String: Any])
+        let entryProperties = try #require(items["properties"] as? [String: [String: Any]])
+        let addTransform = try #require(entryProperties["transform"]?["properties"] as? [String: [String: Any]])
+        #expect(Set(addTransform.keys) == ["centerX", "centerY", "rotation"])
     }
 
     @Test func addTextsCreatesNewTrackWhenIndexOmitted() async throws {
@@ -2008,6 +2019,36 @@ struct ToolExecutorTextFolderTests {
         let clip = h.editor.timeline.tracks[0].clips[0]
         #expect(clip.textContent == "Caption")
         #expect(clip.textStyle?.fontSize == 48)
+    }
+
+    @Test func updateTextAutoFitsContentAtRequestedCenter() async throws {
+        var clip = Fixtures.clip(id: "title", mediaRef: "", mediaType: .text, start: 0, duration: 60)
+        clip.textContent = "I"
+        var style = TextStyle()
+        style.alignment = .right
+        clip.textStyle = style
+        clip.transform = Transform(centerX: 0.5, centerY: 0.5, width: 0.8, height: 0.6)
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+
+        let content = "A much longer title"
+        let result = await h.runRaw("update_text", args: [
+            "clipIds": [clip.id],
+            "content": content,
+            "transform": ["centerX": 0.2, "centerY": 0.3],
+        ])
+
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let updated = try #require(h.editor.clipFor(id: clip.id))
+        let natural = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: CGFloat(h.editor.timeline.width) * 0.9,
+            canvasHeight: CGFloat(h.editor.timeline.height)
+        )
+        #expect(updated.transform.centerX == 0.2)
+        #expect(updated.transform.centerY == 0.3)
+        #expect(abs(updated.transform.width - Double(natural.width) / Double(h.editor.timeline.width)) < 0.0001)
+        #expect(abs(updated.transform.height - Double(natural.height) / Double(h.editor.timeline.height)) < 0.0001)
     }
 
     @Test func addTextsAppliesRichTextStyleFields() async throws {


### PR DESCRIPTION
## Summary
- Remove raw text-box width and height from `add_texts` and `update_text` so Agent-authored text remains fitted to its content.
- Keep `style.widthScale` and `style.heightScale` as the supported Inspector-equivalent controls for stretching glyphs.
- Preserve requested text position and rotation when content or layout-affecting styles trigger auto-fit.

## Approach
- Limit Agent text transforms to normalized center coordinates and rotation while leaving the internal text model and Inspector controls unchanged.
- Reject legacy box dimensions as unknown fields before mutation or undo registration.
- Auto-fit content and style changes before applying requested position and rotation, ensuring the final center remains exact.
- Cover schema discovery, validation failures, state readback, auto-fit behavior, and undo through direct and MCP-boundary tests.

## Testing
- `swift test --filter ToolExecutorTextFolderTests && swift test --filter MCPStaticRotationTests` — passed.
- `swift build && swift test` after rebasing onto latest `main` — passed; 1,446 tests in 228 suites.
- No UI code changed; manual UI verification was not required.

## Change statistics
- Code logic: +17 / -27
- Tests: +91 / -6
- Total: +108 / -33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the agent/MCP contract for text layout (breaking for callers that set transform width/height) and alters update_text ordering for content + transform together.
> 
> **Overview**
> Agent text tools no longer accept **normalized box width/height** on `add_texts` / `update_text` `transform`; only **center**, **rotation**, and **`style.widthScale` / `style.heightScale`** remain for layout control.
> 
> **`update_text`** now **auto-fits** on content or layout-affecting style changes even when a transform is present, running **fit before** applying position/rotation so the requested center stays exact. Legacy `transform.width` / `transform.height` are **rejected as unknown fields** with no timeline mutation.
> 
> Tool descriptions and MCP/schema tests were updated to match; new coverage exercises auto-fit with position, dimension rejection, and undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f9348ec041d5ed9bf0e980d79fed4eca1f82d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->