### PR TITLE
[ui/telemetry] Capture onboarding discovery context

### DIFF
--- a/Sources/PalmierPro/Home/Onboarding/OnboardingModels.swift
+++ b/Sources/PalmierPro/Home/Onboarding/OnboardingModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum OnboardingStep: Int {
-    case welcome, profile, account
+    case welcome, discovery, profile, account
 }
 
 enum OnboardingSampleState: Equatable {
@@ -17,15 +17,31 @@ struct OnboardingOption: Identifiable {
 }
 
 enum OnboardingQuestion: String, CaseIterable, Identifiable {
-    case roles, videoTypes, interests
+    case roles, videoTypes, interests, acquisitionSource, previousEditors
+
     var id: String { rawValue }
+
+    static let profileQuestions: [OnboardingQuestion] = [.roles, .videoTypes, .interests]
+    static let discoveryQuestions: [OnboardingQuestion] = [.acquisitionSource, .previousEditors]
+
     var titleKey: String {
         switch self {
         case .videoTypes: L10n.key("What do you make?")
         case .roles: L10n.key("What best describes your role?")
         case .interests: L10n.key("What interests you most about Palmier Pro?")
+        case .acquisitionSource: L10n.key("How did you find Palmier Pro?")
+        case .previousEditors: L10n.key("Which editors did you use before?")
         }
     }
+
+    var allowsMultipleSelection: Bool {
+        self != .acquisitionSource
+    }
+
+    var exclusiveOptionIDs: Set<String> {
+        self == .previousEditors ? ["none"] : []
+    }
+
     var options: [OnboardingOption] {
         switch self {
         case .videoTypes: [
@@ -55,6 +71,27 @@ enum OnboardingQuestion: String, CaseIterable, Identifiable {
             .init(id: "agent_editing", labelKey: L10n.key("Agentic editing")),
             .init(id: "external_agents", labelKey: L10n.key("Integration with your own agent")),
             .init(id: "video_automation", labelKey: L10n.key("Video automation")),
+        ]
+        case .acquisitionSource: [
+            .init(id: "google", labelKey: L10n.key("Google")),
+            .init(id: "github", labelKey: L10n.key("GitHub")),
+            .init(id: "x", labelKey: L10n.key("X")),
+            .init(id: "instagram", labelKey: L10n.key("Instagram")),
+            .init(id: "youtube", labelKey: L10n.key("YouTube")),
+            .init(id: "hacker_news", labelKey: L10n.key("Hacker News")),
+            .init(id: "word_of_mouth", labelKey: L10n.key("Friend or colleague")),
+            .other,
+        ]
+        case .previousEditors: [
+            .init(id: "premiere_pro", labelKey: L10n.key("Adobe Premiere Pro")),
+            .init(id: "davinci_resolve", labelKey: L10n.key("DaVinci Resolve")),
+            .init(id: "final_cut_pro", labelKey: L10n.key("Final Cut Pro")),
+            .init(id: "capcut", labelKey: L10n.key("CapCut")),
+            .init(id: "instagram_edits", labelKey: L10n.key("Instagram Edits")),
+            .init(id: "imovie", labelKey: L10n.key("iMovie")),
+            .init(id: "descript", labelKey: L10n.key("Descript")),
+            .init(id: "none", labelKey: L10n.key("None")),
+            .other,
         ]
         }
     }

--- a/Sources/PalmierPro/Home/Onboarding/OnboardingOverlay.swift
+++ b/Sources/PalmierPro/Home/Onboarding/OnboardingOverlay.swift
@@ -50,8 +50,8 @@ struct OnboardingOverlay: View {
             .frame(maxWidth: .infinity, alignment: .topLeading)
             .padding(.horizontal, AppTheme.Spacing.xxl)
             .padding(.top, AppTheme.Spacing.xxl)
-            .padding(.bottom, onboarding.step == .profile ? AppTheme.Spacing.md : AppTheme.Spacing.xxl)
-        if onboarding.step == .account {
+            .padding(.bottom, contentBottomPadding)
+        if onboarding.step == .discovery || onboarding.step == .account {
             ScrollView { content }
                 .scrollEdgeEffectStyle(.soft, for: .bottom)
         } else {
@@ -65,8 +65,18 @@ struct OnboardingOverlay: View {
         switch onboarding.step {
         case .welcome:
             OnboardingWelcomeStep()
+        case .discovery:
+            OnboardingQuestionnaireStep(
+                onboarding: onboarding,
+                title: L10n.string("Quick questions"),
+                questions: OnboardingQuestion.discoveryQuestions
+            )
         case .profile:
-            OnboardingProfileStep(onboarding: onboarding)
+            OnboardingQuestionnaireStep(
+                onboarding: onboarding,
+                title: L10n.string("Tell us about your work"),
+                questions: OnboardingQuestion.profileQuestions
+            )
         case .account:
             OnboardingAccountStep(
                 account: account,
@@ -85,8 +95,10 @@ struct OnboardingOverlay: View {
             switch onboarding.step {
             case .welcome:
                 primaryButton(L10n.string("Continue"), action: onboarding.advance)
+            case .discovery:
+                primaryButton(L10n.string("Continue"), action: onboarding.advance)
             case .profile:
-                primaryButton(L10n.string("Continue"), action: onboarding.submitProfile)
+                primaryButton(L10n.string("Continue"), action: onboarding.submitSurvey)
             case .account:
                 secondaryButton(
                     L10n.string("Skip"),
@@ -95,6 +107,15 @@ struct OnboardingOverlay: View {
                 )
                 accountAction
             }
+        }
+    }
+
+    private var contentBottomPadding: CGFloat {
+        switch onboarding.step {
+        case .profile, .discovery:
+            AppTheme.Spacing.md
+        case .welcome, .account:
+            AppTheme.Spacing.xxl
         }
     }
 
@@ -126,7 +147,11 @@ struct OnboardingOverlay: View {
         disabled: Bool? = nil
     ) -> some View {
         Button(label, action: action)
-            .buttonStyle(.capsule(.secondary, size: .regular))
+            .buttonStyle(.capsule(
+                .secondary,
+                size: .regular,
+                fill: AnyShapeStyle(AppTheme.Onboarding.secondaryButtonFill)
+            ))
             .disabled(disabled ?? isBusy)
     }
 

--- a/Sources/PalmierPro/Home/Onboarding/OnboardingSteps.swift
+++ b/Sources/PalmierPro/Home/Onboarding/OnboardingSteps.swift
@@ -27,13 +27,15 @@ struct OnboardingWelcomeStep: View {
     }
 }
 
-struct OnboardingProfileStep: View {
+struct OnboardingQuestionnaireStep: View {
     @Bindable var onboarding: OnboardingStore
+    let title: String
+    let questions: [OnboardingQuestion]
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
-            OnboardingTitle(L10n.string("Tell us about your work"))
-            ForEach(OnboardingQuestion.allCases) { question in
+            OnboardingTitle(title)
+            ForEach(questions) { question in
                 Spacer(minLength: AppTheme.Spacing.md)
                 section(question)
             }
@@ -49,6 +51,7 @@ struct OnboardingProfileStep: View {
                 .foregroundStyle(AppTheme.Text.primaryColor)
             OnboardingFlowLayout(spacing: AppTheme.Spacing.smMd) {
                 ForEach(question.options) { option in
+                    let isSelected = selection.contains(option.id)
                     Button {
                         onboarding.toggle(option, for: question)
                     } label: {
@@ -57,8 +60,9 @@ struct OnboardingProfileStep: View {
                             .lineLimit(1)
                     }
                     .buttonStyle(.capsule(
-                        selection.contains(option.id) ? .prominent : .secondary,
-                        size: .small
+                        isSelected ? .prominent : .secondary,
+                        size: .small,
+                        fill: isSelected ? nil : AnyShapeStyle(AppTheme.Onboarding.secondaryButtonFill)
                     ))
                     .frame(maxWidth: .infinity)
                 }

--- a/Sources/PalmierPro/Home/Onboarding/OnboardingStore.swift
+++ b/Sources/PalmierPro/Home/Onboarding/OnboardingStore.swift
@@ -7,7 +7,7 @@ final class OnboardingStore {
     static let completionKey = "hasSeenWelcome"
     static let shared = OnboardingStore()
 
-    private static let surveyVersion = 1
+    private static let surveyVersion = 2
 
     private(set) var step = OnboardingStep.welcome
     private(set) var isComplete: Bool
@@ -31,8 +31,8 @@ final class OnboardingStore {
         move(by: -1)
     }
 
-    /// Reports the survey once, no matter how often the user steps back into the profile step.
-    func submitProfile() {
+    /// Reports the survey once, no matter how often the user steps back.
+    func submitSurvey() {
         if !didCaptureSurvey {
             didCaptureSurvey = true
             Analytics.capture(.onboardingCompleted, properties: [
@@ -40,6 +40,8 @@ final class OnboardingStore {
                 "roles": selection(for: .roles).sorted(),
                 "video_types": selection(for: .videoTypes).sorted(),
                 "interests": selection(for: .interests).sorted(),
+                "acquisition_source": selection(for: .acquisitionSource).sorted().first ?? "not_provided",
+                "previous_editors": selection(for: .previousEditors).sorted(),
             ])
         }
         advance()
@@ -63,8 +65,22 @@ final class OnboardingStore {
 
     func toggle(_ option: OnboardingOption, for question: OnboardingQuestion) {
         var selection = selection(for: question)
-        if !selection.insert(option.id).inserted {
+
+        if !question.allowsMultipleSelection {
+            selections[question] = selection.contains(option.id) ? [] : [option.id]
+            return
+        }
+
+        if question.exclusiveOptionIDs.contains(option.id) {
+            selections[question] = selection == [option.id] ? [] : [option.id]
+            return
+        }
+
+        selection.subtract(question.exclusiveOptionIDs)
+        if selection.contains(option.id) {
             selection.remove(option.id)
+        } else {
+            selection.insert(option.id)
         }
         selections[question] = selection
     }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -92,6 +92,7 @@
 "Added to %@" = "Added to %@";
 "Adjust" = "Adjust";
 "Adjust Range" = "Adjust Range";
+"Adobe Premiere Pro" = "Adobe Premiere Pro";
 "Ads and branded content" = "Ads and branded content";
 "Agent Mode" = "Agent Mode";
 "Agent Panel" = "Agent Panel";
@@ -155,6 +156,7 @@
 "Canvas Zoom" = "Canvas Zoom";
 "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit." = "Cap characters per caption, including spaces and punctuation. A single word may exceed the limit.";
 "Cap the words shown per caption. None fits each line to the box." = "Cap the words shown per caption. None fits each line to the box.";
+"CapCut" = "CapCut";
 "Captions" = "Captions";
 "Captions will look like this" = "Captions will look like this";
 "Capture Frame to Media" = "Capture Frame to Media";
@@ -254,6 +256,7 @@
 "Custom…" = "Custom…";
 "Cut" = "Cut";
 "Cut to the beat" = "Cut to the beat";
+"DaVinci Resolve" = "DaVinci Resolve";
 "Dark" = "Dark";
 "Dark appearance" = "Dark appearance";
 "Darken" = "Darken";
@@ -286,6 +289,7 @@
 "Describe the sound" = "Describe the sound";
 "Describe the sound (minimum %lld characters)" = "Describe the sound (minimum %lld characters)";
 "Describe the video" = "Describe the video";
+"Descript" = "Descript";
 "Description" = "Description";
 "Deselect & Reset Tool" = "Deselect & Reset Tool";
 "Designer" = "Designer";
@@ -374,6 +378,7 @@
 "Fill prompt" = "Fill prompt";
 "Film Grain" = "Film Grain";
 "Filmmaker" = "Filmmaker";
+"Final Cut Pro" = "Final Cut Pro";
 "First Frame" = "First Frame";
 "First-time sign-ups only" = "First-time sign-ups only";
 "First/Last" = "First/Last";
@@ -394,6 +399,7 @@
 "Frame Rate" = "Frame Rate";
 "Free" = "Free";
 "Freeform" = "Freeform";
+"Friend or colleague" = "Friend or colleague";
 "Full Frame" = "Full Frame";
 "Full Screen" = "Full Screen";
 "Full changelog" = "Full changelog";
@@ -426,14 +432,17 @@
 "Get OpenAI API key" = "Get OpenAI API key";
 "Get a notification when a generation finishes." = "Get a notification when a generation finishes.";
 "Getting the search model ready." = "Getting the search model ready.";
+"GitHub" = "GitHub";
 "Glow" = "Glow";
 "Go to next keyframe" = "Go to next keyframe";
 "Go to previous keyframe" = "Go to previous keyframe";
+"Google" = "Google";
 "Grid" = "Grid";
 "Grid 2×2" = "Grid 2×2";
 "Grid 3×3" = "Grid 3×3";
 "Grid 4×4" = "Grid 4×4";
 "Grouped" = "Grouped";
+"Hacker News" = "Hacker News";
 "Hard Light" = "Hard Light";
 "Height" = "Height";
 "Help" = "Help";
@@ -447,6 +456,7 @@
 "Highlights" = "Highlights";
 "Hobbyist" = "Hobbyist";
 "Hold" = "Hold";
+"How did you find Palmier Pro?" = "How did you find Palmier Pro?";
 "Hue" = "Hue";
 "Hue Curves" = "Hue Curves";
 "Identify Speakers" = "Identify Speakers";
@@ -467,6 +477,8 @@
 "Input" = "Input";
 "Inspector" = "Inspector";
 "Inspector Panel" = "Inspector Panel";
+"Instagram" = "Instagram";
+"Instagram Edits" = "Instagram Edits";
 "Install" = "Install";
 "Install in Claude Desktop" = "Install in Claude Desktop";
 "Install in Cursor" = "Install in Cursor";
@@ -699,6 +711,7 @@
 "Prompt" = "Prompt";
 "Quality" = "Quality";
 "Queued" = "Queued";
+"Quick questions" = "Quick questions";
 "Quit Palmier Pro" = "Quit Palmier Pro";
 "Radius" = "Radius";
 "Range" = "Range";
@@ -1039,6 +1052,7 @@
 "What do you make?" = "What do you make?";
 "What interests you most about Palmier Pro?" = "What interests you most about Palmier Pro?";
 "What's New in v%@" = "What's New in v%@";
+"Which editors did you use before?" = "Which editors did you use before?";
 "White Balance" = "White Balance";
 "Whites" = "Whites";
 "Whole timeline · %@" = "Whole timeline · %@";
@@ -1048,6 +1062,7 @@
 "Word Slide" = "Word Slide";
 "Working on %@" = "Working on %@";
 "Workspace layout" = "Workspace layout";
+"X" = "X";
 "X High" = "X High";
 "You were not charged for this generation" = "You were not charged for this generation";
 "You're all set" = "You're all set";
@@ -1072,6 +1087,7 @@
 "drift-corrected" = "drift-corrected";
 "error" = "error";
 "group moved right to fit" = "group moved right to fit";
+"iMovie" = "iMovie";
 "lowercase" = "lowercase";
 "or add your own Anthropic key" = "or add your own Anthropic key";
 "or add your own OpenAI key" = "or add your own OpenAI key";

--- a/Sources/PalmierPro/Telemetry/Analytics.swift
+++ b/Sources/PalmierPro/Telemetry/Analytics.swift
@@ -258,6 +258,7 @@ enum Analytics {
     private static var allowedCapturePropertyKeys: Set<String> {
         Set([
             "active_day",
+            "acquisition_source",
             "caption_clip_count",
             "caption_group_count",
             "clip_count",
@@ -277,6 +278,7 @@ enum Analytics {
             "model",
             "output_count",
             "project_id",
+            "previous_editors",
             "resolution",
             "roles",
             "session_id",

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -427,6 +427,9 @@ enum AppTheme {
         static let cardWidth: CGFloat = 520
         static let cardHeight: CGFloat = 420
         static let welcomeHeroHeight: CGFloat = 240
+        static var secondaryButtonFill: Color {
+            AppTheme.Accent.primary.opacity(AppTheme.Opacity.muted)
+        }
     }
 
     enum Settings {

--- a/Tests/PalmierProTests/Home/OnboardingStoreTests.swift
+++ b/Tests/PalmierProTests/Home/OnboardingStoreTests.swift
@@ -24,11 +24,22 @@ struct OnboardingStoreTests {
         }
     }
 
-    @Test func profileAdvancesDirectlyToAccount() throws {
+    @Test func discoveryAdvancesToProfile() throws {
         try withDefaults { defaults in
             let store = OnboardingStore(defaults: defaults)
             store.advance()
             store.advance()
+
+            #expect(store.step == .profile)
+        }
+    }
+
+    @Test func submittingSurveyAdvancesToAccount() throws {
+        try withDefaults { defaults in
+            let store = OnboardingStore(defaults: defaults)
+            store.advance()
+            store.advance()
+            store.submitSurvey()
 
             #expect(store.step == .account)
         }
@@ -41,6 +52,7 @@ struct OnboardingStoreTests {
 
             #expect(store.step == .welcome)
 
+            store.advance()
             store.advance()
             store.advance()
             store.advance()
@@ -69,6 +81,35 @@ struct OnboardingStoreTests {
             store.toggle(.other, for: .videoTypes)
 
             #expect(store.selection(for: .videoTypes).isEmpty)
+        }
+    }
+
+    @Test func acquisitionSourceIsSingleSelect() throws {
+        try withDefaults { defaults in
+            let store = OnboardingStore(defaults: defaults)
+            let google = try #require(OnboardingQuestion.acquisitionSource.options.first { $0.id == "google" })
+            let github = try #require(OnboardingQuestion.acquisitionSource.options.first { $0.id == "github" })
+
+            store.toggle(google, for: .acquisitionSource)
+            store.toggle(github, for: .acquisitionSource)
+
+            #expect(store.selection(for: .acquisitionSource) == ["github"])
+        }
+    }
+
+    @Test func noPreviousEditorIsExclusive() throws {
+        try withDefaults { defaults in
+            let store = OnboardingStore(defaults: defaults)
+            let premiere = try #require(OnboardingQuestion.previousEditors.options.first { $0.id == "premiere_pro" })
+            let none = try #require(OnboardingQuestion.previousEditors.options.first { $0.id == "none" })
+            let capcut = try #require(OnboardingQuestion.previousEditors.options.first { $0.id == "capcut" })
+
+            store.toggle(premiere, for: .previousEditors)
+            store.toggle(none, for: .previousEditors)
+            #expect(store.selection(for: .previousEditors) == ["none"])
+
+            store.toggle(capcut, for: .previousEditors)
+            #expect(store.selection(for: .previousEditors) == ["capcut"])
         }
     }
 


### PR DESCRIPTION
## Summary
- ask new users how they found Palmier Pro and which editors they previously used
- capture stable acquisition and editor identifiers in the existing onboarding completion event
- use a warm accent tint for onboarding secondary actions and unselected choices

## Approach
- insert a concise, scrollable discovery questionnaire before the existing work-profile page
- keep acquisition single-select while allowing multiple previous editors, with `None` as an exclusive choice
- share one questionnaire view across both onboarding pages and bump the survey schema to version 2

## Testing
- `scripts/localization/sync.sh`
- `swift test --filter OnboardingStoreTests` — 9 tests passed
- `swift build`
- `git diff --check`
- manually confirmed the updated onboarding button appearance

## Change statistics
- code and UI logic: +103 / -16
- localization inventory: +16 / -0
- tests: +42 / -1
- total: +161 / -17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and telemetry-only onboarding survey expansion; no auth, security, or data-handling paths are changed. Existing installs remain skipped via the same completion key.
> 
> **Overview**
> Adds a **discovery** step before the work-profile questionnaire so new users can report how they found Palmier Pro and which editors they used before.
> 
> Answers are included in the existing `onboarding completed` analytics event (survey version **2**), with acquisition as single-select and `None` exclusive among previous editors. The profile UI is generalized into a shared `OnboardingQuestionnaireStep`, and secondary/unselected chips get a warmer accent fill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9e9c5db0386d90a7dc7c9899df466a13dd7bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->