### PR TITLE
[feat] Add inverted text fill

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -61,7 +61,8 @@ enum AgentInstructions {
           (bar starts) — beats only for fast montage rhythms. Times are source seconds.
         - Text: add_texts for authored overlays; add_captions transcribes the timeline's \
           spoken audio (no targeting) — restyle with update_text and the returned \
-          captionGroupId. fillMode 'footage' stencils layers below through the letter shapes. \
+          captionGroupId. fillMode 'footage' stencils layers below through the letter shapes; \
+          'inverted' uses white Difference-blended glyphs to invert those layers. \
           Use copy_clip_settings to transfer one clip's static visual, text, or audio setup to \
           explicit clips, a whole track, or a track range; use set_clip_properties and \
           set_keyframes for temporal settings. \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -817,7 +817,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .addTexts,
-            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets their alignment-relative horizontal anchor, vertical center, Z rotation, and static X/Y perspective tilt. Left-aligned text grows rightward from x, centered text grows around x, and right-aligned text grows leftward from x. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes. Use add_captions for spoken audio captions. Unknown fields are rejected.",
+            description: "Adds text clips as timeline layers. Omit trackIndex on every entry to create one new top video track; otherwise set trackIndex on every entry. Text boxes auto-fit their content; transform optionally sets their alignment-relative horizontal anchor, vertical center, Z rotation, and static X/Y perspective tilt. Left-aligned text grows rightward from x, centered text grows around x, and right-aligned text grows leftward from x. Use style widthScale and heightScale to stretch glyphs. Use the nested style object for typography, outline, shadow, and background. fillMode 'footage' stencils layers below through the letter shapes; 'inverted' renders white glyphs with Difference blending and ignores color, outline, shadow, and background while active. Use add_captions for spoken audio captions. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: [
                     "entries": [
@@ -838,7 +838,7 @@ enum ToolDefinitions {
                             ], textStyleProperties(detailed: false), [
                                 "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Animation preset; off clears."],
                                 "highlightColor": ["type": "string", "description": "Active-word hex."],
-                                "fillMode": ["type": "string", "enum": ["color", "footage"], "description": "color = solid typography (default). footage = stencil layers below through the letter shapes."],
+                                "fillMode": ["type": "string", "enum": TextFillMode.allCases.map(\.rawValue), "description": "color = solid typography (default). footage = stencil layers below through the letter shapes. inverted = white Difference-blended glyphs; color, outline, shadow, and background are ignored while active."],
                             ]),
                             "required": ["startFrame", "endFrame", "content"],
                         ],
