### PR TITLE
[ui] Make timeline track header resizable

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
@@ -12,10 +12,7 @@ extension EditorViewModel {
     var minZoomScale: Double {
         let totalFrames = timeline.totalFrames
         guard totalFrames > 0, timelineVisibleWidth > 0 else { return Zoom.min }
-        let headerWidth = Double(Layout.trackHeaderWidth)
-        let availableWidth = timelineVisibleWidth - headerWidth
-        guard availableWidth > 0 else { return Zoom.min }
-        let fitAll = availableWidth / (Double(totalFrames) * Zoom.fitAllBuffer)
+        let fitAll = timelineVisibleWidth / (Double(totalFrames) * Zoom.fitAllBuffer)
         return min(Zoom.max, max(Zoom.floor, fitAll))
     }
 

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -213,6 +213,8 @@ private final class TimelineHeaderResizeHandleView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
+    override var isFlipped: Bool { true }
+
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         needsDisplay = true

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -1,13 +1,26 @@
 import SwiftUI
 
+extension NSView {
+    func ownsTimelinePointer(at windowPoint: NSPoint) -> Bool {
+        guard let contentView = window?.contentView else { return false }
+        var hitView = contentView.hitTest(windowPoint)
+        while let current = hitView {
+            if current === self { return true }
+            hitView = current.superview
+        }
+        return false
+    }
+}
+
 struct TimelineContainerView: NSViewRepresentable {
     @Environment(EditorViewModel.self) var editor
 
     func makeNSView(context: Context) -> NSView {
         let container = NSView()
+        let headerWidth = Layout.trackHeaderDefaultWidth
 
         let headerView = TimelineHeaderView(editor: editor)
-        headerView.frame = NSRect(x: 0, y: 0, width: Layout.trackHeaderWidth, height: 0)
+        headerView.frame = NSRect(x: 0, y: 0, width: headerWidth, height: 0)
         headerView.autoresizingMask = [.height]
         container.addSubview(headerView)
 
@@ -24,14 +37,24 @@ struct TimelineContainerView: NSViewRepresentable {
         scrollView.documentView = timelineView
         headerView.requestCanvasRedraw = { [weak timelineView] in timelineView?.needsDisplay = true }
 
-        scrollView.frame = NSRect(x: Layout.trackHeaderWidth, y: 0, width: 0, height: 0)
+        scrollView.frame = NSRect(x: headerWidth, y: 0, width: 0, height: 0)
         scrollView.autoresizingMask = [.width, .height]
         container.addSubview(scrollView)
 
-        let border = TimelineDividerView()
-        border.frame = NSRect(x: Layout.trackHeaderWidth - 1, y: 0, width: 1, height: 0)
-        border.autoresizingMask = [.height]
-        container.addSubview(border)
+        let resizeHandle = TimelineHeaderResizeHandleView(
+            headerView: headerView,
+            scrollView: scrollView,
+            timelineView: timelineView,
+            headerWidth: headerWidth
+        )
+        resizeHandle.frame = NSRect(
+            x: headerWidth,
+            y: 0,
+            width: Layout.trackHeaderResizeHitWidth,
+            height: 0
+        )
+        resizeHandle.autoresizingMask = [.height]
+        container.addSubview(resizeHandle)
 
         context.coordinator.headerView = headerView
         context.coordinator.timelineView = timelineView
@@ -167,11 +190,24 @@ struct TimelineContainerView: NSViewRepresentable {
     }
 }
 
-private final class TimelineDividerView: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        updateAppearanceColors()
+private final class TimelineHeaderResizeHandleView: NSView {
+    private weak var headerView: TimelineHeaderView?
+    private weak var scrollView: NSScrollView?
+    private weak var timelineView: TimelineView?
+    private var headerWidth: CGFloat
+    private var dragStart: (x: CGFloat, width: CGFloat)?
+
+    init(
+        headerView: TimelineHeaderView,
+        scrollView: NSScrollView,
+        timelineView: TimelineView,
+        headerWidth: CGFloat
+    ) {
+        self.headerView = headerView
+        self.scrollView = scrollView
+        self.timelineView = timelineView
+        self.headerWidth = headerWidth
+        super.init(frame: .zero)
     }
 
     @available(*, unavailable)
@@ -179,12 +215,93 @@ private final class TimelineDividerView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        updateAppearanceColors()
+        needsDisplay = true
     }
 
-    private func updateAppearanceColors() {
+    override func draw(_ dirtyRect: NSRect) {
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.backgroundColor = AppTheme.Border.primary.cgColor
+            AppTheme.Border.primary.setFill()
+            let lineWidth = AppTheme.BorderWidth.thin
+            NSRect(
+                x: bounds.minX,
+                y: bounds.minY,
+                width: lineWidth,
+                height: bounds.height
+            ).fill()
         }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let superview else { return nil }
+        let localPoint = convert(point, from: superview)
+        let windowPoint = superview.convert(point, to: nil)
+        guard localPoint.y >= Layout.rulerHeight,
+              !clipHasPriority(at: windowPoint) else { return nil }
+        return super.hitTest(point)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        dragStart = (event.locationInWindow.x, headerWidth)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let dragStart else { return }
+        NSCursor.resizeLeftRight.set()
+        resizeHeader(to: dragStart.width + event.locationInWindow.x - dragStart.x)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard dragStart != nil else { return }
+        dragStart = nil
+    }
+
+    private func resizeHeader(to requestedWidth: CGFloat) {
+        guard let container = superview,
+              let headerView,
+              let scrollView,
+              let timelineView else { return }
+        let width = min(
+            Layout.trackHeaderMaximumWidth,
+            max(Layout.trackHeaderMinimumWidth, requestedWidth)
+        )
+        guard width != headerWidth else { return }
+        headerWidth = width
+        headerView.frame.size.width = width
+        scrollView.frame = NSRect(
+            x: width,
+            y: scrollView.frame.minY,
+            width: max(0, container.bounds.width - width),
+            height: scrollView.frame.height
+        )
+        frame.origin.x = width
+        headerView.needsDisplay = true
+        timelineView.updateContentSize()
+        timelineView.needsDisplay = true
+    }
+
+    private func clipHasPriority(at windowPoint: NSPoint) -> Bool {
+        guard let timelineView else { return false }
+        let point = timelineView.convert(windowPoint, from: nil)
+        let geometry = timelineView.geometry
+        return timelineView.inputController.hitTestClip(
+            at: point,
+            trackIndex: geometry.trackAt(y: point.y),
+            geometry: geometry
+        ) != nil
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        guard ownsTimelinePointer(at: event.locationInWindow) else { return }
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas { removeTrackingArea(area) }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            owner: self
+        ))
     }
 }

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -12,7 +12,7 @@ enum TimelineHeaderSymbol {
     }
 }
 
