### PR TITLE
[fix] Preserve volume when adding first keyframe

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -165,7 +165,7 @@ extension EditorViewModel {
         right.fadeInFrames = 0
 
         (left.opacityTrack,  right.opacityTrack)  = splitKeyframeTrack(clip.opacityTrack,  at: splitOffset, fallback: clip.opacity)
-        (left.volumeTrack,   right.volumeTrack)   = splitKeyframeTrack(clip.volumeTrack,   at: splitOffset, fallback: clip.volume)
+        (left.volumeTrack,   right.volumeTrack)   = splitKeyframeTrack(clip.volumeTrack,   at: splitOffset, fallback: VolumeScale.dbFromLinear(clip.volume))
         (left.positionTrack, right.positionTrack) = splitKeyframeTrack(clip.positionTrack, at: splitOffset, fallback: AnimPair(a: 0, b: 0))
         (left.scaleTrack,    right.scaleTrack)    = splitKeyframeTrack(clip.scaleTrack,    at: splitOffset, fallback: AnimPair(a: 1, b: 1))
         (left.rotationTrack, right.rotationTrack) = splitKeyframeTrack(clip.rotationTrack, at: splitOffset, fallback: 0)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -45,7 +45,7 @@ extension EditorViewModel {
             case .crop:
                 clip.upsertKeyframe(in: \.cropTrack, frame: f, value: clip.cropAt(frame: f))
             case .volume:
-                let currentDb = clip.volumeTrack?.sample(at: f - clip.startFrame, fallback: 0) ?? 0
+                let currentDb = clip.liveVolumeKfDb(at: f) ?? VolumeScale.dbFromLinear(clip.volume)
                 clip.upsertKeyframe(in: \.volumeTrack, frame: f, value: currentDb)
             }
         }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -281,19 +281,15 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     func liveVolumeKfDb(at frame: Int) -> Double? {
         guard contains(timelineFrame: frame),
               let track = volumeTrack, track.isActive else { return nil }
-        return track.sample(at: frame - startFrame, fallback: 0)
+        return track.sample(
+            at: frame - startFrame,
+            fallback: VolumeScale.dbFromLinear(volume)
+        )
     }
 
-    /// Effective linear volume at `frame`: keyframe envelope first, fade ramp on top, static volume as outer gain.
+    /// Effective linear volume at `frame`, including the fade envelope.
     func volumeAt(frame: Int) -> Double {
-        let kfGain: Double
-        if let track = volumeTrack, track.isActive {
-            let dB = track.sample(at: keyframeOffset(forFrame: frame), fallback: 0)
-            kfGain = VolumeScale.linearFromDb(dB)
-        } else {
-            kfGain = 1.0
-        }
-        return volume * kfGain * fadeMultiplier(at: frame)
+        rawVolumeAt(frame: frame) * fadeMultiplier(at: frame)
     }
 
     var hasDenoiseEnabled: Bool {
@@ -308,13 +304,11 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     static let defaultDenoiseAmount: Double = 0.6
 
     func rawVolumeAt(frame: Int) -> Double {
-        let kfGain: Double
-        if let track = volumeTrack, track.isActive {
-            kfGain = VolumeScale.linearFromDb(track.sample(at: keyframeOffset(forFrame: frame), fallback: 0))
-        } else {
-            kfGain = 1.0
-        }
-        return volume * kfGain
+        guard let track = volumeTrack, track.isActive else { return volume }
+        let fallbackDb = VolumeScale.dbFromLinear(volume)
+        return VolumeScale.linearFromDb(
+            track.sample(at: keyframeOffset(forFrame: frame), fallback: fallbackDb)
+        )
     }
 
     /// 0…1 envelope from the fade head/tail ramps.

--- a/Tests/PalmierProTests/Agent/MCPVolumeKeyframeTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPVolumeKeyframeTests.swift
@@ -16,6 +16,9 @@ struct MCPVolumeKeyframeTests {
             startFrame: 0,
             durationFrames: 60
         ).first)
+        let initialLocation = try #require(harness.editor.findClip(id: clipId))
+        harness.editor.timeline.tracks[initialLocation.trackIndex]
+            .clips[initialLocation.clipIndex].volume = VolumeScale.linearFromDb(-12)
         let undoManager = UndoManager()
         harness.editor.undo.attach(undoManager)
 