@@ -849,7 +849,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .updateText,
-            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs. Content and layout-affecting style changes auto-fit the box while preserving its alignment-relative x anchor. transform can reposition, rotate, or apply static X/Y perspective tilt without changing its size. Static Z rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
+            description: "Updates text clips or a captionGroupId. The nested style object is a partial patch: omitted values stay unchanged. Use it for typography, color, outline, shadow, and background. Use style widthScale and heightScale to stretch glyphs. fillMode 'footage' stencils layers below through the glyphs; 'inverted' renders white glyphs with Difference blending and ignores color, outline, shadow, and background while active. Content and layout-affecting style changes auto-fit the box while preserving its alignment-relative x anchor. transform can reposition, rotate, or apply static X/Y perspective tilt without changing its size. Static Z rotation uses clockwise degrees and clears rotation keyframes. Unknown fields are rejected.",
             inputSchema: objectSchema(
                 properties: mergedProperties([
                     "clipIds": [
@@ -867,7 +867,7 @@ enum ToolDefinitions {
                 ], textStyleProperties(detailed: true), [
                     "animation": ["type": "string", "enum": TextAnimation.Preset.agentValues, "description": "Animation preset; off clears."],
                     "highlightColor": ["type": "string", "description": "Active-word hex."],
-                    "fillMode": ["type": "string", "enum": ["color", "footage"], "description": "color = solid typography. footage = stencil layers below through the letter shapes."],
+                    "fillMode": ["type": "string", "enum": TextFillMode.allCases.map(\.rawValue), "description": "color = solid typography. footage = stencil layers below through the letter shapes. inverted = white Difference-blended glyphs; color, outline, shadow, and background are ignored while active."],
                 ]),
                 required: []
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Texts.swift
@@ -366,7 +366,9 @@ extension ToolExecutor {
     private func parseTextFillMode(_ raw: String?, path: String) throws -> TextFillMode? {
         guard let raw else { return nil }
         guard let mode = TextFillMode(rawValue: raw) else {
-            throw ToolError("\(path).fillMode: expected color or footage")
+            throw ToolError(
+                "\(path).fillMode: expected \(TextFillMode.allCases.map(\.rawValue).joined(separator: ", "))"
+            )
         }
         return mode
     }
@@ -673,7 +675,7 @@ extension ToolExecutor {
                     clip.textAnimation = a
                 }
                 if let fillMode {
-                    clip.textFillMode = fillMode == .footage ? .footage : nil
+                    clip.textFillMode = fillMode == .color ? nil : fillMode
                 }
             }
         }

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -66,7 +66,12 @@ enum FrameRenderer {
                 continue
             }
 
-            let mode = layer.clip.blendMode ?? .normal
+            let mode: BlendMode
+            if case .text = layer.source, layer.clip.textFillMode == .inverted {
+                mode = .difference
+            } else {
+                mode = layer.clip.blendMode ?? .normal
+            }
             // Source-over bakes opacity into alpha; blend modes apply it as a fade of
             // the blend RESULT (Photoshop/Premiere semantics), so don't bake it there.
             let isNormal = mode.ciFilterName == nil
@@ -322,9 +327,17 @@ enum FrameRenderer {
         renderSize: CGSize,
         bakeOpacity: Bool = true
     ) -> CIImage? {
-        let clip = layer.clip
+        var clip = layer.clip
         let alpha = min(1.0, max(0.0, clip.opacityAt(frame: frame)))
         guard alpha > 0 else { return nil }
+        if clip.textFillMode == .inverted {
+            var style = clip.textStyle ?? TextStyle()
+            style.color = .init(r: 1, g: 1, b: 1, a: 1)
+            style.border.enabled = false
+            style.shadow.enabled = false
+            style.background.enabled = false
+            clip.textStyle = style
+        }
         guard var image = TextFrameRenderer.image(clip: clip, frame: frame, renderSize: renderSize)?
             .unpremultiplyingAlpha() else { return nil }
 
@@ -337,6 +350,16 @@ enum FrameRenderer {
                 guard let descriptor = EffectRegistry.descriptor(id: effect.type) else { continue }
                 image = descriptor.render(image, effect: effect, atOffset: offset)
             }
+        }
+        if clip.textFillMode == .inverted {
+            let zero = CIVector(x: 0, y: 0, z: 0, w: 0)
+            image = image.applyingFilter("CIColorMatrix", parameters: [
+                "inputRVector": zero,
+                "inputGVector": zero,
+                "inputBVector": zero,
+                "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+                "inputBiasVector": CIVector(x: 1, y: 1, z: 1, w: 0),
+            ])
         }
         image = transformedTextImage(image, clip: clip, frame: frame, renderSize: renderSize)
         image = image.premultiplyingAlpha()

--- a/Sources/PalmierPro/Compositing/FrameRenderer.swift
+++ b/Sources/PalmierPro/Compositing/FrameRenderer.swift
@@ -335,7 +335,8 @@ enum FrameRenderer {
             style.color = .init(r: 1, g: 1, b: 1, a: 1)
             style.border.enabled = false
             style.shadow.enabled = false
-            style.background.enabled = false
+            style.background.color.a = 0
+            style.background.outlineColor.a = 0
             clip.textStyle = style
         }
         guard var image = TextFrameRenderer.image(clip: clip, frame: frame, renderSize: renderSize)?

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+MediaLibrary.swift
@@ -765,7 +765,7 @@ extension EditorViewModel {
             clip.captionGroupId = spec.captionGroupId
             clip.wordTimings = spec.words
             clip.textAnimation = spec.animation
-            clip.textFillMode = spec.fillMode == .footage ? .footage : nil
+            clip.textFillMode = spec.fillMode == .color ? nil : spec.fillMode
             if batchTimeline != nil {
                 batchTimeline!.tracks[spec.trackIndex].clips.append(clip)
             } else {

--- a/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
+++ b/Sources/PalmierPro/Inspector/Tabs/TextTab.swift
@@ -10,8 +10,8 @@ struct TextTab: View {
     private var clipIds: [String] { clips.map(\.id) }
     private var isBatch: Bool { clips.count > 1 }
 
-    private var isFootageFill: Bool {
-        sharedClipValue(clips) { $0.textFillMode ?? .color } == .footage
+    private var showsSolidFillControls: Bool {
+        sharedClipValue(clips) { $0.textFillMode ?? .color } == .color
     }
 
     var body: some View {
@@ -23,7 +23,7 @@ struct TextTab: View {
                     fallback: Self.defaults
                 ),
                 defaults: Self.defaults,
-                showsSolidFillControls: !isFootageFill,
+                showsSolidFillControls: showsSolidFillControls,
                 actions: styleActions,
                 afterAlignment: {
                     positionSection
@@ -48,7 +48,7 @@ struct TextTab: View {
                 ForEach(TextFillMode.allCases, id: \.self) { mode in
                     Button(L10n.string(key: mode.displayName)) {
                         editor.commitClipProperties(clipIds: clipIds) {
-                            $0.textFillMode = mode == .footage ? .footage : nil
+                            $0.textFillMode = mode == .color ? nil : mode
                         }
                     }
                 }

--- a/Sources/PalmierPro/Models/TextFillMode.swift
+++ b/Sources/PalmierPro/Models/TextFillMode.swift
@@ -3,11 +3,13 @@ import Foundation
 enum TextFillMode: String, Codable, Sendable, CaseIterable {
     case color
     case footage
+    case inverted
 
     var displayName: String {
         switch self {
         case .color: L10n.key("Color")
         case .footage: L10n.key("Footage")
+        case .inverted: L10n.key("Inverted")
         }
     }
 }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -476,6 +476,7 @@
 "Integrations" = "Integrations";
 "Intensity" = "Intensity";
 "Invert Colors" = "Invert Colors";
+"Inverted" = "Inverted";
 "Italic" = "Italic";
 "Keep Current" = "Keep Current";
 "Keep Editing" = "Keep Editing";

--- a/Tests/PalmierProTests/Agent/MCPTextFillModeTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPTextFillModeTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP text fill modes")
+@MainActor
+struct MCPTextFillModeTests {
+    @Test func discoveryAddUpdateReadbackValidationAndUndo() async throws {
+        var original = Fixtures.clip(
+            id: "title", mediaRef: "text", mediaType: .text, start: 0, duration: 60
+        )
+        original.textContent = "Original"
+        original.textStyle = TextStyle()
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [original]),
+        ]))
+        let undoManager = UndoManager()
+        harness.editor.undo.attach(undoManager)
+        let server = Server(
+            name: "text-fill-mode-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "text-fill-mode-test", version: "1.0.0")
+
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            let expectedModes = ["color", "footage", "inverted"]
+            let updateText = try #require(tools.first { $0.name == "update_text" })
+            let updateProperties = try #require(
+                updateText.inputSchema.objectValue?["properties"]?.objectValue
+            )
+            let updateModes = try #require(
+                updateProperties["fillMode"]?.objectValue?["enum"]?.arrayValue
+            )
+            #expect(updateModes.compactMap(\.stringValue) == expectedModes)
+
+            let addTexts = try #require(tools.first { $0.name == "add_texts" })
+            let addProperties = try #require(
+                addTexts.inputSchema.objectValue?["properties"]?.objectValue
+            )
+            let entryProperties = try #require(
+                addProperties["entries"]?.objectValue?["items"]?.objectValue?["properties"]?.objectValue
+            )
+            let addModes = try #require(
+                entryProperties["fillMode"]?.objectValue?["enum"]?.arrayValue
+            )
+            #expect(addModes.compactMap(\.stringValue) == expectedModes)
+
+            let add = try await client.callTool(name: "add_texts", arguments: [
+                "entries": .array([.object([
+                    "startFrame": .int(0),
+                    "endFrame": .int(60),
+                    "content": .string("Invert me"),
+                    "fillMode": .string("inverted"),
+                ])]),
+            ])
+            #expect(add.isError != true)
+            let added = try #require(
+                harness.editor.timeline.tracks.flatMap(\.clips).first {
+                    $0.textContent == "Invert me"
+                }
+            )
+            #expect(added.textFillMode == .inverted)
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: added.id) == nil)
+
+            let update = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(original.id)]),
+                "fillMode": .string("inverted"),
+            ])
+            #expect(update.isError != true)
+            #expect(harness.editor.clipFor(id: original.id)?.textFillMode == .inverted)
+            let readback = try await timelineClip(client: client, clipId: original.id)
+            #expect(readback["textFillMode"] as? String == "inverted")
+
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.clipFor(id: original.id)?.textFillMode == nil)
+
+            let invalid = try await client.callTool(name: "update_text", arguments: [
+                "clipIds": .array([.string(original.id)]),
+                "fillMode": .string("difference"),
+            ])
+            #expect(invalid.isError == true)
+            #expect(harness.editor.clipFor(id: original.id)?.textFillMode == nil)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
+    private func timelineClip(client: Client, clipId: String) async throws -> [String: Any] {
+        let result = try await client.callTool(name: "get_timeline")
+        let payload = try json(text(result.content))
+        let tracks = try #require(payload["tracks"] as? [[String: Any]])
+        let clips = tracks.flatMap { $0["clips"] as? [[String: Any]] ?? [] }
+        return try #require(clips.first { $0["id"] as? String == clipId })
+    }
+
+    private func json(_ text: String) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+
+    private func text(_ content: [Tool.Content]) throws -> String {
+        for item in content {
+            if case .text(let text, _, _) = item { return text }
+        }
+        throw CocoaError(.coderReadCorrupt)
+    }
+}

