### PR TITLE
[agent] Anchor text positions to alignment

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -783,7 +783,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addTexts,
-            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets normalized center and rotation. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
+            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets their alignment-relative horizontal anchor, vertical center, and rotation. Left-aligned text grows rightward from x, centered text grows around x, and right-aligned text grows leftward from x. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -798,7 +798,7 @@ enum ToolDefinitions {
                                 "content": ["type": "string", "description": "Text. Supports \\n."],
                                 "transform": [
                                     "type": "object",
-                                    "description": "Optional position and rotation. Set centerX and centerY together. Size always auto-fits the text.",
+                                    "description": "Optional position and rotation. Omitted x or y uses the default centered position. Size always auto-fits the text.",
                                     "properties": textTransformProperties(),
                                 ],
                             ], textStyleProperties(detailed: false), [
@@ -815,7 +815,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .updateText,
-            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box; transform can reposition or rotate it without changing its size. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
+            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box while preserving its alignment-relative x anchor. transform can reposition or rotate it without changing its size. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "clipIds": [
@@ -847,11 +847,8 @@ enum ToolDefinitions {
                     "trackIndex": ["type": "integer", "description": "Caption one current timeline track from get_timeline. Omit to auto-detect the dominant speech track."],
                     "transform": [
                         "type": "object",
-                        "description": "Caption box position; size is auto-fit per caption.",
-                        "properties": [
-                            "centerX": ["type": "number", "description": "0-1 horizontal center."],
-                            "centerY": ["type": "number", "description": "0-1 vertical center."],
-                        ],
+                        "description": "Caption position and rotation; size is auto-fit per caption. x uses the selected text alignment edge.",
+                        "properties": textTransformProperties(),
                     ],
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
                     "maxWords": ["type": "integer", "minimum": 1, "description": "Max words per caption."],
@@ -1160,8 +1157,8 @@ enum ToolDefinitions {
 
     private static func textTransformProperties() -> [String: [String: Any]] {
         [
-            "centerX": ["type": "number", "description": "0-1 horizontal center."],
-            "centerY": ["type": "number", "description": "0-1 vertical center."],
+            "x": ["type": "number", "description": "Normalized horizontal anchor of the unrotated text box: the left edge for left alignment, center for center alignment, or right edge for right alignment."],
+            "y": ["type": "number", "description": "Normalized vertical center."],
             "rotation": ["type": "number", "description": "Clockwise degrees."],
         ]
     }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -14,12 +14,10 @@ extension ToolExecutor {
         var style = TextStyle.caption
         if let stylePatch { Self.applyTextStylePatch(stylePatch, to: &style) }
 
+        let transform = try parseTextTransform(args["transform"], path: "add_captions.transform")
         var center = AppTheme.Caption.defaultCenter
-        if let t = args["transform"] as? [String: Any] {
-            try validateUnknownKeys(t, allowed: ["centerX", "centerY"], path: "add_captions.transform")
-            if let x = t.double("centerX") { center.x = CGFloat(x) }
-            if let y = t.double("centerY") { center.y = CGFloat(y) }
-        }
+        if let x = transform?.x { center.x = CGFloat(x) }
+        if let y = transform?.y { center.y = CGFloat(y) }
 
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "add_captions") ?? TextAnimation()
 
@@ -69,7 +67,24 @@ extension ToolExecutor {
 
         let snapshot = timelineSnapshot(editor)
         let ids = try await editor.generateCaptions(for: request, applying: { mutation in
-            editor.undo.perform("Generate Captions (Agent)", mutation)
+            editor.undo.perform("Generate Captions (Agent)") {
+                let ids = mutation()
+                if transform?.x != nil || transform?.rotation != nil {
+                    editor.commitClipProperties(clipIds: ids, actionName: "Transform Captions (Agent)") { clip in
+                        if let x = transform?.x {
+                            clip.transform.centerX = Self.textCenterX(
+                                anchorX: x,
+                                width: clip.transform.width,
+                                alignment: style.alignment
+                            )
+                        }
+                        if let rotation = transform?.rotation {
+                            clip.transform.rotation = rotation
+                        }
+                    }
+                }
+                return ids
+            }
         })
         guard !ids.isEmpty else { throw ToolError("No speech detected to caption.") }
         return mutationResult(editor, since: snapshot)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -119,7 +119,7 @@ fileprivate struct SetKeyframesInput: DecodableToolArgs {
     static let allowedKeys: Set<String> = ["clipId", "property", "keyframes"]
 }
 
-/// Partial transform shared by clip and text property tools.
+/// Partial transform for generic clip property updates.
 struct ParsedTransform: Decodable {
     var centerX: Double?
     var centerY: Double?

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -100,6 +100,14 @@ fileprivate struct PartialTextSpec {
     let fillMode: TextFillMode?
 }
 
+struct ParsedTextTransform {
+    let x: Double?
+    let y: Double?
+    let rotation: Double?
+
+    var hasAnyField: Bool { x != nil || y != nil || rotation != nil }
+}
+
 extension ToolExecutor {
     private static let addTextsAllowedKeys: Set<String> = Set([
         "trackIndex", "startFrame", "endFrame", "content",
@@ -359,52 +367,56 @@ extension ToolExecutor {
         return mode
     }
 
-    private func parseAddTextTransform(
-        _ tDict: [String: Any]?,
-        content: String, style: TextStyle,
-        canvas: (w: Double, h: Double),
-        path: String
-    ) throws -> Transform? {
-        guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "rotation"], path: "\(path).transform")
-        let cX = try optionalNumber(tDict, key: "centerX", path: "\(path).transform")
-        let cY = try optionalNumber(tDict, key: "centerY", path: "\(path).transform")
-        let rotation = try optionalNumber(tDict, key: "rotation", path: "\(path).transform")
-
-        func autoFit(centerX: Double, centerY: Double) -> Transform {
-            let natural = TextLayout.naturalSize(content: content, style: style, maxWidth: CGFloat(canvas.w) * 0.9, canvasHeight: CGFloat(canvas.h))
-            return Transform(
-                centerX: centerX,
-                centerY: centerY,
-                width: Double(natural.width) / canvas.w,
-                height: Double(natural.height) / canvas.h,
-                rotation: rotation ?? 0
-            )
+    func parseTextTransform(_ raw: Any?, path: String) throws -> ParsedTextTransform? {
+        guard let raw else { return nil }
+        guard let args = raw as? [String: Any] else {
+            throw ToolError("\(path): expected object")
         }
-
-        if cX == nil && cY == nil {
-            guard rotation != nil else { return nil }
-            return autoFit(centerX: 0.5, centerY: 0.5)
-        }
-        guard let cx = cX, let cy = cY else {
-            throw ToolError("\(path): transform must provide both centerX and centerY")
-        }
-        return autoFit(centerX: cx, centerY: cy)
-    }
-
-    private func parseUpdateTextTransform(_ tDict: [String: Any]?, path: String) throws -> ParsedTransform? {
-        guard let tDict else { return nil }
-        try validateUnknownKeys(tDict, allowed: ["centerX", "centerY", "rotation"], path: "\(path).transform")
-        let transform = ParsedTransform(
-            centerX: try optionalNumber(tDict, key: "centerX", path: "\(path).transform"),
-            centerY: try optionalNumber(tDict, key: "centerY", path: "\(path).transform"),
-            width: nil,
-            height: nil,
-            rotation: try optionalNumber(tDict, key: "rotation", path: "\(path).transform"),
-            flipHorizontal: nil,
-            flipVertical: nil
+        try validateUnknownKeys(args, allowed: ["x", "y", "rotation"], path: path)
+        let transform = ParsedTextTransform(
+            x: try optionalNumber(args, key: "x", path: path),
+            y: try optionalNumber(args, key: "y", path: path),
+            rotation: try optionalNumber(args, key: "rotation", path: path)
         )
         return transform.hasAnyField ? transform : nil
+    }
+
+    private func makeAddTextTransform(
+        _ transform: ParsedTextTransform?,
+        content: String, style: TextStyle,
+        canvas: (w: Double, h: Double)
+    ) -> Transform? {
+        guard let transform else { return nil }
+        let natural = TextLayout.naturalSize(
+            content: content,
+            style: style,
+            maxWidth: CGFloat(canvas.w) * 0.9,
+            canvasHeight: CGFloat(canvas.h)
+        )
+        let width = Double(natural.width) / canvas.w
+        return Transform(
+            centerX: transform.x.map { Self.textCenterX(anchorX: $0, width: width, alignment: style.alignment) } ?? 0.5,
+            centerY: transform.y ?? 0.5,
+            width: width,
+            height: Double(natural.height) / canvas.h,
+            rotation: transform.rotation ?? 0
+        )
+    }
+
+    static func textAnchorX(centerX: Double, width: Double, alignment: TextStyle.Alignment) -> Double {
+        switch alignment {
+        case .left: centerX - width / 2
+        case .center: centerX
+        case .right: centerX + width / 2
+        }
+    }
+
+    static func textCenterX(anchorX: Double, width: Double, alignment: TextStyle.Alignment) -> Double {
+        switch alignment {
+        case .left: anchorX + width / 2
+        case .center: anchorX
+        case .right: anchorX - width / 2
+        }
     }
 
     func addTexts(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
@@ -450,11 +462,10 @@ extension ToolExecutor {
                 Self.applyTextStylePatch(patch, to: &style)
             }
 
-            let transform = try parseAddTextTransform(
-                optionalObject(entry, key: "transform", path: path),
+            let transform = makeAddTextTransform(
+                try parseTextTransform(entry["transform"], path: "\(path).transform"),
                 content: content, style: style,
-                canvas: (Double(editor.timeline.width), Double(editor.timeline.height)),
-                path: path
+                canvas: (Double(editor.timeline.width), Double(editor.timeline.height))
             )
 
             partials.append(.init(
@@ -543,10 +554,7 @@ extension ToolExecutor {
         guard !clipIds.isEmpty else { throw ToolError("Provide a non-empty 'clipIds' array or a 'captionGroupId'") }
 
         let textStylePatch = try parseTextStylePatch(args, path: "update_text")
-        let transform = try parseUpdateTextTransform(
-            optionalObject(args, key: "transform", path: "update_text"),
-            path: "update_text"
-        )
+        let transform = try parseTextTransform(args["transform"], path: "update_text.transform")
         let animation = try parseTextAnimation(preset: args.string("animation"), highlightColor: args.string("highlightColor"), path: "update_text")
         let shouldSetAnimation = args.string("animation") != nil
         let highlightOnly = shouldSetAnimation ? nil : try parseColorHex(args.string("highlightColor"), path: "update_text")
@@ -593,6 +601,12 @@ extension ToolExecutor {
         let canvasH = Double(editor.timeline.height)
         editor.undo.perform(actionName) {
             editor.commitClipProperties(clipIds: clipIds) { clip in
+                let originalStyle = clip.textStyle ?? TextStyle()
+                let originalAnchorX = Self.textAnchorX(
+                    centerX: clip.transform.centerX,
+                    width: clip.transform.width,
+                    alignment: originalStyle.alignment
+                )
                 if let content {
                     if clip.textContent != content {
                         clip.wordTimings = nil
@@ -607,8 +621,20 @@ extension ToolExecutor {
                 if shouldFitToContent {
                     _ = editor.fitTextClipToContentIfNeeded(&clip, canvasW: canvasW, canvasH: canvasH)
                 }
-                if let t = transform {
-                    t.apply(to: &clip)
+                let updatedStyle = clip.textStyle ?? TextStyle()
+                if shouldFitToContent || textStylePatch?.alignment != nil || transform?.x != nil {
+                    clip.transform.centerX = Self.textCenterX(
+                        anchorX: transform?.x ?? originalAnchorX,
+                        width: clip.transform.width,
+                        alignment: updatedStyle.alignment
+                    )
+                }
+                if let y = transform?.y {
+                    clip.transform.centerY = y
+                }
+                if let rotation = transform?.rotation {
+                    clip.transform.rotation = rotation
+                    clip.rotationTrack = nil
                 }
                 if shouldSetAnimation {
                     if let animation {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -322,7 +322,27 @@ extension ToolExecutor {
             out["audio"] = audioSummary(partner.clip, trackIndex: partner.trackIndex, visual: clip)
             out.removeValue(forKey: "linkGroupId")
         }
+        if clip["mediaType"] as? String == ClipType.text.rawValue {
+            shapeTextTransform(&out, from: clip)
+        }
         return out
+    }
+
+    private static func shapeTextTransform(_ output: inout [String: Any], from rawClip: [String: Any]) {
+        guard let rawTransform = rawClip["transform"] as? [String: Any],
+              let centerX = (rawTransform["centerX"] as? NSNumber)?.doubleValue,
+              let centerY = (rawTransform["centerY"] as? NSNumber)?.doubleValue,
+              let width = (rawTransform["width"] as? NSNumber)?.doubleValue else { return }
+        let rawAlignment = (rawClip["textStyle"] as? [String: Any])?["alignment"] as? String
+        let alignment = rawAlignment.flatMap(TextStyle.Alignment.init(rawValue:)) ?? .center
+        var transform = output["transform"] as? [String: Any] ?? [:]
+        transform.removeValue(forKey: "centerX")
+        transform.removeValue(forKey: "centerY")
+        transform.removeValue(forKey: "width")
+        transform.removeValue(forKey: "height")
+        transform["x"] = textAnchorX(centerX: centerX, width: width, alignment: alignment)
+        transform["y"] = centerY
+        output["transform"] = transform
     }
 
     /// Removes keys whose values equal the defaults; recurses into nested objects.

--- a/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
@@ -126,8 +126,8 @@ struct MCPStaticRotationTests {
                 "clipIds": .array([.string(original.id)]),
                 "content": .string("A much longer title"),
                 "transform": .object([
-                    "centerX": .double(0.25),
-                    "centerY": .double(0.75),
+                    "x": .double(0.25),
+                    "y": .double(0.75),
                     "rotation": .double(45),
                 ]),
             ])
@@ -160,8 +160,8 @@ struct MCPStaticRotationTests {
                     "endFrame": .int(120),
                     "content": .string("Invalid box"),
                     "transform": .object([
-                        "centerX": .double(0.5),
-                        "centerY": .double(0.5),
+                        "x": .double(0.5),
+                        "y": .double(0.5),
                         "width": .double(0.5),
                     ]),
                 ])]),

--- a/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
@@ -41,6 +41,9 @@ struct MCPTranscriptionTrackTests {
             let maxCharacters = try #require(captionProperties["maxCharacters"]?.objectValue)
             #expect(maxCharacters["type"]?.stringValue == "integer")
             #expect(maxCharacters["minimum"]?.intValue == 1)
+            let transform = try #require(captionProperties["transform"]?.objectValue)
+            let transformProperties = try #require(transform["properties"]?.objectValue)
+            #expect(Set(transformProperties.keys) == ["x", "y", "rotation"])
 
             let transcript = try await client.callTool(
                 name: "get_transcript",

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -433,7 +433,10 @@ struct ToolExecutorReadOnlyTests {
         #expect(shared?["mediaType"] as? String == "text")
         #expect((shared?["textStyle"] as? [String: Any])?["fontName"] as? String == "Avenir")
         let sharedTransform = shared?["transform"] as? [String: Any]
-        #expect(sharedTransform?["centerY"] as? Double == 0.85)
+        #expect(sharedTransform?["x"] as? Double == 0.5)
+        #expect(sharedTransform?["y"] as? Double == 0.85)
+        #expect(sharedTransform?["centerX"] == nil)
+        #expect(sharedTransform?["centerY"] == nil)
         #expect(sharedTransform?["width"] == nil)
         #expect(sharedTransform?["height"] == nil)
 
@@ -1961,7 +1964,7 @@ struct ToolExecutorTextFolderTests {
 
     // MARK: - add_texts
 
-    @Test func textSchemasExposeStyleScaleWithoutBoxDimensions() throws {
+    @Test func textSchemasExposeAlignmentRelativePositionWithoutBoxDimensions() throws {
         let updateTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .updateText })
         let updateProperties = try #require(updateTool.inputSchema["properties"] as? [String: [String: Any]])
         let style = try #require(updateProperties["style"])
@@ -1973,7 +1976,7 @@ struct ToolExecutorTextFolderTests {
         #expect((styleProperties["heightScale"]?["maximum"] as? NSNumber)?.doubleValue == 10)
 
         let updateTransform = try #require(updateProperties["transform"]?["properties"] as? [String: [String: Any]])
-        #expect(Set(updateTransform.keys) == ["centerX", "centerY", "rotation"])
+        #expect(Set(updateTransform.keys) == ["x", "y", "rotation"])
 
         let addTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addTexts })
         let addProperties = try #require(addTool.inputSchema["properties"] as? [String: [String: Any]])
@@ -1981,7 +1984,12 @@ struct ToolExecutorTextFolderTests {
         let items = try #require(entries["items"] as? [String: Any])
         let entryProperties = try #require(items["properties"] as? [String: [String: Any]])
         let addTransform = try #require(entryProperties["transform"]?["properties"] as? [String: [String: Any]])
-        #expect(Set(addTransform.keys) == ["centerX", "centerY", "rotation"])
+        #expect(Set(addTransform.keys) == ["x", "y", "rotation"])
+
+        let captionsTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addCaptions })
+        let captionsProperties = try #require(captionsTool.inputSchema["properties"] as? [String: [String: Any]])
+        let captionsTransform = try #require(captionsProperties["transform"]?["properties"] as? [String: [String: Any]])
+        #expect(Set(captionsTransform.keys) == ["x", "y", "rotation"])
     }
 
     @Test func addTextsCreatesNewTrackWhenIndexOmitted() async throws {
@@ -2021,7 +2029,61 @@ struct ToolExecutorTextFolderTests {
         #expect(clip.textStyle?.fontSize == 48)
     }
 
-    @Test func updateTextAutoFitsContentAtRequestedCenter() async throws {
+    @Test func addTextsPositionsXAtTheSelectedAlignmentEdge() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "endFrame": 60,
+                "content": "Left anchored",
+                "style": ["alignment": "left"],
+                "transform": ["x": 0.1],
+            ]]
+        ])
+
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let clip = try #require(h.editor.timeline.tracks[0].clips.first)
+        #expect(abs(clip.transform.topLeft.x - 0.1) < 0.0001)
+        #expect(clip.transform.centerY == 0.5)
+
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(ToolHarness.textOf(result).utf8)) as? [String: Any]
+        )
+        let transform = try #require(
+            (payload["clips"] as? [[String: Any]])?.first?["transform"] as? [String: Any]
+        )
+        #expect(abs((transform["x"] as? Double ?? -1) - 0.1) < 0.0001)
+        #expect(transform["y"] as? Double == 0.5)
+        #expect(transform["centerX"] == nil)
+        #expect(transform["centerY"] == nil)
+        #expect(transform["width"] == nil)
+        #expect(transform["height"] == nil)
+    }
+
+    @Test func addTextsAllowsYWithoutChangingTheDefaultHorizontalCenter() async throws {
+        let h = ToolHarness()
+        _ = h.editor.insertTrack(at: 0, type: .video)
+
+        let result = await h.runRaw("add_texts", args: [
+            "entries": [[
+                "trackIndex": 0,
+                "startFrame": 0,
+                "endFrame": 60,
+                "content": "Vertically placed",
+                "transform": ["y": 0.8],
+            ]]
+        ])
+
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let clip = try #require(h.editor.timeline.tracks[0].clips.first)
+        #expect(clip.transform.centerX == 0.5)
+        #expect(clip.transform.centerY == 0.8)
+    }
+
+    @Test func updateTextAutoFitsContentAtRequestedAnchor() async throws {
         var clip = Fixtures.clip(id: "title", mediaRef: "", mediaType: .text, start: 0, duration: 60)
         clip.textContent = "I"
         var style = TextStyle()
@@ -2034,7 +2096,7 @@ struct ToolExecutorTextFolderTests {
         let result = await h.runRaw("update_text", args: [
             "clipIds": [clip.id],
             "content": content,
-            "transform": ["centerX": 0.2, "centerY": 0.3],
+            "transform": ["x": 0.2, "y": 0.3],
         ])
 
         #expect(result.isError == false, "\(ToolHarness.textOf(result))")
@@ -2045,10 +2107,38 @@ struct ToolExecutorTextFolderTests {
             maxWidth: CGFloat(h.editor.timeline.width) * 0.9,
             canvasHeight: CGFloat(h.editor.timeline.height)
         )
-        #expect(updated.transform.centerX == 0.2)
+        #expect(abs(updated.transform.centerX + updated.transform.width / 2 - 0.2) < 0.0001)
         #expect(updated.transform.centerY == 0.3)
         #expect(abs(updated.transform.width - Double(natural.width) / Double(h.editor.timeline.width)) < 0.0001)
         #expect(abs(updated.transform.height - Double(natural.height) / Double(h.editor.timeline.height)) < 0.0001)
+
+        let resize = await h.runRaw("update_text", args: [
+            "clipIds": [clip.id],
+            "content": "\(content) that keeps growing",
+        ])
+        #expect(resize.isError == false, "\(ToolHarness.textOf(resize))")
+        let resized = try #require(h.editor.clipFor(id: clip.id))
+        #expect(resized.transform.width > updated.transform.width)
+        #expect(abs(resized.transform.centerX + resized.transform.width / 2 - 0.2) < 0.0001)
+    }
+
+    @Test func updateTextKeepsTheAnchorWhenAlignmentChanges() async throws {
+        var clip = Fixtures.clip(id: "title", mediaRef: "", mediaType: .text, start: 0, duration: 60)
+        clip.textContent = "Title"
+        clip.textStyle = TextStyle()
+        clip.transform = Transform(centerX: 0.4, centerY: 0.6, width: 0.2, height: 0.1)
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+
+        let result = await h.runRaw("update_text", args: [
+            "clipIds": [clip.id],
+            "style": ["alignment": "left"],
+        ])
+
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let updated = try #require(h.editor.clipFor(id: clip.id))
+        #expect(updated.textStyle?.alignment == .left)
+        #expect(abs(updated.transform.topLeft.x - 0.4) < 0.0001)
+        #expect(updated.transform.centerY == 0.6)
     }
 
     @Test func addTextsAppliesRichTextStyleFields() async throws {


### PR DESCRIPTION
## Summary
- Replace text-tool `centerX`/`centerY` inputs with alignment-relative `x` and vertical-center `y` coordinates.
- Keep left, center, and right anchors stable as text content or styling changes its fitted bounds.
- Share the transform contract across authored text and captions, including caption rotation, and return the same `x`/`y` shape from timeline reads.

## Approach
- Preserve center-based transforms internally and convert only at the Agent boundary.
- Parse `x`, `y`, and `rotation` through one strict transform parser; omitted add coordinates retain centered defaults.
- Derive readback anchors from fitted bounds and omit derived text width/height values that tools cannot set.

## Testing
- `swift test --filter ToolExecutorTextFolderTests` — passed.
- `swift test --filter ToolExecutorReadOnlyTests` — passed.
- `swift test --filter MCPStaticRotationTests` — passed.
- `swift test --filter MCPTranscriptionTrackTests` — passed.
- `swift build` — passed.
- [ ] Manual: add left-, center-, and right-aligned titles and verify font/content changes grow from the selected anchor.
- [ ] Manual: generate rotated captions and verify placement, rotation, and undo.

## Change statistics
- Agent implementation: +126 / -68
- Tests: +104 / -11
- Total: +230 / -79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for MCP/agent clients that still send centerX/centerY; behavior of text positioning and caption transforms is intentionally different but localized to the agent tool layer.
> 
> **Overview**
> Agent text and caption tools now use **alignment-relative `x`/`y`** (plus `rotation`) instead of **`centerX`/`centerY`**, with internal transforms still center-based and conversion only at the tool boundary.
> 
> **`x`** is the normalized horizontal anchor for the fitted box (left / center / right edge per alignment); **`y`** is vertical center. **`update_text`** keeps that anchor when content or layout-affecting style changes refit the box, including when alignment changes. **`add_captions`** shares the same transform schema and can apply **rotation** (and alignment-aware **x**) after generation. **`get_timeline`** readback for text clips exposes **`x`/`y`** and drops derived width/height from the agent-facing transform.
> 
> Tool descriptions and tests were updated for the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82fc8ac884fce1bf7e9723b281c0a671a3e02009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->