### PR TITLE
[ui] Select all clips from track headers

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -32,6 +32,14 @@ extension EditorViewModel {
         return "\(type.trackLabelPrefix)\(n)"
     }
 
+    @discardableResult
+    func selectAllClips(onTrack trackId: String) -> Bool {
+        guard let track = timeline.tracks.first(where: { $0.id == trackId }),
+              !track.clips.isEmpty else { return false }
+        selectedClipIds = Set(track.clips.map(\.id))
+        return true
+    }
+
     /// Clamp `requested` so that visual (video/image) tracks always sit above every audio track.
     private func partitionedInsertionIndex(for type: ClipType, requested: Int) -> Int {
         let z = zones

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -36,6 +36,7 @@ extension EditorViewModel {
     func selectAllClips(onTrack trackId: String) -> Bool {
         guard let track = timeline.tracks.first(where: { $0.id == trackId }),
               !track.clips.isEmpty else { return false }
+        selectedGap = nil
         selectedClipIds = Set(track.clips.map(\.id))
         return true
     }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -781,6 +781,7 @@
 "Search skills" = "Search skills";
 "Select" = "Select";
 "Select All" = "Select All";
+"Select All Clips on Track" = "Select All Clips on Track";
 "Select Forward on All Tracks" = "Select Forward on All Tracks";
 "Select Forward on Track" = "Select Forward on Track";
 "Select Range" = "Select Range";

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -181,6 +181,18 @@ final class TimelineHeaderView: NSView {
     private var resizeDrag: (trackIndex: Int, originalHeight: CGFloat)?
     private var reorderDrag: (id: String, before: Timeline)?
 
+    private func hitTestTrack(at point: NSPoint) -> Int? {
+        let geo = TimelineGeometry(editor: editor, bounds: bounds)
+        return editor.timeline.tracks.indices.first { index in
+            NSRect(
+                x: bounds.minX,
+                y: geo.trackY(at: index),
+                width: bounds.width,
+                height: geo.trackHeight(at: index)
+            ).contains(point)
+        }
+    }
+
     private func hitTestResizeHandle(at point: NSPoint) -> Int? {
         let geo = TimelineGeometry(editor: editor, bounds: bounds)
         for i in editor.timeline.tracks.indices {
@@ -190,6 +202,31 @@ final class TimelineHeaderView: NSView {
             }
         }
         return nil
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        guard let trackIndex = hitTestTrack(at: point) else { return nil }
+        let track = editor.timeline.tracks[trackIndex]
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let item = NSMenuItem(
+            title: L10n.string("Select All Clips on Track"),
+            action: #selector(performSelectAllClipsOnTrack(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        item.representedObject = track.id
+        item.isEnabled = !track.clips.isEmpty
+        menu.addItem(item)
+        return menu
+    }
+
+    @objc private func performSelectAllClipsOnTrack(_ sender: NSMenuItem) {
+        guard let trackId = sender.representedObject as? String,
+              editor.selectAllClips(onTrack: trackId) else { return }
+        needsDisplay = true
+        requestCanvasRedraw?()
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
+++ b/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
@@ -16,9 +16,14 @@ struct TrackSelectionTests {
             ]),
         ])
         editor.selectedClipIds = ["audio"]
+        editor.selectedGap = GapSelection(
+            trackIndex: 1,
+            range: FrameRange(start: 60, end: 90)
+        )
 
         #expect(editor.selectAllClips(onTrack: "target"))
         #expect(editor.selectedClipIds == ["video", "title"])
+        #expect(editor.selectedGap == nil)
     }
 
     @Test func unavailableTrackPreservesSelection() {
@@ -27,9 +32,14 @@ struct TrackSelectionTests {
             Fixtures.videoTrack(id: "empty"),
         ])
         editor.selectedClipIds = ["existing"]
+        editor.selectedGap = GapSelection(
+            trackIndex: 0,
+            range: FrameRange(start: 0, end: 30)
+        )
 
         #expect(!editor.selectAllClips(onTrack: "empty"))
         #expect(!editor.selectAllClips(onTrack: "missing"))
         #expect(editor.selectedClipIds == ["existing"])
+        #expect(editor.selectedGap != nil)
     }
 }

--- a/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
+++ b/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorViewModel — track selection")
+@MainActor
+struct TrackSelectionTests {
+    @Test func selectsEveryClipOnTargetTrackOnly() {
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(id: "target", clips: [
+                Fixtures.clip(id: "video", mediaType: .video, start: 0, duration: 30),
+                Fixtures.clip(id: "title", mediaType: .text, start: 30, duration: 30),
+            ]),
+            Fixtures.audioTrack(id: "other", clips: [
+                Fixtures.clip(id: "audio", mediaType: .audio, start: 0, duration: 60),
+            ]),
+        ])
+        editor.selectedClipIds = ["audio"]
+
+        #expect(editor.selectAllClips(onTrack: "target"))
+        #expect(editor.selectedClipIds == ["video", "title"])
+    }
+
+    @Test func unavailableTrackPreservesSelection() {
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(id: "empty"),
+        ])
+        editor.selectedClipIds = ["existing"]
+
+        #expect(!editor.selectAllClips(onTrack: "empty"))
+        #expect(!editor.selectAllClips(onTrack: "missing"))
+        #expect(editor.selectedClipIds == ["existing"])
+    }
+}


### PR DESCRIPTION

<img width="1528" height="696" alt="image" src="https://github.com/user-attachments/assets/5902fed1-3719-4596-89c7-3ab1f484a36c" />


## Summary
- Add an explicit **Select All Clips on Track** action to track-header context menus.
- Replace the current clip selection with every clip on the chosen track while leaving ordinary header clicks unchanged.
- Disable the action for empty tracks so the menu reports the unavailable operation accurately.

## Approach
- Resolve the right-clicked header row with timeline geometry, then store its stable track ID on the menu item.
- Keep selection in `EditorViewModel`, resolving the current track by ID when the action runs so track reordering cannot retarget it.
- Select only clips physically on that track; linked partners on other tracks are intentionally outside this track-scoped command.
- Treat selection as UI state: the operation does not mutate the timeline or create an undo entry.

## Testing
- `scripts/localization/sync.sh` — completed; existing non-English catalog completeness warnings remain.
- `swift test --filter TrackSelectionTests` — passed, 2 tests.
- `swift build` — passed.
- `swift test` — passed, 1,448 tests in 229 suites.
- Manual UI verification not completed:
  - [ ] Right-click populated video, audio, text, and caption track headers and confirm the action selects only that track's clips.
  - [ ] Confirm empty tracks show the disabled action.
  - [ ] Confirm normal clicks, mute/hide, sync lock, reorder, and resize behavior are unchanged.

## Change statistics
- UI and selection logic: +45 / -0
- Localization inventory: +1 / -0
- Tests: +35 / -0
- Total: +81 / -0


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Selection-only UI changes with no timeline mutations; behavior is covered by unit tests.
> 
> **Overview**
> **Track-header context menu** now offers **Select All Clips on Track**, resolved by geometry hit-testing the header row and passing a stable track ID into the menu action.
> 
> **`EditorViewModel.selectAllClips(onTrack:)`** replaces the current clip selection with all clips on that track (by ID), clears gap selection, does not touch the timeline or undo, returns `false` for missing or empty tracks, and leaves existing selection unchanged when unavailable. The menu item is disabled on empty tracks.
> 
> **Localization** adds the English string for the menu title. **Tests** cover successful track-scoped selection and no-op behavior for empty/missing tracks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f1d62dec04a16a8eef69239d9a5ca82d37314a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->