### PR TITLE
[feat] Add non-destructive canvas guides

### DIFF
--- a/Sources/PalmierPro/Preview/CanvasViewingOverlay.swift
+++ b/Sources/PalmierPro/Preview/CanvasViewingOverlay.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+
+struct CanvasOverlaySelection: Equatable {
+    var grid: CanvasGridOverlay?
+    var guides: Set<CanvasGuideOverlay> = []
+    var format: CanvasFormatOverlay?
+
+    var isEmpty: Bool {
+        grid == nil && guides.isEmpty && format == nil
+    }
+
+    mutating func clear() {
+        grid = nil
+        guides.removeAll()
+        format = nil
+    }
+}
+
+enum CanvasGridOverlay: Int, CaseIterable, Identifiable {
+    case two = 2
+    case three = 3
+    case four = 4
+    case five = 5
+
+    var id: Int { rawValue }
+
+    var label: String {
+        "\(rawValue) × \(rawValue)"
+    }
+
+    var linePositions: [CGFloat] {
+        (1..<rawValue).map { CGFloat($0) / CGFloat(rawValue) }
+    }
+}
+
+enum CanvasGuideOverlay: String, CaseIterable, Identifiable {
+    case actionSafe
+    case titleSafe
+    case center
+
+    var id: String { rawValue }
+
+    var localizationKey: String {
+        switch self {
+        case .actionSafe: L10n.key("Action Safe")
+        case .titleSafe: L10n.key("Title Safe")
+        case .center: L10n.key("Center")
+        }
+    }
+
+    var safeZoneInset: CGFloat? {
+        switch self {
+        case .actionSafe: 0.035
+        case .titleSafe: 0.05
+        case .center: nil
+        }
+    }
+}
+
+enum CanvasFormatOverlay: String, CaseIterable, Identifiable {
+    case scope
+    case wide
+    case square
+    case portrait
+
+    var id: String { rawValue }
+
+    var localizationKey: String {
+        switch self {
+        case .scope: L10n.key("Scope (2.39:1)")
+        case .wide: L10n.key("Wide (1.85:1)")
+        case .square: L10n.key("Square (1:1)")
+        case .portrait: L10n.key("Portrait (9:16)")
+        }
+    }
+
+    var aspectRatio: CGFloat {
+        switch self {
+        case .scope: 2.39
+        case .wide: 1.85
+        case .square: 1
+        case .portrait: 9 / 16
+        }
+    }
+
+    func contentRect(in size: CGSize) -> CGRect {
+        CanvasOverlayGeometry.contentRect(aspectRatio: aspectRatio, in: size)
+    }
+}
+
+enum CanvasOverlayGeometry {
+    static func contentRect(aspectRatio: CGFloat, in size: CGSize) -> CGRect {
+        guard aspectRatio > 0, size.width > 0, size.height > 0 else { return .zero }
+        let canvasAspect = size.width / size.height
+        if canvasAspect > aspectRatio {
+            let width = size.height * aspectRatio
+            return CGRect(
+                x: (size.width - width) / 2,
+                y: 0,
+                width: width,
+                height: size.height
+            )
+        }
+        let height = size.width / aspectRatio
+        return CGRect(
+            x: 0,
+            y: (size.height - height) / 2,
+            width: size.width,
+            height: height
+        )
+    }
+
+    static func outsideRects(around contentRect: CGRect, in size: CGSize) -> [CGRect] {
+        [
+            CGRect(x: 0, y: 0, width: size.width, height: contentRect.minY),
+            CGRect(x: 0, y: contentRect.maxY, width: size.width, height: size.height - contentRect.maxY),
+            CGRect(x: 0, y: contentRect.minY, width: contentRect.minX, height: contentRect.height),
+            CGRect(
+                x: contentRect.maxX,
+                y: contentRect.minY,
+                width: size.width - contentRect.maxX,
+                height: contentRect.height
+            ),
+        ].filter { $0.width > 0 && $0.height > 0 }
+    }
+}
+
+struct CanvasViewingOverlay: View {
+    let selection: CanvasOverlaySelection
+
+    var body: some View {
+        if !selection.isEmpty {
+            Canvas { context, size in
+                if let format = selection.format {
+                    drawFormatReference(format, context: &context, size: size)
+                }
+                if let grid = selection.grid {
+                    drawGrid(grid, context: &context, size: size)
+                }
+                for guide in CanvasGuideOverlay.allCases where selection.guides.contains(guide) {
+                    if guide == .center {
+                        drawCenter(context: &context, size: size)
+                    } else {
+                        drawSafeZone(guide, context: &context, size: size)
+                    }
+                }
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private func drawGrid(_ grid: CanvasGridOverlay, context: inout GraphicsContext, size: CGSize) {
+        var path = Path()
+        for position in grid.linePositions {
+            path.move(to: CGPoint(x: size.width * position, y: 0))
+            path.addLine(to: CGPoint(x: size.width * position, y: size.height))
+            path.move(to: CGPoint(x: 0, y: size.height * position))
+            path.addLine(to: CGPoint(x: size.width, y: size.height * position))
+        }
+        strokeGuide(path, context: &context, opacity: AppTheme.Opacity.prominent)
+    }
+
+    private func drawSafeZone(
+        _ guide: CanvasGuideOverlay,
+        context: inout GraphicsContext,
+        size: CGSize
+    ) {
+        guard let inset = guide.safeZoneInset else { return }
+        let dx = size.width * inset
+        let dy = size.height * inset
+        let rect = CGRect(
+            x: dx,
+            y: dy,
+            width: size.width - dx * 2,
+            height: size.height - dy * 2
+        )
+        let opacity = guide == .titleSafe ? AppTheme.Opacity.prominent : AppTheme.Opacity.medium
+        strokeGuide(Path(rect), context: &context, opacity: opacity)
+    }
+
+    private func drawCenter(context: inout GraphicsContext, size: CGSize) {
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let arm = AppTheme.Spacing.lg
+        var path = Path()
+        path.move(to: CGPoint(x: center.x - arm, y: center.y))
+        path.addLine(to: CGPoint(x: center.x + arm, y: center.y))
+        path.move(to: CGPoint(x: center.x, y: center.y - arm))
+        path.addLine(to: CGPoint(x: center.x, y: center.y + arm))
+        strokeGuide(path, context: &context, opacity: AppTheme.Opacity.prominent)
+    }
+
+    private func drawFormatReference(
+        _ format: CanvasFormatOverlay,
+        context: inout GraphicsContext,
+        size: CGSize
+    ) {
+        let contentRect = format.contentRect(in: size)
+        let outsideRects = CanvasOverlayGeometry.outsideRects(around: contentRect, in: size)
+        guard !outsideRects.isEmpty else { return }
+        let fill = GraphicsContext.Shading.color(
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
+        )
+        for rect in outsideRects {
+            context.fill(Path(rect), with: fill)
+        }
+        strokeGuide(Path(contentRect), context: &context, opacity: AppTheme.Opacity.medium)
+    }
+
+    private func strokeGuide(
+        _ path: Path,
+        context: inout GraphicsContext,
+        opacity: Double
+    ) {
+        context.stroke(
+            path,
+            with: .color(AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)),
+            lineWidth: AppTheme.BorderWidth.thick
+        )
+        context.stroke(
+            path,
+            with: .color(AppTheme.MediaOverlay.primaryColor.opacity(opacity)),
+            lineWidth: AppTheme.BorderWidth.hairline
+        )
+    }
+}

--- a/Sources/PalmierPro/Preview/PreviewContainerView.swift
+++ b/Sources/PalmierPro/Preview/PreviewContainerView.swift
@@ -10,6 +10,7 @@ struct PreviewContainerView: View {
 
     @State private var hoveredTabId: String?
     @State private var failedImagePreviewKey: String?
+    @State private var canvasOverlays = CanvasOverlaySelection()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -61,6 +62,7 @@ struct PreviewContainerView: View {
                 if let overlay = offlineOverlay(timelineState: timelineState) {
                     offlinePreview(assetId: overlay.assetId, path: overlay.path, isUnprocessable: overlay.isUnprocessable)
                 }
+                CanvasViewingOverlay(selection: canvasOverlays)
                 if editor.chromaKeySamplingClipId != nil {
                     ChromaKeySamplerOverlayView()
                 } else if editor.cropEditingActive {
@@ -146,6 +148,7 @@ struct PreviewContainerView: View {
             if isTimeline || editor.activePreviewTab.clipType == .video {
                 captureFrameButton
             }
+            guidesMenuButton
             settingsMenuButton(
                 systemImage: "speedometer",
                 label: editor.playbackRate.label,
@@ -170,6 +173,7 @@ struct PreviewContainerView: View {
     private var imageSettingsBar: some View {
         HStack(spacing: AppTheme.Spacing.sm) {
             Spacer()
+            guidesMenuButton
             settingsMenuButton(
                 systemImage: "magnifyingglass",
                 label: zoomBadgeLabel,
@@ -216,6 +220,107 @@ struct PreviewContainerView: View {
         }
     }
 
+    private var guidesMenuButton: some View {
+        settingsMenuButton(
+            systemImage: canvasOverlays.isEmpty ? "viewfinder" : "viewfinder.circle.fill",
+            help: L10n.string("Canvas Guides"),
+            isActive: !canvasOverlays.isEmpty
+        ) {
+            canvasGuideMenuItems
+        }
+    }
+
+    @ViewBuilder
+    private var canvasGuideMenuItems: some View {
+        Menu {
+            Button {
+                canvasOverlays.grid = nil
+            } label: {
+                selectionMenuLabel(
+                    L10n.string("None"),
+                    selected: canvasOverlays.grid == nil
+                )
+            }
+            Divider()
+            ForEach(CanvasGridOverlay.allCases) { grid in
+                Button {
+                    canvasOverlays.grid = grid
+                } label: {
+                    selectionMenuLabel(
+                        grid.label,
+                        selected: canvasOverlays.grid == grid
+                    )
+                }
+            }
+        } label: {
+            Text(L10n.string("Grid"))
+        }
+
+        Menu {
+            ForEach(CanvasGuideOverlay.allCases) { guide in
+                Toggle(
+                    L10n.string(key: guide.localizationKey),
+                    isOn: guideBinding(for: guide)
+                )
+            }
+        } label: {
+            Text(L10n.string("Safe Zones"))
+        }
+
+        Menu {
+            Button {
+                canvasOverlays.format = nil
+            } label: {
+                selectionMenuLabel(
+                    L10n.string("None"),
+                    selected: canvasOverlays.format == nil
+                )
+            }
+            Divider()
+            ForEach(CanvasFormatOverlay.allCases) { format in
+                Button {
+                    canvasOverlays.format = format
+                } label: {
+                    selectionMenuLabel(
+                        L10n.string(key: format.localizationKey),
+                        selected: canvasOverlays.format == format
+                    )
+                }
+            }
+        } label: {
+            Text(L10n.string("Format References"))
+        }
+
+        Divider()
+        Button(L10n.string("Hide Guides")) {
+            canvasOverlays.clear()
+        }
+        .disabled(canvasOverlays.isEmpty)
+    }
+
+    private func guideBinding(for guide: CanvasGuideOverlay) -> Binding<Bool> {
+        Binding(
+            get: { canvasOverlays.guides.contains(guide) },
+            set: { enabled in
+                if enabled {
+                    canvasOverlays.guides.insert(guide)
+                } else {
+                    canvasOverlays.guides.remove(guide)
+                }
+            }
+        )
+    }
+
+    private func selectionMenuLabel(_ label: String, selected: Bool) -> some View {
+        HStack {
+            Text(verbatim: label)
+            Spacer()
+            if selected {
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
     @ViewBuilder
     private var zoomMenuItems: some View {
         ForEach(ZoomPreset.allCases, id: \.self) { preset in
@@ -248,14 +353,15 @@ struct PreviewContainerView: View {
 
     private func settingsMenuButton<MenuContent: View>(
         systemImage: String,
-        label: String,
+        label: String? = nil,
         help: String,
+        isActive: Bool = false,
         @ViewBuilder menu: @escaping () -> MenuContent
     ) -> some View {
         Menu {
             menu()
         } label: {
-            badgeLabel(systemImage: systemImage, text: label)
+            settingsMenuLabel(systemImage: systemImage, text: label, isActive: isActive)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
@@ -263,7 +369,19 @@ struct PreviewContainerView: View {
         .hoverHighlight()
         .help(L10n.string(key: help))
         .accessibilityLabel(L10n.string(key: help))
-        .accessibilityValue(L10n.string(key: label))
+        .accessibilityValue(label.map { L10n.string(key: $0) } ?? "")
+    }
+
+    @ViewBuilder
+    private func settingsMenuLabel(systemImage: String, text: String?, isActive: Bool) -> some View {
+        if let text {
+            badgeLabel(systemImage: systemImage, text: text)
+        } else {
+            Image(systemName: systemImage)
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.semibold))
+                .foregroundStyle(isActive ? AppTheme.Accent.primary : AppTheme.Text.secondaryColor)
+                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
+        }
     }
 
     private func badgeLabel(systemImage: String, text: String) -> some View {

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "About Palmier Pro" = "About Palmier Pro";
 "Account" = "Account";
 "Account settings" = "Account settings";
+"Action Safe" = "Action Safe";
 "Activity unavailable" = "Activity unavailable";
 "Add Range to Chat" = "Add Range to Chat";
 "Add Text" = "Add Text";
@@ -150,6 +151,7 @@
 "Canceling" = "Canceling";
 "Cancels %@" = "Cancels %@";
 "Canvas" = "Canvas";
+"Canvas Guides" = "Canvas Guides";
 "Canvas Zoom" = "Canvas Zoom";
 "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit." = "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit.";
 "Cap the words shown per caption. None fits each line to the box." = "Cap the words shown per caption. None fits each line to the box.";
@@ -386,6 +388,7 @@
 "Font Case" = "Font Case";
 "Footage" = "Footage";
 "For" = "For";
+"Format References" = "Format References";
 "Forward" = "Forward";
 "Founder" = "Founder";
 "Frame Rate" = "Frame Rate";
@@ -426,6 +429,7 @@
 "Glow" = "Glow";
 "Go to next keyframe" = "Go to next keyframe";
 "Go to previous keyframe" = "Go to previous keyframe";
+"Grid" = "Grid";
 "Grid 2×2" = "Grid 2×2";
 "Grid 3×3" = "Grid 3×3";
 "Grid 4×4" = "Grid 4×4";
@@ -433,6 +437,7 @@
 "Hard Light" = "Hard Light";
 "Height" = "Height";
 "Help" = "Help";
+"Hide Guides" = "Hide Guides";
 "Hide Info" = "Hide Info";
 "Hide keyframe timeline" = "Hide keyframe timeline";
 "Hide reasoning" = "Hide reasoning";
@@ -678,6 +683,7 @@
 "Podcast" = "Podcast";
 "Pointer (V)" = "Pointer (V)";
 "Pop In" = "Pop In";
+"Portrait (9:16)" = "Portrait (9:16)";
 "Position" = "Position";
 "Preparing" = "Preparing";
 "Preparing…" = "Preparing…";
@@ -765,6 +771,7 @@
 "Roundness" = "Roundness";
 "Run this command once in Terminal." = "Run this command once in Terminal.";
 "Running on" = "Running on";
+"Safe Zones" = "Safe Zones";
 "Sample Key Color" = "Sample Key Color";
 "Sample Project" = "Sample Project";
 "Sample key color" = "Sample key color";
@@ -780,6 +787,7 @@
 "Save this project to view activity" = "Save this project to view activity";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Saves a copy of this project with all media bundled inside, so it opens on any machine.";
 "Scale" = "Scale";
+"Scope (2.39:1)" = "Scope (2.39:1)";
 "Score my timeline" = "Score my timeline";
 "Screen" = "Screen";
 "Screenshot a frame" = "Screenshot a frame";
@@ -871,6 +879,7 @@
 "Split at Playhead" = "Split at Playhead";
 "Split at Playhead (⌘K)" = "Split at Playhead (⌘K)";
 "Spoken" = "Spoken";
+"Square (1:1)" = "Square (1:1)";
 "Start creating" = "Start creating";
 "Start creating, or explore these to get the most out of Palmier Pro." = "Start creating, or explore these to get the most out of Palmier Pro.";
 "Starts %@s into the group's clock; matched the master with %@%% confidence." = "Starts %@s into the group's clock; matched the master with %@%% confidence.";
@@ -939,6 +948,7 @@
 "Timelines" = "Timelines";
 "Tint" = "Tint";
 "Tints waveforms by speaker. Voices are matched across clips using cloud transcripts." = "Tints waveforms by speaker. Voices are matched across clips using cloud transcripts.";
+"Title Safe" = "Title Safe";
 "Toggle Agent Panel" = "Toggle Agent Panel";
 "Tone" = "Tone";
 "Tools" = "Tools";
@@ -1032,6 +1042,7 @@
 "White Balance" = "White Balance";
 "Whites" = "Whites";
 "Whole timeline · %@" = "Whole timeline · %@";
+"Wide (1.85:1)" = "Wide (1.85:1)";
 "Width" = "Width";
 "Word Reveal" = "Word Reveal";
 "Word Slide" = "Word Slide";

--- a/Tests/PalmierProTests/Editor/CanvasViewingOverlayTests.swift
+++ b/Tests/PalmierProTests/Editor/CanvasViewingOverlayTests.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Testing
+@testable import PalmierPro
+
+@Suite("Canvas viewing overlays")
+struct CanvasViewingOverlayTests {
+    @Test func gridPresetsProvideTwoThroughFiveDivisions() {
+        #expect(CanvasGridOverlay.allCases.map(\.rawValue) == [2, 3, 4, 5])
+    }
+
+    @Test(arguments: CanvasGridOverlay.allCases)
+    func gridPositionsCreateOneFewerLineThanDivisions(grid: CanvasGridOverlay) {
+        #expect(grid.linePositions.count == grid.rawValue - 1)
+        #expect(grid.linePositions.allSatisfy { $0 > 0 && $0 < 1 })
+    }
+
+    @Test func safeZoneInsetsMatchActionAndTitleStandards() {
+        #expect(CanvasGuideOverlay.actionSafe.safeZoneInset == 0.035)
+        #expect(CanvasGuideOverlay.titleSafe.safeZoneInset == 0.05)
+        #expect(CanvasGuideOverlay.center.safeZoneInset == nil)
+    }
+
+    @Test(arguments: CanvasFormatOverlay.allCases)
+    func formatReferenceIsCenteredAndPreservesItsAspect(format: CanvasFormatOverlay) {
+        let canvas = CGSize(width: 1_920, height: 1_080)
+        let rect = format.contentRect(in: canvas)
+
+        #expect(abs(rect.midX - canvas.width / 2) < 0.0001)
+        #expect(abs(rect.midY - canvas.height / 2) < 0.0001)
+        #expect(abs(rect.width / rect.height - format.aspectRatio) < 0.0001)
+        #expect(rect.minX >= 0 && rect.minY >= 0)
+        #expect(rect.maxX <= canvas.width && rect.maxY <= canvas.height)
+    }
+
+    @Test func matchingFormatHasNoOutsideMask() {
+        let size = CGSize(width: 1_080, height: 1_080)
+        let contentRect = CanvasFormatOverlay.square.contentRect(in: size)
+
+        #expect(CanvasOverlayGeometry.outsideRects(around: contentRect, in: size).isEmpty)
+    }
+
+    @Test func clearingSelectionRemovesEveryOverlayCategory() {
+        var selection = CanvasOverlaySelection(
+            grid: .three,
+            guides: [.actionSafe, .center],
+            format: .scope
+        )
+
+        selection.clear()
+
+        #expect(selection.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add viewer-only canvas guides grouped under Grid, Safe Zones, and Format References submenus.
- Provide 2×2 through 5×5 grids, action/title safe areas, a center crosshair, and 2.39:1, 1.85:1, 1:1, and 9:16 format masks.
- Keep guides out of project state, compositor output, frame capture, render, and export.
- Supersedes #169 with the current preview architecture and adds configurable grids.

Closes #167

## Approach
- Own the transient guide selection in `PreviewContainerView` so guide changes do not mutate the timeline or create undo history.
- Render active guides in one non-interactive SwiftUI `Canvas`, omitted entirely when no guide is selected.
- Allow safe-zone guides to combine while keeping grid and format-reference choices individually exclusive to avoid overlapping masks.
- Draw with `AppTheme` colors, opacity, spacing, and border tokens, with localized menu copy.

## Testing
- `swift test --filter CanvasViewingOverlayTests` — passed 6 tests.
- `scripts/localization/sync.sh` — passed.
- `swift build` — passed; existing Convex deployment-target linker warnings remain.
- [ ] Manually verify the three submenu levels and active-state icon.
- [ ] Verify guide combinations across landscape, square, and portrait projects at multiple zoom levels.
- [ ] Verify transform, crop, and canvas selection remain interactive and frame capture/export remain guide-free.

## Change statistics
- Code logic: +347 / -3
- Tests: +53 / -0
- Localization inventory: +11 / -0
- Total: +411 / -3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only overlay UI with no project persistence; guides are drawn with hit testing disabled so they should not block existing canvas interactions.
> 
> **Overview**
> Adds **viewer-only canvas guides** in the preview: grids (2×2–5×5), combinable safe zones (action/title/center), and exclusive format reference masks (scope, wide, square, portrait).
> 
> Guide choices live in **`PreviewContainerView` `@State`** (`CanvasOverlaySelection`), not in the editor or project, so they do not affect undo, export, or frame capture. A new non-interactive **`CanvasViewingOverlay`** draws the active guides on a SwiftUI `Canvas` above the preview stack.
> 
> The transport bar and image settings bar get a **Canvas Guides** menu (nested Grid, Safe Zones, Format References, Hide Guides) with an active viewfinder icon when any guide is on. **`settingsMenuButton`** now supports optional text labels and an active icon style for that control.
> 
> Localization and unit tests cover overlay geometry and selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23f557bc1045979c88a003073847325b106edbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->