### PR TITLE
[fix] Prevent project window transition hangs

### DIFF
--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -99,7 +99,7 @@ final class AppState {
     func showEditor(for project: VideoProject) {
         activateProject(project)
         project.showWindows()
-        HomeWindowController.shared.window?.orderOut(nil)
+        hideHomeIfEditorIsVisible(for: project)
     }
 
     func activateProject(_ project: VideoProject) {
@@ -108,6 +108,16 @@ final class AppState {
             project.editorViewModel.refreshProjectId()
             recordProjectActive(project)
         }
+    }
+
+    func projectWindowDidBecomeKey(_ project: VideoProject) {
+        activateProject(project)
+        hideHomeIfEditorIsVisible(for: project)
+    }
+
+    private func hideHomeIfEditorIsVisible(for project: VideoProject) {
+        guard project.windowControllers.contains(where: { $0.window?.isVisible == true }) else { return }
+        HomeWindowController.shared.window?.orderOut(nil)
     }
 
     // Save and close project; switch to next open or show Home. Throws (without closing) if the save fails.

--- a/Sources/PalmierPro/App/AppState.swift
+++ b/Sources/PalmierPro/App/AppState.swift
@@ -99,6 +99,7 @@ final class AppState {
     func showEditor(for project: VideoProject) {
         activateProject(project)
         project.showWindows()
+        HomeWindowController.shared.window?.orderOut(nil)
     }
 
     func activateProject(_ project: VideoProject) {
@@ -107,7 +108,6 @@ final class AppState {
             project.editorViewModel.refreshProjectId()
             recordProjectActive(project)
         }
-        HomeWindowController.shared.window?.orderOut(nil)
     }
 
     // Save and close project; switch to next open or show Home. Throws (without closing) if the save fails.
@@ -135,9 +135,7 @@ final class AppState {
             return
         }
 
-        activeProject = project
-        HomeWindowController.shared.window?.orderOut(nil)
-        project.showWindows()
+        showEditor(for: project)
         project.windowControllers.first?.window?.makeKeyAndOrderFront(nil)
 
         guard let assetId,
@@ -178,8 +176,8 @@ final class AppState {
         doc.fileURL = url
         doc.fileType = VideoProject.typeIdentifier
         doc.makeWindowControllers()
-        doc.showWindows()
         NSDocumentController.shared.addDocument(doc)
+        showEditor(for: doc)
         return doc
     }
 
@@ -277,8 +275,8 @@ final class AppState {
         }
 
         doc.makeWindowControllers()
-        doc.showWindows()
         NSDocumentController.shared.addDocument(doc)
+        showEditor(for: doc)
         if register { ProjectRegistry.shared.register(resolved) }
         doc.editorViewModel.refreshProjectId()
         recordProjectOpened(doc)

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -496,8 +496,6 @@ class VideoProject: NSDocument {
 
         window.standardWindowButton(.documentIconButton)?.isHidden = true
 
-        AppState.shared.showEditor(for: self)
-
         editorViewModel.searchIndex.projectOpened()
         editorViewModel.updateTelemetryContext()
         Telemetry.breadcrumb(

--- a/Sources/PalmierPro/Project/VideoProject.swift
+++ b/Sources/PalmierPro/Project/VideoProject.swift
@@ -488,7 +488,7 @@ class VideoProject: NSDocument {
         let controller = EditorWindowController(editorViewModel: editorViewModel, window: window)
         controller.onBecameKey = { [weak self] in
             guard let self else { return }
-            AppState.shared.activateProject(self)
+            AppState.shared.projectWindowDidBecomeKey(self)
         }
         window.delegate = controller
         controller.installKeyMonitor()

--- a/Tests/PalmierProTests/App/ProjectWindowPresentationTests.swift
+++ b/Tests/PalmierProTests/App/ProjectWindowPresentationTests.swift
@@ -21,15 +21,7 @@ struct ProjectWindowPresentationTests {
 
     @Test func activationKeepsHomeVisibleUntilEditorIsPresented() {
         _ = NSApplication.shared
-        let project = VideoProject()
-        let editorWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-        let controller = NSWindowController(window: editorWindow)
-        project.addWindowController(controller)
+        let (project, editorWindow) = makeProjectWindow()
         HomeWindowController.shared.showWindow(nil)
         defer { cleanUp(project) }
 
@@ -42,6 +34,32 @@ struct ProjectWindowPresentationTests {
 
         #expect(editorWindow.isVisible)
         #expect(HomeWindowController.shared.window?.isVisible == false)
+    }
+
+    @Test func keyProjectWindowHidesHomeForDocumentControllerPresentation() {
+        _ = NSApplication.shared
+        let (project, editorWindow) = makeProjectWindow()
+        HomeWindowController.shared.showWindow(nil)
+        editorWindow.orderFront(nil)
+        defer { cleanUp(project) }
+
+        AppState.shared.projectWindowDidBecomeKey(project)
+
+        #expect(AppState.shared.activeProject === project)
+        #expect(editorWindow.isVisible)
+        #expect(HomeWindowController.shared.window?.isVisible == false)
+    }
+
+    private func makeProjectWindow() -> (VideoProject, NSWindow) {
+        let project = VideoProject()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        project.addWindowController(NSWindowController(window: window))
+        return (project, window)
     }
 
     private func cleanUp(_ project: VideoProject) {

--- a/Tests/PalmierProTests/App/ProjectWindowPresentationTests.swift
+++ b/Tests/PalmierProTests/App/ProjectWindowPresentationTests.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Testing
+@testable import PalmierPro
+
+@Suite("Project window presentation", .serialized)
+@MainActor
+struct ProjectWindowPresentationTests {
+    @Test func makingWindowControllersDoesNotPresentProject() {
+        _ = NSApplication.shared
+        let project = VideoProject()
+        HomeWindowController.shared.showWindow(nil)
+        defer { cleanUp(project) }
+
+        project.makeWindowControllers()
+
+        #expect(!project.windowControllers.isEmpty)
+        #expect(project.windowControllers.allSatisfy { $0.window?.isVisible == false })
+        #expect(AppState.shared.activeProject !== project)
+        #expect(HomeWindowController.shared.window?.isVisible == true)
+    }
+
+    @Test func activationKeepsHomeVisibleUntilEditorIsPresented() {
+        _ = NSApplication.shared
+        let project = VideoProject()
+        let editorWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let controller = NSWindowController(window: editorWindow)
+        project.addWindowController(controller)
+        HomeWindowController.shared.showWindow(nil)
+        defer { cleanUp(project) }
+
+        AppState.shared.activateProject(project)
+
+        #expect(HomeWindowController.shared.window?.isVisible == true)
+        #expect(!editorWindow.isVisible)
+
+        AppState.shared.showEditor(for: project)
+
+        #expect(editorWindow.isVisible)
+        #expect(HomeWindowController.shared.window?.isVisible == false)
+    }
+
+    private func cleanUp(_ project: VideoProject) {
+        if AppState.shared.activeProject === project {
+            AppState.shared.showHome()
+        }
+        for controller in project.windowControllers {
+            controller.window?.orderOut(nil)
+            project.removeWindowController(controller)
+        }
+        HomeWindowController.shared.window?.orderOut(nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent project creation and opening from hiding Home before the editor is visible, avoiding the AppKit stall captured by [PALMIER-PRO-1N9](https://palmier.sentry.io/issues/7668705543/).
- Preserve Home dismissal for standard Finder and `NSDocumentController` project opens once the editor window becomes key.
- Make window-controller construction presentation-free so each project editor is shown exactly once.

## Approach
- Keep `activateProject` focused on active-project state.
- Hide Home only when the project has a visible editor window, from either `showEditor` or the window-key callback.
- Route project creation, project opening, and generation notifications through `showEditor`; standard document opens use the key-window callback.

## Testing
- [x] `swift test --filter ProjectWindowPresentationTests` — 3 tests passed
- [x] `swift build`
- [x] `swift test` — 1,538 tests passed
- [ ] Manually create and open a project from Home; confirm one editor window appears without a stall
- [ ] Open a `.palmier` package from Finder; confirm Home closes after the editor appears

## Change statistics
- Code logic: +14 / -8
- Tests: +75 / -0
- Total: +89 / -8

Fixes PALMIER-PRO-1N9