### PR TITLE
[fix] Remove open panel launch prewarm

### DIFF
--- a/Sources/PalmierPro/App/AppDelegate.swift
+++ b/Sources/PalmierPro/App/AppDelegate.swift
@@ -29,13 +29,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppNotifications.configure()
 
         AppState.shared.startMCPService()
-
-        // Pre-warm NSOpenPanel to avoid main thread blocking during cold start.
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(3))
-            guard let self, !self.isTerminating else { return }
-            _ = NSOpenPanel()
-        }
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {


### PR DESCRIPTION
## Summary

- Remove the unconditional `NSOpenPanel` construction three seconds after launch.
- Prevent unexplained startup freezes tracked by [PALMIER-PRO-1DS](https://palmier.sentry.io/issues/7641778434/), currently affecting 57 users across 61 events.
- Restore lazy panel creation so only users who request an Open, Import, Export, or Save panel can encounter AppKit's cold-start stall.

## Approach

`NSOpenPanel.init()` synchronously waits for AppKit's open/save-panel XPC service on the main actor. The prewarm added in #423 could not eliminate that wait; it moved it into every launch and made the app freeze without user intent. This change removes only that launch side effect and leaves existing panel call sites unchanged.

The first user-requested panel may still pay the macOS service startup cost. That narrower, action-correlated behavior is preferable to exposing every session, and it keeps the underlying OS limitation explicit rather than masking it with another unconditional stall.

## Testing

- `swift build` — passed.
- Manual verification pending:
  - Launch the packaged app and leave it idle beyond three seconds; the UI should remain responsive.
  - On a cold launch, open the first Open, Import, Export, and Save panel; each should still appear and function normally.

## Change statistics

- Code logic: 0 additions, 7 deletions.
- Tests: no changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single deletion in app launch with no auth or data-path changes; panel behavior at user actions is unchanged.
> 
> **Overview**
> Removes the **3-second post-launch task** in `AppDelegate` that constructed an `NSOpenPanel` on the main actor to pre-warm AppKit’s open/save panel XPC service.
> 
> That prewarm was meant to avoid stalls on the first user-opened panel, but it **blocked every launch** with the same synchronous wait and is linked to startup freezes (e.g. PALMIER-PRO-1DS). Open/import/export/save flows are unchanged: panels are still created lazily at existing call sites when the user triggers them.
> 
> The first panel in a session may still hit the OS cold-start cost, but only in response to user action rather than on idle launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e223e5fecb6fdc399c5686bb54c2dd08bf4a264a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->