@@ -69,6 +72,8 @@ struct MCPVolumeKeyframeTests {
             #expect(abs(stored[0].value) < 0.0001)
             #expect(stored[1].value == -6)
             #expect(stored[2].value == VolumeScale.floorDb)
+            let keyframedClip = harness.editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
+            #expect(abs(keyframedClip.rawVolumeAt(frame: 0) - 1) < 0.0001)
 
             let timelineResult = try await client.callTool(name: "get_timeline")
             let timeline = try json(text(timelineResult.content))

--- a/Tests/PalmierProTests/Timeline/ClipMathTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMathTests.swift
@@ -135,6 +135,21 @@ struct ClipMathTests {
         #expect(abs(clip.volumeAt(frame: 5) - 0.25) < 1e-9)
     }
 
+    @Test func volumeKeyframesStoreAbsoluteDecibels() {
+        var clip = Fixtures.clip(
+            start: 0,
+            duration: 100,
+            volume: VolumeScale.linearFromDb(-12)
+        )
+        clip.volumeTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 0, value: -6),
+        ])
+
+        let expected = VolumeScale.linearFromDb(-6)
+        #expect(abs(clip.rawVolumeAt(frame: 50) - expected) < 1e-9)
+        #expect(abs(clip.volumeAt(frame: 50) - expected) < 1e-9)
+    }
+
     // MARK: - opacityAt + rawOpacityAt
 
     @Test func opacityAtReturnsStaticOpacityWithoutFade() {

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -300,6 +300,26 @@ struct StampKeyframeTests {
         #expect(kf?.frame == 5)
         #expect(kf?.value == 1.0)
     }
+
+    @Test func firstVolumeKeyframePreservesStaticLevel() throws {
+        let volumeDb = -6.0
+        let clip = Fixtures.clip(
+            id: "c1",
+            mediaType: .audio,
+            start: 0,
+            duration: 100,
+            volume: VolumeScale.linearFromDb(volumeDb)
+        )
+        let e = editor([Fixtures.audioTrack(clips: [clip])])
+
+        e.stampKeyframe(clipId: "c1", property: .volume, frame: 50)
+
+        let updated = try #require(e.clipFor(id: "c1"))
+        let keyframe = try #require(updated.volumeTrack?.keyframes.first)
+        #expect(keyframe.frame == 50)
+        #expect(abs(keyframe.value - volumeDb) < 1e-9)
+        #expect(abs(updated.volumeAt(frame: 50) - clip.volumeAt(frame: 50)) < 1e-9)
+    }
 }
 
 @Suite("EditorViewModel — removeClips")


### PR DESCRIPTION
## Summary
- Preserve the displayed and audible level when adding the first volume keyframe to a clip with non-zero gain.
- Treat volume keyframes as absolute clip-gain values instead of offsets, matching the inspector, timeline, and MCP `volumeDb` contract.
- Existing persisted keyframes on clips with non-zero static gain are consequently reinterpreted as absolute levels.

## Approach
- Stamp the clip's current authored dB value when creating its first volume keyframe.
- Make an active volume keyframe track authoritative; use static clip volume only when no keyframes exist, then apply fades to the resulting level.
- Keep clip-split fallback values in dB so all volume keyframe calculations use one unit.
- Cover model sampling, editor stamping, undo, and the MCP boundary.

## Testing
- `swift build` — passed.
- `swift test` — passed: 1,509 tests in 240 suites.
- Manual UI/audio verification not completed:
  - [ ] Set a clip to -6 dB, add its first keyframe, and confirm the inspector and playback remain at -6 dB.
  - [ ] Add and move another keyframe; confirm timeline position, inspector value, and playback interpolation agree.
  - [ ] Verify undo, redo, and removing the final keyframe restore the expected level.

## Change statistics
- Code logic: +13 / -19
- Tests: +40 / -0
- Total: +53 / -19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core audio gain math and persisted keyframe meaning; existing timelines with volume keyframes plus non-default static volume may play back at different levels after upgrade.
> 
> **Overview**
> Fixes a jump in level when adding the first volume keyframe on a clip whose static gain is not 0 dB, and aligns volume animation with **absolute dB** semantics (inspector, timeline, MCP `volumeDb`).
> 
> **Sampling:** An active `volumeTrack` now defines linear gain via interpolated dB values; static `clip.volume` is used only when there are no keyframes. Fades still multiply on top via `rawVolumeAt * fadeMultiplier`. **Stamping / splits:** New volume keyframes capture the current authored dB (`liveVolumeKfDb` or `VolumeScale.dbFromLinear(clip.volume)`); clip split uses the same dB fallback when splitting the volume track.
> 
> **Migration note:** Clips that already had volume keyframes while static gain was non-unity will be **reinterpreted** as absolute levels rather than offsets—audible levels may change until keyframes are adjusted.
> 
> Tests cover model sampling, first-keyframe stamping, MCP round-trip, and playback-level expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6630abe96d627b3650a8b374501330dd48bbae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->