### PR TITLE
[ui] Refine panel and inspector styling

### DIFF
--- a/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
+++ b/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
@@ -1,7 +1,14 @@
 import SwiftUI
 
 struct TitleTabBar: View {
-    let titles: [String]
+    struct Item: Identifiable {
+        let titleKey: String
+        let systemImage: String
+
+        var id: String { titleKey }
+    }
+
+    let items: [Item]
     let selected: String?
     var tourAnchors: [String: TourAnchorID] = [:]
     let onSelect: (String) -> Void
@@ -9,8 +16,8 @@ struct TitleTabBar: View {
 
     var body: some View {
         HStack(spacing: AppTheme.Spacing.zero) {
-            ForEach(titles, id: \.self) { title in
-                tab(title)
+            ForEach(items) { item in
+                tab(item)
             }
         }
         .frame(maxWidth: .infinity)
@@ -24,31 +31,43 @@ struct TitleTabBar: View {
     }
 
     @ViewBuilder
-    private func tab(_ title: String) -> some View {
-        let active = selected == title
-        let hovered = hoveredTitle == title
+    private func tab(_ item: Item) -> some View {
+        let active = selected == item.id
+        let hovered = hoveredTitle == item.id
         let button = Button {
-            onSelect(title)
+            onSelect(item.id)
         } label: {
-            Text(L10n.string(key: title))
-                .font(.system(size: AppTheme.FontSize.sm, weight: active ? AppTheme.FontWeight.medium : AppTheme.FontWeight.regular))
-                .lineLimit(1)
-                .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(tabBackground(active: active, hovered: hovered))
-                .overlay(alignment: .bottom) {
-                    Rectangle()
-                        .fill(active ? AppTheme.Accent.primary : Color.clear)
-                        .frame(height: AppTheme.BorderWidth.thick)
-                }
-                .contentShape(Rectangle())
+            VStack(spacing: AppTheme.Spacing.xxs) {
+                Image(systemName: item.systemImage)
+                    .font(.system(
+                        size: AppTheme.FontSize.xs,
+                        weight: active ? AppTheme.FontWeight.medium : AppTheme.FontWeight.regular
+                    ))
+                    .frame(width: AppTheme.IconSize.xxs, height: AppTheme.IconSize.xxs)
+                    .accessibilityHidden(true)
+                Text(L10n.string(key: item.titleKey))
+                    .font(.system(
+                        size: AppTheme.FontSize.xxs,
+                        weight: active ? AppTheme.FontWeight.medium : AppTheme.FontWeight.regular
+                    ))
+            }
+            .lineLimit(1)
+            .foregroundStyle(active ? AppTheme.Text.primaryColor : AppTheme.Text.tertiaryColor)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(tabBackground(active: active, hovered: hovered))
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(active ? AppTheme.Accent.primary : Color.clear)
+                    .frame(height: AppTheme.BorderWidth.thin)
+            }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { hovering in
-            hoveredTitle = hovering ? title : (hoveredTitle == title ? nil : hoveredTitle)
+            hoveredTitle = hovering ? item.id : (hoveredTitle == item.id ? nil : hoveredTitle)
         }
         .animation(.easeOut(duration: AppTheme.Anim.hover), value: hovered)
-        if let anchor = tourAnchors[title] {
+        if let anchor = tourAnchors[item.id] {
             button.tourAnchor(anchor)
         } else {
             button

--- a/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
+++ b/Sources/PalmierPro/Inspector/Components/TitleTabBar.swift
@@ -20,14 +20,7 @@ struct TitleTabBar: View {
                 tab(item)
             }
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: Layout.panelHeaderHeight)
-        .background(AppTheme.Background.raisedColor)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(AppTheme.Border.primaryColor)
-                .frame(height: AppTheme.BorderWidth.thin)
-        }
+        .panelHeaderBar()
     }
 
     @ViewBuilder

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -157,7 +157,16 @@ struct InspectorView: View {
         VStack(spacing: AppTheme.Spacing.zero) {
             projectInspectorHeader
             ScrollView {
-                EditorPanelGroup(L10n.string("Canvas"), contentSpacing: AppTheme.Spacing.sm) {
+                EditorPanelGroup(
+                    L10n.string("Canvas"),
+                    contentSpacing: AppTheme.Spacing.sm,
+                    contentInsets: EdgeInsets(
+                        top: AppTheme.Spacing.smMd,
+                        leading: AppTheme.Spacing.smMd + AppTheme.IconSize.xs + AppTheme.Spacing.sm,
+                        bottom: AppTheme.Spacing.smMd,
+                        trailing: AppTheme.Spacing.smMd
+                    )
+                ) {
                     menuMetadataRow(label: L10n.string("Resolution"), value: "\(editor.timeline.width) × \(editor.timeline.height)") { qualityMenuItems }
                     menuMetadataRow(label: L10n.string("Frame Rate"), value: "\(editor.timeline.fps) fps") { fpsMenuItems }
                     menuMetadataRow(label: L10n.string("Aspect Ratio"), value: CanvasAspectRatio.displayLabel(width: editor.timeline.width, height: editor.timeline.height)) { aspectMenuItems }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -154,40 +154,43 @@ struct InspectorView: View {
     // MARK: - Project Metadata
 
     private var projectMetadataContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-                metadataSection(title: L10n.string("Project")) {
-                    if let url = editor.projectURL {
-                        plainMetadataRow(
-                            label: L10n.string("Name"),
-                            value: url.deletingPathExtension().lastPathComponent
-                        )
-                        plainMetadataRow(
-                            label: L10n.string("Path"),
-                            value: url.path,
-                            truncate: .middle
-                        )
-                    }
-                    plainMetadataRow(label: L10n.string("Duration"), value: formatDuration(Double(editor.timeline.totalFrames) / Double(editor.timeline.fps)))
-                }
-
-                metadataSection(title: L10n.string("Settings")) {
+        VStack(spacing: AppTheme.Spacing.zero) {
+            projectInspectorHeader
+            ScrollView {
+                EditorPanelGroup(L10n.string("Canvas"), contentSpacing: AppTheme.Spacing.sm) {
                     menuMetadataRow(label: L10n.string("Resolution"), value: "\(editor.timeline.width) × \(editor.timeline.height)") { qualityMenuItems }
                     menuMetadataRow(label: L10n.string("Frame Rate"), value: "\(editor.timeline.fps) fps") { fpsMenuItems }
                     menuMetadataRow(label: L10n.string("Aspect Ratio"), value: CanvasAspectRatio.displayLabel(width: editor.timeline.width, height: editor.timeline.height)) { aspectMenuItems }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    private func metadataSection<Content: View>(
-        title: String,
-        @ViewBuilder content: @escaping () -> Content
-    ) -> some View {
-        EditorPanelGroup(title, contentSpacing: AppTheme.Spacing.sm) {
-            content()
+    private var projectInspectorHeader: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            Image(systemName: "movieclapper")
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                .accessibilityHidden(true)
+            Text(L10n.string("Project Settings"))
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.regular))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+                .lineLimit(1)
+            Spacer(minLength: AppTheme.Spacing.xs)
+            Text(verbatim: projectDuration)
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.regular))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .monospacedDigit()
+                .fixedSize()
         }
+        .padding(.horizontal, AppTheme.Spacing.smMd)
+        .panelHeaderBar()
+    }
+
+    private var projectDuration: String {
+        formatDuration(Double(editor.timeline.totalFrames) / Double(editor.timeline.fps))
     }
 
     private func plainMetadataRow(

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -59,6 +59,18 @@ struct InspectorView: View {
             case .ai: L10n.key("AI Edit")
             }
         }
+
+        var systemImage: String {
+            switch self {
+            case .text: "text.alignleft"
+            case .textAnimate: "diamond"
+            case .video: "video"
+            case .effects: "slider.horizontal.3"
+            case .audio: "waveform"
+            case .multicam: "square.grid.2x2"
+            case .ai: "wand.and.stars"
+            }
+        }
     }
 
     @State private var preferredTab: ClipTab = .video
@@ -401,7 +413,9 @@ struct InspectorView: View {
 
     private func tabBar(_ tabs: [ClipTab], selectedTab: ClipTab?) -> some View {
         TitleTabBar(
-            titles: tabs.map(\.titleKey),
+            items: tabs.map {
+                TitleTabBar.Item(titleKey: $0.titleKey, systemImage: $0.systemImage)
+            },
             selected: selectedTab?.titleKey,
             tourAnchors: tabs.contains(.ai) ? [ClipTab.ai.titleKey: .aiEditTab] : [:]
         ) { title in

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/AudioPanelTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/AudioPanelTab.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct AudioPanelTab: View {
     private enum Tab: String, CaseIterable {
         case speech = "Speech", music = "Music"
+
+        var systemImage: String {
+            switch self {
+            case .speech: "mic"
+            case .music: "music.note"
+            }
+        }
     }
 
     @State private var tab: Tab = .speech
@@ -10,7 +17,9 @@ struct AudioPanelTab: View {
     var body: some View {
         VStack(spacing: AppTheme.Spacing.zero) {
             TitleTabBar(
-                titles: Tab.allCases.map(\.rawValue),
+                items: Tab.allCases.map {
+                    TitleTabBar.Item(titleKey: $0.rawValue, systemImage: $0.systemImage)
+                },
                 selected: tab.rawValue
             ) { title in
                 if let t = Tab(rawValue: title) { tab = t }

--- a/Sources/PalmierPro/Models/ClipType.swift
+++ b/Sources/PalmierPro/Models/ClipType.swift
@@ -9,7 +9,7 @@ enum ClipType: String, Codable, Sendable, CaseIterable {
 
     var sfSymbolName: String {
         switch self {
-        case .video: "film"
+        case .video: "video"
         case .audio: "waveform"
         case .image: "photo"
         case .text: "textformat"

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -610,13 +610,13 @@ struct PreviewContainerView: View {
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xs)
-        .padding(.bottom, AppTheme.Spacing.xs)
+        .frame(height: Layout.panelHeaderHeight)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(isActive ? tab.underlineColor : Color.clear)
-                .frame(height: AppTheme.BorderWidth.medium)
+                .frame(height: AppTheme.BorderWidth.thin)
         }
-        .fixedSize()
+        .fixedSize(horizontal: true, vertical: false)
         .contentShape(Rectangle())
         .onTapGesture {
             editor.selectPreviewTab(id: tab.id)

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -149,6 +149,7 @@
 "Canceled" = "Canceled";
 "Canceling" = "Canceling";
 "Cancels %@" = "Cancels %@";
+"Canvas" = "Canvas";
 "Canvas Zoom" = "Canvas Zoom";
 "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit." = "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit.";
 "Cap the words shown per caption. None fits each line to the box." = "Cap the words shown per caption. None fits each line to the box.";
@@ -686,6 +687,7 @@
 "Product demos" = "Product demos";
 "Project" = "Project";
 "Project Activity" = "Project Activity";
+"Project Settings" = "Project Settings";
 "Projects Couldn’t Be Deleted" = "Projects Couldn’t Be Deleted";
 "Prompt" = "Prompt";
 "Quality" = "Quality";

--- a/Sources/PalmierPro/Timeline/TimelineTabBar.swift
+++ b/Sources/PalmierPro/Timeline/TimelineTabBar.swift
@@ -104,14 +104,13 @@ private struct TimelineTabBarContent: View, Equatable {
             }
         }
         .padding(.horizontal, AppTheme.Spacing.xs)
-        .padding(.vertical, AppTheme.Spacing.xxs)
-        .padding(.bottom, AppTheme.Spacing.xxs)
+        .frame(height: Layout.panelHeaderHeight)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(isActive ? AppTheme.Accent.primary : Color.clear)
-                .frame(height: AppTheme.BorderWidth.medium)
+                .frame(height: AppTheme.BorderWidth.thin)
         }
-        .fixedSize()
+        .fixedSize(horizontal: true, vertical: false)
         .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
         .gesture(TapGesture(count: 2).onEnded { renamingTabId = tab.id })
         .simultaneousGesture(TapGesture().onEnded { editor.activateTimeline(tab.id) })

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -550,9 +550,13 @@ extension View {
     func panelHeaderBar() -> some View {
         frame(maxWidth: .infinity)
             .frame(height: Layout.panelHeaderHeight)
-            .background(AppTheme.Background.raisedColor)
-            .overlay(alignment: .bottom) {
-                Rectangle().fill(AppTheme.Border.primaryColor).frame(height: AppTheme.BorderWidth.thin)
+            .background {
+                ZStack(alignment: .bottom) {
+                    AppTheme.Background.raisedColor
+                    Rectangle()
+                        .fill(AppTheme.Border.primaryColor)
+                        .frame(height: AppTheme.BorderWidth.thin)
+                }
             }
     }
 }

--- a/Sources/PalmierPro/UI/TabStrip.swift
+++ b/Sources/PalmierPro/UI/TabStrip.swift
@@ -10,7 +10,7 @@ struct TabStrip<Item: Identifiable, Tab: View, Trailing: View>: View where Item.
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: AppTheme.Spacing.md) {
+                HStack(spacing: AppTheme.Spacing.zero) {
                     ForEach(items) { item in
                         tab(item).id(item.id)
                     }

--- a/Sources/PalmierPro/Utilities/Constants.swift
+++ b/Sources/PalmierPro/Utilities/Constants.swift
@@ -15,7 +15,7 @@ enum Layout {
     static let chatColumnMax: CGFloat = 640
 
     // Headers & toolbars
-    static let panelHeaderHeight: CGFloat = 28
+    static let panelHeaderHeight: CGFloat = AppTheme.IconSize.xl
     static let toolbarHeight: CGFloat = 38
 
     static let panelGap: CGFloat = 5


### PR DESCRIPTION
## Summary
- Add compact SF Symbol icons above smaller labels in Inspector and Audio panel tabs.
- Replace the default Inspector metadata block with a concise Project Settings header, active duration, and aligned Canvas controls.
- Align Preview and Timeline selection indicators with the shared divider and remove inter-tab gaps.
- Use the Generation panel's recorder symbol consistently for video assets.

## Approach
- Model title tabs as localized title-and-icon items so every tab uses one shared presentation.
- Use a 1 pt active indicator and render the panel divider behind header content, allowing the indicator to replace its active segment without being obscured.
- Keep tabs visually continuous while preserving each tab's internal horizontal padding.
- Keep project settings focused on editable canvas values, with setting labels aligned to the section title.

## Testing
- [x] `swift build`
- [x] `scripts/localization/sync.sh`
- [ ] Open text, video, audio, multicam, and AI-eligible selections; verify icons, labels, hover states, and active indicators.
- [ ] Deselect clips and media; verify the Project Settings header, duration, and aligned Canvas controls.
- [ ] Open multiple Preview and Timeline tabs; verify indicators sit on the divider with no inter-tab gaps.
- [ ] Verify Preview tab closing and Timeline tab closing, selection, renaming, and horizontal scrolling.

Manual UI verification has not been completed.

## Change statistics
- UI code: +119 / -69
- Localization: +2 / -0
- Tests: +0 / -0