### PR TITLE
[fix] Preserve transcription cancellation

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Media.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Media.swift
@@ -195,7 +195,9 @@ extension ToolExecutor {
             imageBlocks = frames.map { .image(base64: $0.jpeg.base64EncodedString(), mediaType: "image/jpeg") }
         }
 
-        switch await transcriptTask {
+        let transcriptOutcome = await transcriptTask
+        try Task.checkCancellation()
+        switch transcriptOutcome {
         case .success(let transcript):
             meta["transcription"] = Self.transcriptionMeta(
                 from: transcript, mapping: mapping, includeWords: args.bool("wordTimestamps") ?? false
@@ -299,8 +301,10 @@ extension ToolExecutor {
         do {
             transcript = try await TranscriptCache.shared.transcript(for: asset.url, isVideo: false, range: range, preferredLocale: preferredLocale)
         } catch {
+            try Task.checkCancellation()
             throw ToolError("Transcription failed: \(error.localizedDescription)")
         }
+        try Task.checkCancellation()
 
         var meta = Self.baseMeta(for: asset)
         if let range { meta["timeRange"] = [range.lowerBound, range.upperBound] }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Transcription.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Transcription.swift
@@ -386,7 +386,7 @@ extension ToolExecutor {
             isVideoByURL[asset.url] = isVideo
         }
 
-        let transcripts = await transcriptsByURL(
+        let transcripts = try await transcriptsByURL(
             for: fragments,
             fps: fps,
             projectId: editor.projectId,
@@ -475,7 +475,7 @@ extension ToolExecutor {
         projectId: String?,
         context: TranscriptionToolContext,
         isVideoByURL: [URL: Bool]
-    ) async -> (results: [URL: TranscriptionResult], skipped: [[String: Any]]) {
+    ) async throws -> (results: [URL: TranscriptionResult], skipped: [[String: Any]]) {
         let rangesByURL = sourceRangesByURL(fragments, fps: fps)
         let outcomes = await withTaskGroup(of: (URL, Result<TranscriptionResult, Error>).self) { group in
             for url in Set(fragments.map(\.url)) {
@@ -506,6 +506,7 @@ extension ToolExecutor {
             for await outcome in group { collected.append(outcome) }
             return collected
         }
+        try Task.checkCancellation()
 
         var results: [URL: TranscriptionResult] = [:]
         var skipped: [[String: Any]] = []

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Captions.swift
@@ -333,6 +333,7 @@ extension EditorViewModel {
             for await outcome in group { collected.append(outcome) }
             return collected
         }
+        try Task.checkCancellation()
 
         var results: [String: TranscriptionResult] = [:]
         var firstError: Error?

--- a/Sources/PalmierPro/Transcription/TranscriptCache.swift
+++ b/Sources/PalmierPro/Transcription/TranscriptCache.swift
@@ -12,6 +12,7 @@ actor TranscriptCache {
     private static let memoryMax = 4
 
     func transcript(for url: URL, isVideo: Bool, range: ClosedRange<Double>?, preferredLocale: Locale? = nil) async throws -> TranscriptionResult {
+        try Task.checkCancellation()
         // When a locale is forced, bypass the cache — locale variants must not overwrite the auto-detected entry.
         if let preferredLocale {
             return isVideo
@@ -27,8 +28,10 @@ actor TranscriptCache {
             full = isVideo
                 ? try await Transcription.transcribeVideoAudio(videoURL: url)
                 : try await Transcription.transcribe(fileURL: url)
+            try Task.checkCancellation()
             if let key { store(full, key: key) }
         }
+        try Task.checkCancellation()
         return range.map { Self.filter(full, to: $0) } ?? full
     }
 

--- a/Sources/PalmierPro/Transcription/Transcription.swift
+++ b/Sources/PalmierPro/Transcription/Transcription.swift
@@ -95,7 +95,16 @@ enum TranscriptionError: LocalizedError {
 enum Transcription {
     private static let audioExtractionGate = AsyncSemaphore(value: 2)
 
+    static func failurePreservingCancellation(
+        _ error: Error,
+        as makeFailure: (String) -> TranscriptionError
+    ) throws -> TranscriptionError {
+        try Task.checkCancellation()
+        return makeFailure(error.localizedDescription)
+    }
+
     static func transcribeVideoAudio(videoURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
+        try Task.checkCancellation()
         let tempAudioURL = try await extractAudioTrack(from: videoURL, range: sourceRange)
         defer { try? FileManager.default.removeItem(at: tempAudioURL) }
         let result = try await transcribe(fileURL: tempAudioURL, censorProfanity: censorProfanity, preferredLocale: preferredLocale)
@@ -128,6 +137,7 @@ enum Transcription {
     }
 
     static func transcribe(fileURL: URL, censorProfanity: Bool = false, preferredLocale: Locale? = nil, sourceRange: ClosedRange<Double>? = nil) async throws -> TranscriptionResult {
+        try Task.checkCancellation()
         if let sourceRange {
             let tempURL = try await extractAudioTrack(from: fileURL, range: sourceRange)
             defer { try? FileManager.default.removeItem(at: tempURL) }
@@ -170,12 +180,13 @@ enum Transcription {
             do {
                 try await install.downloadAndInstall()
             } catch {
+                let failure = try failurePreservingCancellation(error, as: TranscriptionError.modelInstallFailed)
                 Log.transcription.warning(
                     "install model failed locale=\(locale.identifier) error=\(error.localizedDescription)",
                     telemetry: "Transcription model install failed",
                     data: ["locale": locale.identifier(.bcp47), "error": error.localizedDescription]
                 )
-                throw TranscriptionError.modelInstallFailed(error.localizedDescription)
+                throw failure
             }
             Log.transcription.notice(
                 "install model ok locale=\(locale.identifier)",
@@ -188,7 +199,7 @@ enum Transcription {
         do {
             audioFile = try AVAudioFile(forReading: fileURL)
         } catch {
-            throw TranscriptionError.audioExtractionFailed(error.localizedDescription)
+            throw try failurePreservingCancellation(error, as: TranscriptionError.audioExtractionFailed)
         }
 
         let analyzer = SpeechAnalyzer(modules: [transcriber])
@@ -208,22 +219,24 @@ enum Transcription {
             }
         } catch {
             resultsTask.cancel()
+            let failure = try failurePreservingCancellation(error, as: TranscriptionError.analysisFailed)
             Log.transcription.warning(
                 "analyze failed error=\(error.localizedDescription)",
                 telemetry: "Transcription analysis failed",
                 data: ["error": error.localizedDescription]
             )
-            throw TranscriptionError.analysisFailed(error.localizedDescription)
+            throw failure
         }
 
         let collected: [SpeechTranscriber.Result]
         do {
             collected = try await resultsTask.value
         } catch {
-            throw TranscriptionError.analysisFailed(error.localizedDescription)
+            throw try failurePreservingCancellation(error, as: TranscriptionError.analysisFailed)
         }
 
         let decoded = decodeResults(collected, locale: locale)
+        try Task.checkCancellation()
         Log.transcription.notice(
             "ok textChars=\(decoded.text.count) words=\(decoded.words.count) lang=\(decoded.language ?? "?")",
             telemetry: "Transcription finished",
@@ -276,6 +289,7 @@ enum Transcription {
                 try audioFile?.write(from: pcm)
             }
         } catch let error as AudioTrackReader.ReadError {
+            try Task.checkCancellation()
             throw TranscriptionError.audioExtractionFailed(error.message)
         }
 

--- a/Tests/PalmierProTests/Captions/TranscriptionCancellationTests.swift
+++ b/Tests/PalmierProTests/Captions/TranscriptionCancellationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Transcription cancellation")
+struct TranscriptionCancellationTests {
+    private enum SampleError: Error {
+        case failed
+    }
+
+    @Test func cancelledTaskDoesNotConvertFailure() async {
+        let task = Task<TranscriptionError, Error> {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try Transcription.failurePreservingCancellation(
+                SampleError.failed,
+                as: TranscriptionError.analysisFailed
+            )
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test func frameworkCancellationRemainsFailureWhileTaskIsActive() throws {
+        let failure = try Transcription.failurePreservingCancellation(
+            CancellationError(),
+            as: TranscriptionError.analysisFailed
+        )
+
+        guard case .analysisFailed = failure else {
+            Issue.record("Expected an analysis failure")
+            return
+        }
+    }
+
+    @Test func cacheRejectsCancelledRequestBeforeStartingTranscription() async {
+        let task = Task<TranscriptionResult, Error> {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await TranscriptCache.shared.transcript(
+                for: URL(fileURLWithPath: "/missing/transcription-source.wav"),
+                isVideo: false,
+                range: nil
+            )
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve deliberate task cancellation instead of reporting it as a transcription failure.
- Prevent canceled transcript and caption work from caching or committing partial results.
- Keep unexpected `SpeechAnalyzer` cancellation as a real failure when the owning task is still active.

## Approach
- Check task cancellation before translating framework errors into transcription-domain failures or emitting failure telemetry.
- Add cancellation boundaries around transcript cache reads, Agent media inspection, transcript collection, and caption result collection.
- Retain existing nonthrowing task groups and partial-file failure behavior, with one post-group cancellation check before results are consumed.

## Testing
- [x] `swift test --filter '(TranscriptionCancellationTests|CaptionGenerationTests|GetTranscriptParamTests|MCPTranscriptionTrackTests)'` — 50 tests passed.
- [x] `swift build` — passed.
- [x] `swift build --traits BundledSpeech` — passed.
- [ ] Manual: stop an uncached Agent `inspect_media` transcription and verify no transcription cancellation failure is logged.
- [ ] Manual: stop Agent caption generation during transcription and verify no partial caption track or undo entry is created.

## Change statistics
- Code logic: +30 / -7
- Tests: +51 / -0
- Total: +81 / -7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared transcription, cache, and caption commit paths; behavior change is intentional but could affect error handling for in-flight cancellations across Agent and editor features.
> 
> **Overview**
> **Stops user-cancelled transcription from being reported or persisted as failures.**
> 
> Cancellation is checked at key boundaries in `Transcription`, `TranscriptCache`, Agent `inspect_media` / `get_transcript`, and caption transcription batching. A new `failurePreservingCancellation` helper rethrows `CancellationError` when the owning task is cancelled, but still maps real `SpeechAnalyzer` / I/O errors to `TranscriptionError` while the task is active.
> 
> After parallel transcript work finishes, callers verify cancellation **before** attaching metadata, caching on disk, or continuing caption placement—so stopped Agent runs should not log `transcriptionError` or commit partial caption tracks. `transcriptsByURL` is now `async throws` to propagate cancellation from those checks.
> 
> Adds `TranscriptionCancellationTests` for the helper and early cache rejection on cancelled requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c26da2f68224631fd7d8182f994f9f3d6b5baf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->