-/// Fixed track header column drawn to the left of the scrollable timeline.
+/// Resizable track header column drawn to the left of the scrollable timeline.
 final class TimelineHeaderView: NSView {
     unowned var editor: EditorViewModel
 

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1138,12 +1138,15 @@ final class TimelineView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
+        guard ownsTimelinePointer(at: event.locationInWindow) else {
+            setHoveredClipId(nil)
+            return
+        }
         inputController.mouseMoved(with: event, geometry: geometry)
     }
 
     override func mouseExited(with event: NSEvent) {
         setHoveredClipId(nil)
-        NSCursor.arrow.set()
     }
 
     override func scrollWheel(with event: NSEvent) {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -411,7 +411,10 @@ enum AppTheme {
         static let timelineClipDetailMinWidth: CGFloat = 32
         static let timelineClipControlsMinWidth: CGFloat = 48
         static let timelineTabRenameWidth: CGFloat = 120
-        static let timelineTrackHeaderWidth: CGFloat = 160
+        static let timelineTrackHeaderDefaultWidth: CGFloat = 160
+        static let timelineTrackHeaderMinimumWidth: CGFloat = 112
+        static let timelineTrackHeaderMaximumWidth: CGFloat = 320
+        static let timelineTrackHeaderResizeHitWidth: CGFloat = 8
         static let timelineClipLabelMinWidth: CGFloat = 56
         static let timelineBadgePadH: CGFloat = 4
         static let timelineBadgePadV: CGFloat = 1

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -25,7 +25,10 @@ enum Layout {
     static let timelineDefaultHeightFraction: CGFloat = 0.35
     static let trackHeight: CGFloat = TrackSize.defaultHeight
     static let rulerHeight: CGFloat = 24
-    static let trackHeaderWidth = AppTheme.ComponentSize.timelineTrackHeaderWidth
+    static let trackHeaderDefaultWidth = AppTheme.ComponentSize.timelineTrackHeaderDefaultWidth
+    static let trackHeaderMinimumWidth = AppTheme.ComponentSize.timelineTrackHeaderMinimumWidth
+    static let trackHeaderMaximumWidth = AppTheme.ComponentSize.timelineTrackHeaderMaximumWidth
+    static let trackHeaderResizeHitWidth = AppTheme.ComponentSize.timelineTrackHeaderResizeHitWidth
     static let dropZoneHeight: CGFloat = 60
     static let insertThreshold: CGFloat = 10
     static let dragThreshold: CGFloat = 3

--- a/Tests/PalmierProTests/Timeline/TimelineZoomTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineZoomTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import PalmierPro
+
+@Suite("Timeline zoom")
+@MainActor
+struct TimelineZoomTests {
+    @Test func minimumZoomUsesScrollableViewportWidth() {
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 100)]),
+        ])
+        editor.timelineVisibleWidth = 600
+
+        #expect(editor.minZoomScale == 2)
+    }
+}


