### PR TITLE
[fix] Prevent final captions from flashing

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -864,7 +864,7 @@ enum ToolDefinitions {
                         "type": "number",
                         "minimum": CaptionGapSettings.maximumGapRange.lowerBound,
                         "maximum": CaptionGapSettings.maximumGapRange.upperBound,
-                        "description": "Extend each caption to close a shorter gap before the next generated caption. Default 0.25 seconds; 0 disables.",
+                        "description": "Extend captions to close shorter gaps and hold the final caption for up to this duration. Default 0.5 seconds; 0 disables.",
                     ],
                 ], textStyleProperties(detailed: false), [
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Caption animation preset. Omit for static captions; set only when the user asks for animation."],

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -212,6 +212,7 @@ extension EditorViewModel {
                 }
             },
             fps: timeline.fps,
+            timelineEndFrame: preparationTimeline.totalFrames,
             canvasWidth: timeline.width,
             canvasHeight: timeline.height,
             style: request.style,

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionGapSettings.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionGapSettings.swift
@@ -1,6 +1,6 @@
 struct CaptionGapSettings: Equatable, Sendable {
     static let maximumGapRange = 0.0...2.0
-    static let `default` = CaptionGapSettings(uncheckedMaximumGapSeconds: 0.25)
+    static let `default` = CaptionGapSettings(uncheckedMaximumGapSeconds: 0.5)
 
     let maximumGapSeconds: Double
 

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -10,6 +10,7 @@ enum CaptionSpecBuilder {
     struct Input: Sendable {
         let targets: [Target]
         let fps: Int
+        let timelineEndFrame: Int
         let canvasWidth: Int
         let canvasHeight: Int
         let style: TextStyle
@@ -80,7 +81,8 @@ enum CaptionSpecBuilder {
         return adjustedCaptionTiming(
             in: specs,
             settings: input.gapSettings,
-            fps: input.fps
+            fps: input.fps,
+            timelineEndFrame: input.timelineEndFrame
         )
     }
 
@@ -92,7 +94,8 @@ enum CaptionSpecBuilder {
     private static func adjustedCaptionTiming(
         in specs: [EditorViewModel.TextClipSpec],
         settings: CaptionGapSettings,
-        fps: Int
+        fps: Int,
+        timelineEndFrame: Int
     ) -> [EditorViewModel.TextClipSpec] {
         let orderedIndices = specs.indices.sorted {
             let lhsStart = specs[$0].startFrame
@@ -126,6 +129,23 @@ enum CaptionSpecBuilder {
                     durationFrames: duration,
                     extendWordCycle: true
                 )
+            }
+        }
+
+        if maximumGapFrames > 0,
+           let lastIndex = captions.indices.last,
+           let currentEnd = endFrame(of: captions[lastIndex].spec) {
+            let available = timelineEndFrame.subtractingReportingOverflow(currentEnd)
+            if !available.overflow {
+                let holdFrames = min(maximumGapFrames, max(0, available.partialValue))
+                let duration = captions[lastIndex].spec.durationFrames.addingReportingOverflow(holdFrames)
+                if holdFrames > 0, !duration.overflow {
+                    captions[lastIndex].spec = resized(
+                        captions[lastIndex].spec,
+                        durationFrames: duration.partialValue,
+                        extendWordCycle: true
+                    )
+                }
             }
         }
         return captions.map(\.spec)

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionTab.swift
@@ -213,7 +213,7 @@ struct CaptionTab: View {
             }
             InspectorRow(
                 label: L10n.string("Close gaps"),
-                labelHelp: L10n.string("Extends a caption to close gaps up to this duration."),
+                labelHelp: L10n.string("Extends captions across short gaps and holds the final caption."),
                 onReset: {
                     maximumGapSeconds = CaptionGapSettings.default.maximumGapSeconds
                 }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "Export…" = "Export…";
 "Exposure" = "Exposure";
 "Extend" = "Extend";
-"Extends a caption to close gaps up to this duration." = "Extends a caption to close gaps up to this duration.";
+"Extends captions across short gaps and holds the final caption." = "Extends captions across short gaps and holds the final caption.";
 "Extra Large" = "Extra Large";
 "FLUX Enhance" = "FLUX Enhance";
 "Fade In" = "Fade In";

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -77,6 +77,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         id: String,
         startFrame: Int,
         durationFrames: Int,
+        captionDurationFrames: Int? = nil,
         hasWordTiming: Bool = true
     ) -> CaptionSpecBuilder.Target {
         let clip = Fixtures.clip(
@@ -86,7 +87,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             start: startFrame,
             duration: durationFrames
         )
-        let captionDuration = min(0.7, Double(durationFrames) / 30)
+        let captionDuration = Double(captionDurationFrames ?? min(21, durationFrames)) / 30
         let result = TranscriptionResult(
             text: id,
             language: "en",
@@ -102,12 +103,14 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
     private func input(
         targets: [CaptionSpecBuilder.Target],
         maximumGapSeconds: Double = CaptionGapSettings.default.maximumGapSeconds,
+        timelineEndFrame: Int? = nil,
         maxCharacters: Int? = nil,
         animation: TextAnimation? = nil
     ) -> CaptionSpecBuilder.Input {
         CaptionSpecBuilder.Input(
             targets: targets,
             fps: 30,
+            timelineEndFrame: timelineEndFrame ?? targets.map(\.clip.endFrame).max() ?? 0,
             canvasWidth: 1920,
             canvasHeight: 1080,
             style: TextStyle(),
@@ -140,6 +143,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         let input = CaptionSpecBuilder.Input(
             targets: [.init(clip: clip, result: result)],
             fps: 30,
+            timelineEndFrame: clip.endFrame,
             canvasWidth: 1920,
             canvasHeight: 1080,
             style: TextStyle(),
@@ -157,7 +161,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(specs.count == 1)
         #expect(spec.content == "HELLO WORLD")
         #expect(spec.startFrame == 30)
-        #expect(spec.durationFrames == 30)
+        #expect(spec.durationFrames == 45)
         #expect(spec.transform != nil)
         #expect(spec.words?.map(\.text) == ["hello", "world"])
     }
@@ -189,15 +193,16 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
     }
 
     @Test(arguments: [
-        (6, 0.25, 27),
-        (7, 0.25, 28),
-        (8, 0.25, 21),
-        (6, 0.0, 21),
+        (6, 0.25, 27, 28),
+        (7, 0.25, 28, 28),
+        (8, 0.25, 21, 28),
+        (6, 0.0, 21, 21),
     ])
     func closesOnlyGapsWithinTheFrameRoundedThreshold(
         gapFrames: Int,
         maximumGapSeconds: Double,
-        expectedFirstDuration: Int
+        expectedFirstDuration: Int,
+        expectedLastDuration: Int
     ) async throws {
         let specs = try await CaptionSpecBuilder.build(input(
             targets: [
@@ -212,7 +217,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         ))
 
         #expect(specs.map(\.startFrame) == [0, 21 + gapFrames])
-        #expect(specs.map(\.durationFrames) == [expectedFirstDuration, 21])
+        #expect(specs.map(\.durationFrames) == [expectedFirstDuration, expectedLastDuration])
         #expect(specs[0].words == [WordTiming(text: "one", startFrame: 0, endFrame: 21)])
     }
 
@@ -237,9 +242,10 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             animation: TextAnimation(preset: preset)
         ))
 
-        #expect(specs.map(\.durationFrames) == [27, 21])
+        #expect(specs.map(\.durationFrames) == [27, 30])
         #expect(specs[0].startFrame + specs[0].durationFrames == specs[1].startFrame)
         #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 27 : 21))
+        #expect(specs[1].words?.last?.endFrame == (preset == .wordCycle ? 30 : 21))
     }
 
     @Test func oneFrameAnimatedCaptionClosesTheFollowingGapWithoutOverlap() async throws {
@@ -252,7 +258,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
             animation: TextAnimation(preset: .fadeIn)
         ))
 
-        #expect(specs.map(\.durationFrames) == [27, 6, 21])
+        #expect(specs.map(\.durationFrames) == [27, 6, 30])
         #expect(specs[0].startFrame + specs[0].durationFrames == specs[1].startFrame)
         #expect(specs[1].startFrame + specs[1].durationFrames == specs[2].startFrame)
     }
@@ -275,11 +281,11 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         let specs = try await CaptionSpecBuilder.build(input(targets: [
             gapTarget(id: "outer", startFrame: 0, durationFrames: 40),
             gapTarget(id: "nested", startFrame: 10, durationFrames: 5),
-            gapTarget(id: "next", startFrame: 26, durationFrames: 30),
+            gapTarget(id: "next", startFrame: 31, durationFrames: 30),
         ]))
 
-        #expect(specs.map(\.startFrame) == [0, 10, 26])
-        #expect(specs.map(\.durationFrames) == [10, 5, 21])
+        #expect(specs.map(\.startFrame) == [0, 10, 31])
+        #expect(specs.map(\.durationFrames) == [10, 5, 30])
     }
 
     @Test func shorterPreviousCaptionOwnsOverlappingFrames() async throws {
@@ -357,8 +363,34 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
         #expect(specs.map(\.durationFrames) == [1, 1, 1])
     }
 
+    @Test(arguments: [
+        (100, 0.5, 16),
+        (10, 0.5, 10),
+        (100, 0.0, 1),
+    ])
+    func holdsTheFinalCaptionWithinTheTimeline(
+        timelineEndFrame: Int,
+        maximumGapSeconds: Double,
+        expectedDuration: Int
+    ) async throws {
+        let specs = try await CaptionSpecBuilder.build(input(
+            targets: [
+                gapTarget(
+                    id: "last",
+                    startFrame: 0,
+                    durationFrames: timelineEndFrame,
+                    captionDurationFrames: 1
+                )
+            ],
+            maximumGapSeconds: maximumGapSeconds,
+            timelineEndFrame: timelineEndFrame
+        ))
+
+        #expect(specs.map(\.durationFrames) == [expectedDuration])
+    }
+
     @Test func captionGapSettingsValidateAndRoundDownToFrames() {
-        #expect(CaptionGapSettings.default.maximumGapFrames(fps: 30) == 7)
+        #expect(CaptionGapSettings.default.maximumGapFrames(fps: 30) == 15)
         #expect(CaptionGapSettings(maximumGapSeconds: 0)?.maximumGapFrames(fps: 30) == 0)
         #expect(CaptionGapSettings(maximumGapSeconds: -0.1) == nil)
         #expect(CaptionGapSettings(maximumGapSeconds: 2.1) == nil)


### PR DESCRIPTION
## Summary
- Increase the default Close gaps duration from 250 ms to 500 ms.
- Use the same setting as a bounded trailing hold for the final generated caption so very short final words remain readable.
- Keep exact caption timing and overlap behavior unchanged when Close gaps is set to zero.

## Approach
- Pass the pre-caption timeline end into caption timing preparation.
- Extend only the final generated caption, capped at the existing timeline end so caption generation cannot create a black tail.
- Reuse the existing resize path so word-cycle timing follows the hold while other word timing remains exact.

## Testing
- `swift test --filter '(CaptionBuilderTests|CaptionSpecBuilderTests|TextAnimationRenderTests|GetTranscriptParamTests|MCPTranscriptionTrackTests)'` — passed on this independent branch.
- `swift build` — passed on this independent branch.
- [ ] Manual: generate captions ending in a one-frame word with at least 500 ms of remaining footage and verify the final caption holds.
- [ ] Manual: set Close gaps to 0 and verify the final caption keeps exact transcript timing.
- [ ] Manual: place the final word near timeline end and verify the hold is capped without extending the timeline.

## Change statistics
- Core caption logic: +24 / -3
- Agent, UI, and localization: +3 / -3
- Tests: +46 / -14
- Total: +73 / -20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caption timing and default UX only; hold is capped at timeline end and disabled when Close gaps is zero, with no auth or export-path changes.
> 
> **Overview**
> Fixes **final captions disappearing too quickly** by treating the existing **Close gaps** control as both inter-caption gap fill and a **trailing hold** on the last caption.
> 
> The default **Close gaps** duration moves from **250ms to 500ms**. Caption generation now receives **`timelineEndFrame`** from the pre-caption timeline snapshot; after the usual gap-closing pass, **`CaptionSpecBuilder`** lengthens only the **last** caption by up to that gap budget, **without exceeding the timeline end** (no black tail). Word-cycle animation follows the hold via the existing resize path; **Close gaps at 0** keeps exact transcript timing with no trailing extension.
> 
> **Agent**, **Captions** UI help, and **localization** copy now describe gap closing plus final hold. Tests cover the new hold behavior and updated duration expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d649744309e83aff42a6389a28cbf8cee4736c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->