### PR TITLE
[cleanup] Remove redundant text animation presets

### DIFF
--- a/Sources/PalmierPro/Compositing/TextAnimator.swift
+++ b/Sources/PalmierPro/Compositing/TextAnimator.swift
@@ -23,8 +23,6 @@ enum TextAnimator {
         let dur = max(1, anim.perWordFrames)
         let t = progress(rel, start: 0, dur: dur)
         switch anim.preset {
-        case .fadeIn:
-            return ClipState(opacity: Float(t))
         case .popIn:
             return ClipState(opacity: Float(t), scale: 0.6 + 0.4 * CGFloat(t))
         case .slideUp:
@@ -51,13 +49,6 @@ enum TextAnimator {
         case .wordSlide:
             let t = progress(rel, start: word.startFrame, dur: hand)
             return WordState(opacity: Float(t), dy: 0.5 * (1 - CGFloat(t)), color: activeTint(anim, word, rel, base))
-        case .wordPop:
-            let u = linear(rel, start: word.startFrame, dur: hand)
-            return WordState(opacity: Float(smoothstep(u)), scale: 0.6 + 0.4 * overshoot(u),
-                             color: activeTint(anim, word, rel, base))
-        case .wordCycle:
-            let on = activeRamp(rel, word: word, ramp: hand)
-            return WordState(opacity: Float(on), color: activeTint(anim, word, rel, base))
         case .highlightPop:
             let ramp = min(hand, 4)
             let on = heldHighlightAmount(rel, word: word, nextWord: nextWord, ramp: ramp)
@@ -115,12 +106,6 @@ enum TextAnimator {
         guard rel > start else { return 0 }
         guard rel < start + dur else { return 1 }
         return Double(rel - start) / Double(dur)
-    }
-
-    /// Back-ease that overshoots past 1 before settling — a spring/bounce on the way in.
-    private static func overshoot(_ t: Double) -> CGFloat {
-        let s = 1.70158, p = t - 1
-        return CGFloat(1 + (s + 1) * p * p * p + s * p * p)
     }
 
     /// 0 outside the active span, with the ramp shortened so fast words reach 1.

--- a/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
+++ b/Sources/PalmierPro/MediaPanel/CaptionsTab/CaptionSpecBuilder.swift
@@ -156,8 +156,7 @@ enum CaptionSpecBuilder {
                ) {
                 captions[previousIndex].spec = resized(
                     captions[previousIndex].spec,
-                    durationFrames: duration,
-                    extendWordCycle: true
+                    durationFrames: duration
                 )
             }
         }
@@ -172,8 +171,7 @@ enum CaptionSpecBuilder {
                 if holdFrames > 0, !duration.overflow {
                     captions[lastIndex].spec = resized(
                         captions[lastIndex].spec,
-                        durationFrames: duration.partialValue,
-                        extendWordCycle: true
+                        durationFrames: duration.partialValue
                     )
                 }
             }
@@ -243,8 +241,7 @@ enum CaptionSpecBuilder {
     private static func resized(
         _ spec: EditorViewModel.TextClipSpec,
         durationFrames: Int,
-        wordOffsetFrames: Int = 0,
-        extendWordCycle: Bool = false
+        wordOffsetFrames: Int = 0
     ) -> EditorViewModel.TextClipSpec {
         var resized = spec
         resized.durationFrames = durationFrames
@@ -258,11 +255,6 @@ enum CaptionSpecBuilder {
             return end > start
                 ? WordTiming(text: word.text, startFrame: start, endFrame: end)
                 : nil
-        }
-        if extendWordCycle,
-           resized.animation?.preset == .wordCycle,
-           let lastIndex = words.indices.last {
-            words[lastIndex].endFrame = durationFrames
         }
         resized.words = words.isEmpty ? nil : words
         return resized

--- a/Sources/PalmierPro/Models/TextAnimation.swift
+++ b/Sources/PalmierPro/Models/TextAnimation.swift
@@ -14,18 +14,17 @@ struct TextAnimation: Codable, Sendable, Equatable {
     enum Preset: String, Codable, CaseIterable, Sendable {
         case none
         // Whole-clip / per-line.
-        case fadeIn, popIn, slideUp, typewriter
+        case popIn, slideUp, typewriter
         // Per word.
-        case wordReveal, wordSlide, wordPop, wordCycle, highlightPop, highlightBlock
+        case wordReveal, wordSlide, highlightPop, highlightBlock
 
         enum RenderMode { case entrance, perWord, typewriter }
 
         var renderMode: RenderMode {
             switch self {
-            case .none, .fadeIn, .popIn, .slideUp: .entrance
+            case .none, .popIn, .slideUp: .entrance
             case .typewriter: .typewriter
-            case .wordReveal, .wordSlide, .wordPop, .wordCycle,
-                 .highlightPop, .highlightBlock: .perWord
+            case .wordReveal, .wordSlide, .highlightPop, .highlightBlock: .perWord
             }
         }
 
@@ -35,14 +34,11 @@ struct TextAnimation: Codable, Sendable, Equatable {
         var displayName: String {
             switch self {
             case .none: L10n.key("Off")
-            case .fadeIn: L10n.key("Fade In")
             case .popIn: L10n.key("Pop In")
             case .slideUp: L10n.key("Slide Up")
             case .typewriter: L10n.key("Typewriter")
             case .wordReveal: L10n.key("Word Reveal")
             case .wordSlide: L10n.key("Word Slide")
-            case .wordPop: L10n.key("Word Pop")
-            case .wordCycle: L10n.key("Word Cycle")
             case .highlightPop: L10n.key("Highlight")
             case .highlightBlock: L10n.key("Highlight Block")
             }
@@ -50,9 +46,8 @@ struct TextAnimation: Codable, Sendable, Equatable {
 
         static let agentValues: [String] = ["off"] + allCases.filter { $0 != .none }.map(\.rawValue)
 
-        static let perLine: [Preset] = [.fadeIn, .popIn, .slideUp, .typewriter]
-        static let perWord: [Preset] = [.wordReveal, .wordSlide, .wordPop, .wordCycle,
-                                        .highlightPop, .highlightBlock]
+        static let perLine: [Preset] = [.popIn, .slideUp, .typewriter]
+        static let perWord: [Preset] = [.wordReveal, .wordSlide, .highlightPop, .highlightBlock]
     }
 
     var isActive: Bool { preset != .none }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -1030,8 +1030,6 @@
 "Whites" = "Whites";
 "Whole timeline · %@" = "Whole timeline · %@";
 "Width" = "Width";
-"Word Cycle" = "Word Cycle";
-"Word Pop" = "Word Pop";
 "Word Reveal" = "Word Reveal";
 "Word Slide" = "Word Slide";
 "Working on %@" = "Working on %@";

--- a/Tests/PalmierProTests/Agent/MCPTextAnimationTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTextAnimationTests.swift
@@ -1,0 +1,50 @@
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP text animations")
+@MainActor
+struct MCPTextAnimationTests {
+    @Test func discoveryAndValidationExcludeRemovedPresets() async throws {
+        var clip = Fixtures.clip(
+            id: "title", mediaRef: "text", mediaType: .text, start: 0, duration: 60
+        )
+        clip.textContent = "Title"
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [clip]),
+        ]))
+        let server = Server(
+            name: "text-animation-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "text-animation-test", version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            let updateText = try #require(tools.first { $0.name == "update_text" })
+            let properties = try #require(updateText.inputSchema.objectValue?["properties"]?.objectValue)
+            let presets = try #require(properties["animation"]?.objectValue?["enum"]?.arrayValue)
+
+            for preset in ["fadeIn", "wordPop", "wordCycle"] {
+                #expect(!presets.contains(.string(preset)))
+                let result = try await client.callTool(name: "update_text", arguments: [
+                    "clipIds": .array([.string(clip.id)]),
+                    "animation": .string(preset),
+                ])
+                #expect(result.isError == true)
+                #expect(harness.editor.clipFor(id: clip.id)?.textAnimation == nil)
+            }
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+}

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -2624,12 +2624,12 @@ struct SetClipPropertiesTests {
 
         let result = await h.runRaw("update_text", args: [
             "clipIds": ["title"],
-            "animation": "wordPop",
+            "animation": "wordSlide",
         ])
 
         #expect(result.isError == false, "\(ToolHarness.textOf(result))")
         let animation = h.editor.timeline.tracks[0].clips[0].textAnimation
-        #expect(animation?.preset == .wordPop)
+        #expect(animation?.preset == .wordSlide)
         #expect(animation?.perWordFrames == 12)
         #expect(animation?.highlight == highlight)
     }

--- a/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionBuilderTests.swift
@@ -131,8 +131,8 @@ struct CaptionBuilderTests {
         ])
         let specs = CaptionBuilder.specs(
             for: [p], sourceClip: clip, trackIndex: 0, fps: 30,
-            style: TextStyle(), captionGroupId: "g1", animation: TextAnimation(preset: .wordPop))
-        #expect(specs[0].animation?.preset == .wordPop)
+            style: TextStyle(), captionGroupId: "g1", animation: TextAnimation(preset: .wordSlide))
+        #expect(specs[0].animation?.preset == .wordSlide)
         let words = try! #require(specs[0].words)
         #expect(words.map(\.text) == ["hi", "there"])
         #expect(words[0].startFrame == 0 && words[0].endFrame == 12)   // clip-relative
@@ -148,7 +148,7 @@ struct CaptionBuilderTests {
 
         let specs = CaptionBuilder.specs(
             for: [p], sourceClip: source, trackIndex: 0, fps: 30,
-            style: TextStyle(), captionGroupId: nil, animation: TextAnimation(preset: .wordPop))
+            style: TextStyle(), captionGroupId: nil, animation: TextAnimation(preset: .wordSlide))
 
         let words = try! #require(specs[0].words)
         #expect(words == [

--- a/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
+++ b/Tests/PalmierProTests/Captions/CaptionGenerationTests.swift
@@ -222,14 +222,11 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
     }
 
     @Test(arguments: [
-        TextAnimation.Preset.fadeIn,
-        .popIn,
+        TextAnimation.Preset.popIn,
         .slideUp,
         .typewriter,
         .wordReveal,
         .wordSlide,
-        .wordPop,
-        .wordCycle,
     ])
     func closesAnimatedCaptionGapWithoutOverlap(
         preset: TextAnimation.Preset
@@ -244,8 +241,8 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
 
         #expect(specs.map(\.durationFrames) == [27, 30])
         #expect(specs[0].startFrame + specs[0].durationFrames == specs[1].startFrame)
-        #expect(specs[0].words?.last?.endFrame == (preset == .wordCycle ? 27 : 21))
-        #expect(specs[1].words?.last?.endFrame == (preset == .wordCycle ? 30 : 21))
+        #expect(specs[0].words?.last?.endFrame == 21)
+        #expect(specs[1].words?.last?.endFrame == 21)
     }
 
     @Test func oneFrameAnimatedCaptionClosesTheFollowingGapWithoutOverlap() async throws {
@@ -255,7 +252,7 @@ private func mediaAsset(_ id: String, hasAudio: Bool = true) -> MediaAsset {
                 gapTarget(id: "two", startFrame: 27, durationFrames: 1, hasWordTiming: false),
                 gapTarget(id: "three", startFrame: 33, durationFrames: 30),
             ],
-            animation: TextAnimation(preset: .fadeIn)
+            animation: TextAnimation(preset: .popIn)
         ))
 
         #expect(specs.map(\.durationFrames) == [27, 6, 30])

--- a/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextAnimationRenderTests.swift
@@ -65,14 +65,6 @@ struct TextAnimationRenderTests {
         return preset == .highlightBlock ? state.bgColor?.a ?? 0 : state.color.r
     }
 
-    @Test func wordPopRevealsProgressively() {
-        let c = clip(TextAnimation(preset: .wordPop, perWordFrames: 6))
-        let early = pixels(c, frame: 5)   // only ONE has started
-        let late = pixels(c, frame: 80)   // all three in
-        #expect(brightCount(early) > 0, "first word should be visible early")
-        #expect(brightCount(late) > brightCount(early) * 2, "more words visible later (\(brightCount(early)) → \(brightCount(late)))")
-    }
-
     @Test func highlightPopColorsActiveWord() {
         let c = clip(TextAnimation(preset: .highlightPop, perWordFrames: 6, highlight: .init(r: 1, g: 0.85, b: 0, a: 1)))
         let mid = pixels(c, frame: 45)  // TWO active → some yellow

--- a/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
+++ b/Tests/PalmierProTests/Rendering/TextRasterCacheTests.swift
@@ -61,7 +61,7 @@ struct TextRasterCacheTests {
     }
 
     @Test func entranceAnimationSharesOneBaseRaster() {
-        let c = clip(content: uniqueContent("Entrance"), anim: TextAnimation(preset: .fadeIn))
+        let c = clip(content: uniqueContent("Entrance"), anim: TextAnimation(preset: .popIn))
         let count = rasterCount(of: c.textContent!) {
             for frame in 0..<8 {
                 _ = TextFrameRenderer.image(clip: c, frame: frame, renderSize: size)

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -561,15 +561,15 @@ struct ClipPropertyCommitTests {
         e.undo.attach(undoManager)
 
         e.commitClipProperties(clipIds: ["a", "b"]) {
-            $0.textAnimation = TextAnimation(preset: .wordPop)
+            $0.textAnimation = TextAnimation(preset: .wordSlide)
         }
 
-        #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation?.preset == .wordPop })
+        #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation?.preset == .wordSlide })
         undoManager.undo()
         #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation == nil })
         #expect(undoManager.canUndo == false)
         undoManager.redo()
-        #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation?.preset == .wordPop })
+        #expect(e.timeline.tracks[0].clips.allSatisfy { $0.textAnimation?.preset == .wordSlide })
         #expect(undoManager.canRedo == false)
     }
 

--- a/Tests/PalmierProTests/Timeline/ClipSettingsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipSettingsTests.swift
@@ -9,7 +9,7 @@ struct ClipSettingsTests {
         var source = Fixtures.clip(id: "source", mediaRef: "", mediaType: .text, start: 0, duration: 60)
         source.textContent = "Title"
         source.textStyle = TextStyle(fontName: "Avenir", fontSize: 48, isBold: true)
-        source.textAnimation = TextAnimation(preset: .wordPop)
+        source.textAnimation = TextAnimation(preset: .wordSlide)
         source.textFillMode = .footage
         source.opacity = 0.65
         source.transform.centerX = 0.2

--- a/Tests/PalmierProTests/Timeline/RebuildCacheIdentityTests.swift
+++ b/Tests/PalmierProTests/Timeline/RebuildCacheIdentityTests.swift
@@ -27,7 +27,7 @@ struct RebuildCacheIdentityTests {
         var clip = edited.tracks[0].clips[1]
         clip.textContent = "Different words"
         clip.textStyle = TextStyle(fontSize: 200)
-        clip.textAnimation = TextAnimation(preset: .wordPop)
+        clip.textAnimation = TextAnimation(preset: .wordSlide)
         clip.transform.centerY = 0.2
         edited.tracks[0].clips[1] = clip
 


### PR DESCRIPTION
## Summary
- Remove Fade In, Word Pop, and Word Cycle from the shared text and caption animation presets.
- Remove their renderer and caption-timing paths so each remaining preset has a distinct purpose.
- Keep Agent and MCP discovery aligned with the UI preset set.

## Approach
- Use `TextAnimation.Preset` as the single source for the gallery and Agent schemas.
- Delete the Word Pop overshoot renderer and Word Cycle gap-extension behavior instead of retaining compatibility paths.
- Verify MCP discovery omits the removed values and rejects stale requests without mutating text clips.

## Testing
- `scripts/localization/sync.sh` — passed, including `swift build`.
- `swift test --filter 'TextAnimationRenderTests|CaptionGenerationTests|CaptionBuilderTests|ClipSettingsTests|RebuildCacheIdentityTests|ClipMutationsTests|updateTextRejectsRemovedAnimations|updateTextAnimationPreservesExistingHighlight'` — 109 tests passed.
- `swift test --filter 'CaptionGenerationTests|TextRasterCacheTests|MCPTextAnimationTests'` — 34 tests passed.
- [ ] Open the text/caption Animation gallery and confirm Fade In, Word Pop, and Word Cycle are absent.
- [ ] Apply the remaining presets and verify preview, playback, and undo.

## Change statistics
- Code logic: +9 / -37
- Tests: +65 / -26
- Localization: +0 / -2
- Total: +74 / -65

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caption gap timing and animation rendering for projects that may still reference removed preset raw values on disk; MCP correctly rejects stale names but decoded legacy presets may fall back to `.none` via Codable.
> 
> **Overview**
> **Removes three overlapping text animation presets** — **Fade In**, **Word Pop**, and **Word Cycle** — from the shared `TextAnimation.Preset` set used by the UI gallery, captions, and Agent/MCP (`agentValues`).
> 
> **Rendering and caption timing** no longer special-case them: `TextAnimator` drops clip **fadeIn** entrance, per-word **wordPop** / **wordCycle**, and the **overshoot** helper; `CaptionSpecBuilder` no longer passes **`extendWordCycle`** when closing gaps, so extended caption duration does not stretch the last word’s timing for **wordCycle**.
> 
> **Localization** drops the **Word Cycle** and **Word Pop** strings. Tests switch remaining presets (e.g. **popIn**, **wordSlide**) and add **MCPTextAnimationTests** so **`update_text`** discovery omits removed values and rejects stale preset names without mutating clips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce71fdb80891934446a11c68dd12f5b18673c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->