--- a/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
@@ -56,6 +56,20 @@ struct CompositorTextLayerTests {
         return n
     }
 
+    private func visibleBounds(_ frame: CompositorRenderTests.Frame) -> CGRect? {
+        let height = frame.bytes.count / (frame.w * 4)
+        var bounds = CGRect.null
+        for y in 0..<height {
+            for x in 0..<frame.w {
+                let pixel = frame.at(x, y)
+                if pixel.r + pixel.g + pixel.b > 30 {
+                    bounds = bounds.union(CGRect(x: x, y: y, width: 1, height: 1))
+                }
+            }
+        }
+        return bounds.isNull ? nil : bounds
+    }
+
     @Test func textCompositesOverVideo() async throws {
         let tl = CompositorRenderTests.timelineWith(
             Fixtures.videoTrack(clips: [textClip("HELLO")]),                       // track 0: top
@@ -102,6 +116,40 @@ struct CompositorTextLayerTests {
         #expect(invertedPixels > 100)
         #expect(inverted.tl == original.tl)
         #expect(inverted.tr == original.tr)
+    }
+
+    @Test func invertedFillPreservesBackgroundPaddingLayout() async throws {
+        var normal = textClip("HELLO")
+        var style = normal.textStyle ?? TextStyle()
+        style.alignment = .left
+        style.background = .init(
+            enabled: true,
+            color: .init(r: 0, g: 0, b: 0, a: 0),
+            paddingX: 80,
+            paddingY: 30
+        )
+        normal.textStyle = style
+        normal.transform = Transform(topLeft: (0.05, 0.25), width: 0.9, height: 0.5)
+        var inverted = normal
+        inverted.textFillMode = .inverted
+
+        let normalFrame = try await CompositorRenderTests.render(
+            CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [normal])),
+            frame: 15,
+            renderSize: Self.size
+        )
+        let invertedFrame = try await CompositorRenderTests.render(
+            CompositorRenderTests.timelineWith(Fixtures.videoTrack(clips: [inverted])),
+            frame: 15,
+            renderSize: Self.size
+        )
+
+        let normalBounds = try #require(visibleBounds(normalFrame))
+        let invertedBounds = try #require(visibleBounds(invertedFrame))
+        #expect(abs(invertedBounds.minX - normalBounds.minX) <= 1)
+        #expect(abs(invertedBounds.minY - normalBounds.minY) <= 1)
+        #expect(abs(invertedBounds.width - normalBounds.width) <= 1)
+        #expect(abs(invertedBounds.height - normalBounds.height) <= 1)
     }
 
     @Test func textObeysTrackZOrder() async throws {

--- a/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
+++ b/Tests/PalmierProTests/Rendering/CompositorTextLayerTests.swift
@@ -65,6 +65,45 @@ struct CompositorTextLayerTests {
         #expect(whiteInBand(f) > 30, "white text should composite over the video: \(whiteInBand(f))")
     }
 
+    @Test func invertedFillUsesWhiteDifferenceBlend() async throws {
+        var text = textClip("HELLO")
+        text.textFillMode = .inverted
+        var style = text.textStyle ?? TextStyle()
+        style.color = .init(r: 0.2, g: 0.4, b: 0.6, a: 1)
+        style.fontScale = 4
+        style.isBold = true
+        style.border.enabled = true
+        style.shadow.enabled = true
+        style.background.enabled = true
+        text.textStyle = style
+        text.transform = Transform(topLeft: (0.05, 0.25), width: 0.9, height: 0.5)
+
+        let background = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "bg")])
+        )
+        let composited = CompositorRenderTests.timelineWith(
+            Fixtures.videoTrack(clips: [text]),
+            Fixtures.videoTrack(clips: [CompositorFixtures.patternClip(id: "bg")])
+        )
+        let original = try await CompositorRenderTests.render(background, frame: 15, renderSize: Self.size)
+        let inverted = try await CompositorRenderTests.render(composited, frame: 15, renderSize: Self.size)
+        var invertedPixels = 0
+        for y in 0..<Int(Self.size.height) {
+            for x in 0..<Int(Self.size.width) {
+                let source = original.at(x, y)
+                let result = inverted.at(x, y)
+                let matchesInverse = abs(result.r - (255 - source.r)) < 30
+                    && abs(result.g - (255 - source.g)) < 30
+                    && abs(result.b - (255 - source.b)) < 30
+                if matchesInverse { invertedPixels += 1 }
+            }
+        }
+
+        #expect(invertedPixels > 100)
+        #expect(inverted.tl == original.tl)
+        #expect(inverted.tr == original.tr)
+    }
+
     @Test func textObeysTrackZOrder() async throws {
         // Same two layers, but the opaque full-frame video is on top → it must hide the text.
         let behind = CompositorRenderTests.timelineWith(


### PR DESCRIPTION
ref: https://www.instagram.com/reel/DXgdmXMDETj/?hl=en
<img width="1293" height="777" alt="Screenshot 2026-08-10 at 3 09 48 PM" src="https://github.com/user-attachments/assets/3f07b083-6d1e-4846-a57c-e68bb99a652f" />

## Summary
- Add an Inverted text fill that reverses the composited image beneath each glyph.
- Keep the inspector simple by hiding solid color, outline, shadow, and background controls while the mode is active without discarding their stored values.
- Expose the fill through Agent and MCP text tools with readback, validation, and undo coverage.

## Approach
- Model Inverted as a `TextFillMode` so UI, persistence, copy settings, and Agent operations share one source of truth.
- Render a decoration-free white glyph silhouette, then use the existing Core Image Difference blend path against the accumulated layers below it.
- Suppress background pixels without disabling background layout, preserving stored padding and wrapping.
- Preserve the normal text renderer for animation, transforms, opacity, stacking, playback, and export; only the glyph color preparation and blend selection change.
- Generate fill-mode schemas from `TextFillMode.allCases` so tool discovery cannot drift from the app.

## Testing
- `scripts/localization/sync.sh` — passed, including `swift build`.
- `swift test --filter 'CompositorTextLayerTests|MCPTextFillModeTests|TextClipPlaybackTests|ClipSettingsTests'` — 22 tests passed.
- `swift test` — 1,512 tests passed.
- After rebasing onto current `main`: `swift build && swift test --filter 'CompositorTextLayerTests|MCPTextFillModeTests'` — build passed; 17 tests passed.
- After the padding-layout fix: `swift test --filter CompositorTextLayerTests` — 17 tests passed.
- [ ] Select Fill > Inverted over light, dark, mid-gray, and moving footage; verify only the glyph region inverts.
- [ ] Switch back to Color and verify stored color, outline, shadow, and background settings return.
- [ ] Verify preview, playback, undo, project reopen, and rendered video export.

## Change statistics
- Code logic, UI, and Agent contracts: +43 / -14
- Tests: +205 / -0
- Localization: +1 / -0
- Total: +249 / -14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Core Image compositing path for text layers (preview and export), but the scope is limited to the new fill mode and is backed by compositor and MCP tests.
>
> **Overview**
> Adds **Inverted** as a third text fill mode alongside Color and Footage. In the compositor, inverted text renders a plain white glyph (outline, shadow, and background pixels are ignored) and composites with **Difference** so the pixels under each letter are inverted. Stored background padding remains active for layout and wrapping.
>
> The inspector hides solid typography controls whenever fill is not **Color**, without clearing stored style values. Fill mode is persisted as `nil` for color and the raw mode for footage/inverted. Agent instructions, `add_texts` / `update_text` schemas, and fill-mode parsing now derive allowed values from `TextFillMode.allCases`.
>
> New MCP coverage exercises discovery, add/update, timeline readback, validation, and undo; compositor tests assert the inverted blend and padded-layout behavior.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2775ab2f6414fa13eac827d49f4f2686c2afe8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->