### PR TITLE
[agent] Add in-app skill management

### DIFF
--- a/Sources/PalmierPro/Agent/Skills/Skill.swift
+++ b/Sources/PalmierPro/Agent/Skills/Skill.swift
@@ -2,6 +2,12 @@ import Foundation
 
 /// A skill is a folder under `~/.palmier/skills/<id>/` with a `SKILL.md` file
 struct Skill: Identifiable, Sendable {
+    enum Limits {
+        static let maximumNameLength = 120
+        static let maximumDescriptionLength = 500
+        static let maximumInstructionsLength = 50_000
+    }
+
     let id: String  // folder name
     let name: String
     let description: String
@@ -9,6 +15,17 @@ struct Skill: Identifiable, Sendable {
 }
 
 enum SkillFrontmatter {
+    static func contents(name: String, description: String, instructions: String) -> String {
+        """
+        ---
+        name: \(name)
+        description: \(description)
+        ---
+
+        \(instructions)
+        """
+    }
+
     /// Splits a SKILL.md into its frontmatter fields and body
     static func parse(_ text: String) -> (fields: [String: String], body: String) {
         var fields: [String: String] = [:]
@@ -43,25 +60,40 @@ enum SkillFrontmatter {
         return (name, description, parsed.body)
     }
 
-    static func replacingName(_ text: String, name: String) -> String {
-        let lines = text.components(separatedBy: "\n")
-        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
-            return "---\nname: \(name)\n---\n\n" + text
+    static func replacingFields(
+        _ text: String,
+        name: String? = nil,
+        description: String? = nil,
+        instructions: String? = nil
+    ) -> String {
+        var lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---",
+              var closingIndex = lines.indices.dropFirst().first(where: {
+                  lines[$0].trimmingCharacters(in: .whitespaces) == "---"
+              }) else {
+            let parsed = parse(text)
+            return contents(
+                name: name ?? parsed.fields["name"] ?? "New skill",
+                description: description ?? parsed.fields["description"] ?? "Describe when to use this skill.",
+                instructions: instructions ?? parsed.body
+            )
         }
-        var front: [String] = []
-        var replaced = false
-        var i = 1
-        while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "---" {
-            if let colon = lines[i].firstIndex(of: ":"),
-               lines[i][..<colon].trimmingCharacters(in: .whitespaces) == "name" {
-                front.append("name: \(name)"); replaced = true
+
+        func replace(_ key: String, with value: String) {
+            if let index = (1..<closingIndex).first(where: { index in
+                guard let colon = lines[index].firstIndex(of: ":") else { return false }
+                return lines[index][..<colon].trimmingCharacters(in: .whitespaces) == key
+            }) {
+                lines[index] = "\(key): \(value)"
             } else {
-                front.append(lines[i])
+                lines.insert("\(key): \(value)", at: closingIndex)
+                closingIndex += 1
             }
-            i += 1
         }
-        if !replaced { front.insert("name: \(name)", at: 0) }
-        let rest = i < lines.count ? lines[i...].joined(separator: "\n") : "---"
-        return "---\n" + front.joined(separator: "\n") + "\n" + rest
+
+        if let name { replace("name", with: name) }
+        if let description { replace("description", with: description) }
+        guard let instructions else { return lines.joined(separator: "\n") }
+        return lines[...closingIndex].joined(separator: "\n") + "\n\n" + instructions
     }
 }

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -457,13 +457,13 @@ final class SkillStore {
     func delete(_ skill: Skill) async -> Bool {
         await serializeMutation("delete skill \(skill.id)") { [self] in
             guard var ledger else { return false }
-            try await Self.performFileOperation {
-                try FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
-            }
             ledger.installed.removeValue(forKey: skill.id)
             ledger.suppressed.insert(skill.id)
             try await Self.persistLedger(ledger, directory: storageDirectory)
             self.ledger = ledger
+            try await Self.performFileOperation {
+                try FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
+            }
             await reloadInBackground()
             return true
         } ?? false

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -54,9 +54,16 @@ private struct PersistedSkillLedger: Codable {
 @Observable
 @MainActor
 final class SkillStore {
+    enum UpdateResult: Sendable {
+        case updated(Skill)
+        case unchanged(Skill)
+        case failed
+    }
+
     static let shared = SkillStore()
 
     private(set) var skills: [Skill] = []
+    private let storageDirectory: URL
 
     private var ledger: SkillLedger?
 
@@ -72,21 +79,23 @@ final class SkillStore {
             .appendingPathComponent(".palmier/skills", isDirectory: true)
     }
 
-    nonisolated private static var ledgerURL: URL { directory.appendingPathComponent(".installed.json") }
-
     private var reloadGeneration = 0
     private var syncTask: Task<Void, Never>?
     private var mutationTask: Task<Void, Never>?
 
-    private init() {
+    private convenience init() { self.init(directory: Self.directory) }
+
+    init(directory: URL) {
+        storageDirectory = directory
         Task { await reloadSkills() }
     }
 
     private func reloadInBackground() async {
         reloadGeneration += 1
         let generation = reloadGeneration
+        let directory = storageDirectory
         let result = await Task.detached(priority: .utility) {
-            (Self.scan(), Self.loadLedger())
+            (Self.scan(directory: directory), Self.loadLedger(directory: directory))
         }.value
         guard generation == reloadGeneration else { return }
         apply(result.0)
@@ -125,7 +134,7 @@ final class SkillStore {
         )
     }
 
-    nonisolated static func scan() -> SkillScan {
+    nonisolated static func scan(directory: URL = SkillStore.directory) -> SkillScan {
         let fm = FileManager.default
         var found: [Skill] = []
         var bodies: [String: String] = [:]
@@ -222,7 +231,7 @@ final class SkillStore {
     func install(_ entry: SkillCatalogEntry, automatically: Bool = false) async -> Bool {
         guard ledger != nil else { return false }
         guard let url = SkillCatalog.bodyURL(path: entry.path) else { return false }
-        guard let dir = Self.skillDirectory(for: entry.id) else {
+        guard let dir = Self.skillDirectory(for: entry.id, directory: storageDirectory) else {
             Log.agent.error("install skill \(entry.id) rejected: invalid id")
             return false
         }
@@ -266,7 +275,7 @@ final class SkillStore {
                 }
                 ledger.installed[entry.id] = entry.sha
                 ledger.suppressed.remove(entry.id)
-                try await Self.persistLedger(ledger)
+                try await Self.persistLedger(ledger, directory: storageDirectory)
                 self.ledger = ledger
                 return true
             } ?? false
@@ -295,10 +304,13 @@ final class SkillStore {
     }
 
     /// Resolves `~/.palmier/skills/<id>/` only when `id` is a single safe path component.
-    nonisolated static func skillDirectory(for id: String) -> URL? {
+    nonisolated static func skillDirectory(
+        for id: String,
+        directory: URL = SkillStore.directory
+    ) -> URL? {
         guard isValidSkillId(id) else { return nil }
         let dir = directory.appendingPathComponent(id, isDirectory: true).standardizedFileURL
-        guard isUnderSkillsRoot(dir) else { return nil }
+        guard isUnderSkillsRoot(dir, directory: directory) else { return nil }
         return dir
     }
 
@@ -308,7 +320,7 @@ final class SkillStore {
         return true
     }
 
-    nonisolated private static func isUnderSkillsRoot(_ url: URL) -> Bool {
+    nonisolated private static func isUnderSkillsRoot(_ url: URL, directory: URL) -> Bool {
         let root = directory.standardizedFileURL.path
         let path = url.standardizedFileURL.path
         return path == root || path.hasPrefix(root + "/")
@@ -325,7 +337,8 @@ final class SkillStore {
         try operation()
     }
 
-    nonisolated private static func loadLedger() -> SkillLedger? {
+    nonisolated private static func loadLedger(directory: URL) -> SkillLedger? {
+        let ledgerURL = directory.appendingPathComponent(".installed.json")
         guard FileManager.default.fileExists(atPath: ledgerURL.path) else { return SkillLedger() }
         guard let data = try? Data(contentsOf: ledgerURL) else { return nil }
         return decodeLedger(data)
@@ -346,7 +359,7 @@ final class SkillStore {
     }
 
     @concurrent
-    private static func persistLedger(_ ledger: SkillLedger) async throws {
+    private static func persistLedger(_ ledger: SkillLedger, directory: URL) async throws {
         let persisted = PersistedSkillLedger(
             version: PersistedSkillLedger.currentVersion,
             installed: ledger.installed,
@@ -354,6 +367,7 @@ final class SkillStore {
         )
         let data = try JSONEncoder().encode(persisted)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let ledgerURL = directory.appendingPathComponent(".installed.json")
         try data.write(to: ledgerURL, options: .atomic)
     }
 
@@ -373,9 +387,9 @@ final class SkillStore {
 
     func openFolder() {
         try? FileManager.default.createDirectory(
-            at: Self.directory, withIntermediateDirectories: true
+            at: storageDirectory, withIntermediateDirectories: true
         )
-        NSWorkspace.shared.open(Self.directory)
+        NSWorkspace.shared.open(storageDirectory)
     }
 
     func reveal(_ url: URL) {
@@ -392,6 +406,34 @@ final class SkillStore {
             await reloadInBackground()
             return true
         } ?? false
+    }
+
+    func update(
+        _ skill: Skill,
+        name: String?,
+        description: String?,
+        instructions: String?
+    ) async -> UpdateResult {
+        await serializeMutation("update skill \(skill.id)") { [self] in
+            let path = skill.path
+            let changed = try await Self.performFileOperation {
+                let raw = try String(contentsOf: path, encoding: .utf8)
+                let updated = SkillFrontmatter.replacingFields(
+                    raw,
+                    name: name,
+                    description: description,
+                    instructions: instructions
+                )
+                guard updated != raw else { return false }
+                try Data(updated.utf8).write(to: path, options: .atomic)
+                return true
+            }
+            await reloadInBackground()
+            guard let saved = skills.first(where: { $0.id == skill.id }) else {
+                return UpdateResult.failed
+            }
+            return changed ? .updated(saved) : .unchanged(saved)
+        } ?? .failed
     }
 
     /// Copies under a `palmier-` prefix so we only overwrite our own prior copy
@@ -420,7 +462,7 @@ final class SkillStore {
             }
             if ledger.installed.removeValue(forKey: skill.id) != nil {
                 ledger.suppressed.insert(skill.id)
-                try await Self.persistLedger(ledger)
+                try await Self.persistLedger(ledger, directory: storageDirectory)
                 self.ledger = ledger
             }
             await reloadInBackground()
@@ -440,10 +482,13 @@ final class SkillStore {
         """
 
     @discardableResult
-    func createSkill(raw: String) async -> String? {
+    func createSkill(raw: String, preferredID: String? = nil) async -> String? {
         guard let parsed = SkillFrontmatter.requiredFields(raw) else { return nil }
         guard let id = await serializeMutation("create skill", { [self] in
-            let id = try await Self.performFileOperation { try Self.createSkillFile(raw: raw) }
+            let directory = storageDirectory
+            let id = try await Self.performFileOperation {
+                try Self.createSkillFile(raw: raw, preferredID: preferredID, directory: directory)
+            }
             await reloadInBackground()
             return id
         }) else {
@@ -453,17 +498,48 @@ final class SkillStore {
         return id
     }
 
-    nonisolated private static func createSkillFile(raw: String) throws -> String {
+    nonisolated static func suggestedID(for name: String) -> String {
+        let words = name.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+        let candidate = String(words.joined(separator: "-").prefix(64))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return candidate.isEmpty ? "new-skill" : candidate
+    }
+
+    nonisolated private static func createSkillFile(
+        raw: String,
+        preferredID: String?,
+        directory: URL
+    ) throws -> String {
         let fm = FileManager.default
-        var id = "new-skill"
-        var n = 2
-        while fm.fileExists(atPath: Self.directory.appendingPathComponent(id).path) {
-            id = "new-skill-\(n)"; n += 1
+        let validatedPreferredID = preferredID.flatMap { isValidSkillId($0) ? $0 : nil }
+        let baseID = validatedPreferredID ?? "new-skill"
+        var id = baseID
+        if validatedPreferredID != nil {
+            let existing = directory.appendingPathComponent(id, isDirectory: true)
+                .appendingPathComponent("SKILL.md")
+            if fm.fileExists(atPath: existing.path) {
+                guard try String(contentsOf: existing, encoding: .utf8) == raw else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                return id
+            }
+        } else {
+            var n = 2
+            while fm.fileExists(atPath: directory.appendingPathComponent(id).path) {
+                id = "\(baseID)-\(n)"; n += 1
+            }
         }
-        let dir = Self.directory.appendingPathComponent(id, isDirectory: true)
+        let dir = directory.appendingPathComponent(id, isDirectory: true)
         let md = dir.appendingPathComponent("SKILL.md")
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        try raw.write(to: md, atomically: true, encoding: .utf8)
+        do {
+            try raw.write(to: md, atomically: true, encoding: .utf8)
+        } catch {
+            try? fm.removeItem(at: dir)
+            throw error
+        }
         return id
     }
 
@@ -479,7 +555,7 @@ final class SkillStore {
 
     nonisolated private static func renameSkillFile(_ skill: Skill, to name: String) throws {
         let text = try String(contentsOf: skill.path, encoding: .utf8)
-        let updated = SkillFrontmatter.replacingName(text, name: name)
+        let updated = SkillFrontmatter.replacingFields(text, name: name)
         try updated.write(to: skill.path, atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -460,11 +460,10 @@ final class SkillStore {
             try await Self.performFileOperation {
                 try FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
             }
-            if ledger.installed.removeValue(forKey: skill.id) != nil {
-                ledger.suppressed.insert(skill.id)
-                try await Self.persistLedger(ledger, directory: storageDirectory)
-                self.ledger = ledger
-            }
+            ledger.installed.removeValue(forKey: skill.id)
+            ledger.suppressed.insert(skill.id)
+            try await Self.persistLedger(ledger, directory: storageDirectory)
+            self.ledger = ledger
             await reloadInBackground()
             return true
         } ?? false

--- a/Sources/PalmierPro/Agent/Skills/SkillStore.swift
+++ b/Sources/PalmierPro/Agent/Skills/SkillStore.swift
@@ -457,12 +457,23 @@ final class SkillStore {
     func delete(_ skill: Skill) async -> Bool {
         await serializeMutation("delete skill \(skill.id)") { [self] in
             guard var ledger else { return false }
+            let originalLedger = ledger
             ledger.installed.removeValue(forKey: skill.id)
             ledger.suppressed.insert(skill.id)
             try await Self.persistLedger(ledger, directory: storageDirectory)
             self.ledger = ledger
-            try await Self.performFileOperation {
-                try FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
+            do {
+                try await Self.performFileOperation {
+                    try FileManager.default.removeItem(at: skill.path.deletingLastPathComponent())
+                }
+            } catch let removalError {
+                do {
+                    try await Self.persistLedger(originalLedger, directory: storageDirectory)
+                    self.ledger = originalLedger
+                } catch {
+                    Log.agent.error("restore skill ledger failed: \(error.localizedDescription)")
+                }
+                throw removalError
             }
             await reloadInBackground()
             return true

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -71,6 +71,7 @@ enum ToolName: String, CaseIterable, Sendable {
     // Meta
     case sendFeedback = "send_feedback"
     case readSkill = "read_skill"
+    case manageSkills = "manage_skills"
 }
 
 struct AgentTool: @unchecked Sendable {
@@ -1162,6 +1163,41 @@ enum ToolDefinitions {
         )
     )
 
+    /// In-app assistant only
+    static let manageSkills = AgentTool(
+        name: .manageSkills,
+        description: "Create, update, or permanently remove reusable skills for the in-app assistant. Set `action` to: `create` with name, description, and complete Markdown instructions; `update` with an exact skill id and at least one field to replace; or `remove` with an exact skill id. Updates are partial patches, but `instructions`, when present, replaces the complete Markdown body, so call read_skill first when preserving existing instructions. Use remove only when the user explicitly asks to delete that skill. The app generates and returns a stable id for created skills.",
+        inputSchema: objectSchema(
+            properties: [
+                "action": [
+                    "type": "string",
+                    "enum": ["create", "update", "remove"],
+                    "description": "Skill operation.",
+                ],
+                "id": [
+                    "type": "string",
+                    "description": "Update/remove only. Exact skill id listed under # Skills.",
+                ],
+                "name": [
+                    "type": "string",
+                    "maxLength": Skill.Limits.maximumNameLength,
+                    "description": "Create/update. Concise skill display name on one line.",
+                ],
+                "description": [
+                    "type": "string",
+                    "maxLength": Skill.Limits.maximumDescriptionLength,
+                    "description": "Create/update. One-line trigger description explaining when the assistant should use the skill.",
+                ],
+                "instructions": [
+                    "type": "string",
+                    "maxLength": Skill.Limits.maximumInstructionsLength,
+                    "description": "Create/update. Complete replacement Markdown instructions without YAML frontmatter.",
+                ],
+            ],
+            required: ["action"]
+        )
+    )
+
     /// MCP server only
     static let manageProject = AgentTool(
         name: .manageProject,
@@ -1188,7 +1224,7 @@ enum ToolDefinitions {
     )
 
     static var mcpServer: [AgentTool] { all + [manageProject] }
-    static var inAppAgent: [AgentTool] { all + [readSkill] }
+    static var inAppAgent: [AgentTool] { all + [readSkill, manageSkills] }
 
     private static func textTransformProperties() -> [String: [String: Any]] {
         [

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Skills.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Skills.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+extension ToolExecutor {
+    func manageSkills(_ args: [String: Any]) async throws -> ToolResult {
+        guard let action = args.string("action") else {
+            throw ToolError("manage_skills.action: expected one of: create, update, remove")
+        }
+        switch action {
+        case "create":
+            return try await createSkill(args)
+        case "update":
+            return try await updateSkill(args)
+        case "remove":
+            return try await removeSkill(args)
+        default:
+            throw ToolError("Unknown skill action '\(action)'. Expected one of: create, update, remove.")
+        }
+    }
+
+    private func createSkill(_ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(
+            args,
+            allowed: ["action", "name", "description", "instructions"],
+            path: "manage_skills"
+        )
+        let name = try requiredSkillText(
+            args,
+            key: "name",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumNameLength,
+            singleLine: true
+        )
+        let description = try requiredSkillText(
+            args,
+            key: "description",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumDescriptionLength,
+            singleLine: true
+        )
+        let instructions = try requiredSkillText(
+            args,
+            key: "instructions",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumInstructionsLength,
+            singleLine: false
+        )
+        let id = SkillStore.suggestedID(for: name)
+
+        if let existing = skillStore.skills.first(where: { $0.id == id }) {
+            guard existing.name == name,
+                  existing.description == description,
+                  skillStore.body(for: id) == instructions else {
+                throw ToolError("A skill with id '\(id)' already exists. Use manage_skills with action='update'.")
+            }
+            return skillReceipt(status: "unchanged", skill: existing)
+        }
+
+        let raw = SkillFrontmatter.contents(
+            name: name,
+            description: description,
+            instructions: instructions
+        )
+        guard let createdID = await skillStore.createSkill(raw: raw, preferredID: id),
+              let skill = skillStore.skills.first(where: { $0.id == createdID }) else {
+            throw ToolError("Could not create skill '\(name)'.")
+        }
+        return skillReceipt(status: "created", skill: skill)
+    }
+
+    private func updateSkill(_ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(
+            args,
+            allowed: ["action", "id", "name", "description", "instructions"],
+            path: "manage_skills"
+        )
+        guard let id = args.string("id") else {
+            throw ToolError("manage_skills.id: expected non-empty string for update")
+        }
+        let name = try optionalSkillText(
+            args,
+            key: "name",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumNameLength,
+            singleLine: true
+        )
+        let description = try optionalSkillText(
+            args,
+            key: "description",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumDescriptionLength,
+            singleLine: true
+        )
+        let instructions = try optionalSkillText(
+            args,
+            key: "instructions",
+            path: "manage_skills",
+            maximumLength: Skill.Limits.maximumInstructionsLength,
+            singleLine: false
+        )
+        guard name != nil || description != nil || instructions != nil else {
+            throw ToolError("manage_skills update requires at least one of: name, description, instructions.")
+        }
+        guard let skill = skillStore.skills.first(where: { $0.id == id }) else {
+            throw ToolError("Unknown skill: \(id)")
+        }
+
+        var changed: [String] = []
+        if let name, name != skill.name { changed.append("name") }
+        if let description, description != skill.description { changed.append("description") }
+        if let instructions, instructions != skillStore.body(for: id) { changed.append("instructions") }
+        guard !changed.isEmpty else {
+            return skillReceipt(status: "unchanged", skill: skill)
+        }
+
+        switch await skillStore.update(
+            skill,
+            name: name,
+            description: description,
+            instructions: instructions
+        ) {
+        case .updated(let saved):
+            return skillReceipt(status: "updated", skill: saved, changed: changed)
+        case .unchanged(let saved):
+            return skillReceipt(status: "unchanged", skill: saved)
+        case .failed:
+            throw ToolError("Could not update skill '\(id)'.")
+        }
+    }
+
+    private func removeSkill(_ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["action", "id"], path: "manage_skills")
+        guard let id = args.string("id") else {
+            throw ToolError("manage_skills.id: expected non-empty string for remove")
+        }
+        guard let skill = skillStore.skills.first(where: { $0.id == id }) else {
+            throw ToolError("Unknown skill: \(id)")
+        }
+        guard await skillStore.delete(skill) else {
+            throw ToolError("Could not remove skill '\(id)'.")
+        }
+        return .ok(Self.jsonString([
+            "status": "removed",
+            "id": skill.id,
+            "name": skill.name,
+        ]) ?? "{}")
+    }
+
+    private func requiredSkillText(
+        _ args: [String: Any],
+        key: String,
+        path: String,
+        maximumLength: Int,
+        singleLine: Bool
+    ) throws -> String {
+        guard let value = try optionalSkillText(
+            args,
+            key: key,
+            path: path,
+            maximumLength: maximumLength,
+            singleLine: singleLine
+        ) else {
+            throw ToolError("\(path).\(key): expected non-empty string")
+        }
+        return value
+    }
+
+    private func optionalSkillText(
+        _ args: [String: Any],
+        key: String,
+        path: String,
+        maximumLength: Int,
+        singleLine: Bool
+    ) throws -> String? {
+        guard args.keys.contains(key) else { return nil }
+        guard let raw = args[key] as? String else {
+            throw ToolError("\(path).\(key): expected string")
+        }
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            throw ToolError("\(path).\(key): expected non-empty string")
+        }
+        guard value.count <= maximumLength else {
+            throw ToolError("\(path).\(key): maximum length is \(maximumLength) characters")
+        }
+        guard !singleLine || value.rangeOfCharacter(from: .newlines) == nil else {
+            throw ToolError("\(path).\(key): expected one line")
+        }
+        return value
+    }
+
+    private func skillReceipt(
+        status: String,
+        skill: Skill,
+        changed: [String]? = nil
+    ) -> ToolResult {
+        var payload: [String: Any] = [
+            "status": status,
+            "skill": [
+                "id": skill.id,
+                "name": skill.name,
+                "description": skill.description,
+            ],
+        ]
+        if let changed { payload["changed"] = changed }
+        return .ok(Self.jsonString(payload) ?? "{}")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -17,6 +17,7 @@ final class ToolExecutor {
     private(set) var mcpSessionActivation = Analytics.SessionActivation()
     private let analyticsSessionID = UUID().uuidString
     let exportQueue: ExportQueue
+    let skillStore: SkillStore
 
     var editor: EditorViewModel? {
         frontmostProjectProvider == nil ? inAppEditor : sessionProject?.editorViewModel
@@ -31,18 +32,27 @@ final class ToolExecutor {
 
     var frontmostProject: VideoProject? { frontmostProjectProvider?() }
 
-    init(editor: EditorViewModel, exportQueue: ExportQueue = .shared) {
+    init(
+        editor: EditorViewModel,
+        exportQueue: ExportQueue = .shared,
+        skillStore: SkillStore = .shared
+    ) {
         self.inAppEditor = editor
         self.frontmostProjectProvider = nil
         self.exportQueue = exportQueue
+        self.skillStore = skillStore
     }
 
-    init(projectProvider: @escaping () -> VideoProject?, exportQueue: ExportQueue = .shared) {
+    init(
+        projectProvider: @escaping () -> VideoProject?,
+        exportQueue: ExportQueue = .shared
+    ) {
         let project = projectProvider()
         self.inAppEditor = nil
         self.frontmostProjectProvider = projectProvider
         self.boundProject = project
         self.exportQueue = exportQueue
+        self.skillStore = .shared
     }
 
     func bindProject(_ project: VideoProject?) {
@@ -81,7 +91,9 @@ final class ToolExecutor {
     ) async -> ToolResult {
         let args = Self.droppingAutofilledBlanks(from: args)
         let started = ContinuousClock.now
-        guard let tool = ToolName(rawValue: name) else {
+        guard let tool = ToolName(rawValue: name),
+              origin.source != "mcp"
+                || ToolDefinitions.mcpServer.contains(where: { $0.name == tool }) else {
             let result = ToolResult.error("Unknown tool: \(name)")
             captureToolAnalytics(
                 toolName: name,
@@ -351,6 +363,7 @@ final class ToolExecutor {
         case .createTimeline:     return try createTimeline(editor, args)
         case .setActiveTimeline:  return try setActiveTimeline(editor, args)
         case .readSkill:     return readSkill(args)
+        case .manageSkills:  return try await manageSkills(args)
         case .manageProject:
             return await manageProject(args)
         }
@@ -360,13 +373,13 @@ final class ToolExecutor {
         guard let id = args.string("id") else {
             return .error("read_skill requires an 'id'.")
         }
-        guard let body = SkillStore.shared.body(for: id) else {
+        guard let body = skillStore.body(for: id) else {
             return .error("Unknown skill: \(id)")
         }
         Analytics.captureSkillRead(
             skillID: id,
-            skillSHA: SkillStore.shared.contentSHA(for: id),
-            skillOrigin: SkillStore.shared.origin(for: id).rawValue
+            skillSHA: skillStore.contentSHA(for: id),
+            skillOrigin: skillStore.origin(for: id).rawValue
         )
         return .ok(body)
     }

--- a/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
+++ b/Sources/PalmierPro/Settings/Skill/SkillDetailSheet.swift
@@ -386,12 +386,12 @@ struct SkillDetailSheet: View {
         editingTitle = false
         guard !name.isEmpty else { return }
         if isDraft {
-            draft = SkillFrontmatter.replacingName(draft, name: name)
+            draft = SkillFrontmatter.replacingFields(draft, name: name)
             return
         }
         guard let skill else { return }
         if editing {
-            draft = SkillFrontmatter.replacingName(draft, name: name)
+            draft = SkillFrontmatter.replacingFields(draft, name: name)
             return
         }
         guard name != skill.name else { return }

--- a/Tests/PalmierProTests/Agent/SkillFrontmatterTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillFrontmatterTests.swift
@@ -14,12 +14,32 @@ struct SkillFrontmatterTests {
         #expect(SkillFrontmatter.requiredFields(emptyDescription) == nil)
     }
 
-    @Test func replacingNameKeepsTheDraftInstructions() {
+    @Test func replacingOnlyNameKeepsTheDraftInstructions() {
         let draft = "---\nname: New skill\ndescription: Edit clips.\n---\n\n## Workflow\n1. First step."
 
-        let updated = SkillFrontmatter.replacingName(draft, name: "Editing")
+        let updated = SkillFrontmatter.replacingFields(draft, name: "Editing")
 
         #expect(updated == "---\nname: Editing\ndescription: Edit clips.\n---\n\n## Workflow\n1. First step.")
+    }
+
+    @Test func replacingFieldsPreservesUnchangedFrontmatter() {
+        let draft = "---\nname: Editing\ndescription: Edit clips.\nsource: local\n---\n\nOld instructions"
+
+        let updated = SkillFrontmatter.replacingFields(
+            draft,
+            description: "Tighten interview edits.",
+            instructions: "## Workflow\nRemove pauses."
+        )
+
+        #expect(
+            updated
+                == "---\nname: Editing\ndescription: Tighten interview edits.\nsource: local\n---\n\n## Workflow\nRemove pauses."
+        )
+    }
+
+    @Test func suggestedSkillIDIsStableAndFilesystemSafe() {
+        #expect(SkillStore.suggestedID(for: "  Interview Cleanup & Pacing  ") == "interview-cleanup-pacing")
+        #expect(SkillStore.suggestedID(for: "///") == "new-skill")
     }
 
     @Test @MainActor func newSkillTemplateIsValidBeforeItIsSaved() {

--- a/Tests/PalmierProTests/Agent/SkillToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillToolTests.swift
@@ -16,12 +16,24 @@ private final class SkillToolHarness {
         executor = ToolExecutor(editor: editor, skillStore: store)
     }
 
-    func run(
-        _ name: String,
-        args: [String: Any],
+    func call(
+        _ action: String,
+        id: String? = nil,
+        name: String? = nil,
+        description: String? = nil,
+        instructions: String? = nil,
         source: String = "agent"
     ) async -> ToolResult {
-        await executor.execute(name: name, args: args, source: source)
+        var args: [String: Any] = ["action": action]
+        if let id { args["id"] = id }
+        if let name { args["name"] = name }
+        if let description = description ?? (action == "create" ? "Use this skill." : nil) {
+            args["description"] = description
+        }
+        if let instructions = instructions ?? (action == "create" ? "Follow the workflow." : nil) {
+            args["instructions"] = instructions
+        }
+        return await executor.execute(name: "manage_skills", args: args, source: source)
     }
 }
 
@@ -31,12 +43,10 @@ struct SkillToolTests {
     @Test func schemasAreExposedOnlyToTheInAppAgent() throws {
         let inAppNames = Set(ToolDefinitions.inAppAgent.map(\.name))
         let mcpNames = Set(ToolDefinitions.mcpServer.map(\.name))
-
         #expect(inAppNames.contains(.manageSkills))
         #expect(!mcpNames.contains(.manageSkills))
 
         let tool = try #require(ToolDefinitions.inAppAgent.first { $0.name == .manageSkills })
-        #expect(tool.inputSchema["required"] as? [String] == ["action"])
         let properties = try #require(tool.inputSchema["properties"] as? [String: [String: Any]])
         #expect(properties["action"]?["enum"] as? [String] == ["create", "update", "remove"])
         #expect(Set(properties.keys) == ["action", "id", "name", "description", "instructions"])
@@ -44,47 +54,47 @@ struct SkillToolTests {
 
     @Test func createUpdateAndRemoveSkill() async throws {
         try await withHarness { harness in
-            let createArgs = [
-                "action": "create",
-                "name": "Interview Cleanup",
-                "description": "Tighten spoken interviews.",
-                "instructions": "## Workflow\nRemove pauses, then remove filler words.",
-            ]
-            let created = await harness.run("manage_skills", args: createArgs)
+            let initialInstructions = "## Workflow\nRemove pauses, then remove filler words."
+            let created = await harness.call(
+                "create",
+                name: "Interview Cleanup",
+                description: "Tighten spoken interviews.",
+                instructions: initialInstructions
+            )
             let createdJSON = try resultJSON(created)
             let createdSkill = try #require(createdJSON["skill"] as? [String: Any])
-
             #expect(createdJSON["status"] as? String == "created")
             #expect(createdSkill["id"] as? String == "interview-cleanup")
-            #expect(harness.store.body(for: "interview-cleanup") == createArgs["instructions"])
+            #expect(harness.store.body(for: "interview-cleanup") == initialInstructions)
 
-            let repeated = await harness.run("manage_skills", args: createArgs)
+            let repeated = await harness.call(
+                "create",
+                name: "Interview Cleanup",
+                description: "Tighten spoken interviews.",
+                instructions: initialInstructions
+            )
             #expect(try resultJSON(repeated)["status"] as? String == "unchanged")
             #expect(harness.store.skills.count == 1)
 
-            let updated = await harness.run("manage_skills", args: [
-                "action": "update",
-                "id": "interview-cleanup",
-                "description": "Tighten interviews while preserving intent.",
-                "instructions": "## Workflow\nRemove pauses conservatively.",
-            ])
+            let updated = await harness.call(
+                "update",
+                id: "interview-cleanup",
+                description: "Tighten interviews while preserving intent.",
+                instructions: "## Workflow\nRemove pauses conservatively."
+            )
             let updatedJSON = try resultJSON(updated)
             #expect(updatedJSON["status"] as? String == "updated")
             #expect(updatedJSON["changed"] as? [String] == ["description", "instructions"])
-            #expect(harness.store.skills.first?.description == "Tighten interviews while preserving intent.")
             #expect(harness.store.body(for: "interview-cleanup") == "## Workflow\nRemove pauses conservatively.")
 
-            let unchanged = await harness.run("manage_skills", args: [
-                "action": "update",
-                "id": "interview-cleanup",
-                "description": "Tighten interviews while preserving intent.",
-            ])
+            let unchanged = await harness.call(
+                "update",
+                id: "interview-cleanup",
+                description: "Tighten interviews while preserving intent."
+            )
             #expect(try resultJSON(unchanged)["status"] as? String == "unchanged")
 
-            let removed = await harness.run("manage_skills", args: [
-                "action": "remove",
-                "id": "interview-cleanup",
-            ])
+            let removed = await harness.call("remove", id: "interview-cleanup")
             #expect(try resultJSON(removed)["status"] as? String == "removed")
             #expect(harness.store.skills.isEmpty)
         }
@@ -92,70 +102,43 @@ struct SkillToolTests {
 
     @Test func removingLocalSkillSuppressesMatchingCatalogID() async throws {
         try await withHarness { harness in
-            let created = await harness.run("manage_skills", args: [
-                "action": "create",
-                "name": "Catalog Collision",
-                "description": "Exercise a colliding catalog identifier.",
-                "instructions": "Follow the workflow.",
-            ])
-            #expect(!created.isError)
-
-            let removed = await harness.run("manage_skills", args: [
-                "action": "remove",
-                "id": "catalog-collision",
-            ])
-            #expect(!removed.isError)
-
+            #expect(!(await harness.call("create", name: "Catalog Collision")).isError)
+            #expect(!(await harness.call("remove", id: "catalog-collision")).isError)
             let ledger = try #require(await persistedLedger(in: harness.directory))
             #expect(ledger.suppressed.contains("catalog-collision"))
-            #expect(
-                !SkillStore.shouldAutomaticallyInstall(
-                    localSHA: nil,
-                    installedSHA: ledger.installed["catalog-collision"],
-                    catalogSHA: "catalog",
-                    isSuppressed: ledger.suppressed.contains("catalog-collision")
-                )
-            )
         }
     }
 
     @Test func ledgerWriteFailureLeavesSkillIntact() async throws {
         try await withHarness { harness in
-            let created = await harness.run("manage_skills", args: [
-                "action": "create",
-                "name": "Protected Skill",
-                "description": "Remain intact when suppression cannot be saved.",
-                "instructions": "Follow the workflow.",
-            ])
-            #expect(!created.isError)
+            #expect(!(await harness.call("create", name: "Protected Skill")).isError)
             try await blockLedgerWrites(in: harness.directory)
-
-            let removed = await harness.run("manage_skills", args: [
-                "action": "remove",
-                "id": "protected-skill",
-            ])
-
-            #expect(removed.isError)
-            #expect(harness.store.skills.contains { $0.id == "protected-skill" })
+            #expect((await harness.call("remove", id: "protected-skill")).isError)
             #expect(await skillFileExists(id: "protected-skill", in: harness.directory))
+        }
+    }
+
+    @Test func folderRemovalFailureRestoresLedger() async throws {
+        try await withHarness { harness in
+            let missing = Skill(
+                id: "missing",
+                name: "Missing",
+                description: "Missing fixture.",
+                path: harness.directory.appendingPathComponent("missing/SKILL.md")
+            )
+            #expect(!(await harness.store.delete(missing)))
+            let ledger = try #require(await persistedLedger(in: harness.directory))
+            #expect(ledger == SkillLedger())
         }
     }
 
     @Test func rejectsInvalidUpdatesAndMCPCalls() async throws {
         try await withHarness { harness in
-            let invalidUpdate = await harness.run("manage_skills", args: [
-                "action": "update",
-                "id": "missing",
-            ])
+            let invalidUpdate = await harness.call("update", id: "missing")
             #expect(invalidUpdate.isError)
             #expect(resultText(invalidUpdate).contains("at least one"))
 
-            let mcpCreate = await harness.run("manage_skills", args: [
-                "action": "create",
-                "name": "Private workflow",
-                "description": "Use a private workflow.",
-                "instructions": "Do the work.",
-            ], source: "mcp")
+            let mcpCreate = await harness.call("create", name: "Private Workflow", source: "mcp")
             #expect(mcpCreate.isError)
             #expect(resultText(mcpCreate).contains("Unknown tool"))
             #expect(harness.store.skills.isEmpty)

--- a/Tests/PalmierProTests/Agent/SkillToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillToolTests.swift
@@ -119,6 +119,28 @@ struct SkillToolTests {
         }
     }
 
+    @Test func ledgerWriteFailureLeavesSkillIntact() async throws {
+        try await withHarness { harness in
+            let created = await harness.run("manage_skills", args: [
+                "action": "create",
+                "name": "Protected Skill",
+                "description": "Remain intact when suppression cannot be saved.",
+                "instructions": "Follow the workflow.",
+            ])
+            #expect(!created.isError)
+            try await blockLedgerWrites(in: harness.directory)
+
+            let removed = await harness.run("manage_skills", args: [
+                "action": "remove",
+                "id": "protected-skill",
+            ])
+
+            #expect(removed.isError)
+            #expect(harness.store.skills.contains { $0.id == "protected-skill" })
+            #expect(await skillFileExists(id: "protected-skill", in: harness.directory))
+        }
+    }
+
     @Test func rejectsInvalidUpdatesAndMCPCalls() async throws {
         try await withHarness { harness in
             let invalidUpdate = await harness.run("manage_skills", args: [
@@ -173,6 +195,21 @@ struct SkillToolTests {
             return nil
         }
         return SkillStore.decodeLedger(data)
+    }
+
+    @concurrent
+    private func blockLedgerWrites(in directory: URL) async throws {
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(".installed.json", isDirectory: true),
+            withIntermediateDirectories: false
+        )
+    }
+
+    @concurrent
+    private func skillFileExists(id: String, in directory: URL) async -> Bool {
+        FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(id).appendingPathComponent("SKILL.md").path
+        )
     }
 
     @concurrent

--- a/Tests/PalmierProTests/Agent/SkillToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillToolTests.swift
@@ -5,10 +5,12 @@ import Testing
 @MainActor
 private final class SkillToolHarness {
     let editor = EditorViewModel()
+    let directory: URL
     let store: SkillStore
     let executor: ToolExecutor
 
     init(directory: URL) {
+        self.directory = directory
         let store = SkillStore(directory: directory)
         self.store = store
         executor = ToolExecutor(editor: editor, skillStore: store)
@@ -88,6 +90,35 @@ struct SkillToolTests {
         }
     }
 
+    @Test func removingLocalSkillSuppressesMatchingCatalogID() async throws {
+        try await withHarness { harness in
+            let created = await harness.run("manage_skills", args: [
+                "action": "create",
+                "name": "Catalog Collision",
+                "description": "Exercise a colliding catalog identifier.",
+                "instructions": "Follow the workflow.",
+            ])
+            #expect(!created.isError)
+
+            let removed = await harness.run("manage_skills", args: [
+                "action": "remove",
+                "id": "catalog-collision",
+            ])
+            #expect(!removed.isError)
+
+            let ledger = try #require(await persistedLedger(in: harness.directory))
+            #expect(ledger.suppressed.contains("catalog-collision"))
+            #expect(
+                !SkillStore.shouldAutomaticallyInstall(
+                    localSHA: nil,
+                    installedSHA: ledger.installed["catalog-collision"],
+                    catalogSHA: "catalog",
+                    isSuppressed: ledger.suppressed.contains("catalog-collision")
+                )
+            )
+        }
+    }
+
     @Test func rejectsInvalidUpdatesAndMCPCalls() async throws {
         try await withHarness { harness in
             let invalidUpdate = await harness.run("manage_skills", args: [
@@ -134,6 +165,14 @@ struct SkillToolTests {
     private func resultText(_ result: ToolResult) -> String {
         guard case .text(let text) = result.content.first else { return "" }
         return text
+    }
+
+    @concurrent
+    private func persistedLedger(in directory: URL) async -> SkillLedger? {
+        guard let data = try? Data(contentsOf: directory.appendingPathComponent(".installed.json")) else {
+            return nil
+        }
+        return SkillStore.decodeLedger(data)
     }
 
     @concurrent

--- a/Tests/PalmierProTests/Agent/SkillToolTests.swift
+++ b/Tests/PalmierProTests/Agent/SkillToolTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private final class SkillToolHarness {
+    let editor = EditorViewModel()
+    let store: SkillStore
+    let executor: ToolExecutor
+
+    init(directory: URL) {
+        let store = SkillStore(directory: directory)
+        self.store = store
+        executor = ToolExecutor(editor: editor, skillStore: store)
+    }
+
+    func run(
+        _ name: String,
+        args: [String: Any],
+        source: String = "agent"
+    ) async -> ToolResult {
+        await executor.execute(name: name, args: args, source: source)
+    }
+}
+
+@Suite("In-app skill tools")
+@MainActor
+struct SkillToolTests {
+    @Test func schemasAreExposedOnlyToTheInAppAgent() throws {
+        let inAppNames = Set(ToolDefinitions.inAppAgent.map(\.name))
+        let mcpNames = Set(ToolDefinitions.mcpServer.map(\.name))
+
+        #expect(inAppNames.contains(.manageSkills))
+        #expect(!mcpNames.contains(.manageSkills))
+
+        let tool = try #require(ToolDefinitions.inAppAgent.first { $0.name == .manageSkills })
+        #expect(tool.inputSchema["required"] as? [String] == ["action"])
+        let properties = try #require(tool.inputSchema["properties"] as? [String: [String: Any]])
+        #expect(properties["action"]?["enum"] as? [String] == ["create", "update", "remove"])
+        #expect(Set(properties.keys) == ["action", "id", "name", "description", "instructions"])
+    }
+
+    @Test func createUpdateAndRemoveSkill() async throws {
+        try await withHarness { harness in
+            let createArgs = [
+                "action": "create",
+                "name": "Interview Cleanup",
+                "description": "Tighten spoken interviews.",
+                "instructions": "## Workflow\nRemove pauses, then remove filler words.",
+            ]
+            let created = await harness.run("manage_skills", args: createArgs)
+            let createdJSON = try resultJSON(created)
+            let createdSkill = try #require(createdJSON["skill"] as? [String: Any])
+
+            #expect(createdJSON["status"] as? String == "created")
+            #expect(createdSkill["id"] as? String == "interview-cleanup")
+            #expect(harness.store.body(for: "interview-cleanup") == createArgs["instructions"])
+
+            let repeated = await harness.run("manage_skills", args: createArgs)
+            #expect(try resultJSON(repeated)["status"] as? String == "unchanged")
+            #expect(harness.store.skills.count == 1)
+
+            let updated = await harness.run("manage_skills", args: [
+                "action": "update",
+                "id": "interview-cleanup",
+                "description": "Tighten interviews while preserving intent.",
+                "instructions": "## Workflow\nRemove pauses conservatively.",
+            ])
+            let updatedJSON = try resultJSON(updated)
+            #expect(updatedJSON["status"] as? String == "updated")
+            #expect(updatedJSON["changed"] as? [String] == ["description", "instructions"])
+            #expect(harness.store.skills.first?.description == "Tighten interviews while preserving intent.")
+            #expect(harness.store.body(for: "interview-cleanup") == "## Workflow\nRemove pauses conservatively.")
+
+            let unchanged = await harness.run("manage_skills", args: [
+                "action": "update",
+                "id": "interview-cleanup",
+                "description": "Tighten interviews while preserving intent.",
+            ])
+            #expect(try resultJSON(unchanged)["status"] as? String == "unchanged")
+
+            let removed = await harness.run("manage_skills", args: [
+                "action": "remove",
+                "id": "interview-cleanup",
+            ])
+            #expect(try resultJSON(removed)["status"] as? String == "removed")
+            #expect(harness.store.skills.isEmpty)
+        }
+    }
+
+    @Test func rejectsInvalidUpdatesAndMCPCalls() async throws {
+        try await withHarness { harness in
+            let invalidUpdate = await harness.run("manage_skills", args: [
+                "action": "update",
+                "id": "missing",
+            ])
+            #expect(invalidUpdate.isError)
+            #expect(resultText(invalidUpdate).contains("at least one"))
+
+            let mcpCreate = await harness.run("manage_skills", args: [
+                "action": "create",
+                "name": "Private workflow",
+                "description": "Use a private workflow.",
+                "instructions": "Do the work.",
+            ], source: "mcp")
+            #expect(mcpCreate.isError)
+            #expect(resultText(mcpCreate).contains("Unknown tool"))
+            #expect(harness.store.skills.isEmpty)
+        }
+    }
+
+    private func withHarness(
+        _ operation: @MainActor (SkillToolHarness) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("palmier-skill-tools-\(UUID().uuidString)", isDirectory: true)
+        let harness = SkillToolHarness(directory: directory)
+        await harness.store.reloadSkills()
+        do {
+            try await operation(harness)
+        } catch {
+            await removeDirectory(directory)
+            throw error
+        }
+        await removeDirectory(directory)
+    }
+
+    private func resultJSON(_ result: ToolResult) throws -> [String: Any] {
+        #expect(!result.isError, "\(resultText(result))")
+        let data = Data(resultText(result).utf8)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func resultText(_ result: ToolResult) -> String {
+        guard case .text(let text) = result.content.first else { return "" }
+        return text
+    }
+
+    @concurrent
+    private func removeDirectory(_ directory: URL) async {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}


### PR DESCRIPTION
## Summary
- Add an in-app-only `manage_skills` tool for creating, partially updating, and removing reusable skills.
- Persist skill changes through the existing serialized `SkillStore`, with stable generated IDs, explicit no-op receipts, and catalog suppression on removal.
- Keep the MCP surface isolated so external agents continue using their own skill management.

## Approach
- Expose one action-based tool (`create`, `update`, `remove`) because all operations share the same skill resource and content fields.
- Generate canonical `SKILL.md` frontmatter from structured inputs and preserve unrelated frontmatter during partial updates.
- Serialize read-modify-write updates inside `SkillStore` to prevent stale chat or UI edits from overwriting newer skill content.
- Derive MCP eligibility from `ToolDefinitions.mcpServer`, making the advertised tool set the access-control source of truth.
- Inject an isolated skill directory for deterministic tests without touching the user's real skills.

## Testing
- `swift test` — 1,535 tests in 246 suites passed.
- `swift build` — passed.
- Covered create, idempotent retry, partial update, update no-op, removal, catalog-collision suppression, ledger-write and folder-removal rollback safety, schema exposure, invalid updates, and direct MCP rejection.
- Not completed: live in-app conversation verification. Manual plan:
  - Ask the in-app agent to create a reusable skill and confirm it appears in Skills with the returned ID and content.
  - Ask it to update that skill, then read it back and confirm omitted fields remain unchanged.
  - Ask it to remove the skill and confirm it disappears and is not exposed through MCP.

## Change statistics
- Code logic: +430 / -56
- Tests: +224 / -2
- Total: +654 / -58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds agent-driven filesystem mutations for skill create/update/delete and tightens MCP tool gating. Safeguards and tests reduce risk, but this still touches an important agent capability surface.
> 
> **Overview**
> Lets the **in-app assistant** create, partially update, and remove reusable skills via a new `manage_skills` tool. MCP stays isolated—the tool is advertised only on `inAppAgent`, and MCP execution now rejects anything outside `ToolDefinitions.mcpServer`.
> 
> Skill persistence gains structured create/update support: stable IDs from skill names, partial frontmatter/body patches through `replacingFields`, idempotent create receipts, and safer deletes that suppress catalog reinstalls and roll the ledger back if folder removal fails. `SkillStore` also accepts an injectable directory so tests can exercise the flow without touching the real skills folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6737bf1086c0af7dbd9b73a50a537c1b1a150a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->