### PR TITLE
[fix/perf] Prevent full-timeline mutation receipt encoding

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
@@ -122,7 +122,7 @@ extension ToolExecutor {
         guard !collapsedGids.isEmpty else { return [] }
         changed = changed.filter { gidByMember[$0].map { !collapsedGids.contains($0) } ?? true }
 
-        guard let rawTracks = Self.rawTimelineDict(editor.timeline)?["tracks"] as? [[String: Any]] else { return [] }
+        let rawTracks = Self.focusedRawTracks(editor, captionGroupIds: collapsedGids)
         var out: [[String: Any]] = []
         for track in Self.compactTracks(rawTracks, editor: editor, window: nil, captionDetail: false) {
             for var group in track["captionGroups"] as? [[String: Any]] ?? [] {
@@ -136,8 +136,8 @@ extension ToolExecutor {
 
     /// Returns clips in get_timeline shape with track index, folding audio and captions.
     private func readShapedClips(_ editor: EditorViewModel, ids: Set<String>) -> [[String: Any]] {
-        guard !ids.isEmpty,
-              let rawTracks = Self.rawTimelineDict(editor.timeline)?["tracks"] as? [[String: Any]] else { return [] }
+        guard !ids.isEmpty else { return [] }
+        let rawTracks = Self.focusedRawTracks(editor, clipIds: ids)
         let tracks = Self.compactTracks(rawTracks, editor: editor, window: nil, captionDetail: true)
 
         var byId: [String: [String: Any]] = [:]

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -50,10 +50,14 @@ extension ToolExecutor {
         captionGroupIds: Set<String> = []
     ) -> [[String: Any]] {
         var linkGroupIds = Set<String>()
+        var includedCaptionGroupIds = captionGroupIds
         for track in editor.timeline.tracks {
             for clip in track.clips where clipIds.contains(clip.id) {
                 if let linkGroupId = clip.linkGroupId {
                     linkGroupIds.insert(linkGroupId)
+                }
+                if let captionGroupId = clip.captionGroupId {
+                    includedCaptionGroupIds.insert(captionGroupId)
                 }
             }
         }
@@ -61,7 +65,7 @@ extension ToolExecutor {
         return editor.timeline.tracks.map { track in
             let clips = track.clips.filter { clip in
                 clipIds.contains(clip.id)
-                    || clip.captionGroupId.map(captionGroupIds.contains) == true
+                    || clip.captionGroupId.map(includedCaptionGroupIds.contains) == true
                     || clip.linkGroupId.map(linkGroupIds.contains) == true
             }
             return [

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -44,6 +44,38 @@ extension ToolExecutor {
         try? JSONSerialization.jsonObject(with: JSONEncoder().encode(timeline)) as? [String: Any]
     }
 
+    static func focusedRawTracks(
+        _ editor: EditorViewModel,
+        clipIds: Set<String> = [],
+        captionGroupIds: Set<String> = []
+    ) -> [[String: Any]] {
+        var linkGroupIds = Set<String>()
+        for track in editor.timeline.tracks {
+            for clip in track.clips where clipIds.contains(clip.id) {
+                if let linkGroupId = clip.linkGroupId {
+                    linkGroupIds.insert(linkGroupId)
+                }
+            }
+        }
+
+        return editor.timeline.tracks.map { track in
+            let clips = track.clips.filter { clip in
+                clipIds.contains(clip.id)
+                    || clip.captionGroupId.map(captionGroupIds.contains) == true
+                    || clip.linkGroupId.map(linkGroupIds.contains) == true
+            }
+            return [
+                "id": track.id,
+                "type": track.type.rawValue,
+                "clips": clips.compactMap(Self.rawClipDict),
+            ]
+        }
+    }
+
+    private static func rawClipDict(_ clip: Clip) -> [String: Any]? {
+        try? JSONSerialization.jsonObject(with: JSONEncoder().encode(clip)) as? [String: Any]
+    }
+
     func timelineEntries(_ editor: EditorViewModel, detailed: Bool = false) -> [[String: Any]] {
         editor.timelines.map { t in
             var e: [String: Any] = ["timelineId": t.id, "name": t.name]

--- a/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
+++ b/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
@@ -45,6 +45,46 @@ struct TimelineToolsTests {
         #expect(result?["window"] == nil)
     }
 
+    @Test func mutationReceiptSnapshotExcludesUnrelatedClips() {
+        var visual = Fixtures.clip(id: "visual", start: 0, duration: 30)
+        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 0, duration: 30)
+        visual.linkGroupId = "linked"
+        audio.linkGroupId = "linked"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                visual,
+                Fixtures.clip(id: "unrelated", start: 60, duration: 30),
+            ]),
+            Fixtures.audioTrack(clips: [audio]),
+        ]))
+
+        let tracks = ToolExecutor.focusedRawTracks(h.editor, clipIds: [visual.id])
+        let ids = Set(tracks.flatMap { track in
+            (track["clips"] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
+        })
+
+        #expect(ids == [visual.id, audio.id])
+    }
+
+    @Test func captionReceiptSnapshotIncludesOnlyRequestedGroup() {
+        var first = Fixtures.clip(id: "first", mediaType: .text, start: 0, duration: 30)
+        var second = Fixtures.clip(id: "second", mediaType: .text, start: 30, duration: 30)
+        var unrelated = Fixtures.clip(id: "unrelated", mediaType: .text, start: 60, duration: 30)
+        first.captionGroupId = "requested"
+        second.captionGroupId = "requested"
+        unrelated.captionGroupId = "other"
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [first, second, unrelated]),
+        ]))
+
+        let tracks = ToolExecutor.focusedRawTracks(h.editor, captionGroupIds: ["requested"])
+        let ids = Set(tracks.flatMap { track in
+            (track["clips"] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
+        })
+
+        #expect(ids == [first.id, second.id])
+    }
+
     @Test func createTimelineSwitchesAndInheritsSettings() async throws {
         let h = ToolHarness()
         h.editor.timeline.fps = 60

--- a/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
+++ b/Tests/PalmierProTests/Agent/TimelineToolsTests.swift
@@ -66,7 +66,7 @@ struct TimelineToolsTests {
         #expect(ids == [visual.id, audio.id])
     }
 
-    @Test func captionReceiptSnapshotIncludesOnlyRequestedGroup() {
+    @Test func mutationReceiptSnapshotIncludesChangedCaptionSiblings() {
         var first = Fixtures.clip(id: "first", mediaType: .text, start: 0, duration: 30)
         var second = Fixtures.clip(id: "second", mediaType: .text, start: 30, duration: 30)
         var unrelated = Fixtures.clip(id: "unrelated", mediaType: .text, start: 60, duration: 30)
@@ -77,7 +77,7 @@ struct TimelineToolsTests {
             Fixtures.videoTrack(clips: [first, second, unrelated]),
         ]))
 
-        let tracks = ToolExecutor.focusedRawTracks(h.editor, captionGroupIds: ["requested"])
+        let tracks = ToolExecutor.focusedRawTracks(h.editor, clipIds: [first.id])
         let ids = Set(tracks.flatMap { track in
             (track["clips"] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
         })

--- a/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
+++ b/Tests/PalmierProTests/Agent/ToolExecutorTests.swift
@@ -2571,6 +2571,33 @@ struct SetClipPropertiesTests {
         #expect(group?["textPreview"] as? String == "word0 … word2")
     }
 
+    @Test func updateTextSingleCaptionReceiptPreservesDeviantStyle() async {
+        var clips: [Clip] = []
+        for i in 0..<3 {
+            var clip = Fixtures.clip(id: "cap-\(i)", mediaRef: "text", mediaType: .text, start: i * 30, duration: 30)
+            clip.captionGroupId = "g1"
+            clip.textContent = "word\(i)"
+            clip.textStyle = TextStyle()
+            clips.append(clip)
+        }
+        let h = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: clips)]))
+
+        let result = await h.runRaw("update_text", args: [
+            "clipIds": ["cap-1"],
+            "style": ["color": "#FF0000"],
+        ])
+
+        #expect(result.isError == false, "\(ToolHarness.textOf(result))")
+        let json = (try? JSONSerialization.jsonObject(with: Data(ToolHarness.textOf(result).utf8))) as? [String: Any]
+        let receipt = (json?["clips"] as? [[String: Any]])?.first
+        let color = (receipt?["textStyle"] as? [String: Any])?["color"] as? [String: Any]
+        #expect(receipt?["id"] as? String == "cap-1")
+        #expect(receipt?["captionGroupId"] as? String == "g1")
+        #expect(color?["r"] == nil)
+        #expect((color?["g"] as? NSNumber)?.doubleValue == 0)
+        #expect((color?["b"] as? NSNumber)?.doubleValue == 0)
+    }
+
     @Test func updateTextCaptionGroupAcceptsRichTextStyleFields() async {
         var a = Fixtures.clip(id: "cap-a", mediaRef: "text", mediaType: .text, start: 0, duration: 30)
         var b = Fixtures.clip(id: "cap-b", mediaRef: "text", mediaType: .text, start: 30, duration: 30)


### PR DESCRIPTION
## Summary
- Prevent Agent mutation receipts from serializing and compacting the entire timeline on the main actor.
- Address the app-hang path reported in [PALMIER-PRO-ZG](https://palmier.sentry.io/issues/7604317628/) when a mutation only needs to return a small set of changed clips.
- Preserve linked audio folding, caption-group modal/deviant shaping, track indexes, and existing receipt shapes.

## Approach
- Build focused raw track shells containing only changed clips and any linked partners needed to produce an authoritative receipt.
- Expand a changed caption clip to its complete caption group before shared-style and deviant-property analysis.
- Include every member of an affected caption group when its shared summary must be recomputed.
- Keep full `get_timeline` reads unchanged; only the shared mutation-receipt path uses focused encoding.
- Prefer focused work over moving full-timeline serialization off-main: the receipt should remain proportional to the mutation instead of the project size.

## Testing
- `swift test --filter updateTextSingleCaptionReceiptPreservesDeviantStyle` — passed.
- `swift test --filter TimelineToolsTests` — passed.
- `swift test --filter ToolExecutorTests` — passed.
- `swift build` — passed; existing Convex archive deployment-target linker warnings remain.
- MCP end-to-end through the built app's HTTP server on an isolated 120-clip project:
  - Updating one text clip returned exactly that clip, completed in 8.5 ms, and undo restored its content.
  - Adding one text clip returned exactly that clip, completed in 9.1 ms, and undo restored the 120-clip count.
  - Project close completed successfully with no MCP tool errors.
- Manual UI reproduction on the affected customer project was not completed.

## Change statistics
- Code logic: +39 / -3
- Tests: +67 / -0
- Total: +106 / -3