### PR TITLE
[ui] Show not-charged notice for refunded failures

### DIFF
--- a/Sources/PalmierPro/Generation/GenerationBackend.swift
+++ b/Sources/PalmierPro/Generation/GenerationBackend.swift
@@ -103,6 +103,7 @@ struct BackendGenerationJob: Decodable, Sendable {
     let resultUrls: [String]?
     let errorMessage: String?
     let costCredits: Int?
+    let refundedCredits: Int?
     let completedAt: Double?
 }
 

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -640,6 +640,7 @@ final class GenerationService {
             for placeholder in placeholders {
                 updateGenerationMetadata(placeholder, editor: editor, status: .failed(message)) { input in
                     input.backendJobId = backendJobId
+                    input.refundedCredits = job.refundedCredits
                 }
             }
             editor.onProjectCheckpointRequired?()

--- a/Sources/PalmierPro/Models/MediaAsset.swift
+++ b/Sources/PalmierPro/Models/MediaAsset.swift
@@ -115,6 +115,11 @@ final class MediaAsset: Identifiable {
         if case .failed = generationStatus { return generationInput?.resultURLs?.isEmpty == false }
         return false
     }
+
+    var wasGenerationRefunded: Bool {
+        guard case .failed = generationStatus else { return false }
+        return (generationInput?.refundedCredits ?? 0) > 0
+    }
     var generatingLabel: String {
         switch generationStatus {
         case .preparing: L10n.key("Preparing…")

--- a/Sources/PalmierPro/Models/MediaManifest.swift
+++ b/Sources/PalmierPro/Models/MediaManifest.swift
@@ -80,6 +80,7 @@ struct GenerationInput: Codable, Sendable, Equatable {
     var backendJobId: String?
     var outputIndex: Int?
     var resultURLs: [String]?
+    var refundedCredits: Int?
 }
 
 enum MediaSource: Codable, Sendable, Equatable {

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -537,6 +537,13 @@ struct PreviewContainerView: View {
                 }
                 .frame(maxWidth: 520, maxHeight: 240)
                 .fixedSize(horizontal: false, vertical: true)
+                if activeMediaAsset?.wasGenerationRefunded == true {
+                    Text(L10n.string("You were not charged for this generation"))
+                        .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                        .foregroundStyle(AppTheme.Status.successColor)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, AppTheme.Spacing.lg)
+                }
                 if let asset = activeMediaAsset, asset.pendingDownloadURL != nil {
                     Button {
                         editor.generationService.retryDownload(asset: asset, editor: editor)

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -1035,6 +1035,7 @@
 "Working on %@" = "Working on %@";
 "Workspace layout" = "Workspace layout";
 "X High" = "X High";
+"You were not charged for this generation" = "You were not charged for this generation";
 "You're all set" = "You're all set";
 "YouTube" = "YouTube";
 "Your Lottie animation is ready." = "Your Lottie animation is ready.";

--- a/Tests/PalmierProTests/Generation/BackendGenerationJobTests.swift
+++ b/Tests/PalmierProTests/Generation/BackendGenerationJobTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+struct BackendGenerationJobTests {
+    @Test func decodesOptionalRefundedCredits() throws {
+        let withRefund = try JSONDecoder().decode(BackendGenerationJob.self, from: Data("""
+        {"_id":"j1","status":"failed","errorMessage":"err","costCredits":27,"refundedCredits":27,"completedAt":1}
+        """.utf8))
+        let withoutRefund = try JSONDecoder().decode(BackendGenerationJob.self, from: Data("""
+        {"_id":"j2","status":"succeeded","resultUrls":["https://example.com/out.mp4"],"costCredits":10,"completedAt":1}
+        """.utf8))
+        #expect(withRefund.refundedCredits == 27)
+        #expect(withoutRefund.refundedCredits == nil)
+    }
+}

--- a/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
+++ b/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
@@ -45,4 +45,28 @@ import Testing
         #expect(restored.generationInput?.draft == true)
         #expect(MediaAsset(entry: restored, resolvedURL: generated.url).canEnhanceDraft)
     }
+
+    @Test func refundedCreditsSurviveManifestRoundTrip() throws {
+        var input = GenerationInput(
+            prompt: "Fail", model: "flux-3", duration: 5,
+            aspectRatio: "16:9", resolution: "720p"
+        )
+        input.refundedCredits = 12
+        let generated = MediaAsset(
+            url: URL(fileURLWithPath: "/tmp/failed.mp4"),
+            type: .video,
+            name: "Failed",
+            generationInput: input
+        )
+        generated.generationStatus = .failed("Provider error")
+        let data = try JSONEncoder().encode(generated.toManifestEntry(projectURL: nil))
+        let asset = MediaAsset(
+            entry: try JSONDecoder().decode(MediaManifestEntry.self, from: data),
+            resolvedURL: generated.url
+        )
+        #expect(asset.generationInput?.refundedCredits == 12)
+        #expect(asset.wasGenerationRefunded)
+        asset.generationInput?.refundedCredits = 0
+        #expect(!asset.wasGenerationRefunded)
+    }
 }


### PR DESCRIPTION

<img width="1340" height="777" alt="Screenshot 2026-08-10 at 12 38 55 PM" src="https://github.com/user-attachments/assets/2b333a18-b0b0-45fd-8c17-4f0833468a97" />


## Summary
- Persist `refundedCredits` from failed backend generation jobs onto `GenerationInput`
- Show “You were not charged for this generation” in the failed-generation preview when a positive refund was recorded
- Decode `refundedCredits` on `BackendGenerationJob` and cover round-trip / decode with focused tests

## Approach
Failed jobs now carry `refundedCredits` from the backend. The preview overlay uses `wasGenerationRefunded` (`refundedCredits > 0`) so zero/non-refunded failures stay silent. Requires the companion backend change that always writes `refundedCredits` on failure (`0` when not refunded).

## Testing
- `scripts/localization/sync.sh`
- `swift test --filter 'BackendGenerationJobTests|ManifestMetadataTests'` (5 passed)
- Bugbot: no findings

### Manual
1. Trigger a refunded generation failure and open the asset in preview — green not-charged line under the error
2. Trigger a non-refunded failure (or download retry) — no not-charged line

## Change statistics
- Logic: ~+40
- Tests: ~+16

Made with [Cursor](https://cursor.com)