### PR DESCRIPTION
## Summary
- let editors resize the timeline track-header column between defined minimum and maximum widths
- keep ruler/playhead and frame-zero clip interactions ahead of the resize target
- calculate fit-to-timeline zoom from the actual scrollable viewport width

## Approach
- add a narrow AppKit resize handle that updates the existing header and timeline frames directly
- use hit ownership so overlapping timeline tracking areas do not replace the resize cursor
- exclude the ruler and occupied clip regions from header-resize hit testing
- keep the width as transient workspace state, resetting to the default when the timeline view is recreated

## Testing
- `swift build`
- `swift test --filter TimelineZoomTests` — 1 test passed
- `git diff --check`
- manually verified horizontal resizing, stable hover cursor, vertical track resizing, ruler/playhead priority, and frame-zero clip trimming

## Change statistics
- code logic: +145 / -22
- tests: +16 / -0
- total: +161 / -22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timeline layout, pointer hit priority, and min-zoom math; behavior is localized to the editor UI but easy to regress on edge interactions (ruler, frame-zero clips, cursor).
> 
> **Overview**
> Editors can **drag the boundary** between the track-header column and the scrollable timeline within **min/max width** limits. The old static divider is replaced by an AppKit **resize handle** that redraws the border, updates header and scroll view frames, and refreshes timeline content size on drag.
> 
> **Hit testing** keeps ruler/playhead and **clips under the handle** ahead of resize: the handle ignores hits above the ruler and defers when a clip would win. **`ownsTimelinePointer`** coordinates resize cursor vs timeline hover so overlapping tracking areas do not fight; timeline `mouseMoved` only runs when the pointer is owned by the timeline subtree.
> 
> **Fit-to-timeline minimum zoom** now uses the full **`timelineVisibleWidth`** (scroll viewport) instead of subtracting header width, with a **`TimelineZoomTests`** case locking that behavior. Header width stays **transient** (default on recreate); layout constants are split into default, minimum, maximum, and resize hit width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab401230f7f8a3a3e7d6a2480790fe2773dc0a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->