### PR TITLE
[feat] Add perspective tilt to text clips

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -812,7 +812,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addTexts,
-            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets their alignment-relative horizontal anchor, vertical center, and rotation. Left-aligned text grows rightward from x, centered text grows around x, and right-aligned text grows leftward from x. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
+            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets their alignment-relative horizontal anchor, vertical center, Z rotation, and static X/Y perspective tilt. Left-aligned text grows rightward from x, centered text grows around x, and right-aligned text grows leftward from x. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -844,7 +844,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .updateText,
-            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box while preserving its alignment-relative x anchor. transform can reposition or rotate it without changing its size. Static rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
+            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box while preserving its alignment-relative x anchor. transform can reposition, rotate, or apply static X/Y perspective tilt without changing its size. Static Z rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "clipIds": [
@@ -877,7 +877,7 @@ enum ToolDefinitions {
                     "transform": [
                         "type": "object",
                         "description": "Caption position and rotation; size is auto-fit per caption. x uses the selected text alignment edge.",
-                        "properties": textTransformProperties(),
+                        "properties": textTransformProperties(includesTilt: false),
                     ],
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
                     "maxWords": ["type": "integer", "minimum": 1, "description": "Max words per caption."],
@@ -1184,12 +1184,17 @@ enum ToolDefinitions {
     static var mcpServer: [AgentTool] { all + [manageProject] }
     static var inAppAgent: [AgentTool] { all + [readSkill] }
 
-    private static func textTransformProperties() -> [String: [String: Any]] {
-        [
+    private static func textTransformProperties(includesTilt: Bool = true) -> [String: [String: Any]] {
+        var properties: [String: [String: Any]] = [
             "x": ["type": "number", "description": "Normalized horizontal anchor of the unrotated text box: the left edge for left alignment, center for center alignment, or right edge for right alignment."],
             "y": ["type": "number", "description": "Normalized vertical center."],
-            "rotation": ["type": "number", "description": "Clockwise degrees."],
+            "rotation": ["type": "number", "description": "Clockwise Z-axis degrees."],
         ]
+        if includesTilt {
+            properties["rotationX"] = ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static X-axis perspective rotation in degrees. Positive tips the top edge away from the viewer."]
+            properties["rotationY"] = ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static Y-axis perspective rotation in degrees. Positive brings the right edge toward the viewer."]
+        }
+        return properties
     }
 
     private static func textStyleProperties(detailed: Bool) -> [String: [String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -877,7 +877,7 @@ enum ToolDefinitions {
                     "transform": [
                         "type": "object",
                         "description": "Caption position and rotation; size is auto-fit per caption. x uses the selected text alignment edge.",
-                        "properties": textTransformProperties(includesTilt: false),
+                        "properties": textTransformProperties(),
                     ],
                     "censorProfanity": ["type": "boolean", "description": "Mask profanity."],
                     "maxWords": ["type": "integer", "minimum": 1, "description": "Max words per caption."],
@@ -1184,17 +1184,14 @@ enum ToolDefinitions {
     static var mcpServer: [AgentTool] { all + [manageProject] }
     static var inAppAgent: [AgentTool] { all + [readSkill] }
 
-    private static func textTransformProperties(includesTilt: Bool = true) -> [String: [String: Any]] {
-        var properties: [String: [String: Any]] = [
+    private static func textTransformProperties() -> [String: [String: Any]] {
+        [
             "x": ["type": "number", "description": "Normalized horizontal anchor of the unrotated text box: the left edge for left alignment, center for center alignment, or right edge for right alignment."],
             "y": ["type": "number", "description": "Normalized vertical center."],
             "rotation": ["type": "number", "description": "Clockwise Z-axis degrees."],
+            "rotationX": ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static X-axis perspective rotation in degrees. Positive tips the top edge away from the viewer."],
+            "rotationY": ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static Y-axis perspective rotation in degrees. Positive brings the right edge toward the viewer."],
         ]
-        if includesTilt {
-            properties["rotationX"] = ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static X-axis perspective rotation in degrees. Positive tips the top edge away from the viewer."]
-            properties["rotationY"] = ["type": "number", "minimum": Transform.tiltRotationRange.lowerBound, "maximum": Transform.tiltRotationRange.upperBound, "description": "Static Y-axis perspective rotation in degrees. Positive brings the right edge toward the viewer."]
-        }
-        return properties
     }
 
     private static func textStyleProperties(detailed: Bool) -> [String: [String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -15,10 +15,6 @@ extension ToolExecutor {
         if let stylePatch { Self.applyTextStylePatch(stylePatch, to: &style) }
 
         let transform = try parseTextTransform(args["transform"], path: "add_captions.transform")
-        guard transform?.rotationX == nil,
-              transform?.rotationY == nil else {
-            throw ToolError("add_captions.transform supports x, y, and rotation; use update_text to tilt captions")
-        }
         var center = AppTheme.Caption.defaultCenter
         if let x = transform?.x { center.x = CGFloat(x) }
         if let y = transform?.y { center.y = CGFloat(y) }
@@ -73,7 +69,8 @@ extension ToolExecutor {
         let ids = try await editor.generateCaptions(for: request, applying: { mutation in
             editor.undo.perform("Generate Captions (Agent)") {
                 let ids = mutation()
-                if transform?.x != nil || transform?.rotation != nil {
+                if transform?.x != nil || transform?.rotation != nil
+                    || transform?.rotationX != nil || transform?.rotationY != nil {
                     editor.commitClipProperties(clipIds: ids, actionName: "Transform Captions (Agent)") { clip in
                         if let x = transform?.x {
                             clip.transform.centerX = Self.textCenterX(
@@ -84,6 +81,12 @@ extension ToolExecutor {
                         }
                         if let rotation = transform?.rotation {
                             clip.transform.rotation = rotation
+                        }
+                        if let rotationX = transform?.rotationX {
+                            clip.transform.rotationX = rotationX
+                        }
+                        if let rotationY = transform?.rotationY {
+                            clip.transform.rotationY = rotationY
                         }
                     }
                 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Captions.swift
@@ -15,6 +15,10 @@ extension ToolExecutor {
         if let stylePatch { Self.applyTextStylePatch(stylePatch, to: &style) }
 
         let transform = try parseTextTransform(args["transform"], path: "add_captions.transform")
+        guard transform?.rotationX == nil,
+              transform?.rotationY == nil else {
+            throw ToolError("add_captions.transform supports x, y, and rotation; use update_text to tilt captions")
+        }
         var center = AppTheme.Caption.defaultCenter
         if let x = transform?.x { center.x = CGFloat(x) }
         if let y = transform?.y { center.y = CGFloat(y) }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -104,8 +104,12 @@ struct ParsedTextTransform {
     let x: Double?
     let y: Double?
     let rotation: Double?
+    let rotationX: Double?
+    let rotationY: Double?
 
-    var hasAnyField: Bool { x != nil || y != nil || rotation != nil }
+    var hasAnyField: Bool {
+        x != nil || y != nil || rotation != nil || rotationX != nil || rotationY != nil
+    }
 }
 
 extension ToolExecutor {
@@ -372,11 +376,18 @@ extension ToolExecutor {
         guard let args = raw as? [String: Any] else {
             throw ToolError("\(path): expected object")
         }
-        try validateUnknownKeys(args, allowed: ["x", "y", "rotation"], path: path)
+        try validateUnknownKeys(
+            args,
+            allowed: ["x", "y", "rotation", "rotationX", "rotationY"],
+            path: path
+        )
+        let tilt = Transform.tiltRotationRange
         let transform = ParsedTextTransform(
             x: try optionalNumber(args, key: "x", path: path),
             y: try optionalNumber(args, key: "y", path: path),
-            rotation: try optionalNumber(args, key: "rotation", path: path)
+            rotation: try optionalNumber(args, key: "rotation", path: path),
+            rotationX: try optionalNumber(args, key: "rotationX", path: path, range: tilt),
+            rotationY: try optionalNumber(args, key: "rotationY", path: path, range: tilt)
         )
         return transform.hasAnyField ? transform : nil
     }
@@ -399,7 +410,9 @@ extension ToolExecutor {
             centerY: transform.y ?? 0.5,
             width: width,
             height: Double(natural.height) / canvas.h,
-            rotation: transform.rotation ?? 0
+            rotation: transform.rotation ?? 0,
+            rotationX: transform.rotationX ?? 0,
+            rotationY: transform.rotationY ?? 0
         )
     }
 
@@ -635,6 +648,12 @@ extension ToolExecutor {
                 if let rotation = transform?.rotation {
                     clip.transform.rotation = rotation
                     clip.rotationTrack = nil
+                }
+                if let rotationX = transform?.rotationX {
+                    clip.transform.rotationX = rotationX
+                }
+                if let rotationY = transform?.rotationY {
+                    clip.transform.rotationY = rotationY
                 }
                 if shouldSetAnimation {
                     if let animation {

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -106,7 +106,7 @@ enum FrameRenderer {
         guard let image = TextFrameRenderer.image(clip: clip, frame: frame, renderSize: renderSize) else {
             return nil
         }
-        return rotatedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
+        return transformedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
     }
 
     /// Children composite at the child canvas; the nest clip's pipeline runs on the result.
@@ -338,7 +338,7 @@ enum FrameRenderer {
                 image = descriptor.render(image, effect: effect, atOffset: offset)
             }
         }
-        image = rotatedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
+        image = transformedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
         image = image.premultiplyingAlpha()
 
         if bakeOpacity, alpha < 1 {
@@ -349,21 +349,52 @@ enum FrameRenderer {
         return image
     }
 
-    private static func rotatedTextImage(
+    private static func transformedTextImage(
         _ image: CIImage,
         clip: Clip,
         frame: Int,
         renderSize: CGSize
     ) -> CIImage {
-        let rotation = CompositionBuilder.canvasRotationTransform(
-            for: clip.transformAt(frame: frame),
-            renderSize: renderSize
-        )
+        let transform = clip.transformAt(frame: frame)
+        if transform.hasTiltRotation {
+            return tiltedTextImage(image, transform: transform, renderSize: renderSize)
+        }
+
+        let rotation = CompositionBuilder.canvasRotationTransform(for: transform, renderSize: renderSize)
         guard !rotation.isIdentity else { return image }
         let ciTransform = flipY(renderSize.height)
             .concatenating(rotation)
             .concatenating(flipY(renderSize.height))
         return image.transformed(by: ciTransform)
+    }
+
+    /// Projects the raster's actual extent, so glyphs drawn off canvas can tilt back into frame.
+    private static func tiltedTextImage(
+        _ image: CIImage,
+        transform: Transform,
+        renderSize: CGSize
+    ) -> CIImage {
+        let source = image.extent.isInfinite
+            ? image.cropped(to: CGRect(origin: .zero, size: renderSize))
+            : image
+        guard !source.extent.isEmpty else { return image }
+
+        let flip = flipY(renderSize.height)
+        let corners = TextTiltGeometry.corners(
+            of: source.extent.applying(flip),
+            around: CGPoint(
+                x: transform.centerX * renderSize.width,
+                y: transform.centerY * renderSize.height
+            ),
+            transform: transform,
+            canvasSize: renderSize
+        )
+        return source.applyingFilter("CIPerspectiveTransform", parameters: [
+            "inputTopLeft": CIVector(cgPoint: corners.topLeft.applying(flip)),
+            "inputTopRight": CIVector(cgPoint: corners.topRight.applying(flip)),
+            "inputBottomRight": CIVector(cgPoint: corners.bottomRight.applying(flip)),
+            "inputBottomLeft": CIVector(cgPoint: corners.bottomLeft.applying(flip)),
+        ])
     }
 
     private static func flipY(_ height: CGFloat) -> CGAffineTransform {

--- a/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/TextFrameRenderer.swift
@@ -111,6 +111,17 @@ enum TextFrameRenderer {
         return rect.insetBy(dx: -2, dy: -2).integral
     }
 
+    /// Lines with their origins resolved into the frame path's coordinate space.
+    private static func positionedLines(in frame: CTFrame) -> [(line: CTLine, origin: CGPoint)] {
+        let lines = CTFrameGetLines(frame) as? [CTLine] ?? []
+        var origins = [CGPoint](repeating: .zero, count: lines.count)
+        CTFrameGetLineOrigins(frame, CFRange(location: 0, length: 0), &origins)
+        let frameOrigin = CTFrameGetPath(frame).boundingBox.origin
+        return lines.indices.map { index in
+            (lines[index], CGPoint(x: frameOrigin.x + origins[index].x, y: frameOrigin.y + origins[index].y))
+        }
+    }
+
     private static func placed(_ image: CIImage, _ raster: CGRect) -> CIImage {
         image.transformed(by: CGAffineTransform(translationX: raster.minX, y: raster.minY))
     }
@@ -163,15 +174,10 @@ enum TextFrameRenderer {
     private static func drawOverlines(_ ctx: CGContext, frame: CTFrame, style: TextStyle,
                                       fontSize: CGFloat) {
         guard style.isOverlined else { return }
-        let lines = CTFrameGetLines(frame) as? [CTLine] ?? []
-        var origins = [CGPoint](repeating: .zero, count: lines.count)
-        CTFrameGetLineOrigins(frame, CFRange(location: 0, length: 0), &origins)
-        let frameBounds = CTFrameGetPath(frame).boundingBox
         let font = style.resolvedFont(size: fontSize)
-        for (index, line) in lines.enumerated() {
+        for (line, origin) in positionedLines(in: frame) {
             let width = CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil) - CTLineGetTrailingWhitespaceWidth(line))
-            drawOverline(ctx, x: frameBounds.minX + origins[index].x, y: frameBounds.minY + origins[index].y,
-                         width: width, font: font, color: style.color)
+            drawOverline(ctx, x: origin.x, y: origin.y, width: width, font: font, color: style.color)
         }
     }
 
@@ -244,15 +250,11 @@ enum TextFrameRenderer {
             for: NSAttributedString(string: content, attributes: style.attributes(size: fontSize)),
             in: boxes.text
         )
-        let lines = CTFrameGetLines(ctFrame) as? [CTLine] ?? []
-        var origins = [CGPoint](repeating: .zero, count: lines.count)
-        CTFrameGetLineOrigins(ctFrame, CFRange(location: 0, length: 0), &origins)
-        let frameBounds = CTFrameGetPath(ctFrame).boundingBox
 
         let tokens = words(in: content)
         let timings = tokenTimings(tokens, clip.wordTimings, duration: clip.durationFrames)
         var pens = [PerWordLayout.TokenPen?](repeating: nil, count: tokens.count)
-        for (li, line) in lines.enumerated() {
+        for (line, origin) in positionedLines(in: ctFrame) {
             let lineRange = CTLineGetStringRange(line)
             for (ti, tok) in tokens.enumerated() {
                 guard tok.range.location >= lineRange.location,
@@ -260,8 +262,8 @@ enum TextFrameRenderer {
                 let startOff = CTLineGetOffsetForStringIndex(line, tok.range.location, nil)
                 let endOff = CTLineGetOffsetForStringIndex(line, tok.range.location + tok.range.length, nil)
                 pens[ti] = PerWordLayout.TokenPen(
-                    x: frameBounds.minX + origins[li].x + startOff - raster.minX,
-                    y: frameBounds.minY + origins[li].y - raster.minY,
+                    x: origin.x + startOff - raster.minX,
+                    y: origin.y - raster.minY,
                     width: endOff - startOff
                 )
             }

--- a/Sources/PalmierPro/Compositing/TextTiltGeometry.swift
+++ b/Sources/PalmierPro/Compositing/TextTiltGeometry.swift
@@ -1,0 +1,88 @@
+import CoreGraphics
+
+struct TextTiltCorners {
+    let topLeft: CGPoint
+    let topRight: CGPoint
+    let bottomRight: CGPoint
+    let bottomLeft: CGPoint
+
+    var points: [CGPoint] { [topLeft, topRight, bottomRight, bottomLeft] }
+
+    func contains(_ point: CGPoint) -> Bool {
+        let quad = points
+        var hasPositive = false
+        var hasNegative = false
+        for (index, start) in quad.enumerated() {
+            let end = quad[(index + 1) % quad.count]
+            let cross = (end.x - start.x) * (point.y - start.y)
+                - (end.y - start.y) * (point.x - start.x)
+            hasPositive = hasPositive || cross > 0
+            hasNegative = hasNegative || cross < 0
+        }
+        return !(hasPositive && hasNegative)
+    }
+}
+
+/// Projective X/Y tilt plus Z rotation, in top-left canvas coordinates.
+enum TextTiltGeometry {
+    static func corners(
+        of rect: CGRect,
+        around pivot: CGPoint,
+        transform: Transform,
+        canvasSize: CGSize
+    ) -> TextTiltCorners {
+        let (sinX, cosX) = sinCos(transform.rotationX)
+        let (sinY, cosY) = sinCos(transform.rotationY)
+        let (sinZ, cosZ) = sinCos(transform.rotation)
+
+        let canvasExtent = max(canvasSize.width, canvasSize.height)
+        guard canvasExtent.isFinite, canvasExtent > 0 else {
+            return TextTiltCorners(
+                topLeft: CGPoint(x: rect.minX, y: rect.minY),
+                topRight: CGPoint(x: rect.maxX, y: rect.minY),
+                bottomRight: CGPoint(x: rect.maxX, y: rect.maxY),
+                bottomLeft: CGPoint(x: rect.minX, y: rect.maxY)
+            )
+        }
+        // Focal length is rect-independent so every surface shares one projection.
+        let maxHalfWidth = max(
+            abs(transform.width) * canvasSize.width / 2,
+            abs(pivot.x),
+            abs(canvasSize.width - pivot.x)
+        )
+        let maxHalfHeight = max(
+            abs(transform.height) * canvasSize.height / 2,
+            abs(pivot.y),
+            abs(canvasSize.height - pivot.y)
+        )
+        let maxDepth = maxHalfWidth * abs(sinY) + maxHalfHeight * abs(sinX * cosY)
+        let focalLength = max(canvasExtent * 2, maxDepth + canvasExtent / 4)
+
+        func project(_ point: CGPoint) -> CGPoint {
+            let x = point.x - pivot.x
+            let y = -(point.y - pivot.y)
+            let tiltedX = x * cosY + y * sinX * sinY
+            let tiltedY = y * cosX
+            let depth = -x * sinY + y * sinX * cosY
+            let scale = focalLength / (focalLength + depth)
+            let projectedX = tiltedX * scale
+            let projectedY = -tiltedY * scale
+            return CGPoint(
+                x: pivot.x + projectedX * cosZ - projectedY * sinZ,
+                y: pivot.y + projectedX * sinZ + projectedY * cosZ
+            )
+        }
+
+        return TextTiltCorners(
+            topLeft: project(CGPoint(x: rect.minX, y: rect.minY)),
+            topRight: project(CGPoint(x: rect.maxX, y: rect.minY)),
+            bottomRight: project(CGPoint(x: rect.maxX, y: rect.maxY)),
+            bottomLeft: project(CGPoint(x: rect.minX, y: rect.maxY))
+        )
+    }
+
+    private static func sinCos(_ degrees: Double) -> (sin: CGFloat, cos: CGFloat) {
+        let radians = CGFloat(degrees * .pi / 180)
+        return (sin(radians), cos(radians))
+    }
+}

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -27,6 +27,7 @@ struct TextTab: View {
                 actions: styleActions,
                 afterAlignment: {
                     positionSection
+                    tiltSection
                     rotationSection
                     fillModeRow
                 },
@@ -120,6 +121,44 @@ struct TextTab: View {
             }
         ) {
             InspectorPositionFields(clips: clips)
+        }
+    }
+
+    private var tiltSection: some View {
+        InspectorRow(
+            label: L10n.string("Tilt"),
+            onReset: {
+                editor.commitClipProperties(clipIds: clipIds, actionName: "Reset Text Tilt") {
+                    $0.transform.rotationX = 0
+                    $0.transform.rotationY = 0
+                }
+            }
+        ) {
+            HStack(spacing: AppTheme.Spacing.sm) {
+                tiltField("X", keyPath: \.rotationX)
+                tiltField("Y", keyPath: \.rotationY)
+            }
+            .fixedSize()
+        }
+    }
+
+    private func tiltField(_ axis: String, keyPath: WritableKeyPath<Transform, Double>) -> some View {
+        ScrubbableNumberField(
+            value: sharedClipValue(clips) { $0.transform[keyPath: keyPath] },
+            range: Transform.tiltRotationRange,
+            format: "%.0f",
+            valueSuffix: "°",
+            fieldWidth: AppTheme.EditorPanel.compactNumericFieldWidth,
+            trailingLabel: axis,
+            onChanged: { value in
+                editor.applyClipProperties(clipIds: clipIds) {
+                    $0.transform[keyPath: keyPath] = value
+                }
+            }
+        ) { value in
+            editor.commitClipProperties(clipIds: clipIds, actionName: "Change Text Tilt") {
+                $0.transform[keyPath: keyPath] = value
+            }
         }
     }
 

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -484,13 +484,19 @@ extension Clip {
 }
 
 struct Transform: Codable, Sendable, Equatable, Hashable {
+    static let tiltRotationRange = -89.0...89.0
+
     var centerX: Double = 0.5
     var centerY: Double = 0.5
     var width: Double = 1
     var height: Double = 1
     var rotation: Double = 0 // degrees, positive = clockwise
+    var rotationX: Double = 0
+    var rotationY: Double = 0
     var flipHorizontal: Bool = false
     var flipVertical: Bool = false
+
+    var hasTiltRotation: Bool { rotationX != 0 || rotationY != 0 }
 
     var topLeft: (x: Double, y: Double) {
         (centerX - width / 2, centerY - height / 2)
@@ -506,6 +512,8 @@ struct Transform: Codable, Sendable, Equatable, Hashable {
         width: Double = 1,
         height: Double = 1,
         rotation: Double = 0,
+        rotationX: Double = 0,
+        rotationY: Double = 0,
         flipHorizontal: Bool = false,
         flipVertical: Bool = false
     ) {
@@ -514,6 +522,8 @@ struct Transform: Codable, Sendable, Equatable, Hashable {
         self.width = width
         self.height = height
         self.rotation = rotation
+        self.rotationX = rotationX
+        self.rotationY = rotationY
         self.flipHorizontal = flipHorizontal
         self.flipVertical = flipVertical
     }
@@ -533,7 +543,8 @@ struct Transform: Codable, Sendable, Equatable, Hashable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case centerX, centerY, width, height, rotation, flipHorizontal, flipVertical
+        case centerX, centerY, width, height, rotation, rotationX, rotationY
+        case flipHorizontal, flipVertical
         // Legacy keys
         case x, y
     }
@@ -559,6 +570,8 @@ struct Transform: Codable, Sendable, Equatable, Hashable {
         self.width = w
         self.height = h
         self.rotation = try c.decodeIfPresent(Double.self, forKey: .rotation) ?? 0
+        self.rotationX = try c.decodeIfPresent(Double.self, forKey: .rotationX) ?? 0
+        self.rotationY = try c.decodeIfPresent(Double.self, forKey: .rotationY) ?? 0
         self.flipHorizontal = try c.decodeIfPresent(Bool.self, forKey: .flipHorizontal) ?? false
         self.flipVertical = try c.decodeIfPresent(Bool.self, forKey: .flipVertical) ?? false
     }
@@ -570,6 +583,8 @@ struct Transform: Codable, Sendable, Equatable, Hashable {
         try c.encode(width, forKey: .width)
         try c.encode(height, forKey: .height)
         try c.encode(rotation, forKey: .rotation)
+        try c.encode(rotationX, forKey: .rotationX)
+        try c.encode(rotationY, forKey: .rotationY)
         try c.encode(flipHorizontal, forKey: .flipHorizontal)
         try c.encode(flipVertical, forKey: .flipVertical)
     }

--- a/Sources/PalmierPro/Preview/PreviewHitTester.swift
+++ b/Sources/PalmierPro/Preview/PreviewHitTester.swift
@@ -31,23 +31,22 @@ enum PreviewHitTester {
     }
 
     private static func textHit(_ clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
-        transformedHit(clip, frame: frame, point: point, videoRect: videoRect, crop: nil)
+        let transform = clip.transformAt(frame: frame)
+        let rect = clipFrame(transform, videoRect: videoRect)
+        guard rect.width > 0, rect.height > 0 else { return false }
+        return TextTiltGeometry.corners(
+            of: rect,
+            around: CGPoint(x: rect.midX, y: rect.midY),
+            transform: transform,
+            canvasSize: videoRect.size
+        ).contains(point)
     }
 
     private static func videoHit(_ clip: Clip, frame: Int, point: CGPoint, videoRect: CGRect) -> Bool {
-        transformedHit(clip, frame: frame, point: point, videoRect: videoRect, crop: clip.cropAt(frame: frame))
-    }
-
-    private static func transformedHit(
-        _ clip: Clip,
-        frame: Int,
-        point: CGPoint,
-        videoRect: CGRect,
-        crop: Crop?
-    ) -> Bool {
         let t = clip.transformAt(frame: frame)
         let rect = clipFrame(t, videoRect: videoRect)
         guard rect.width > 0, rect.height > 0 else { return false }
+        let crop = clip.cropAt(frame: frame)
 
         // Move the point into the clip's unrotated local space (origin at clip center).
         let center = CGPoint(x: rect.midX, y: rect.midY)
@@ -58,10 +57,10 @@ enum PreviewHitTester {
         let ly = -dx * s + dy * c
 
         let halfW = rect.width / 2, halfH = rect.height / 2
-        let left = -halfW + (crop?.left ?? 0) * rect.width
-        let right = halfW - (crop?.right ?? 0) * rect.width
-        let top = -halfH + (crop?.top ?? 0) * rect.height
-        let bottom = halfH - (crop?.bottom ?? 0) * rect.height
+        let left = -halfW + crop.left * rect.width
+        let right = halfW - crop.right * rect.width
+        let top = -halfH + crop.top * rect.height
+        let bottom = halfH - crop.bottom * rect.height
         return lx >= left && lx <= right && ly >= top && ly <= bottom
     }
 

--- a/Sources/PalmierPro/Preview/TransformOverlayView.swift
+++ b/Sources/PalmierPro/Preview/TransformOverlayView.swift
@@ -11,37 +11,14 @@ struct TransformOverlayView: View {
             let videoRect = videoContentRect(in: geo.size)
 
             if let clip = selectedClip {
-                let frame = editor.activeFrame
-                let xform = clip.transformAt(frame: frame)
+                let xform = clip.transformAt(frame: editor.activeFrame)
                 let clipRect = clipFrame(xform, videoRect: videoRect)
-                let rotation = xform.rotation
-                let halfW = clipRect.width / 2
-                let halfH = clipRect.height / 2
 
-                let hit = rotatedHitTarget(clipRect.size, degrees: rotation)
-                Rectangle()
-                    .fill(AppTheme.MediaOverlay.primaryColor.opacity(0.001))
-                    .frame(width: hit.frame.width, height: hit.frame.height)
-                    .contentShape(hit.shape)
-                    .position(x: clipRect.midX, y: clipRect.midY)
-                    .gesture(moveGesture(clip: clip, videoRect: videoRect))
-
-                ZStack {
-                    Rectangle()
-                        .stroke(borderColor, lineWidth: AppTheme.BorderWidth.thin)
-                    ForEach(Corner.allCases, id: \.self) { corner in
-                        let off = cornerOffset(corner, halfW: halfW, halfH: halfH)
-                        Rectangle()
-                            .fill(borderColor)
-                            .frame(width: handleSize, height: handleSize)
-                            .offset(x: off.x, y: off.y)
-                            .pointerStyle(.frameResize(position: corner.resizePosition))
-                            .gesture(resizeGesture(clip: clip, corner: corner, videoRect: videoRect))
-                    }
+                if clip.mediaType == .text && xform.hasTiltRotation {
+                    tiltOverlay(clip: clip, transform: xform, clipRect: clipRect, videoRect: videoRect)
+                } else {
+                    boxOverlay(clip: clip, clipRect: clipRect, rotation: xform.rotation, videoRect: videoRect)
                 }
-                .frame(width: clipRect.width, height: clipRect.height)
-                .rotationEffect(.degrees(rotation))
-                .position(x: clipRect.midX, y: clipRect.midY)
             }
 
             if selectedClip != nil && (centerGuideX || editor.rotationSnapGuidesVisible) {
@@ -60,6 +37,73 @@ struct TransformOverlayView: View {
             }
         }
         .allowsHitTesting(selectedClip != nil)
+    }
+
+    @ViewBuilder
+    private func boxOverlay(
+        clip: Clip,
+        clipRect: CGRect,
+        rotation: Double,
+        videoRect: CGRect
+    ) -> some View {
+        let hit = rotatedHitTarget(clipRect.size, degrees: rotation)
+        Rectangle()
+            .fill(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.hitTarget))
+            .frame(width: hit.frame.width, height: hit.frame.height)
+            .contentShape(hit.shape)
+            .position(x: clipRect.midX, y: clipRect.midY)
+            .gesture(moveGesture(clip: clip, videoRect: videoRect))
+
+        ZStack {
+            Rectangle()
+                .stroke(borderColor, lineWidth: AppTheme.BorderWidth.thin)
+            ForEach(Corner.allCases, id: \.self) { corner in
+                let off = cornerOffset(corner, halfW: clipRect.width / 2, halfH: clipRect.height / 2)
+                Rectangle()
+                    .fill(borderColor)
+                    .frame(width: handleSize, height: handleSize)
+                    .offset(x: off.x, y: off.y)
+                    .pointerStyle(.frameResize(position: corner.resizePosition))
+                    .gesture(resizeGesture(clip: clip, corner: corner, videoRect: videoRect))
+            }
+        }
+        .frame(width: clipRect.width, height: clipRect.height)
+        .rotationEffect(.degrees(rotation))
+        .position(x: clipRect.midX, y: clipRect.midY)
+    }
+
+    private func tiltOverlay(
+        clip: Clip,
+        transform: Transform,
+        clipRect: CGRect,
+        videoRect: CGRect
+    ) -> some View {
+        let corners = TextTiltGeometry.corners(
+            of: clipRect,
+            around: CGPoint(x: clipRect.midX, y: clipRect.midY),
+            transform: transform,
+            canvasSize: videoRect.size
+        )
+        let outline = Path { path in
+            path.addLines(corners.points)
+            path.closeSubpath()
+        }
+        return ZStack {
+            outline
+                .fill(AppTheme.MediaOverlay.primaryColor.opacity(AppTheme.Opacity.hitTarget))
+                .contentShape(outline)
+                .gesture(moveGesture(clip: clip, videoRect: videoRect))
+            outline.stroke(borderColor, lineWidth: AppTheme.BorderWidth.thin)
+            ForEach(Corner.allCases, id: \.self) { corner in
+                Rectangle()
+                    .fill(borderColor)
+                    .frame(width: handleSize, height: handleSize)
+                    .position(corner.point(in: corners))
+                    .pointerStyle(.frameResize(position: corner.resizePosition))
+                    .gesture(resizeGesture(clip: clip, corner: corner, videoRect: videoRect))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Gestures
@@ -301,6 +345,15 @@ struct TransformOverlayView: View {
             case .bottomRight: .bottomTrailing
             }
         }
+
+        func point(in corners: TextTiltCorners) -> CGPoint {
+            switch self {
+            case .topLeft: corners.topLeft
+            case .topRight: corners.topRight
+            case .bottomLeft: corners.bottomLeft
+            case .bottomRight: corners.bottomRight
+            }
+        }
     }
 }
 
@@ -319,7 +372,7 @@ enum TransformOverlayMath {
         moved.centerX += translation.width / videoRect.width
         moved.centerY += translation.height / videoRect.height
 
-        if start.rotation == 0 {
+        if start.rotation == 0 && !start.hasTiltRotation {
             moved.snapToCanvasEdges(threshold: Snap.thresholdPixels / Double(videoRect.width))
         }
         let guides = moved.snapCenterToCanvasCenter(

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -921,6 +921,7 @@
 "Three-Up" = "Three-Up";
 "Threshold" = "Threshold";
 "Thumbnail Size" = "Thumbnail Size";
+"Tilt" = "Tilt";
 "Timecode" = "Timecode";
 "Timeline" = "Timeline";
 "Timeline Format" = "Timeline Format";

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -273,6 +273,7 @@ enum AppTheme {
 
     enum Opacity {
         static let opaque: Double = 1
+        static let hitTarget: Double = 0.001
         static let subtle: Double = 0.04
         static let hint: Double = 0.06
         static let faint: Double = 0.08

--- a/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPStaticRotationTests.swift
@@ -23,6 +23,8 @@ struct MCPStaticRotationTests {
             let entryProperties = try #require(entries["items"]?.objectValue?["properties"]?.objectValue)
             let addTransform = try #require(entryProperties["transform"]?.objectValue?["properties"]?.objectValue)
             #expect(addTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+            #expect(addTransform["rotationX"]?.objectValue?["type"]?.stringValue == "number")
+            #expect(addTransform["rotationY"]?.objectValue?["type"]?.stringValue == "number")
             #expect(addTransform["width"] == nil)
             #expect(addTransform["height"] == nil)
 
@@ -30,6 +32,8 @@ struct MCPStaticRotationTests {
             let updateProperties = try #require(updateTool.inputSchema.objectValue?["properties"]?.objectValue)
             let updateTransform = try #require(updateProperties["transform"]?.objectValue?["properties"]?.objectValue)
             #expect(updateTransform["rotation"]?.objectValue?["type"]?.stringValue == "number")
+            #expect(updateTransform["rotationX"]?.objectValue?["minimum"]?.intValue == -89)
+            #expect(updateTransform["rotationY"]?.objectValue?["maximum"]?.intValue == 89)
             #expect(updateTransform["width"] == nil)
             #expect(updateTransform["height"] == nil)
         }
@@ -46,16 +50,28 @@ struct MCPStaticRotationTests {
                     "startFrame": .int(0),
                     "endFrame": .int(60),
                     "content": .string("Rotated title"),
-                    "transform": .object(["rotation": .double(30)]),
+                    "transform": .object([
+                        "rotation": .double(30),
+                        "rotationX": .double(20),
+                        "rotationY": .double(-25),
+                    ]),
                 ])]),
             ])
             #expect(addResult.isError != true)
             let textClip = try #require(harness.editor.timeline.tracks.flatMap(\.clips).first { $0.mediaType == .text })
             let clipId = textClip.id
             #expect(textClip.transform.rotation == 30)
+            #expect(textClip.transform.rotationX == 20)
+            #expect(textClip.transform.rotationY == -25)
             #expect(textClip.transform.width < 1)
             #expect(textClip.transform.height < 1)
-            try await expectTimelineRotation(30, clipId: clipId, client: client)
+            try await expectTimelineRotation(
+                30,
+                rotationX: 20,
+                rotationY: -25,
+                clipId: clipId,
+                client: client
+            )
 
             let keyframeResult = try await client.callTool(name: "set_keyframes", arguments: [
                 "clipId": .string(clipId),
@@ -67,6 +83,16 @@ struct MCPStaticRotationTests {
             ])
             #expect(keyframeResult.isError != true)
 
+            let tiltResult = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(clipId)]),
+                "transform": .object([
+                    "rotationX": .double(-15),
+                    "rotationY": .double(35),
+                ]),
+            ])
+            #expect(tiltResult.isError != true)
+            #expect(harness.editor.clipFor(id: clipId)?.rotationTrack?.keyframes.map(\.value) == [15, 45])
+
             let updateResult = try await client.callTool(name: "update_text", arguments: [
                 "clipIds": .array([.string(clipId)]),
                 "transform": .object(["rotation": .double(90)]),
@@ -77,14 +103,26 @@ struct MCPStaticRotationTests {
             #expect(notes?.contains { $0.contains("cleared existing rotation keyframes") } == true)
             let updated = try #require(harness.editor.clipFor(id: clipId))
             #expect(updated.transform.rotation == 90)
+            #expect(updated.transform.rotationX == -15)
+            #expect(updated.transform.rotationY == 35)
             #expect(updated.rotationTrack == nil)
             #expect(updated.transform.width == textClip.transform.width)
             #expect(updated.transform.height == textClip.transform.height)
-            try await expectTimelineRotation(90, clipId: clipId, client: client)
+            try await expectTimelineRotation(
+                90,
+                rotationX: -15,
+                rotationY: 35,
+                clipId: clipId,
+                client: client
+            )
 
             let repeatedResult = try await client.callTool(name: "update_text", arguments: [
                 "clipIds": .array([.string(clipId)]),
-                "transform": .object(["rotation": .double(90)]),
+                "transform": .object([
+                    "rotation": .double(90),
+                    "rotationX": .double(-15),
+                    "rotationY": .double(35),
+                ]),
             ])
             #expect(repeatedResult.isError != true)
             let repeatedReceipt = try json(text(repeatedResult.content))
@@ -94,6 +132,13 @@ struct MCPStaticRotationTests {
             let restoredTrack = try #require(harness.editor.clipFor(id: clipId)?.rotationTrack)
             #expect(restoredTrack.keyframes.map(\.value) == [15, 45])
             #expect(harness.editor.clipFor(id: clipId)?.transform.rotation == 30)
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotationX == -15)
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotationY == 35)
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: clipId)?.rotationTrack?.keyframes.map(\.value) == [15, 45])
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotationX == 20)
+            #expect(harness.editor.clipFor(id: clipId)?.transform.rotationY == -25)
 
             #expect((try await client.callTool(name: "undo")).isError != true)
             #expect(harness.editor.clipFor(id: clipId)?.rotationTrack == nil)
@@ -221,6 +266,13 @@ struct MCPStaticRotationTests {
 
             #expect(result.isError == true)
             #expect(harness.editor.clipFor(id: "title")?.transform.rotation == 12)
+
+            let outOfRange = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string("title")]),
+                "transform": .object(["rotationX": .double(90)]),
+            ])
+            #expect(outOfRange.isError == true)
+            #expect(harness.editor.clipFor(id: "title")?.transform.rotationX == 0)
             #expect((try await client.callTool(name: "undo")).isError == true)
         }
     }
@@ -252,7 +304,13 @@ struct MCPStaticRotationTests {
         await client.disconnect()
     }
 
-    private func expectTimelineRotation(_ expected: Double, clipId: String, client: Client) async throws {
+    private func expectTimelineRotation(
+        _ expected: Double,
+        rotationX: Double? = nil,
+        rotationY: Double? = nil,
+        clipId: String,
+        client: Client
+    ) async throws {
         let timelineResult = try await client.callTool(name: "get_timeline")
         let timeline = try json(text(timelineResult.content))
         let clip = try #require(((timeline["tracks"] as? [[String: Any]]) ?? [])
@@ -260,6 +318,12 @@ struct MCPStaticRotationTests {
             .first { ($0["id"] as? String).map { clipId.hasPrefix($0) || $0.hasPrefix(clipId) } == true })
         let transform = try #require(clip["transform"] as? [String: Any])
         #expect((transform["rotation"] as? NSNumber)?.doubleValue == expected)
+        if let rotationX {
+            #expect((transform["rotationX"] as? NSNumber)?.doubleValue == rotationX)
+        }
+        if let rotationY {
+            #expect((transform["rotationY"] as? NSNumber)?.doubleValue == rotationY)
+        }
         #expect((clip["keyframes"] as? [String: Any])?["rotation"] == nil)
     }
 

--- a/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
@@ -70,6 +70,11 @@ struct MCPTranscriptionTrackTests {
                 arguments: ["maxCharacters": .int(0)]
             )
             #expect(invalidMaxCharacters.isError == true)
+            let invalidTilt = try await client.callTool(
+                name: "add_captions",
+                arguments: ["transform": .object(["rotationX": .double(20)])]
+            )
+            #expect(invalidTilt.isError == true)
         } catch {
             await server.stop()
             await client.disconnect()

--- a/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTranscriptionTrackTests.swift
@@ -43,7 +43,7 @@ struct MCPTranscriptionTrackTests {
             #expect(maxCharacters["minimum"]?.intValue == 1)
             let transform = try #require(captionProperties["transform"]?.objectValue)
             let transformProperties = try #require(transform["properties"]?.objectValue)
-            #expect(Set(transformProperties.keys) == ["x", "y", "rotation"])
+            #expect(Set(transformProperties.keys) == ["x", "y", "rotation", "rotationX", "rotationY"])
 
             let transcript = try await client.callTool(
                 name: "get_transcript",
@@ -72,7 +72,7 @@ struct MCPTranscriptionTrackTests {
             #expect(invalidMaxCharacters.isError == true)
             let invalidTilt = try await client.callTool(
                 name: "add_captions",
-                arguments: ["transform": .object(["rotationX": .double(20)])]
+                arguments: ["transform": .object(["rotationX": .double(90)])]
             )
             #expect(invalidTilt.isError == true)
         } catch {

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1976,7 +1976,7 @@ struct ToolExecutorTextFolderTests {
         #expect((styleProperties["heightScale"]?["maximum"] as? NSNumber)?.doubleValue == 10)
 
         let updateTransform = try #require(updateProperties["transform"]?["properties"] as? [String: [String: Any]])
-        #expect(Set(updateTransform.keys) == ["x", "y", "rotation"])
+        #expect(Set(updateTransform.keys) == ["x", "y", "rotation", "rotationX", "rotationY"])
 
         let addTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addTexts })
         let addProperties = try #require(addTool.inputSchema["properties"] as? [String: [String: Any]])
@@ -1984,7 +1984,7 @@ struct ToolExecutorTextFolderTests {
         let items = try #require(entries["items"] as? [String: Any])
         let entryProperties = try #require(items["properties"] as? [String: [String: Any]])
         let addTransform = try #require(entryProperties["transform"]?["properties"] as? [String: [String: Any]])
-        #expect(Set(addTransform.keys) == ["x", "y", "rotation"])
+        #expect(Set(addTransform.keys) == ["x", "y", "rotation", "rotationX", "rotationY"])
 
         let captionsTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addCaptions })
         let captionsProperties = try #require(captionsTool.inputSchema["properties"] as? [String: [String: Any]])

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -1989,7 +1989,7 @@ struct ToolExecutorTextFolderTests {
         let captionsTool = try #require(ToolDefinitions.mcpServer.first { $0.name == .addCaptions })
         let captionsProperties = try #require(captionsTool.inputSchema["properties"] as? [String: [String: Any]])
         let captionsTransform = try #require(captionsProperties["transform"]?["properties"] as? [String: [String: Any]])
-        #expect(Set(captionsTransform.keys) == ["x", "y", "rotation"])
+        #expect(Set(captionsTransform.keys) == ["x", "y", "rotation", "rotationX", "rotationY"])
     }
 
     @Test func addTextsCreatesNewTrackWhenIndexOmitted() async throws {

--- a/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
@@ -56,4 +56,25 @@ struct PreviewSelectionTests {
         #expect(rotatedOnlyPoint == "text")
         #expect(unrotatedOnlyPoint == nil)
     }
+
+    @Test func tiltedTextUsesProjectedHitTarget() {
+        let editor = EditorViewModel()
+        var text = Fixtures.clip(id: "text", mediaRef: "", mediaType: .text, start: 0, duration: 20)
+        text.transform = Transform(width: 0.6, height: 0.2, rotationY: 60)
+        var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [text])])
+        timeline.width = 320
+        timeline.height = 180
+        editor.timeline = timeline
+
+        #expect(PreviewHitTester.clipID(
+            at: CGPoint(x: 160, y: 90),
+            viewSize: CGSize(width: 320, height: 180),
+            editor: editor
+        ) == "text")
+        #expect(PreviewHitTester.clipID(
+            at: CGPoint(x: 90, y: 90),
+            viewSize: CGSize(width: 320, height: 180),
+            editor: editor
+        ) == nil)
+    }
 }

--- a/Tests/PalmierProTests/Editor/TextClipLayoutTests.swift
+++ b/Tests/PalmierProTests/Editor/TextClipLayoutTests.swift
@@ -14,6 +14,8 @@ struct TextClipLayoutTests {
             width: 1,
             height: 1,
             rotation: 37,
+            rotationX: 20,
+            rotationY: -30,
             flipHorizontal: true,
             flipVertical: true
         )
@@ -22,6 +24,8 @@ struct TextClipLayoutTests {
 
         #expect(changed)
         #expect(clip.transform.rotation == 37)
+        #expect(clip.transform.rotationX == 20)
+        #expect(clip.transform.rotationY == -30)
         #expect(clip.transform.flipHorizontal)
         #expect(clip.transform.flipVertical)
     }

--- a/Tests/PalmierProTests/Editor/TransformOverlayMathTests.swift
+++ b/Tests/PalmierProTests/Editor/TransformOverlayMathTests.swift
@@ -40,4 +40,25 @@ struct TransformOverlayMathTests {
         #expect(result.guides.x)
         #expect(!result.guides.y)
     }
+
+    @Test func tiltedMoveDoesNotSnapUnprojectedCanvasEdges() {
+        let start = Transform(
+            centerX: 0.202,
+            centerY: 0.7,
+            width: 0.4,
+            height: 0.2,
+            rotationY: 30
+        )
+
+        let result = TransformOverlayMath.movedTransform(
+            start,
+            by: .zero,
+            in: CGRect(x: 0, y: 0, width: 1_000, height: 500)
+        )
+
+        #expect(result.transform.centerX == 0.202)
+        #expect(result.transform.rotationY == 30)
+        #expect(!result.guides.x)
+        #expect(!result.guides.y)
+    }
 }

--- a/Tests/PalmierProTests/Media/ProjectRoundTripTests.swift
+++ b/Tests/PalmierProTests/Media/ProjectRoundTripTests.swift
@@ -51,6 +51,7 @@ struct ProjectRoundTripTests {
     @Test func clipTransformAndCropSurviveRoundTrip() throws {
         var clip = Fixtures.clip(start: 0, duration: 30)
         clip.transform = Transform(centerX: 0.4, centerY: 0.6, width: 0.5, height: 0.5, rotation: 45,
+                                   rotationX: 20, rotationY: -30,
                                    flipHorizontal: true, flipVertical: false)
         clip.crop = Crop(left: 0.1, top: 0.2, right: 0.3, bottom: 0.4)
         clip.edgeRounding = 0.35
@@ -62,6 +63,8 @@ struct ProjectRoundTripTests {
         #expect(dc.transform.centerX == 0.4)
         #expect(dc.transform.centerY == 0.6)
         #expect(dc.transform.rotation == 45)
+        #expect(dc.transform.rotationX == 20)
+        #expect(dc.transform.rotationY == -30)
         #expect(dc.transform.flipHorizontal == true)
         #expect(dc.crop == Crop(left: 0.1, top: 0.2, right: 0.3, bottom: 0.4))
         #expect(dc.edgeRounding == 0.35)

--- a/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
@@ -24,13 +24,23 @@ struct CompositorTextLayerTests {
         return c
     }
 
-    private func backgroundTextClip(rotation: Double = 0) -> Clip {
+    private func backgroundTextClip(
+        rotation: Double = 0,
+        rotationX: Double = 0,
+        rotationY: Double = 0
+    ) -> Clip {
         var clip = textClip(" ")
         var style = clip.textStyle ?? TextStyle()
         style.color.a = 0
         style.background = .init(enabled: true, color: .init(r: 1, g: 1, b: 1, a: 1))
         clip.textStyle = style
-        clip.transform = Transform(width: 0.6, height: 0.2, rotation: rotation)
+        clip.transform = Transform(
+            width: 0.6,
+            height: 0.2,
+            rotation: rotation,
+            rotationX: rotationX,
+            rotationY: rotationY
+        )
         return clip
     }
 
@@ -73,6 +83,89 @@ struct CompositorTextLayerTests {
 
         #expect(CompositorFixtures.isWhite(frame.at(160, 30)))
         #expect(CompositorFixtures.isBlack(frame.at(80, 90)))
+    }
+
+    @Test func textUsesXTiltRotation() async throws {
+        let timeline = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [backgroundTextClip(rotationX: 60)])
+        )
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(frame.at(160, 90)))
+        #expect(CompositorFixtures.isBlack(frame.at(160, 75)))
+    }
+
+    @Test func textUsesYTiltRotation() async throws {
+        let timeline = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [backgroundTextClip(rotationY: 60)])
+        )
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(frame.at(160, 90)))
+        #expect(CompositorFixtures.isBlack(frame.at(90, 90)))
+    }
+
+    @Test func tiltedTextSamplesZRotationKeyframes() async throws {
+        var text = backgroundTextClip(rotationX: 60)
+        text.rotationTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: 0),
+            Keyframe(frame: 30, value: 90),
+        ])
+        let timeline = CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [text]))
+
+        let horizontal = try await CompositorRenderTests.render(timeline, frame: 0, renderSize: Self.size)
+        let vertical = try await CompositorRenderTests.render(timeline, frame: 30, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isBlack(horizontal.at(160, 75)))
+        #expect(CompositorFixtures.isWhite(vertical.at(160, 75)))
+    }
+
+    @Test func tiltedTextMatchesProjectedClipCorners() async throws {
+        var text = backgroundTextClip(rotation: 25, rotationX: 30, rotationY: -45)
+        text.transform.centerX = 0.25
+        text.transform.centerY = 0.35
+        text.effects = [Effect.make("color.exposure", ["ev": 0.25])]
+        let timeline = CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [text]))
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+        let rect = CGRect(x: -16, y: 45, width: 192, height: 36)
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let corners = TextTiltGeometry.corners(
+            of: rect,
+            around: center,
+            transform: text.transform,
+            canvasSize: Self.size
+        )
+
+        for corner in [corners.topLeft, corners.topRight, corners.bottomRight, corners.bottomLeft] {
+            let inside = CGPoint(
+                x: corner.x * 0.8 + center.x * 0.2,
+                y: corner.y * 0.8 + center.y * 0.2
+            )
+            #expect(CompositorFixtures.isWhite(frame.at(Int(inside.x), Int(inside.y))))
+        }
+    }
+
+    @Test func offCanvasTextCanRotateIntoTheFinalFrame() async throws {
+        var text = backgroundTextClip(rotation: -90, rotationY: 30)
+        text.transform.centerX = 0
+        let timeline = CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [text]))
+
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(CompositorFixtures.isWhite(frame.at(10, 130)))
+    }
+
+    @Test func oversizedTiltKeepsAValidProjectedQuad() {
+        let center = CGPoint(x: 160, y: 90)
+        let corners = TextTiltGeometry.corners(
+            of: CGRect(x: -1_120, y: -270, width: 2_560, height: 720),
+            around: center,
+            transform: Transform(width: 8, height: 4, rotationX: 75, rotationY: 89),
+            canvasSize: Self.size
+        )
+
+        #expect(corners.points.allSatisfy { $0.x.isFinite && $0.y.isFinite })
+        #expect(corners.contains(center))
     }
 
     @Test func textRotationSamplesKeyframes() async throws {
@@ -123,6 +216,19 @@ struct CompositorTextLayerTests {
 
         #expect(!CompositorFixtures.isBlack(frame.at(160, 30)))
         #expect(CompositorFixtures.isBlack(frame.at(80, 90)))
+    }
+
+    @Test func footageFillUsesTextTiltRotation() async throws {
+        var text = backgroundTextClip(rotationY: 60)
+        text.textFillMode = .footage
+        let timeline = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [text]),
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "bg")])
+        )
+        let frame = try await CompositorRenderTests.render(timeline, frame: 15, renderSize: Self.size)
+
+        #expect(!CompositorFixtures.isBlack(frame.at(160, 90)))
+        #expect(CompositorFixtures.isBlack(frame.at(90, 90)))
     }
 
     @Test func footageFillStencilsVideoThroughGlyphs() async throws {


### PR DESCRIPTION
## Summary
- Add static X/Y perspective tilt for text clips while preserving existing keyframeable Z rotation.
- Keep glyphs outside the canvas available to rotate back into view, clipping only during final compositing.
- Carry tilt through the inspector, selection overlay, hit testing, persistence, undo, and Agent/MCP text tools.

## Approach
- Store `rotationX` and `rotationY` on `Transform` with an explicit ±89° contract and no new keyframe tracks.
- Use one projective geometry implementation for rendering, preview overlays, and hit testing, with a clip-and-canvas-derived focal bound that prevents oversized text from crossing the camera plane.
- Transform each text raster's actual Core Image extent so off-canvas glyphs, backgrounds, and effects are not discarded before projection.
- Preserve the existing Z rotation path when X/Y tilt is inactive; static X/Y updates leave Z keyframes intact.
- Use one shared text-transform schema across `add_texts`, `update_text`, and `add_captions`.

## Testing
### Automated
- `scripts/localization/sync.sh` — passed
- `swift build` — passed
- `swift test` — 1,489 tests passed across 235 suites

### Manual UI verification
Not completed yet.

- Select a text clip and scrub positive and negative X/Y Tilt values, including values near ±89°.
- Confirm the projected selection outline and handles track the rendered text while moving and resizing.
- Confirm text outside the canvas can tilt back into view without premature clipping.
- Verify undo, save/reopen, footage fill, Z-rotation keyframes, and a video export.

## Change statistics
- Product code: +329 / -74
- Design system and localization: +2 / -0
- Tests: +235 / -11
- Total: +566 / -85