### PR TITLE
[ui] Add editable crop aspect ratios

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -705,8 +705,8 @@ final class EditorViewModel {
         }
     }
 
-    func displayedCropAspectRatio(for clip: Clip) -> CropAspectRatio? {
-        if let ratio = cropAspectLock.aspectRatio { return ratio }
+    func displayedCropAspectRatio(for clip: Clip, preferLockedRatio: Bool = true) -> CropAspectRatio? {
+        if preferLockedRatio, let ratio = cropAspectLock.aspectRatio { return ratio }
         guard let dimensions = sourceDimensions(for: clip) else { return nil }
         let crop = clip.cropAt(frame: activeFrame)
         if crop.isIdentity {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -705,6 +705,18 @@ final class EditorViewModel {
         }
     }
 
+    func displayedCropAspectRatio(for clip: Clip) -> CropAspectRatio? {
+        if let ratio = cropAspectLock.aspectRatio { return ratio }
+        guard let dimensions = sourceDimensions(for: clip) else { return nil }
+        let crop = clip.cropAt(frame: activeFrame)
+        if crop.isIdentity {
+            return CropAspectRatio(pixelWidth: dimensions.width, pixelHeight: dimensions.height)
+        }
+        guard crop.visibleWidthFraction > 0, crop.visibleHeightFraction > 0 else { return nil }
+        let sourceAspect = Double(dimensions.width) / Double(dimensions.height)
+        return CropAspectRatio(pixelAspect: sourceAspect * crop.visibleWidthFraction / crop.visibleHeightFraction)
+    }
+
     func removeClipInternal(id: String) {
         for i in timeline.tracks.indices {
             timeline.tracks[i].clips.removeAll { $0.id == id }

--- a/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
+++ b/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
@@ -78,6 +78,7 @@ struct CropAspectFields: View {
             updateValues(from: ratio)
             return
         }
+        guard abs(newRatio.pixelAspect - ratio.pixelAspect) > 1e-4 else { return }
         onCommit(newRatio)
     }
 

--- a/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
+++ b/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
@@ -1,0 +1,90 @@
+import AppKit
+import SwiftUI
+
+struct CropAspectFields: View {
+    let ratio: CropAspectRatio
+    let onCommit: (CropAspectRatio) -> Void
+
+    @State private var horizontal: Double
+    @State private var vertical: Double
+    @State private var cancelling = false
+    @FocusState private var focusedField: Field?
+
+    init(
+        ratio: CropAspectRatio,
+        onCommit: @escaping (CropAspectRatio) -> Void
+    ) {
+        self.ratio = ratio
+        self.onCommit = onCommit
+        _horizontal = State(initialValue: ratio.horizontal)
+        _vertical = State(initialValue: ratio.vertical)
+    }
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.xxs) {
+            ratioField("Width", value: $horizontal, field: .horizontal, alignment: .trailing)
+            Text(verbatim: ":")
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+            ratioField("Height", value: $vertical, field: .vertical, alignment: .leading)
+        }
+        .padding(.horizontal, AppTheme.Spacing.xs)
+        .editorValueField(active: focusedField != nil)
+        .fixedSize()
+        .help(L10n.string("Choose a crop aspect"))
+        .onChange(of: ratio) { _, newRatio in
+            guard focusedField == nil else { return }
+            updateValues(from: newRatio)
+        }
+        .onChange(of: focusedField) { oldField, newField in
+            guard oldField != nil, newField == nil else { return }
+            if cancelling {
+                cancelling = false
+            } else {
+                commitInput()
+            }
+        }
+    }
+
+    private func ratioField(
+        _ label: String,
+        value: Binding<Double>,
+        field: Field,
+        alignment: TextAlignment
+    ) -> some View {
+        TextField(
+            String(),
+            value: value,
+            format: .number.grouping(.never).precision(.fractionLength(0...4))
+        )
+            .textFieldStyle(.plain)
+            .multilineTextAlignment(alignment)
+            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium).monospacedDigit())
+            .foregroundStyle(AppTheme.Text.primaryColor)
+            .frame(width: AppTheme.EditorPanel.compactNumericFieldWidth, height: AppTheme.EditorPanel.fieldMinHeight)
+            .focused($focusedField, equals: field)
+            .onSubmit { focusedField = nil }
+            .onExitCommand {
+                updateValues(from: ratio)
+                cancelling = true
+                focusedField = nil
+            }
+            .accessibilityLabel(L10n.string("Aspect ratio: \(label)"))
+    }
+
+    private func commitInput() {
+        guard let newRatio = CropAspectRatio(horizontal: horizontal, vertical: vertical) else {
+            NSSound.beep()
+            updateValues(from: ratio)
+            return
+        }
+        onCommit(newRatio)
+    }
+
+    private func updateValues(from ratio: CropAspectRatio) {
+        horizontal = ratio.horizontal
+        vertical = ratio.vertical
+    }
+
+    private enum Field: Hashable { case horizontal, vertical }
+}

