### PR TITLE
[agent/ui] Add shared clip settings transfer

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -61,6 +61,9 @@ enum AgentInstructions {
         - Text: add_texts for authored overlays; add_captions transcribes the timeline's \
           spoken audio (no targeting) — restyle with update_text and the returned \
           captionGroupId. fillMode 'footage' stencils layers below through the letter shapes. \
+          Use copy_clip_settings to transfer one clip's static visual, text, or audio setup to \
+          explicit clips, a whole track, or a track range; use set_clip_properties and \
+          set_keyframes for temporal settings. \
           Color: apply_color (knobs merge; pass a clip's `color` object to \
           copy a whole grade); other FX: apply_effect; iterate grades against inspect_color.
         - Transcription language: omit unless the user names the spoken language. Cloud \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -33,6 +33,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case rippleDeleteRanges = "ripple_delete_ranges"
     case swapClipMedia = "swap_clip_media"
     case setClipProperties = "set_clip_properties"
+    case copyClipSettings = "copy_clip_settings"
     case setKeyframes = "set_keyframes"
     case applyLayout = "apply_layout"
     case syncClips = "sync_clips"
@@ -541,6 +542,34 @@ enum ToolDefinitions {
                     ],
                 ],
                 required: ["clipIds"]
+            )
+        ),
+        AgentTool(
+            name: .copyClipSettings,
+            description: "Copy one clip's static settings to one or more clips of the same media type in a single undoable action. Use for requests such as \"make these shots look like that one,\" \"use this title style,\" or \"give these audio clips the same treatment.\"\n\nChoose exactly one target mode. targetClipIds applies to an explicit list and refuses any mismatched media type. targetTrack selects every same-type clip on one stable trackId; add range [startFrame, endFrame) to limit it to clips intersecting that part of the timeline. Track mode excludes the source and mismatched clips, returns compact matched/changed/unchanged/incompatible counts instead of clip IDs, and refuses when no compatible clips match.\n\nVideo, image, Lottie, and nested-timeline clips copy transform, crop, opacity, edge rounding/softness, blend mode, and the complete effect stack including color. Text clips copy typography/style, text animation, fill mode, position, rotation, flips, opacity, and effects; target text, word timings, and caption membership stay intact, and the box is refit to the target content. Audio clips copy volume and effects, including denoise. Settings absent from the source clear the corresponding target setting.\n\nThis does NOT copy placement, duration, trims, speed, fades, top-level keyframes, media, links, caption groups, or multicam membership. Use set_clip_properties and set_keyframes for temporal changes. Linked audio is a separate audio clip: copy it explicitly using the nested audio.id from get_timeline.",
+            inputSchema: objectSchema(
+                properties: [
+                    "sourceClipId": ["type": "string", "description": "Clip whose current static settings are copied."],
+                    "targetClipIds": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description": "Explicit destination clips. Every target must have the same mediaType as the source. Use this or targetTrack, not both.",
+                    ],
+                    "targetTrack": objectSchema(
+                        properties: [
+                            "trackId": ["type": "string", "description": "Stable trackId from get_timeline."],
+                            "range": [
+                                "type": "array",
+                                "items": ["type": "integer"],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "description": "Optional [startFrame, endFrame) timeline range. Only intersecting clips are considered; omit for the whole track.",
+                            ],
+                        ],
+                        required: ["trackId"]
+                    ),
+                ],
+                required: ["sourceClipId"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Clips.swift
@@ -104,6 +104,18 @@ fileprivate struct SetClipPropertiesInput: DecodableToolArgs {
     }
 }
 
+fileprivate struct CopyClipSettingsInput: DecodableToolArgs {
+    struct TargetTrack: Decodable {
+        let trackId: String
+        let range: [Int]?
+    }
+
+    let sourceClipId: String
+    let targetClipIds: [String]?
+    let targetTrack: TargetTrack?
+    static let allowedKeys: Set<String> = ["sourceClipId", "targetClipIds", "targetTrack"]
+}
+
 fileprivate struct RippleDeleteRangesInput: DecodableToolArgs {
     let clipId: String?
     let trackIndex: Int?
@@ -830,6 +842,102 @@ extension ToolExecutor {
             throw ToolError("\(field) must be 'linear' or 'smooth' (got '\(rawValue)')")
         }
         return value
+    }
+
+    // MARK: copy_clip_settings
+
+    func copyClipSettings(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        if let rawTargetTrack = args["targetTrack"] {
+            guard let targetTrack = rawTargetTrack as? [String: Any] else {
+                throw ToolError("copy_clip_settings.targetTrack: expected object")
+            }
+            try validateUnknownKeys(
+                targetTrack,
+                allowed: ["trackId", "range"],
+                path: "copy_clip_settings.targetTrack"
+            )
+        }
+        let input: CopyClipSettingsInput = try decodeToolArgs(args, path: "copy_clip_settings")
+        guard (input.targetClipIds != nil) != (input.targetTrack != nil) else {
+            throw ToolError("Provide exactly one of 'targetClipIds' or 'targetTrack'")
+        }
+
+        let settings = try editor.clipSettingsSnapshot(for: input.sourceClipId)
+
+        var targetSelection: [String: Any]?
+        var incompatibleClipCount = 0
+        var sourceExcluded = false
+        let targetClipIds: [String]
+        if let explicitIds = input.targetClipIds {
+            var seen = Set<String>()
+            targetClipIds = explicitIds.filter { seen.insert($0).inserted }
+            guard !targetClipIds.isEmpty else {
+                throw ToolError("Provide a non-empty 'targetClipIds' array")
+            }
+        } else {
+            guard let targetTrack = input.targetTrack else {
+                throw ToolError("Provide exactly one of 'targetClipIds' or 'targetTrack'")
+            }
+            guard let track = editor.timeline.tracks.first(where: { $0.id == targetTrack.trackId }) else {
+                throw ToolError("Track not found: \(targetTrack.trackId)")
+            }
+            let range: Range<Int>?
+            if let frames = targetTrack.range {
+                guard frames.count == 2, frames[0] >= 0, frames[1] > frames[0] else {
+                    throw ToolError("targetTrack.range must be [startFrame, endFrame) with 0 <= startFrame < endFrame")
+                }
+                range = frames[0]..<frames[1]
+            } else {
+                range = nil
+            }
+            let scopedClips = track.clips.filter { clip in
+                range.map { clip.startFrame < $0.upperBound && clip.endFrame > $0.lowerBound } ?? true
+            }
+            targetClipIds = scopedClips.compactMap {
+                $0.id != input.sourceClipId && $0.mediaType == settings.mediaType ? $0.id : nil
+            }
+            sourceExcluded = scopedClips.contains { $0.id == input.sourceClipId }
+            incompatibleClipCount = scopedClips.count {
+                $0.id != input.sourceClipId && $0.mediaType != settings.mediaType
+            }
+            guard !targetClipIds.isEmpty else {
+                throw ToolError("No \(settings.mediaType.rawValue) clips matched targetTrack \(targetTrack.trackId)")
+            }
+            var selection: [String: Any] = ["trackId": targetTrack.trackId]
+            if let frames = targetTrack.range { selection["range"] = frames }
+            targetSelection = selection
+        }
+
+        let snapshot = timelineSnapshot(editor)
+        let transfer = try editor.applyClipSettings(
+            settings,
+            to: targetClipIds,
+            actionName: "Copy Clip Settings (Agent)"
+        )
+
+        var extra: [String: Any] = [
+            "changed": !transfer.changedClipIds.isEmpty,
+            "sourceClipId": input.sourceClipId,
+            "mediaType": settings.mediaType.rawValue,
+        ]
+        if let targetSelection {
+            extra["targetTrack"] = targetSelection
+            extra["matchedClipCount"] = targetClipIds.count
+            extra["changedClipCount"] = transfer.changedClipIds.count
+            extra["unchangedClipCount"] = transfer.unchangedClipIds.count
+            extra["incompatibleClipCount"] = incompatibleClipCount
+            extra["sourceExcluded"] = sourceExcluded
+        } else {
+            extra["targetClipIds"] = targetClipIds
+            extra["changedClipIds"] = transfer.changedClipIds
+            extra["unchangedClipIds"] = transfer.unchangedClipIds
+        }
+        return mutationResult(
+            editor,
+            since: snapshot,
+            touched: targetSelection == nil ? transfer.changedClipIds : [],
+            extra: extra
+        )
     }
 
     // MARK: set_keyframes

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -301,6 +301,7 @@ final class ToolExecutor {
         case .applyLayout:      return try applyLayout(editor, args)
         case .swapClipMedia:    return try swapClipMedia(editor, args)
         case .setClipProperties: return try setClipProperties(editor, args)
+        case .copyClipSettings: return try copyClipSettings(editor, args)
         case .setKeyframes:     return try setKeyframes(editor, args)
         case .splitClips:       return try splitClips(editor, args)
         case .rippleDeleteRanges: return try rippleDeleteRanges(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipSettings.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+struct ClipSettingsSnapshot: Sendable {
+    let sourceClipId: String
+    fileprivate let clip: Clip
+
+    var mediaType: ClipType { clip.mediaType }
+}
+
+struct ClipSettingsTransferResult: Sendable, Equatable {
+    let changedClipIds, unchangedClipIds: [String]
+}
+
+enum ClipSettingsTransferError: LocalizedError, Equatable {
+    case emptyTargets
+    case clipNotFound(String)
+    case incompatibleType(source: ClipType, targetId: String, target: ClipType)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTargets:
+            "Provide at least one target clip."
+        case .clipNotFound(let id):
+            "Clip not found: \(id)"
+        case .incompatibleType(let source, let targetId, let target):
+            "Clip \(targetId) is \(target.rawValue); copied settings require \(source.rawValue) clips."
+        }
+    }
+}
+
+extension EditorViewModel {
+    func copiedClipSettings(for mediaType: ClipType) -> ClipSettingsSnapshot? {
+        let sources = clipClipboard.map(\.clip).filter { $0.mediaType == mediaType }
+        guard sources.count == 1, let source = sources.first else { return nil }
+        return ClipSettingsSnapshot(sourceClipId: source.id, clip: source)
+    }
+
+    func pasteClipSettingsFromClipboard(to clipIds: [String]) {
+        guard let mediaType = clipIds.compactMap({ clipFor(id: $0)?.mediaType }).first,
+              let settings = copiedClipSettings(for: mediaType) else {
+            mediaPanelToast = MediaPanelToast(message: L10n.string("Copy one clip of the same type and try again."))
+            return
+        }
+        do {
+            _ = try applyClipSettings(settings, to: clipIds)
+        } catch {
+            mediaPanelToast = MediaPanelToast(message: L10n.string("Select compatible clips and paste settings again."))
+            Log.editor.notice("paste clip settings failed: \(error)")
+        }
+    }
+
+    func clipSettingsSnapshot(for clipId: String) throws -> ClipSettingsSnapshot {
+        guard let clip = clipFor(id: clipId) else {
+            throw ClipSettingsTransferError.clipNotFound(clipId)
+        }
+        return ClipSettingsSnapshot(sourceClipId: clipId, clip: clip)
+    }
+
+    func compatibleClipSettingsTargets(in clipIds: [String], for snapshot: ClipSettingsSnapshot) -> [String] {
+        clipIds.filter {
+            $0 != snapshot.sourceClipId && clipFor(id: $0)?.mediaType == snapshot.mediaType
+        }
+    }
+
+    @discardableResult
+    func applyClipSettings(
+        _ snapshot: ClipSettingsSnapshot,
+        to targetClipIds: [String],
+        actionName: String = L10n.string("Paste Clip Settings")
+    ) throws -> ClipSettingsTransferResult {
+        var seen = Set<String>()
+        let targetClipIds = targetClipIds.filter { seen.insert($0).inserted }
+        guard !targetClipIds.isEmpty else {
+            throw ClipSettingsTransferError.emptyTargets
+        }
+
+        var replacements: [String: Clip] = [:]
+        for clipId in targetClipIds {
+            guard let target = clipFor(id: clipId) else {
+                throw ClipSettingsTransferError.clipNotFound(clipId)
+            }
+            guard target.mediaType == snapshot.mediaType else {
+                throw ClipSettingsTransferError.incompatibleType(
+                    source: snapshot.mediaType,
+                    targetId: clipId,
+                    target: target.mediaType
+                )
+            }
+            replacements[clipId] = clipId == snapshot.sourceClipId
+                ? target
+                : applyingStaticSettings(from: snapshot.clip, to: target)
+        }
+
+        let changedClipIds = targetClipIds.filter {
+            guard let current = clipFor(id: $0), let replacement = replacements[$0] else { return false }
+            return current != replacement
+        }
+        let changed = Set(changedClipIds)
+        commitClipProperties(clipIds: changedClipIds, actionName: actionName) { clip in
+            if let replacement = replacements[clip.id] {
+                clip = replacement
+            }
+        }
+        return ClipSettingsTransferResult(
+            changedClipIds: changedClipIds,
+            unchangedClipIds: targetClipIds.filter { !changed.contains($0) }
+        )
+    }
+
+    private func applyingStaticSettings(from source: Clip, to target: Clip) -> Clip {
+        var result = target
+        result.effects = source.effects
+
+        switch source.mediaType {
+        case .audio:
+            result.volume = source.volume
+        case .text:
+            result.opacity = source.opacity
+            result.textStyle = source.textStyle
+            result.textAnimation = source.textAnimation
+            result.textFillMode = source.textFillMode
+            _ = fitTextClipToContentIfNeeded(
+                &result,
+                canvasW: Double(timeline.width),
+                canvasH: Double(timeline.height)
+            )
+            result.transform.centerX = source.transform.centerX
+            result.transform.centerY = source.transform.centerY
+            result.transform.rotation = source.transform.rotation
+            result.transform.flipHorizontal = source.transform.flipHorizontal
+            result.transform.flipVertical = source.transform.flipVertical
+        case .video, .image, .lottie, .sequence:
+            result.opacity = source.opacity
+            result.transform = source.transform
+            result.crop = source.crop
+            result.edgeRounding = source.edgeRounding
+            result.edgeSoftness = source.edgeSoftness
+            result.blendMode = source.blendMode
+        }
+        return result
+    }
+}

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -221,6 +221,7 @@
 "Copy" = "Copy";
 "Copy Path" = "Copy Path";
 "Copy message" = "Copy message";
+"Copy one clip of the same type and try again." = "Copy one clip of the same type and try again.";
 "Copy prompt" = "Copy prompt";
 "Corner Radius" = "Corner Radius";
 "Could not install the on-device speech model: %@" = "Could not install the on-device speech model: %@";
@@ -653,6 +654,8 @@
 "Palmier couldn't load this source file. It may be missing, on an ejected drive, or unreadable." = "Palmier couldn't load this source file. It may be missing, on an ejected drive, or unreadable.";
 "Palmier loaded this clip's source file but couldn't prepare it for playback. The file may be corrupt or in an unsupported format." = "Palmier loaded this clip's source file but couldn't prepare it for playback. The file may be corrupt or in an unsupported format.";
 "Paste" = "Paste";
+"Paste Clip Settings" = "Paste Clip Settings";
+"Paste Settings" = "Paste Settings";
 "Path" = "Path";
 "Per line" = "Per line";
 "Per word" = "Per word";
@@ -785,6 +788,7 @@
 "Select Forward on Track" = "Select Forward on Track";
 "Select Range" = "Select Range";
 "Select a single clip to enable" = "Select a single clip to enable";
+"Select compatible clips and paste settings again." = "Select compatible clips and paste settings again.";
 "Select media files or folders to import" = "Select media files or folders to import";
 "Selected" = "Selected";
 "Selected Clips · %lld" = "Selected Clips · %lld";

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1101,6 +1101,15 @@ final class TimelineView: NSView {
             pasteItem.representedObject = ["trackIndex": hit.trackIndex, "frame": clickFrame] as [String: Any]
             timelineItems.append(pasteItem)
         }
+        if let snapshot = editor.copiedClipSettings(for: clip.mediaType) {
+            let targetIds = editor.compatibleClipSettingsTargets(in: targetClipIds, for: snapshot)
+            if !targetIds.isEmpty {
+                let pasteSettingsItem = NSMenuItem(title: L10n.string("Paste Settings"), action: #selector(performPasteClipSettings(_:)), keyEquivalent: "")
+                pasteSettingsItem.target = self
+                pasteSettingsItem.representedObject = targetIds
+                timelineItems.append(pasteSettingsItem)
+            }
+        }
         if editor.canLinkSelected {
             let item = NSMenuItem(title: L10n.string("Link"), action: #selector(performLink(_:)), keyEquivalent: "")
             item.target = self
@@ -1371,6 +1380,12 @@ final class TimelineView: NSView {
 
     @objc private func performCopyClips(_ sender: Any?) {
         editor.copySelectedClipsToClipboard()
+    }
+
+    @objc private func performPasteClipSettings(_ sender: Any?) {
+        guard let clipIds = (sender as? NSMenuItem)?.representedObject as? [String] else { return }
+        editor.pasteClipSettingsFromClipboard(to: clipIds)
+        needsDisplay = true
     }
 
     @objc private func performPasteClips(_ sender: Any?) {

--- a/Tests/PalmierProTests/Agent/MCPCopyClipSettingsTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPCopyClipSettingsTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP copy clip settings", .serialized)
+@MainActor
+struct MCPCopyClipSettingsTests {
+    @Test func discoveryCopyReadbackNoOpValidationAndUndo() async throws {
+        var source = Fixtures.clip(id: "source-video", mediaRef: "source-media", start: 0, duration: 60)
+        source.opacity = 0.45
+        source.transform = Transform(centerX: 0.25, centerY: 0.75, width: 0.4, height: 0.6, rotation: 15)
+        source.crop = Crop(left: 0.1, top: 0.2, right: 0, bottom: 0)
+        source.edgeRounding = 0.3
+        source.blendMode = .screen
+        source.effects = [.make("stylize.invert")]
+
+        var target = Fixtures.clip(id: "target-video", mediaRef: "target-media", start: 90, duration: 45, speed: 1.25)
+        target.fadeInFrames = 6
+        target.opacityTrack = KeyframeTrack(keyframes: [Keyframe(frame: 10, value: 0.7)])
+        let originalTarget = target
+        let audio = Fixtures.clip(id: "target-audio", mediaType: .audio, start: 90, duration: 45)
+        let image = Fixtures.clip(id: "target-image", mediaType: .image, start: 135, duration: 25)
+
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(id: "video-track", clips: [source, target, image]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+        let undo = UndoManager()
+        harness.editor.undo.attach(undo)
+
+        let server = Server(
+            name: "palmier-pro-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "copy-clip-settings-test", version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            let tool = try #require(tools.first { $0.name == "copy_clip_settings" })
+            let properties = try #require(tool.inputSchema.objectValue?["properties"]?.objectValue)
+            #expect(properties["sourceClipId"]?.objectValue?["type"]?.stringValue == "string")
+            #expect(properties["targetClipIds"]?.objectValue?["type"]?.stringValue == "array")
+            #expect(properties["targetTrack"]?.objectValue?["type"]?.stringValue == "object")
+
+            let arguments: [String: Value] = [
+                "sourceClipId": .string(source.id),
+                "targetTrack": .object([
+                    "trackId": .string("video-track"),
+                    "range": .array([.int(0), .int(160)]),
+                ]),
+            ]
+            let result = try await client.callTool(name: "copy_clip_settings", arguments: arguments)
+            #expect(result.isError != true)
+            let receipt = try json(text(result.content))
+            #expect(receipt["changed"] as? Bool == true)
+            #expect(receipt["matchedClipCount"] as? Int == 1)
+            #expect(receipt["changedClipCount"] as? Int == 1)
+            #expect(receipt["unchangedClipCount"] as? Int == 0)
+            #expect(receipt["incompatibleClipCount"] as? Int == 1)
+            #expect(receipt["sourceExcluded"] as? Bool == true)
+            #expect(receipt["targetClipIds"] == nil)
+            #expect(receipt["changedClipIds"] == nil)
+            #expect(receipt["excludedClipIds"] == nil)
+            #expect(receipt["clips"] == nil)
+
+            let repeated = try await client.callTool(name: "copy_clip_settings", arguments: arguments)
+            #expect(repeated.isError != true)
+            let repeatedReceipt = try json(text(repeated.content))
+            #expect(repeatedReceipt["changed"] as? Bool == false)
+            #expect(repeatedReceipt["changedClipCount"] as? Int == 0)
+            #expect(repeatedReceipt["unchangedClipCount"] as? Int == 1)
+            #expect(repeatedReceipt["unchangedClipIds"] == nil)
+
+            let timelineResult = try await client.callTool(name: "get_timeline")
+            let timeline = try json(text(timelineResult.content))
+            let readTarget = try #require(((timeline["tracks"] as? [[String: Any]]) ?? [])
+                .flatMap { ($0["clips"] as? [[String: Any]]) ?? [] }
+                .first { ($0["id"] as? String).map { target.id.hasPrefix($0) } == true })
+            #expect((readTarget["opacity"] as? NSNumber)?.doubleValue == source.opacity)
+            #expect(readTarget["blendMode"] as? String == source.blendMode?.rawValue)
+            #expect((readTarget["transform"] as? [String: Any])?["centerX"] as? Double == source.transform.centerX)
+            #expect((readTarget["keyframes"] as? [String: Any])?["opacity"] != nil)
+            #expect(readTarget["fadeInFrames"] as? Int == originalTarget.fadeInFrames)
+            #expect((readTarget["speed"] as? NSNumber)?.doubleValue == originalTarget.speed)
+            #expect((readTarget["effects"] as? [[String: Any]])?.first?["type"] as? String == "stylize.invert")
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: target.id) == originalTarget)
+            #expect((try await client.callTool(name: "undo")).isError == true)
+
+            let invalid = try await client.callTool(name: "copy_clip_settings", arguments: [
+                "sourceClipId": .string(source.id),
+                "targetClipIds": .array([.string(target.id), .string(audio.id)]),
+            ])
+            #expect(invalid.isError == true)
+            #expect(harness.editor.clipFor(id: target.id) == originalTarget)
+            #expect((try await client.callTool(name: "undo")).isError == true)
+
+            let emptyRange = try await client.callTool(name: "copy_clip_settings", arguments: [
+                "sourceClipId": .string(source.id),
+                "targetTrack": .object([
+                    "trackId": .string("video-track"),
+                    "range": .array([.int(135), .int(160)]),
+                ]),
+            ])
+            #expect(emptyRange.isError == true)
+            #expect((try await client.callTool(name: "undo")).isError == true)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
+    private func json(_ text: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+
+    private func text(_ content: [Tool.Content]) throws -> String {
+        for item in content {
+            if case .text(let text, _, _) = item { return text }
+        }
+        throw CocoaError(.coderReadCorrupt)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/ClipSettingsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipSettingsTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Clip settings transfer")
+@MainActor
+struct ClipSettingsTests {
+    @Test func textSettingsPreserveContentTimingAndAnimationTracks() throws {
+        var source = Fixtures.clip(id: "source", mediaRef: "", mediaType: .text, start: 0, duration: 60)
+        source.textContent = "Title"
+        source.textStyle = TextStyle(fontName: "Avenir", fontSize: 48, isBold: true)
+        source.textAnimation = TextAnimation(preset: .wordPop)
+        source.textFillMode = .footage
+        source.opacity = 0.65
+        source.transform.centerX = 0.2
+        source.transform.centerY = 0.8
+        source.transform.rotation = -8
+        source.effects = [.make("stylize.invert")]
+
+        var target = Fixtures.clip(id: "target", mediaRef: "", mediaType: .text, start: 90, duration: 120)
+        target.textContent = "A much longer target title"
+        target.wordTimings = [WordTiming(text: "A", startFrame: 0, endFrame: 10)]
+        target.captionGroupId = "captions"
+        target.opacityTrack = KeyframeTrack(keyframes: [Keyframe(frame: 20, value: 0.5)])
+        let original = target
+
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [source, target])])
+        editor.selectedClipIds = [source.id]
+        editor.copySelectedClipsToClipboard()
+        let snapshot = try #require(editor.copiedClipSettings(for: .text))
+        _ = try editor.applyClipSettings(snapshot, to: [target.id])
+        let updated = try #require(editor.clipFor(id: target.id))
+
+        #expect(updated.textContent == original.textContent)
+        #expect(updated.wordTimings == original.wordTimings)
+        #expect(updated.captionGroupId == original.captionGroupId)
+        #expect(updated.durationFrames == original.durationFrames)
+        #expect(updated.opacityTrack == original.opacityTrack)
+        #expect(updated.textStyle == source.textStyle)
+        #expect(updated.textAnimation == source.textAnimation)
+        #expect(updated.textFillMode == source.textFillMode)
+        #expect(updated.opacity == source.opacity)
+        #expect(updated.effects == source.effects)
+        #expect(updated.transform.centerX == source.transform.centerX)
+        #expect(updated.transform.centerY == source.transform.centerY)
+        #expect(updated.transform.rotation == source.transform.rotation)
+        #expect(updated.transform.width < source.transform.width)
+    }
+
+    @Test func audioSettingsCopyVolumeAndEffectsOnly() throws {
+        var source = Fixtures.clip(id: "source", mediaType: .audio, start: 0, duration: 60, volume: 0.35)
+        source.effects = [.make(Clip.denoiseEffectType, ["amount": 0.75])]
+        var target = Fixtures.clip(id: "target", mediaType: .audio, start: 70, duration: 30, volume: 1)
+        target.fadeOutFrames = 8
+        target.volumeTrack = KeyframeTrack(keyframes: [Keyframe(frame: 5, value: -6)])
+        let original = target
+
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.audioTrack(clips: [source, target])])
+        let snapshot = try editor.clipSettingsSnapshot(for: source.id)
+        _ = try editor.applyClipSettings(snapshot, to: [target.id])
+        let updated = try #require(editor.clipFor(id: target.id))
+
+        #expect(updated.volume == source.volume)
+        #expect(updated.effects == source.effects)
+        #expect(updated.fadeOutFrames == original.fadeOutFrames)
+        #expect(updated.volumeTrack == original.volumeTrack)
+        #expect(updated.startFrame == original.startFrame)
+        #expect(updated.durationFrames == original.durationFrames)
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared static clip-settings transfer so video, text, and audio clips can reuse an authored look or treatment without changing timing, content, links, or keyframes
- expose the operation through timeline Copy → Paste Settings and the `copy_clip_settings` Agent/MCP tool
- support explicit clip targets, whole tracks, and timeline ranges with atomic validation, one-step undo, no-op receipts, and compact bulk results

## Approach
- capture an immutable `ClipSettingsSnapshot`, then apply only the settings owned by the source media type through one editor-domain operation shared by UI and Agent callers
- reuse the normal clip clipboard in the UI; Paste Settings appears only when exactly one copied clip matches the selected target type
- resolve Agent track/range selectors to compatible clip IDs before mutation, reject invalid or empty selections, and summarize bulk track operations with counts rather than returning every clip ID
- intentionally leave placement, trims, duration, speed, fades, top-level keyframes, links, caption membership, and multicam membership unchanged; linked audio is copied explicitly by its own clip ID

## Testing
- `scripts/localization/sync.sh` — passed
- `swift test --filter ClipSettings` — 3 tests in 2 suites passed
- `swift build && swift test` after rebasing onto `origin/main` — build passed; 1,463 tests in 233 suites passed
- live MCP against the running app and an open sample project:
  - discovered and validated the final `copy_clip_settings` schema
  - copied text settings to multiple explicit targets, independently read state back, verified content/timing preservation, repeated as a no-op, and undid once
  - copied audio settings with ranged and whole-track selectors, verified compact counts plus preserved fades/keyframes, repeated as a no-op, and undid each mutation
  - copied video transform, opacity, edge treatment, blend mode, effect stack, and color grade; verified timing, linked audio, and temporal keyframes remained unchanged
  - exercised missing/both/empty target modes, duplicate/self targets, malformed/negative/zero-width ranges, media-type mismatch, no compatible track clips, unknown source/target/track IDs, and unknown fields
  - undid all test setup and confirmed the sample timeline matched its initial state
- manual UI verification pending: Copy one clip, select one or more same-type targets, choose Paste Settings, then verify one-step Undo and linked video/audio targeting

## Change statistics
- code logic: +298 / -0
- localization inventory: +4 / -0
- tests: +205 / -0
- total: +507 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk timeline mutations across many clips and effect stacks; validation is strict by media type but wrong targets could still overwrite grades/styles at scale.
> 
> **Overview**
> Introduces **static clip settings transfer** so users and agents can reuse one clip’s look on other same-type clips without touching timing, trims, keyframes, links, or caption content.
> 
> **Editor domain:** New `ClipSettingsSnapshot` / `applyClipSettings` on `EditorViewModel` copies media-type-specific static fields (visual transform/crop/effects, text style/animation/fill, audio volume/effects) in a single undo step; missing source values clear targets. UI **Copy → Paste Settings** reuses the clip clipboard (exactly one copied clip of the matching type) and targets compatible selected clips.
> 
> **Agent/MCP:** New **`copy_clip_settings`** tool with `sourceClipId` plus either `targetClipIds` or `targetTrack` (optional frame range); track mode returns count summaries instead of every ID. Agent instructions now point editors at this tool vs `set_clip_properties` / `set_keyframes` for temporal changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538ff4dcae8f1a93bc277e8ba0d73db75915ea79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->