### PR TITLE
[ui] Show Agent activity on the timeline

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
@@ -6,6 +6,7 @@ private struct AgentLocatedClip: Equatable {
 extension ToolName {
     private static let timelineChangePublishers: Set<ToolName> = [
         .setProjectSettings,
+        .manageTracks,
         .manageClipLinks,
         .addClips, .insertClips, .moveClips, .removeClips,
         .splitClips, .rippleDeleteRanges, .swapClipMedia,
@@ -37,9 +38,11 @@ extension ToolExecutor {
             guard let current = afterClips[id], current != previous else { return nil }
             return id
         })
+        let mutatedTrackIds = changedTrackIds(before: before, after: after)
         editor.showAgentChanges(
             addedClipIds: addedClipIds,
-            mutatedClipIds: mutatedClipIds
+            mutatedClipIds: mutatedClipIds,
+            mutatedTrackIds: mutatedTrackIds
         )
     }
 
@@ -52,6 +55,32 @@ extension ToolExecutor {
         }
         return result
     }
+
+    private func changedTrackIds(before: Timeline, after: Timeline) -> Set<String> {
+        let beforeTracks = Dictionary(
+            before.tracks.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let afterTracks = Dictionary(
+            after.tracks.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let survivingIds = Set(beforeTracks.keys).intersection(afterTracks.keys)
+        var changed = Set(survivingIds.filter { id in
+            guard let previous = beforeTracks[id], let current = afterTracks[id] else { return false }
+            return previous.muted != current.muted
+                || previous.hidden != current.hidden
+                || previous.syncLocked != current.syncLocked
+        })
+
+        // Ignore index shifts caused only by insertion or removal.
+        let beforeOrder = before.tracks.map(\.id).filter(survivingIds.contains)
+        let afterOrder = after.tracks.map(\.id).filter(survivingIds.contains)
+        changed.formUnion(zip(beforeOrder, afterOrder).compactMap { previous, current in
+            previous == current ? nil : current
+        })
+        return changed
+    }
 }
 
 // MARK: - Read highlights
@@ -61,7 +90,7 @@ extension ToolExecutor {
         for tool: ToolName,
         args: [String: Any],
         editor: EditorViewModel
-    ) throws -> AgentActivityHighlight? {
+    ) -> AgentActivityHighlight? {
         var readClipIds = Set<String>()
         var range: Range<Int>?
         switch tool {
@@ -69,7 +98,7 @@ extension ToolExecutor {
             if let clipId = args.string("clipId") { readClipIds.insert(clipId) }
         case .getTranscript, .getMulticam:
             if let clipId = args.string("clipId") { readClipIds.insert(clipId) }
-            range = try timelineReadWindow(args, editor: editor)
+            range = timelineReadWindow(args, editor: editor)
         case .inspectTimeline:
             let start = max(0, args.int("startFrame") ?? 0)
             if start < Int.max {
@@ -77,7 +106,7 @@ extension ToolExecutor {
                 range = clampedTimelineReadRange(start: start, end: end, editor: editor)
             }
         case .getTimeline:
-            range = try timelineReadWindow(args, editor: editor)
+            range = timelineReadWindow(args, editor: editor)
         case .captureFrame:
             if let frame = args.int("timelineFrame"), frame >= 0, frame < Int.max {
                 range = clampedTimelineReadRange(start: frame, end: frame + 1, editor: editor)
@@ -94,8 +123,14 @@ extension ToolExecutor {
     private func timelineReadWindow(
         _ args: [String: Any],
         editor: EditorViewModel
-    ) throws -> Range<Int>? {
-        guard let window = try Self.frameWindow(args) else { return nil }
+    ) -> Range<Int>? {
+        let window: Range<Int>?
+        do {
+            window = try Self.frameWindow(args)
+        } catch {
+            return nil
+        }
+        guard let window else { return nil }
         let end = window.upperBound == Int.max ? editor.timeline.totalFrames : window.upperBound
         return clampedTimelineReadRange(start: window.lowerBound, end: end, editor: editor)
     }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
@@ -10,7 +10,7 @@ extension ToolName {
         .manageClipLinks,
         .addClips, .insertClips, .moveClips, .removeClips,
         .splitClips, .rippleDeleteRanges, .swapClipMedia,
-        .setClipProperties, .setKeyframes, .applyLayout, .syncClips, .undo,
+        .setClipProperties, .copyClipSettings, .setKeyframes, .applyLayout, .syncClips, .undo,
         .manageMulticam, .changeCam,
         .removeWords, .removeSilence,
         .addTexts, .updateText, .addCaptions,

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+AgentActivity.swift
@@ -1,0 +1,113 @@
+private struct AgentLocatedClip: Equatable {
+    let trackId: String
+    let clip: Clip
+}
+
+extension ToolName {
+    private static let timelineChangePublishers: Set<ToolName> = [
+        .setProjectSettings,
+        .manageClipLinks,
+        .addClips, .insertClips, .moveClips, .removeClips,
+        .splitClips, .rippleDeleteRanges, .swapClipMedia,
+        .setClipProperties, .setKeyframes, .applyLayout, .syncClips, .undo,
+        .manageMulticam, .changeCam,
+        .removeWords, .removeSilence,
+        .addTexts, .updateText, .addCaptions,
+        .applyColor, .applyEffect, .denoiseAudio,
+        .generateAudio,
+    ]
+
+    var publishesTimelineChanges: Bool {
+        Self.timelineChangePublishers.contains(self)
+    }
+}
+
+// MARK: - Change highlights
+
+extension ToolExecutor {
+    func publishAgentChanges(
+        before: Timeline,
+        after: Timeline,
+        editor: EditorViewModel
+    ) {
+        let beforeClips = locatedClips(in: before)
+        let afterClips = locatedClips(in: after)
+        let addedClipIds = Set(afterClips.keys).subtracting(beforeClips.keys)
+        let mutatedClipIds = Set<String>(beforeClips.compactMap { id, previous in
+            guard let current = afterClips[id], current != previous else { return nil }
+            return id
+        })
+        editor.showAgentChanges(
+            addedClipIds: addedClipIds,
+            mutatedClipIds: mutatedClipIds
+        )
+    }
+
+    private func locatedClips(in timeline: Timeline) -> [String: AgentLocatedClip] {
+        var result: [String: AgentLocatedClip] = [:]
+        for track in timeline.tracks {
+            for clip in track.clips {
+                result[clip.id] = AgentLocatedClip(trackId: track.id, clip: clip)
+            }
+        }
+        return result
+    }
+}
+
+// MARK: - Read highlights
+
+extension ToolExecutor {
+    func timelineReadActivity(
+        for tool: ToolName,
+        args: [String: Any],
+        editor: EditorViewModel
+    ) throws -> AgentActivityHighlight? {
+        var readClipIds = Set<String>()
+        var range: Range<Int>?
+        switch tool {
+        case .inspectMedia, .inspectColor:
+            if let clipId = args.string("clipId") { readClipIds.insert(clipId) }
+        case .getTranscript, .getMulticam:
+            if let clipId = args.string("clipId") { readClipIds.insert(clipId) }
+            range = try timelineReadWindow(args, editor: editor)
+        case .inspectTimeline:
+            let start = max(0, args.int("startFrame") ?? 0)
+            if start < Int.max {
+                let end = args.int("endFrame").flatMap { $0 > start ? $0 : nil } ?? start + 1
+                range = clampedTimelineReadRange(start: start, end: end, editor: editor)
+            }
+        case .getTimeline:
+            range = try timelineReadWindow(args, editor: editor)
+        case .captureFrame:
+            if let frame = args.int("timelineFrame"), frame >= 0, frame < Int.max {
+                range = clampedTimelineReadRange(start: frame, end: frame + 1, editor: editor)
+            }
+        default:
+            return nil
+        }
+
+        readClipIds = Set(readClipIds.filter { editor.findClip(id: $0) != nil })
+        guard !readClipIds.isEmpty || range != nil else { return nil }
+        return AgentActivityHighlight(readClipIds: readClipIds, range: range)
+    }
+
+    private func timelineReadWindow(
+        _ args: [String: Any],
+        editor: EditorViewModel
+    ) throws -> Range<Int>? {
+        guard let window = try Self.frameWindow(args) else { return nil }
+        let end = window.upperBound == Int.max ? editor.timeline.totalFrames : window.upperBound
+        return clampedTimelineReadRange(start: window.lowerBound, end: end, editor: editor)
+    }
+
+    private func clampedTimelineReadRange(
+        start: Int,
+        end: Int,
+        editor: EditorViewModel
+    ) -> Range<Int>? {
+        let lower = max(0, start)
+        let upper = min(editor.timeline.totalFrames, end)
+        guard lower < upper else { return nil }
+        return lower..<upper
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -150,7 +150,7 @@ final class ToolExecutor {
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
             readRevision = editor.beginAgentTimelineRead(
-                try timelineReadActivity(for: tool, args: resolved, editor: editor)
+                timelineReadActivity(for: tool, args: resolved, editor: editor)
             )
             result = try await run(tool, editor, resolved)
         } catch let err as ToolError {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -136,9 +136,12 @@ final class ToolExecutor {
             )
             return result
         }
+        let activeTimelineIdBefore = editor.activeTimelineId
+        let nonAgentMutationRevisionBefore = editor.nonAgentTimelineMutationRevision
         let before = editor.timelines
         let idsBefore = currentIdUniverse(editor)
         let result: ToolResult
+        var readRevision: Int?
         Log.agent.notice(
             "tool start name=\(tool.rawValue)",
             telemetry: "Agent tool started",
@@ -146,11 +149,30 @@ final class ToolExecutor {
         )
         do {
             let resolved = try expandingIdPrefixes(in: args, editor: editor)
+            readRevision = editor.beginAgentTimelineRead(
+                try timelineReadActivity(for: tool, args: resolved, editor: editor)
+            )
             result = try await run(tool, editor, resolved)
         } catch let err as ToolError {
             result = .error(err.message)
         } catch {
             result = .error(error.localizedDescription)
+        }
+        if let readRevision {
+            editor.endAgentTimelineRead(readRevision, succeeded: !result.isError)
+        }
+        let timelineChanged = editor.timelines != before
+        if !result.isError,
+           timelineChanged,
+           tool.publishesTimelineChanges,
+           editor.nonAgentTimelineMutationRevision == nonAgentMutationRevisionBefore,
+           editor.activeTimelineId == activeTimelineIdBefore,
+           let previousTimeline = before.first(where: { $0.id == activeTimelineIdBefore }) {
+            publishAgentChanges(
+                before: previousTimeline,
+                after: editor.timeline,
+                editor: editor
+            )
         }
         feedbackState.record(result, for: tool)
         let elapsed = started.duration(to: .now).seconds
@@ -158,7 +180,7 @@ final class ToolExecutor {
         let payload: Telemetry.Payload = [
             "tool": tool.rawValue,
             "durationSeconds": elapsed,
-            "timelineChanged": editor.timelines != before
+            "timelineChanged": timelineChanged
         ]
         if result.isError {
             Log.agent.warning(
@@ -179,7 +201,7 @@ final class ToolExecutor {
             projectId: editor.projectId,
             result: result,
             started: started,
-            timelineChanged: editor.timelines != before
+            timelineChanged: timelineChanged
         )
         // Shorten on pre ∪ post ids: new ids and just-removed ids both stay short.
         return await shorteningIds(in: result, editor: editor, alsoKnown: idsBefore)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AgentActivity.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AgentActivity.swift
@@ -2,6 +2,7 @@ struct AgentActivityHighlight: Equatable {
     var readClipIds: Set<String> = []
     var addedClipIds: Set<String> = []
     var mutatedClipIds: Set<String> = []
+    var mutatedTrackIds: Set<String> = []
     var range: Range<Int>?
     var isActive = false
     var revision = 0
@@ -11,18 +12,25 @@ struct AgentActivityHighlight: Equatable {
     }
 
     var isEmpty: Bool {
-        !isRead && addedClipIds.isEmpty && mutatedClipIds.isEmpty
+        !isRead && addedClipIds.isEmpty && mutatedClipIds.isEmpty && mutatedTrackIds.isEmpty
     }
 }
 
 extension EditorViewModel {
-    func showAgentChanges(addedClipIds: Set<String>, mutatedClipIds: Set<String>) {
-        guard !addedClipIds.isEmpty || !mutatedClipIds.isEmpty else { return }
+    func showAgentChanges(
+        addedClipIds: Set<String>,
+        mutatedClipIds: Set<String>,
+        mutatedTrackIds: Set<String> = []
+    ) {
+        guard !addedClipIds.isEmpty || !mutatedClipIds.isEmpty || !mutatedTrackIds.isEmpty else {
+            return
+        }
         var activity = agentActivity.isRead
             ? AgentActivityHighlight(revision: agentActivity.revision)
             : agentActivity
         activity.addedClipIds.formUnion(addedClipIds)
         activity.mutatedClipIds.formUnion(mutatedClipIds)
+        activity.mutatedTrackIds.formUnion(mutatedTrackIds)
         activity.mutatedClipIds.subtract(activity.addedClipIds)
         activity.isActive = false
         activity.revision &+= 1
@@ -32,6 +40,7 @@ extension EditorViewModel {
 
     func beginAgentTimelineRead(_ highlight: AgentActivityHighlight?) -> Int? {
         guard var highlight, highlight.isRead else { return nil }
+        guard agentActivity.isEmpty || agentActivity.isRead else { return nil }
         agentActivityClearTask?.cancel()
         agentActivityClearTask = nil
         highlight.isActive = true

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AgentActivity.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+AgentActivity.swift
@@ -1,0 +1,74 @@
+struct AgentActivityHighlight: Equatable {
+    var readClipIds: Set<String> = []
+    var addedClipIds: Set<String> = []
+    var mutatedClipIds: Set<String> = []
+    var range: Range<Int>?
+    var isActive = false
+    var revision = 0
+
+    var isRead: Bool {
+        !readClipIds.isEmpty || range != nil
+    }
+
+    var isEmpty: Bool {
+        !isRead && addedClipIds.isEmpty && mutatedClipIds.isEmpty
+    }
+}
+
+extension EditorViewModel {
+    func showAgentChanges(addedClipIds: Set<String>, mutatedClipIds: Set<String>) {
+        guard !addedClipIds.isEmpty || !mutatedClipIds.isEmpty else { return }
+        var activity = agentActivity.isRead
+            ? AgentActivityHighlight(revision: agentActivity.revision)
+            : agentActivity
+        activity.addedClipIds.formUnion(addedClipIds)
+        activity.mutatedClipIds.formUnion(mutatedClipIds)
+        activity.mutatedClipIds.subtract(activity.addedClipIds)
+        activity.isActive = false
+        activity.revision &+= 1
+        agentActivity = activity
+        scheduleAgentActivityClear(after: AppTheme.Anim.agentChangeHighlightDuration)
+    }
+
+    func beginAgentTimelineRead(_ highlight: AgentActivityHighlight?) -> Int? {
+        guard var highlight, highlight.isRead else { return nil }
+        agentActivityClearTask?.cancel()
+        agentActivityClearTask = nil
+        highlight.isActive = true
+        highlight.revision = agentActivity.revision &+ 1
+        agentActivity = highlight
+        return highlight.revision
+    }
+
+    func endAgentTimelineRead(_ revision: Int, succeeded: Bool) {
+        guard revision == agentActivity.revision, agentActivity.isRead, agentActivity.isActive else {
+            return
+        }
+        guard succeeded else {
+            clearAgentActivity()
+            return
+        }
+        agentActivity.isActive = false
+        agentActivity.revision &+= 1
+        scheduleAgentActivityClear(after: AppTheme.Anim.agentReadHighlightDuration)
+    }
+
+    func clearAgentActivity() {
+        guard !agentActivity.isEmpty || agentActivityClearTask != nil else { return }
+        agentActivityClearTask?.cancel()
+        agentActivityClearTask = nil
+        agentActivity = AgentActivityHighlight(revision: agentActivity.revision &+ 1)
+    }
+
+    private func scheduleAgentActivityClear(after duration: Double) {
+        let revision = agentActivity.revision
+        agentActivityClearTask?.cancel()
+        agentActivityClearTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(duration))
+            guard let self,
+                  !Task.isCancelled,
+                  self.agentActivity.revision == revision else { return }
+            self.clearAgentActivity()
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -96,6 +96,7 @@ extension EditorViewModel {
         selectedTimelineRange = nil
         pendingSwapClipId = nil
         pendingSwapTargetClipIds = []
+        clearAgentActivity()
         dragBefore = [:]
         preDragTimeline = nil
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -34,9 +34,14 @@ final class EditorViewModel {
     var timelines: [Timeline] {
         didSet {
             timelineRenderRevision &+= 1
+            let source = Analytics.origin?.source
+            if source != "agent", source != "mcp" {
+                nonAgentTimelineMutationRevision &+= 1
+            }
             if pendingSwapClipId != nil { cancelMediaSwap() }
         }
     }
+    @ObservationIgnored var nonAgentTimelineMutationRevision = 0
     var activeTimelineId: String
     var openTimelineIds: [String]
     @ObservationIgnored var liveViewStates: [String: TimelineViewState] = [:]
@@ -149,6 +154,8 @@ final class EditorViewModel {
     var pendingEditTransitionPlacement: PendingTransitionPlacement?
     /// Clip ids currently awaiting an AI-generated replacement.
     var pendingReplacements: Set<String> = []
+    var agentActivity = AgentActivityHighlight()
+    @ObservationIgnored var agentActivityClearTask: Task<Void, Never>?
     var cropEditingActive: Bool = false
     var chromaKeySamplingClipId: String?
     /// Two-up in/out frames shown in the viewer while a slip drag is active.

--- a/Sources/PalmierPro/Timeline/AgentActivityLayerSupport.swift
+++ b/Sources/PalmierPro/Timeline/AgentActivityLayerSupport.swift
@@ -1,0 +1,52 @@
+import AppKit
+
+enum AgentActivityLayerSupport {
+    static func updateMask(
+        _ layer: CALayer,
+        bounds: CGRect,
+        rulerHeight: CGFloat
+    ) {
+        let mask = (layer.mask as? CAShapeLayer) ?? CAShapeLayer()
+        mask.frame = bounds
+        mask.fillColor = AppTheme.MediaOverlay.background.cgColor
+        mask.path = CGPath(
+            rect: CGRect(
+                x: 0,
+                y: rulerHeight,
+                width: bounds.width,
+                height: max(0, bounds.height - rulerHeight)
+            ),
+            transform: nil
+        )
+        layer.mask = mask
+    }
+
+    static func updateAnimation(
+        _ layer: CALayer,
+        hasHighlight: Bool,
+        staysVisible: Bool,
+        hold: Double,
+        duration: Double
+    ) {
+        layer.removeAnimation(forKey: "agentActivityFade")
+        guard hasHighlight else {
+            layer.opacity = 0
+            return
+        }
+        guard !staysVisible else {
+            layer.opacity = 1
+            return
+        }
+
+        layer.opacity = 0
+        let animation = CAKeyframeAnimation(keyPath: "opacity")
+        animation.values = [1, 1, 0]
+        animation.keyTimes = [0, NSNumber(value: hold / duration), 1]
+        animation.timingFunctions = [
+            CAMediaTimingFunction(name: .linear),
+            CAMediaTimingFunction(name: .easeOut),
+        ]
+        animation.duration = duration
+        layer.add(animation, forKey: "agentActivityFade")
+    }
+}

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -69,6 +69,7 @@ struct TimelineContainerView: NSViewRepresentable {
             selectedClipIds: editor.selectedClipIds,
             selectedTimelineRange: editor.selectedTimelineRange,
             pendingReplacements: editor.pendingReplacements,
+            agentActivity: editor.agentActivity,
             generatingAssetIds: Set(editor.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
         )
 
@@ -111,6 +112,7 @@ struct TimelineContainerView: NSViewRepresentable {
         let selectedClipIds: Set<String>
         let selectedTimelineRange: TimelineRangeSelection?
         let pendingReplacements: Set<String>
+        let agentActivity: AgentActivityHighlight
         let generatingAssetIds: Set<String>
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -69,7 +69,6 @@ struct TimelineContainerView: NSViewRepresentable {
             selectedClipIds: editor.selectedClipIds,
             selectedTimelineRange: editor.selectedTimelineRange,
             pendingReplacements: editor.pendingReplacements,
-            agentActivity: editor.agentActivity,
             generatingAssetIds: Set(editor.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
         )
 
@@ -78,6 +77,7 @@ struct TimelineContainerView: NSViewRepresentable {
             context.coordinator.timelineView?.needsDisplay = true
             context.coordinator.headerView?.needsDisplay = true
         }
+        context.coordinator.updateAgentActivity(editor.agentActivity)
 
         if let x = editor.timelineScrollRestoreX,
            let scrollView = context.coordinator.scrollView {
@@ -112,7 +112,6 @@ struct TimelineContainerView: NSViewRepresentable {
         let selectedClipIds: Set<String>
         let selectedTimelineRange: TimelineRangeSelection?
         let pendingReplacements: Set<String>
-        let agentActivity: AgentActivityHighlight
         let generatingAssetIds: Set<String>
     }
 
@@ -122,10 +121,18 @@ struct TimelineContainerView: NSViewRepresentable {
         var scrollView: NSScrollView?
         weak var editor: EditorViewModel?
         private var renderState: RenderState?
+        private var agentActivity = AgentActivityHighlight()
 
         func needsRender(for next: RenderState) -> Bool {
             defer { renderState = next }
             return renderState != next
+        }
+
+        @MainActor func updateAgentActivity(_ next: AgentActivityHighlight) {
+            guard agentActivity != next else { return }
+            agentActivity = next
+            timelineView?.updateAgentActivityOverlay()
+            headerView?.updateAgentActivityOverlay()
         }
 
         @MainActor @objc func scrollViewBoundsChanged(_ notification: Notification) {

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -27,11 +27,14 @@ final class TimelineHeaderView: NSView {
     var hideButtonRects: [Int: NSRect] = [:]
     var syncLockButtonRects: [Int: NSRect] = [:]
     var dragHandleRects: [Int: NSRect] = [:]
+    private let agentTrackLayer = CAShapeLayer()
+    private var displayedAgentTrackRevision = -1
 
     init(editor: EditorViewModel) {
         self.editor = editor
         super.init(frame: .zero)
         wantsLayer = true
+        configureAgentTrackLayer()
         updateAppearanceColors()
     }
 
@@ -132,6 +135,7 @@ final class TimelineHeaderView: NSView {
             ctx.setFillColor(AppTheme.Border.primary.cgColor)
             ctx.fill(NSRect(x: 0, y: handleY, width: headerWidth, height: 1))
         }
+        syncAgentTrackLayer(geometry: geo, headerWidth: headerWidth)
 
         // Thick divider between the video zone and the audio zone,
         let z = editor.zones
@@ -140,6 +144,81 @@ final class TimelineHeaderView: NSView {
             ctx.setFillColor(AppTheme.Border.divider.cgColor)
             ctx.fill(NSRect(x: 0, y: dividerY - 1, width: headerWidth, height: 2))
         }
+    }
+
+    func updateAgentActivityOverlay() {
+        syncAgentTrackLayer(
+            geometry: TimelineGeometry(editor: editor, bounds: bounds),
+            headerWidth: bounds.width
+        )
+    }
+
+    private func configureAgentTrackLayer() {
+        agentTrackLayer.fillColor = nil
+        agentTrackLayer.lineWidth = AppTheme.BorderWidth.thick
+        agentTrackLayer.shadowOpacity = AppTheme.AgentActivity.changeGlowOpacity
+        agentTrackLayer.shadowRadius = AppTheme.AgentActivity.changeGlowRadius
+        agentTrackLayer.shadowOffset = .zero
+        agentTrackLayer.zPosition = 90
+        agentTrackLayer.opacity = 0
+        layer?.addSublayer(agentTrackLayer)
+    }
+
+    private func updateAgentTrackColor() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let color = AppTheme.AgentActivity.mutated.cgColor
+            agentTrackLayer.strokeColor = color
+            agentTrackLayer.shadowColor = color
+        }
+    }
+
+    private func syncAgentTrackLayer(geometry: TimelineGeometry, headerWidth: CGFloat) {
+        let activity = editor.agentActivity
+        guard !activity.mutatedTrackIds.isEmpty
+                || activity.revision != displayedAgentTrackRevision else { return }
+        let path = CGMutablePath()
+        for (index, track) in editor.timeline.tracks.enumerated()
+            where activity.mutatedTrackIds.contains(track.id) {
+            let rect = NSRect(
+                x: 0,
+                y: geometry.trackY(at: index),
+                width: headerWidth,
+                height: geometry.trackHeight(at: index)
+            )
+            guard rect.intersects(bounds) else { continue }
+            let ringRect = rect
+                .offsetBy(dx: -bounds.minX, dy: -bounds.minY)
+                .insetBy(
+                    dx: AppTheme.BorderWidth.hairline,
+                    dy: AppTheme.BorderWidth.hairline
+                )
+            path.addRoundedRect(
+                in: ringRect,
+                cornerWidth: AppTheme.Radius.xs,
+                cornerHeight: AppTheme.Radius.xs
+            )
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        agentTrackLayer.frame = bounds
+        agentTrackLayer.path = path.isEmpty ? nil : path
+        AgentActivityLayerSupport.updateMask(
+            agentTrackLayer,
+            bounds: agentTrackLayer.bounds,
+            rulerHeight: Layout.rulerHeight
+        )
+        CATransaction.commit()
+
+        guard activity.revision != displayedAgentTrackRevision else { return }
+        displayedAgentTrackRevision = activity.revision
+        AgentActivityLayerSupport.updateAnimation(
+            agentTrackLayer,
+            hasHighlight: !activity.mutatedTrackIds.isEmpty,
+            staysVisible: false,
+            hold: AppTheme.Anim.agentChangeHighlightHold,
+            duration: AppTheme.Anim.agentChangeHighlightDuration
+        )
     }
 
     /// Draw a toggleable SF Symbol button; returns the hit-test rect (padded).
@@ -174,6 +253,7 @@ final class TimelineHeaderView: NSView {
                 .foregroundColor: AppTheme.Text.secondary.usingColorSpace(.sRGB) ?? AppTheme.Text.secondary,
             ]
         }
+        updateAgentTrackColor()
     }
 
     // MARK: - Input handling (mute/hide/resize)

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -9,6 +9,12 @@ final class TimelineView: NSView {
     private(set) var snapOverlay: SnapIndicatorOverlay!
     private var generatingClipOverlays: [String: NSHostingView<ClipGeneratingOverlay>] = [:]
     private var clipDisplayRects: [String: NSRect] = [:]
+    private let agentActivityLayer = CALayer()
+    private let agentAddedLayer = CAShapeLayer()
+    private let agentMutatedLayer = CAShapeLayer()
+    private let agentReadLayer = CAShapeLayer()
+    private let agentRangeLayer = CAShapeLayer()
+    private var displayedAgentActivityRevision = -1
     private var derivedCacheRevision: Int = -1
     private var cachedLinkOffsets: [String: Int] = [:]
     private var cachedAngleLabels: [String: [String: String]] = [:]
@@ -25,6 +31,7 @@ final class TimelineView: NSView {
         editor.onCancelTimelineDrag = { [weak self] in self?.inputController.cancelActiveDrag() }
         wantsLayer = true
         updateAppearanceColors()
+        configureAgentActivityLayers()
         canvas.wantsLayer = true
         canvas.layerContentsRedrawPolicy = .onSetNeedsDisplay
         addSubview(canvas)
@@ -81,6 +88,36 @@ final class TimelineView: NSView {
     private func updateAppearanceColors() {
         effectiveAppearance.performAsCurrentDrawingAppearance {
             layer?.backgroundColor = Self.trackBg
+        }
+    }
+
+    private func configureAgentActivityLayers() {
+        agentActivityLayer.zPosition = 80
+        layer?.addSublayer(agentActivityLayer)
+        let styles = [
+            (agentRangeLayer, AppTheme.AgentActivity.read, AppTheme.AgentActivity.readFill,
+             AppTheme.BorderWidth.thin, Float(0), CGFloat(0), CGFloat(0)),
+            (agentReadLayer, AppTheme.AgentActivity.read, nil,
+             AppTheme.BorderWidth.medium, AppTheme.AgentActivity.readGlowOpacity,
+             AppTheme.AgentActivity.readGlowRadius, CGFloat(9)),
+            (agentAddedLayer, AppTheme.AgentActivity.added, nil,
+             AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
+             AppTheme.AgentActivity.changeGlowRadius, CGFloat(10)),
+            (agentMutatedLayer, AppTheme.AgentActivity.mutated, nil,
+             AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
+             AppTheme.AgentActivity.changeGlowRadius, CGFloat(10)),
+        ]
+        for (layer, color, fillColor, lineWidth, glowOpacity, glowRadius, zPosition) in styles {
+            layer.fillColor = fillColor?.cgColor
+            layer.strokeColor = color.cgColor
+            layer.lineWidth = lineWidth
+            layer.shadowColor = color.cgColor
+            layer.shadowOpacity = glowOpacity
+            layer.shadowRadius = glowRadius
+            layer.shadowOffset = .zero
+            layer.zPosition = zPosition
+            layer.opacity = 0
+            agentActivityLayer.addSublayer(layer)
         }
     }
 
@@ -255,6 +292,7 @@ final class TimelineView: NSView {
             drawRippleInsertGapBand(preview: rippleInsertPreview, geometry: geo, context: ctx)
         }
         drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx, rippleInsertPreview: rippleInsertPreview)
+        syncAgentActivityLayers()
         drawGapSelection(geometry: geo, context: ctx)
         syncGeneratingClipOverlays(geometry: geo)
 
@@ -317,6 +355,139 @@ final class TimelineView: NSView {
     func updatePlayheadLayer() { playheadOverlay.update() }
 
     // MARK: - Clip drawing with ghost support
+
+    private func syncAgentActivityLayers() {
+        let activity = editor.agentActivity
+        let viewport = visibleRect
+        guard !viewport.isEmpty else { return }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        updateAgentActivityFrame(viewport)
+        agentAddedLayer.path = agentClipPath(for: activity.addedClipIds, viewport: viewport)
+        agentMutatedLayer.path = agentClipPath(for: activity.mutatedClipIds, viewport: viewport)
+        agentReadLayer.path = agentClipPath(for: activity.readClipIds, viewport: viewport)
+        agentRangeLayer.path = agentRangePath(for: activity.range, viewport: viewport)
+        CATransaction.commit()
+
+        guard activity.revision != displayedAgentActivityRevision else { return }
+        displayedAgentActivityRevision = activity.revision
+        let hold = activity.isRead
+            ? AppTheme.Anim.agentReadHighlightHold
+            : AppTheme.Anim.agentChangeHighlightHold
+        let duration = activity.isRead
+            ? AppTheme.Anim.agentReadHighlightDuration
+            : AppTheme.Anim.agentChangeHighlightDuration
+        let highlights = [
+            (agentAddedLayer, !activity.addedClipIds.isEmpty),
+            (agentMutatedLayer, !activity.mutatedClipIds.isEmpty),
+            (agentReadLayer, !activity.readClipIds.isEmpty),
+            (agentRangeLayer, activity.range != nil),
+        ]
+        for (layer, hasHighlight) in highlights {
+            updateAgentActivityAnimation(
+                layer,
+                hasHighlight: hasHighlight,
+                staysVisible: activity.isActive,
+                hold: hold,
+                duration: duration
+            )
+        }
+    }
+
+    private func agentClipPath(for clipIds: Set<String>, viewport: NSRect) -> CGPath? {
+        let combinedPath = CGMutablePath()
+        for clipId in clipIds {
+            guard let rect = clipDisplayRects[clipId], rect.intersects(viewport) else { continue }
+            let ringRect = rect
+                .offsetBy(dx: -viewport.minX, dy: -viewport.minY)
+                .insetBy(
+                    dx: AppTheme.BorderWidth.hairline,
+                    dy: AppTheme.BorderWidth.hairline
+                )
+            guard ringRect.width > 0, ringRect.height > 0 else { continue }
+            combinedPath.addRoundedRect(
+                in: ringRect,
+                cornerWidth: Trim.clipCornerRadius,
+                cornerHeight: Trim.clipCornerRadius
+            )
+        }
+        return combinedPath.isEmpty ? nil : combinedPath
+    }
+
+    private func agentRangePath(
+        for range: Range<Int>?,
+        viewport: NSRect
+    ) -> CGPath? {
+        guard let range else { return nil }
+        let geo = geometry
+        let minX = geo.xForFrame(range.lowerBound)
+        let maxX = geo.xForFrame(range.upperBound)
+        let y = Double(geo.rulerHeight)
+        let documentRect = NSRect(
+            x: minX,
+            y: y,
+            width: max(Double(AppTheme.BorderWidth.medium), maxX - minX),
+            height: max(0, Double(bounds.height - geo.rulerHeight))
+        )
+        let visibleRange = documentRect.intersection(viewport)
+        guard !visibleRange.isNull, !visibleRange.isEmpty else { return nil }
+        return CGPath(
+            rect: visibleRange.offsetBy(dx: -viewport.minX, dy: -viewport.minY),
+            transform: nil
+        )
+    }
+
+    private func updateAgentActivityFrame(_ viewport: NSRect) {
+        agentActivityLayer.frame = viewport
+        for layer in [agentAddedLayer, agentMutatedLayer, agentReadLayer, agentRangeLayer] {
+            layer.frame = agentActivityLayer.bounds
+        }
+        let mask = (agentActivityLayer.mask as? CAShapeLayer) ?? CAShapeLayer()
+        let rulerHeight = Double(geometry.rulerHeight)
+        mask.frame = agentActivityLayer.bounds
+        mask.fillColor = AppTheme.MediaOverlay.background.cgColor
+        mask.path = CGPath(
+            rect: NSRect(
+                x: 0,
+                y: rulerHeight,
+                width: viewport.width,
+                height: max(0, Double(viewport.height) - rulerHeight)
+            ),
+            transform: nil
+        )
+        agentActivityLayer.mask = mask
+    }
+
+    private func updateAgentActivityAnimation(
+        _ layer: CAShapeLayer,
+        hasHighlight: Bool,
+        staysVisible: Bool,
+        hold: Double,
+        duration: Double
+    ) {
+        layer.removeAnimation(forKey: "agentActivityFade")
+        guard hasHighlight else {
+            layer.opacity = 0
+            return
+        }
+        if staysVisible {
+            layer.opacity = 1
+            return
+        }
+
+        layer.opacity = 0
+        let animation = CAKeyframeAnimation(keyPath: "opacity")
+        let fadeStart = hold / duration
+        animation.values = [1, 1, 0]
+        animation.keyTimes = [0, NSNumber(value: fadeStart), 1]
+        animation.timingFunctions = [
+            CAMediaTimingFunction(name: .linear),
+            CAMediaTimingFunction(name: .easeOut),
+        ]
+        animation.duration = duration
+        layer.add(animation, forKey: "agentActivityFade")
+    }
 
     private func drawClips(
         geometry geo: TimelineGeometry,

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -30,8 +30,8 @@ final class TimelineView: NSView {
         editor.mediaVisualCache.timelineView = self
         editor.onCancelTimelineDrag = { [weak self] in self?.inputController.cancelActiveDrag() }
         wantsLayer = true
-        updateAppearanceColors()
         configureAgentActivityLayers()
+        updateAppearanceColors()
         canvas.wantsLayer = true
         canvas.layerContentsRedrawPolicy = .onSetNeedsDisplay
         addSubview(canvas)
@@ -89,35 +89,48 @@ final class TimelineView: NSView {
         effectiveAppearance.performAsCurrentDrawingAppearance {
             layer?.backgroundColor = Self.trackBg
         }
+        updateAgentActivityColors()
     }
 
     private func configureAgentActivityLayers() {
         agentActivityLayer.zPosition = 80
         layer?.addSublayer(agentActivityLayer)
         let styles = [
-            (agentRangeLayer, AppTheme.AgentActivity.read, AppTheme.AgentActivity.readFill,
-             AppTheme.BorderWidth.thin, Float(0), CGFloat(0), CGFloat(0)),
-            (agentReadLayer, AppTheme.AgentActivity.read, nil,
-             AppTheme.BorderWidth.medium, AppTheme.AgentActivity.readGlowOpacity,
+            (agentRangeLayer, CGFloat.zero, Float(0), CGFloat(0), CGFloat(0)),
+            (agentReadLayer, AppTheme.BorderWidth.medium, AppTheme.AgentActivity.readGlowOpacity,
              AppTheme.AgentActivity.readGlowRadius, CGFloat(9)),
-            (agentAddedLayer, AppTheme.AgentActivity.added, nil,
-             AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
+            (agentAddedLayer, AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
              AppTheme.AgentActivity.changeGlowRadius, CGFloat(10)),
-            (agentMutatedLayer, AppTheme.AgentActivity.mutated, nil,
-             AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
+            (agentMutatedLayer, AppTheme.BorderWidth.thick, AppTheme.AgentActivity.changeGlowOpacity,
              AppTheme.AgentActivity.changeGlowRadius, CGFloat(10)),
         ]
-        for (layer, color, fillColor, lineWidth, glowOpacity, glowRadius, zPosition) in styles {
-            layer.fillColor = fillColor?.cgColor
-            layer.strokeColor = color.cgColor
+        for (layer, lineWidth, glowOpacity, glowRadius, zPosition) in styles {
             layer.lineWidth = lineWidth
-            layer.shadowColor = color.cgColor
             layer.shadowOpacity = glowOpacity
             layer.shadowRadius = glowRadius
             layer.shadowOffset = .zero
             layer.zPosition = zPosition
             layer.opacity = 0
             agentActivityLayer.addSublayer(layer)
+        }
+        for layer in [agentReadLayer, agentAddedLayer, agentMutatedLayer] {
+            layer.fillColor = nil
+        }
+    }
+
+    private func updateAgentActivityColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let styles = [
+                (agentAddedLayer, AppTheme.AgentActivity.added),
+                (agentMutatedLayer, AppTheme.AgentActivity.mutated),
+                (agentReadLayer, AppTheme.AgentActivity.read),
+            ]
+            for (layer, color) in styles {
+                layer.strokeColor = color.cgColor
+                layer.shadowColor = color.cgColor
+            }
+            agentRangeLayer.fillColor = AppTheme.AgentActivity.readFill.cgColor
+            agentRangeLayer.strokeColor = nil
         }
     }
 
@@ -353,11 +366,13 @@ final class TimelineView: NSView {
     }
 
     func updatePlayheadLayer() { playheadOverlay.update() }
+    func updateAgentActivityOverlay() { syncAgentActivityLayers() }
 
     // MARK: - Clip drawing with ghost support
 
     private func syncAgentActivityLayers() {
         let activity = editor.agentActivity
+        guard !activity.isEmpty || activity.revision != displayedAgentActivityRevision else { return }
         let viewport = visibleRect
         guard !viewport.isEmpty else { return }
 
@@ -385,7 +400,7 @@ final class TimelineView: NSView {
             (agentRangeLayer, activity.range != nil),
         ]
         for (layer, hasHighlight) in highlights {
-            updateAgentActivityAnimation(
+            AgentActivityLayerSupport.updateAnimation(
                 layer,
                 hasHighlight: hasHighlight,
                 staysVisible: activity.isActive,
@@ -443,50 +458,11 @@ final class TimelineView: NSView {
         for layer in [agentAddedLayer, agentMutatedLayer, agentReadLayer, agentRangeLayer] {
             layer.frame = agentActivityLayer.bounds
         }
-        let mask = (agentActivityLayer.mask as? CAShapeLayer) ?? CAShapeLayer()
-        let rulerHeight = Double(geometry.rulerHeight)
-        mask.frame = agentActivityLayer.bounds
-        mask.fillColor = AppTheme.MediaOverlay.background.cgColor
-        mask.path = CGPath(
-            rect: NSRect(
-                x: 0,
-                y: rulerHeight,
-                width: viewport.width,
-                height: max(0, Double(viewport.height) - rulerHeight)
-            ),
-            transform: nil
+        AgentActivityLayerSupport.updateMask(
+            agentActivityLayer,
+            bounds: agentActivityLayer.bounds,
+            rulerHeight: geometry.rulerHeight
         )
-        agentActivityLayer.mask = mask
-    }
-
-    private func updateAgentActivityAnimation(
-        _ layer: CAShapeLayer,
-        hasHighlight: Bool,
-        staysVisible: Bool,
-        hold: Double,
-        duration: Double
-    ) {
-        layer.removeAnimation(forKey: "agentActivityFade")
-        guard hasHighlight else {
-            layer.opacity = 0
-            return
-        }
-        if staysVisible {
-            layer.opacity = 1
-            return
-        }
-
-        layer.opacity = 0
-        let animation = CAKeyframeAnimation(keyPath: "opacity")
-        let fadeStart = hold / duration
-        animation.values = [1, 1, 0]
-        animation.keyTimes = [0, NSNumber(value: fadeStart), 1]
-        animation.timingFunctions = [
-            CAMediaTimingFunction(name: .linear),
-            CAMediaTimingFunction(name: .easeOut),
-        ]
-        animation.duration = duration
-        layer.add(animation, forKey: "agentActivityFade")
     }
 
     private func drawClips(

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -190,6 +190,22 @@ enum AppTheme {
         static var warningColor: Color { Color(warning) }
     }
 
+    enum AgentActivity {
+        static let added = NSColor.systemGreen
+        static let mutated = NSColor.systemOrange
+        static let read = NSColor(
+            srgbRed: 0x64 / 255.0,
+            green: 0x74 / 255.0,
+            blue: 0x8B / 255.0,
+            alpha: 1
+        )
+        static let readFill = read.withAlphaComponent(AppTheme.Opacity.faint)
+        static let changeGlowOpacity: Float = 0.8
+        static let changeGlowRadius: CGFloat = 8
+        static let readGlowOpacity: Float = 0.35
+        static let readGlowRadius: CGFloat = 4
+    }
+
     // MARK: - Text
 
     enum Text {
@@ -510,6 +526,12 @@ enum AppTheme {
         static let transition: Double = 0.2
         static let pulse: Double = 0.8
         static let slipPreviewRefresh: Duration = .milliseconds(67)
+        static let agentChangeHighlightHold: Double = 1.0
+        static let agentChangeHighlightFade: Double = 0.3
+        static let agentChangeHighlightDuration = agentChangeHighlightHold + agentChangeHighlightFade
+        static let agentReadHighlightHold: Double = 0.7
+        static let agentReadHighlightFade: Double = 0.25
+        static let agentReadHighlightDuration = agentReadHighlightHold + agentReadHighlightFade
     }
 }
 

--- a/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
@@ -50,9 +50,31 @@ struct AgentActivityHighlightTests {
         harness.editor.clearAgentActivity()
     }
 
+    @Test func copySettingsHighlightsOnlyChangedTargets() async throws {
+        var source = Fixtures.clip(id: "source", start: 0, duration: 30)
+        source.opacity = 0.5
+        let target = Fixtures.clip(id: "target", start: 40, duration: 30)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [source, target]),
+        ]))
+        let args: [String: Any] = [
+            "sourceClipId": source.id,
+            "targetClipIds": [target.id],
+        ]
+
+        _ = try await harness.runOK("copy_clip_settings", args: args)
+        #expect(harness.editor.agentActivity.mutatedClipIds == [target.id])
+        harness.editor.clearAgentActivity()
+
+        _ = try await harness.runOK("copy_clip_settings", args: args)
+        #expect(harness.editor.agentActivity.isEmpty)
+    }
+
     @Test func onlyMutationToolsPublishTimelineChanges() {
         let excluded: [ToolName] = [.inspectTimeline, .getTranscript, .organizeMedia]
-        let included: [ToolName] = [.manageTracks, .setClipProperties, .denoiseAudio, .generateAudio]
+        let included: [ToolName] = [
+            .manageTracks, .setClipProperties, .copyClipSettings, .denoiseAudio, .generateAudio,
+        ]
         #expect(excluded.allSatisfy { !$0.publishesTimelineChanges })
         #expect(included.allSatisfy { $0.publishesTimelineChanges })
     }

--- a/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
@@ -51,42 +51,87 @@ struct AgentActivityHighlightTests {
     }
 
     @Test func onlyMutationToolsPublishTimelineChanges() {
-        let excluded: [ToolName] = [.inspectTimeline, .getTranscript, .manageTracks, .organizeMedia]
-        let included: [ToolName] = [.setClipProperties, .denoiseAudio, .generateAudio]
+        let excluded: [ToolName] = [.inspectTimeline, .getTranscript, .organizeMedia]
+        let included: [ToolName] = [.manageTracks, .setClipProperties, .denoiseAudio, .generateAudio]
         #expect(excluded.allSatisfy { !$0.publishesTimelineChanges })
         #expect(included.allSatisfy { $0.publishesTimelineChanges })
     }
 
-    @Test func mapsOnlyVisibleTimelineReads() throws {
+    @Test func manageTracksHighlightsReorderAndFlagChanges() async throws {
+        var first = Fixtures.videoTrack()
+        first.id = "first"
+        var second = Fixtures.videoTrack()
+        second.id = "second"
+        var audio = Fixtures.audioTrack()
+        audio.id = "audio"
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [first, second, audio]))
+
+        _ = try await harness.runOK("manage_tracks", args: [
+            "reorder": [["index": 0, "to": 1]],
+            "set": [
+                ["index": 0, "hidden": true, "syncLocked": false],
+                ["index": 2, "muted": true],
+            ],
+        ])
+
+        #expect(harness.editor.agentActivity.mutatedTrackIds == [first.id, second.id, audio.id])
+        harness.editor.clearAgentActivity()
+
+        _ = try await harness.runOK("manage_tracks", args: ["remove": [0]])
+        #expect(harness.editor.agentActivity.isEmpty)
+    }
+
+    @Test func mapsOnlyVisibleTimelineReads() {
         let (harness, clip) = harnessWithClip()
         func activity(
             _ tool: ToolName,
             _ args: [String: Any] = [:]
-        ) throws -> AgentActivityHighlight? {
-            try harness.executor.timelineReadActivity(for: tool, args: args, editor: harness.editor)
+        ) -> AgentActivityHighlight? {
+            harness.executor.timelineReadActivity(for: tool, args: args, editor: harness.editor)
         }
 
-        let clipActivity = try activity(.inspectMedia, ["clipId": clip.id])
-        let clipRead = try #require(clipActivity)
-        #expect(clipRead.readClipIds == [clip.id])
+        #expect(activity(.inspectMedia, ["clipId": clip.id])?.readClipIds == [clip.id])
 
-        let combinedActivity = try activity(.getTranscript, [
+        let combinedRead = activity(.getTranscript, [
             "clipId": clip.id,
             "startFrame": 10,
             "endFrame": 20,
         ])
-        let combinedRead = try #require(combinedActivity)
-        #expect(combinedRead.readClipIds == [clip.id])
-        #expect(combinedRead.range == 10..<20)
+        #expect(combinedRead?.readClipIds == [clip.id])
+        #expect(combinedRead?.range == 10..<20)
 
-        let excludedReads = try [
+        let excludedReads = [
             activity(.getMedia),
             activity(.getTimeline),
             activity(.getTimeline, ["startFrame": 0, "endFrame": 0]),
+            activity(.getTimeline, ["startFrame": 20, "endFrame": 10]),
             activity(.inspectTimeline, ["startFrame": Int.max]),
             activity(.getTimeline, ["startFrame": 1_000, "endFrame": 2_000]),
         ]
         #expect(excludedReads.allSatisfy { $0 == nil })
+    }
+
+    @Test func readDoesNotReplaceVisibleWrite() {
+        let editor = EditorViewModel()
+        editor.showAgentChanges(addedClipIds: ["clip"], mutatedClipIds: [])
+
+        let read = editor.beginAgentTimelineRead(AgentActivityHighlight(readClipIds: ["clip"]))
+
+        #expect(read == nil)
+        #expect(editor.agentActivity.addedClipIds == ["clip"])
+        editor.clearAgentActivity()
+    }
+
+    @Test func readRoutingDoesNotPreemptToolValidation() async {
+        let harness = ToolHarness()
+        let result = await harness.runRaw("get_multicam", args: [
+            "groupId": "missing",
+            "startFrame": 20,
+            "endFrame": 10,
+        ])
+
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).contains("No multicam group"))
     }
 
     @Test func readLifecycleIgnoresOverlapAndClearsErrors() throws {
@@ -149,7 +194,7 @@ struct AgentActivityHighlightTests {
         #expect(abs(AppTheme.Anim.agentReadHighlightDuration - 0.95) < 0.0001)
     }
 
-    @Test func classifiesFiveThousandClipRippleWithinInteractiveBudget() {
+    @Test func classifiesFiveThousandClipRipple() {
         let clips = (0..<5_000).map {
             Fixtures.clip(id: "clip-\($0)", start: $0 * 10, duration: 10)
         }
@@ -159,26 +204,26 @@ struct AgentActivityHighlightTests {
             after.tracks[0].clips[index].startFrame += 5
         }
         let harness = ToolHarness(timeline: before)
-        let elapsed = ContinuousClock().measure {
-            harness.executor.publishAgentChanges(
-                before: before,
-                after: after,
-                editor: harness.editor
-            )
-        }
-
-        print("5,000-clip Agent highlight classification: \(elapsed)")
+        harness.executor.publishAgentChanges(
+            before: before,
+            after: after,
+            editor: harness.editor
+        )
         #expect(harness.editor.agentActivity.mutatedClipIds.count == 5_000)
-        #expect(elapsed < .milliseconds(100))
         harness.editor.clearAgentActivity()
     }
 
     @Test func writePrecedenceCoalescesAndTimelineSwitchClears() {
         let editor = EditorViewModel()
         editor.showAgentChanges(addedClipIds: ["clip"], mutatedClipIds: [])
-        editor.showAgentChanges(addedClipIds: [], mutatedClipIds: ["clip", "other"])
+        editor.showAgentChanges(
+            addedClipIds: [],
+            mutatedClipIds: ["clip", "other"],
+            mutatedTrackIds: ["track"]
+        )
         #expect(editor.agentActivity.addedClipIds == ["clip"])
         #expect(editor.agentActivity.mutatedClipIds == ["other"])
+        #expect(editor.agentActivity.mutatedTrackIds == ["track"])
 
         let nextTimeline = Fixtures.timeline()
         editor.timelines.append(nextTimeline)

--- a/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
+++ b/Tests/PalmierProTests/Agent/AgentActivityHighlightTests.swift
@@ -1,0 +1,188 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Agent activity highlights")
+@MainActor
+struct AgentActivityHighlightTests {
+    private func harnessWithClip(duration: Int = 100) -> (ToolHarness, Clip) {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: duration)
+        let timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        return (ToolHarness(timeline: timeline), clip)
+    }
+
+    @Test func classifierSeparatesAddedAndMutatedClips() {
+        let mutated = Fixtures.clip(id: "mutated", start: 0, duration: 10)
+        let removed = Fixtures.clip(id: "removed", start: 20, duration: 10)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [mutated, removed]),
+        ]))
+        let before = harness.editor.timeline
+        harness.editor.timeline.tracks[0].clips[0].startFrame = 5
+        harness.editor.timeline.tracks[0].clips.removeAll { $0.id == removed.id }
+        harness.editor.timeline.tracks[0].clips.append(
+            Fixtures.clip(id: "added", start: 30, duration: 10)
+        )
+
+        harness.executor.publishAgentChanges(
+            before: before,
+            after: harness.editor.timeline,
+            editor: harness.editor
+        )
+
+        #expect(harness.editor.agentActivity.addedClipIds == ["added"])
+        #expect(harness.editor.agentActivity.mutatedClipIds == [mutated.id])
+        harness.editor.clearAgentActivity()
+    }
+
+    @Test func executorHighlightsOnlyActualPropertyChanges() async throws {
+        let (harness, clip) = harnessWithClip(duration: 30)
+        _ = try await harness.runOK("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "opacity": 1.0,
+        ])
+        #expect(harness.editor.agentActivity.isEmpty)
+
+        _ = try await harness.runOK("set_clip_properties", args: [
+            "clipIds": [clip.id],
+            "opacity": 0.5,
+        ])
+        #expect(harness.editor.agentActivity.mutatedClipIds == [clip.id])
+        harness.editor.clearAgentActivity()
+    }
+
+    @Test func onlyMutationToolsPublishTimelineChanges() {
+        let excluded: [ToolName] = [.inspectTimeline, .getTranscript, .manageTracks, .organizeMedia]
+        let included: [ToolName] = [.setClipProperties, .denoiseAudio, .generateAudio]
+        #expect(excluded.allSatisfy { !$0.publishesTimelineChanges })
+        #expect(included.allSatisfy { $0.publishesTimelineChanges })
+    }
+
+    @Test func mapsOnlyVisibleTimelineReads() throws {
+        let (harness, clip) = harnessWithClip()
+        func activity(
+            _ tool: ToolName,
+            _ args: [String: Any] = [:]
+        ) throws -> AgentActivityHighlight? {
+            try harness.executor.timelineReadActivity(for: tool, args: args, editor: harness.editor)
+        }
+
+        let clipActivity = try activity(.inspectMedia, ["clipId": clip.id])
+        let clipRead = try #require(clipActivity)
+        #expect(clipRead.readClipIds == [clip.id])
+
+        let combinedActivity = try activity(.getTranscript, [
+            "clipId": clip.id,
+            "startFrame": 10,
+            "endFrame": 20,
+        ])
+        let combinedRead = try #require(combinedActivity)
+        #expect(combinedRead.readClipIds == [clip.id])
+        #expect(combinedRead.range == 10..<20)
+
+        let excludedReads = try [
+            activity(.getMedia),
+            activity(.getTimeline),
+            activity(.getTimeline, ["startFrame": 0, "endFrame": 0]),
+            activity(.inspectTimeline, ["startFrame": Int.max]),
+            activity(.getTimeline, ["startFrame": 1_000, "endFrame": 2_000]),
+        ]
+        #expect(excludedReads.allSatisfy { $0 == nil })
+    }
+
+    @Test func readLifecycleIgnoresOverlapAndClearsErrors() throws {
+        let editor = EditorViewModel()
+        let first = try #require(editor.beginAgentTimelineRead(
+            AgentActivityHighlight(readClipIds: ["first"])
+        ))
+        #expect(editor.agentActivity.isActive)
+
+        let second = try #require(editor.beginAgentTimelineRead(
+            AgentActivityHighlight(readClipIds: ["second"])
+        ))
+        editor.endAgentTimelineRead(first, succeeded: true)
+        #expect(editor.agentActivity.readClipIds == ["second"])
+        #expect(editor.agentActivity.isActive)
+
+        editor.endAgentTimelineRead(second, succeeded: false)
+        #expect(editor.agentActivity.isEmpty)
+
+        let third = try #require(editor.beginAgentTimelineRead(
+            AgentActivityHighlight(range: 10..<20)
+        ))
+        editor.endAgentTimelineRead(third, succeeded: true)
+        #expect(editor.agentActivity.range == 10..<20)
+        #expect(!editor.agentActivity.isActive)
+        editor.clearAgentActivity()
+    }
+
+    @Test func windowedTimelineReadFadesAfterSuccess() async throws {
+        let (harness, _) = harnessWithClip()
+        _ = try await harness.runOK("get_timeline", args: [
+            "startFrame": 10,
+            "endFrame": 20,
+        ])
+
+        #expect(harness.editor.agentActivity.range == 10..<20)
+        #expect(!harness.editor.agentActivity.isActive)
+        harness.editor.clearAgentActivity()
+    }
+
+    @Test func timelineTracksNonAgentMutationInterleaving() {
+        let editor = EditorViewModel()
+        let initialRevision = editor.nonAgentTimelineMutationRevision
+        editor.timeline.tracks = [Fixtures.videoTrack()]
+        #expect(editor.nonAgentTimelineMutationRevision == initialRevision + 1)
+
+        let revision = editor.nonAgentTimelineMutationRevision
+        Analytics.$origin.withValue(.init(source: "agent", sessionID: "test")) {
+            editor.timeline.tracks.append(Fixtures.audioTrack())
+        }
+        #expect(editor.nonAgentTimelineMutationRevision == revision)
+    }
+
+    @Test func highlightTimingsMatchActivityType() {
+        #expect(AppTheme.Anim.agentChangeHighlightHold == 1.0)
+        #expect(AppTheme.Anim.agentChangeHighlightFade == 0.3)
+        #expect(abs(AppTheme.Anim.agentChangeHighlightDuration - 1.3) < 0.0001)
+        #expect(AppTheme.Anim.agentReadHighlightHold == 0.7)
+        #expect(AppTheme.Anim.agentReadHighlightFade == 0.25)
+        #expect(abs(AppTheme.Anim.agentReadHighlightDuration - 0.95) < 0.0001)
+    }
+
+    @Test func classifiesFiveThousandClipRippleWithinInteractiveBudget() {
+        let clips = (0..<5_000).map {
+            Fixtures.clip(id: "clip-\($0)", start: $0 * 10, duration: 10)
+        }
+        let before = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: clips)])
+        var after = before
+        for index in after.tracks[0].clips.indices {
+            after.tracks[0].clips[index].startFrame += 5
+        }
+        let harness = ToolHarness(timeline: before)
+        let elapsed = ContinuousClock().measure {
+            harness.executor.publishAgentChanges(
+                before: before,
+                after: after,
+                editor: harness.editor
+            )
+        }
+
+        print("5,000-clip Agent highlight classification: \(elapsed)")
+        #expect(harness.editor.agentActivity.mutatedClipIds.count == 5_000)
+        #expect(elapsed < .milliseconds(100))
+        harness.editor.clearAgentActivity()
+    }
+
+    @Test func writePrecedenceCoalescesAndTimelineSwitchClears() {
+        let editor = EditorViewModel()
+        editor.showAgentChanges(addedClipIds: ["clip"], mutatedClipIds: [])
+        editor.showAgentChanges(addedClipIds: [], mutatedClipIds: ["clip", "other"])
+        #expect(editor.agentActivity.addedClipIds == ["clip"])
+        #expect(editor.agentActivity.mutatedClipIds == ["other"])
+
+        let nextTimeline = Fixtures.timeline()
+        editor.timelines.append(nextTimeline)
+        editor.activateTimeline(nextTimeline.id)
+        #expect(editor.agentActivity.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Show green glow/fade rings around clips the Agent adds and orange rings around clips it actually changes.
- Show orange track-header rings for Agent track reorder, mute/hide, and sync-lock changes.
- Show slate `#64748B` indicators for clip-scoped and explicit timeline-range reads so users can see what the Agent is inspecting.
- Suppress indicators for no-ops, metadata-only reads, disjoint/unwindowed reads, tool errors, active-timeline changes, and interleaved manual edits.

## Approach

- Classify successful Agent timeline mutations from before/after timeline values, with explicit mutation-tool eligibility and write-over-read precedence.
- Route content-reading tools into the same unified `AgentActivityHighlight` state used by writes; reads remain visible while work is active, then hold and fade.
- Render activity through shared masked Core Animation layers that stay below the sticky ruler and update independently from full timeline redraws.
- Keep activity transient and session-only: no project persistence, undo entries, selection changes, or Agent contract changes.
- Track removals and pure clip deletions intentionally remain unanimated because there is no surviving visual target.

## Testing

- `swift build` — passed after rebase.
- `swift test --filter 'AgentActivityHighlightTests|MCPCopyClipSettingsTests'` — 15 tests across 2 suites passed.
- `swift test` — 1,480 tests across 235 suites passed.
- 5,000-clip classification measured around 11 ms in a debug build; deterministic coverage verifies all 5,000 mutations are classified.
- Exercised add, mutate, copy settings, clip read, range read, reorder, hide, and sync-lock flows through the local MCP server in isolated test projects.
- Claude Opus 5 reviewed the complete branch for edge cases, bugs, concurrency, rendering, performance, and simplification; all blocking findings were addressed.

Manual UI verification still required:

- [ ] Confirm added, mutated, read, and track-header colors/glows in Light and Dark appearances.
- [ ] Scroll horizontally and vertically while an indicator is active.
- [ ] Zoom while an indicator is active.
- [ ] Collapse and reopen the timeline panel during an indicator.
- [ ] Confirm a write immediately followed by a read preserves the write indicator.
- [ ] Confirm reordered track rings follow the resulting rows.

## Change statistics

- Agent classification and activity state: +264 / -3
- Timeline rendering and theme: +310 / -0
- Tests: +256 / -1
- Total: +830 / -4