--- a/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
+++ b/Sources/PalmierPro/Inspector/Components/CropAspectFields.swift
@@ -78,7 +78,7 @@ struct CropAspectFields: View {
             updateValues(from: ratio)
             return
         }
-        guard abs(newRatio.pixelAspect - ratio.pixelAspect) > 1e-4 else { return }
+        guard newRatio != ratio else { return }
         onCommit(newRatio)
     }
 

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -1023,6 +1023,7 @@ struct InspectorView: View {
     }
 
     private func applyCropPreset(_ preset: CropAspectLock, on clip: Clip) {
+        let currentAspect = editor.displayedCropAspectRatio(for: clip)?.pixelAspect
         editor.cropAspectLock = preset
         switch preset {
         case .free:
@@ -1031,6 +1032,7 @@ struct InspectorView: View {
             editor.commitCrop(clipId: clip.id, newCrop: Crop())
         default:
             guard let target = preset.pixelAspect else { return }
+            guard currentAspect.map({ abs($0 - target) > 1e-4 }) ?? true else { return }
             editor.commitCrop(clipId: clip.id, newCrop: editor.cropFittingAspect(for: clip, targetPixelAspect: target))
         }
     }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -1023,7 +1023,7 @@ struct InspectorView: View {
     }
 
     private func applyCropPreset(_ preset: CropAspectLock, on clip: Clip) {
-        let currentAspect = editor.displayedCropAspectRatio(for: clip)?.pixelAspect
+        let currentAspect = editor.displayedCropAspectRatio(for: clip, preferLockedRatio: false)?.pixelAspect
         editor.cropAspectLock = preset
         switch preset {
         case .free:

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -950,9 +950,18 @@ struct InspectorView: View {
                     editor.cropEditingActive.toggle()
                 }
                 .disabled(disabled)
-                cropMenu(single: single)
-                if let cid = single?.id {
-                    keyframeControls(clipId: cid, property: .crop)
+                if editing, let clip = single, let ratio = editor.displayedCropAspectRatio(for: clip) {
+                    HStack(spacing: AppTheme.Spacing.xxs) {
+                        CropAspectFields(ratio: ratio) {
+                            applyCropPreset(.locked(to: $0), on: clip)
+                        }
+                        cropMenu(single: clip, compact: true)
+                    }
+                } else {
+                    cropMenu(single: single)
+                }
+                if let clipId = single?.id {
+                    keyframeControls(clipId: clipId, property: .crop)
                 } else {
                     keyframeControlsPlaceholder
                 }
@@ -962,33 +971,33 @@ struct InspectorView: View {
         .opacity(disabled ? 0.4 : 1)
     }
 
-    @ViewBuilder
-    private func cropMenu(single: Clip?) -> some View {
+    private func cropMenu(single: Clip?, compact: Bool = false) -> some View {
         let active = editor.cropAspectLock
-        Menu {
-            ForEach(CropAspectLock.allCases, id: \.self) { preset in
-                Button {
-                    if let clip = single { applyCropPreset(preset, on: clip) }
-                } label: {
-                    if preset == active {
-                        Label(preset.localizedLabel, systemImage: "checkmark")
-                    } else {
-                        Text(preset.localizedLabel)
-                    }
-                }
+        return Menu {
+            if let single {
+                cropMenuItems(for: single)
             }
         } label: {
-            HStack(spacing: AppTheme.Spacing.xs) {
-                Text(active.localizedLabel)
-                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium).monospacedDigit())
-                    .foregroundStyle(AppTheme.Text.secondaryColor)
+            if compact {
                 Image(systemName: "chevron.down")
                     .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
-                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .frame(width: AppTheme.IconSize.md, height: AppTheme.EditorPanel.fieldMinHeight)
+                    .editorValueField()
+                    .contentShape(Rectangle())
+            } else {
+                HStack(spacing: AppTheme.Spacing.xs) {
+                    Text(active.localizedLabel)
+                        .font(.system(size: AppTheme.FontSize.sm, weight: .medium).monospacedDigit())
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: AppTheme.FontSize.xxs, weight: .semibold))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                }
+                .padding(.horizontal, AppTheme.Spacing.sm)
+                .padding(.vertical, AppTheme.Spacing.xxs)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, AppTheme.Spacing.sm)
-            .padding(.vertical, AppTheme.Spacing.xxs)
-            .contentShape(Rectangle())
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
@@ -997,11 +1006,26 @@ struct InspectorView: View {
         .help(L10n.string("Choose a crop aspect"))
     }
 
+    @ViewBuilder
+    private func cropMenuItems(for clip: Clip) -> some View {
+        let active = editor.cropAspectLock
+        ForEach(CropAspectLock.presets, id: \.self) { preset in
+            Button {
+                applyCropPreset(preset, on: clip)
+            } label: {
+                if preset == active {
+                    Label(preset.localizedLabel, systemImage: "checkmark")
+                } else {
+                    Text(preset.localizedLabel)
+                }
+            }
+        }
+    }
+
     private func applyCropPreset(_ preset: CropAspectLock, on clip: Clip) {
         editor.cropAspectLock = preset
         switch preset {
         case .free:
-            // Don't mutate crop; user keeps current shape and drags freely.
             break
         case .original:
             editor.commitCrop(clipId: clip.id, newCrop: Crop())

--- a/Sources/PalmierPro/Localization/UILocalization.swift
+++ b/Sources/PalmierPro/Localization/UILocalization.swift
@@ -29,9 +29,9 @@ extension CropAspectLock {
     @MainActor
     var localizedLabel: String {
         switch self {
-        case .free: L10n.string("Custom")
+        case .free: L10n.string("Freeform")
         case .original: L10n.string("Original")
-        case .r16x9, .r9x16, .r1x1, .r4x3, .r3x4, .r21x9: label
+        case .fixed: label
         }
     }
 }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -631,32 +631,80 @@ struct Crop: Codable, Sendable, Equatable {
     var visibleHeightFraction: Double { max(0, 1 - top - bottom) }
 }
 
-/// Aspect-ratio constraint for the Crop overlay.
-enum CropAspectLock: Hashable, CaseIterable {
-    case free, original, r16x9, r9x16, r1x1, r4x3, r3x4, r21x9
+struct CropAspectRatio: Hashable, Sendable {
+    let horizontal: Double
+    let vertical: Double
+
+    init?(horizontal: Double, vertical: Double) {
+        guard horizontal.isFinite, vertical.isFinite,
+              horizontal > 0, vertical > 0,
+              (horizontal / vertical).isFinite else { return nil }
+        self.horizontal = horizontal
+        self.vertical = vertical
+    }
+
+    init?(pixelWidth: Int, pixelHeight: Int) {
+        guard pixelWidth > 0, pixelHeight > 0 else { return nil }
+        var a = pixelWidth
+        var b = pixelHeight
+        while b != 0 { (a, b) = (b, a % b) }
+        self.init(horizontal: Double(pixelWidth / a), vertical: Double(pixelHeight / a))
+    }
+
+    init?(pixelAspect: Double) {
+        guard pixelAspect.isFinite, pixelAspect > 0 else { return nil }
+        self.init(horizontal: max(pixelAspect, 1), vertical: max(1 / pixelAspect, 1))
+    }
+
+    var pixelAspect: Double { horizontal / vertical }
+    var horizontalText: String { Self.format(horizontal) }
+    var verticalText: String { Self.format(vertical) }
+    var label: String { "\(horizontalText):\(verticalText)" }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.6g", locale: Locale(identifier: "en_US_POSIX"), value)
+    }
+
+    static func preset(_ horizontal: Double, _ vertical: Double) -> CropAspectRatio {
+        CropAspectRatio(validatedHorizontal: horizontal, vertical: vertical)
+    }
+
+    private init(validatedHorizontal: Double, vertical: Double) {
+        self.horizontal = validatedHorizontal
+        self.vertical = vertical
+    }
+}
+
+enum CropAspectLock: Hashable, Sendable {
+    case free, original, fixed(CropAspectRatio)
+
+    static let r16x9 = fixed(CropAspectRatio.preset(16, 9))
+    static let r9x16 = fixed(CropAspectRatio.preset(9, 16))
+    static let r1x1 = fixed(CropAspectRatio.preset(1, 1))
+    static let r4x3 = fixed(CropAspectRatio.preset(4, 3))
+    static let r3x4 = fixed(CropAspectRatio.preset(3, 4))
+    static let r21x9 = fixed(CropAspectRatio.preset(21, 9))
+    static let presets = [free, original, r16x9, r9x16, r1x1, r4x3, r3x4, r21x9]
 
     var label: String {
         switch self {
-        case .free: "Custom"
+        case .free: "Freeform"
         case .original: "Original"
-        case .r16x9: "16:9"
-        case .r9x16: "9:16"
-        case .r1x1: "1:1"
-        case .r4x3: "4:3"
-        case .r3x4: "3:4"
-        case .r21x9: "21:9"
+        case let .fixed(ratio): ratio.label
         }
     }
 
-    var pixelAspect: Double? {
-        switch self {
-        case .free, .original: nil
-        case .r16x9: 16.0 / 9.0
-        case .r9x16: 9.0 / 16.0
-        case .r1x1: 1.0
-        case .r4x3: 4.0 / 3.0
-        case .r3x4: 3.0 / 4.0
-        case .r21x9: 21.0 / 9.0
-        }
+    var aspectRatio: CropAspectRatio? {
+        guard case let .fixed(ratio) = self else { return nil }
+        return ratio
+    }
+
+    var pixelAspect: Double? { aspectRatio?.pixelAspect }
+
+    static func locked(to ratio: CropAspectRatio) -> CropAspectLock {
+        presets.first {
+            guard let preset = $0.pixelAspect else { return false }
+            return abs(preset - ratio.pixelAspect) < 1e-9
+        } ?? .fixed(ratio)
     }
 }

--- a/Sources/PalmierPro/Preview/CropOverlayView.swift
+++ b/Sources/PalmierPro/Preview/CropOverlayView.swift
@@ -200,15 +200,9 @@ struct CropOverlayView: View {
 
     private func lockedAspectNormalized(for clip: Clip) -> Double? {
         guard let target = editor.cropAspectLock.pixelAspect,
-              let srcAspect = sourcePixelAspect(for: clip), srcAspect > 0 else { return nil }
+              let dimensions = editor.sourceDimensions(for: clip) else { return nil }
+        let srcAspect = Double(dimensions.width) / Double(dimensions.height)
         return target / srcAspect
-    }
-
-    private func sourcePixelAspect(for clip: Clip) -> Double? {
-        guard let asset = editor.mediaAssets.first(where: { $0.id == clip.mediaRef }),
-              let sw = asset.sourceWidth, let sh = asset.sourceHeight,
-              sw > 0, sh > 0 else { return nil }
-        return Double(sw) / Double(sh)
     }
 
     // MARK: - Layout

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -243,7 +243,6 @@
 "Crop" = "Crop";
 "Crop applies to one clip at a time" = "Crop applies to one clip at a time";
 "Curves" = "Curves";
-"Custom" = "Custom";
 "Custom Aspect Ratio" = "Custom Aspect Ratio";
 "Custom…" = "Custom…";
 "Cut" = "Cut";
@@ -385,6 +384,7 @@
 "Founder" = "Founder";
 "Frame Rate" = "Frame Rate";
 "Free" = "Free";
+"Freeform" = "Freeform";
 "Full Frame" = "Full Frame";
 "Full Screen" = "Full Screen";
 "Full changelog" = "Full changelog";

--- a/Tests/PalmierProTests/Rendering/TransformCropTests.swift
+++ b/Tests/PalmierProTests/Rendering/TransformCropTests.swift
@@ -129,9 +129,37 @@ struct CropAspectLockTests {
         #expect(CropAspectLock.r21x9.pixelAspect == 21.0 / 9.0)
     }
 
-    @Test func allCasesAreEnumerable() {
-        // Pinning down the case list so anyone adding a case has to update label/pixelAspect too.
-        #expect(CropAspectLock.allCases.count == 8)
+    @Test func customAspectUsesEnteredComponents() throws {
+        let ratio = try #require(CropAspectRatio(horizontal: 2.39, vertical: 1))
+        let lock = CropAspectLock.locked(to: ratio)
+
+        #expect(lock == .fixed(ratio))
+        #expect(lock.pixelAspect == 2.39)
+        #expect(lock.label == "2.39:1")
+    }
+
+    @Test func customAspectMatchingPresetUsesPresetLock() throws {
+        let ratio = try #require(CropAspectRatio(horizontal: 16, vertical: 9))
+        #expect(CropAspectLock.locked(to: ratio) == .r16x9)
+    }
+
+}
+
+@Suite("CropAspectRatio")
+struct CropAspectRatioTests {
+
+    @Test func pixelDimensionsReduceToRatioComponents() throws {
+        let ratio = try #require(CropAspectRatio(pixelWidth: 3840, pixelHeight: 2160))
+        #expect(ratio.horizontal == 16)
+        #expect(ratio.vertical == 9)
+    }
+
+    @Test func invalidComponentsAreRejected() {
+        #expect(CropAspectRatio(horizontal: 0, vertical: 1) == nil)
+        #expect(CropAspectRatio(horizontal: -1, vertical: 1) == nil)
+        #expect(CropAspectRatio(horizontal: 1, vertical: 0) == nil)
+        #expect(CropAspectRatio(horizontal: .infinity, vertical: 1) == nil)
+        #expect(CropAspectRatio(horizontal: 1, vertical: .nan) == nil)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add inline width and height ratio fields while crop mode is active.
- Keep the crop preset menu available beside manual entry and rename the unconstrained mode to Freeform.
- Apply custom ratios through the existing crop mutation and undo path without committing untouched values or recentering equivalent ratios.

## Approach
- Represent fixed crop constraints with a validated `CropAspectRatio` shared by presets and custom values.
- Commit the two ratio fields together when editing ends; Return applies the pair and Escape restores the previous ratio.
- Leave untouched component pairs unchanged; edited equivalent ratios set the fixed lock without refitting the current crop.
- Compare preset targets with the selected clip’s crop geometry at the playhead rather than the global lock state.
- Derive displayed values from the active crop and shared source dimensions, including nested timelines.

## Testing
- `scripts/localization/sync.sh` — passed.
- `swift test --filter CropAspect` — passed.
- `swift build` — passed.
- `swift test` — passed with 1,449 tests. Transient unrelated failures in text raster caching and frame sampling passed on isolated retry and full rerun.
- Manual UI verification — custom ratio entry, crop presets, and the compact crop-mode layout confirmed in the app.
- Not separately verified manually: invalid or extreme ratio entry, untouched/equivalent ratio exits after the review fixes, reapplying a preset after selection or keyframe divergence, and keyframed crop interaction.

## Change statistics
- Editor, UI, and domain logic: +228 / -57
- Localization: +3 / -3
- Tests: +31 / -3
- Total: +262 / -63 (net +199)