### PR TITLE
[ui] Simplify audio keyframe controls

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -153,11 +153,7 @@ extension EditorViewModel {
             case .crop:
                 clip.upsertKeyframe(in: \.cropTrack, frame: f, value: clip.cropAt(frame: f))
             case .volume:
-                let staticDb = VolumeScale.dbFromLinear(clip.volume)
-                let currentDb = clip.volumeTrack?.sample(
-                    at: f - clip.startFrame,
-                    fallback: staticDb
-                ) ?? staticDb
+                let currentDb = clip.volumeTrack?.sample(at: f - clip.startFrame, fallback: 0) ?? 0
                 clip.upsertKeyframe(in: \.volumeTrack, frame: f, value: currentDb)
             }
         }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Keyframes.swift
@@ -153,7 +153,11 @@ extension EditorViewModel {
             case .crop:
                 clip.upsertKeyframe(in: \.cropTrack, frame: f, value: clip.cropAt(frame: f))
             case .volume:
-                let currentDb = clip.volumeTrack?.sample(at: f - clip.startFrame, fallback: 0) ?? 0
+                let staticDb = VolumeScale.dbFromLinear(clip.volume)
+                let currentDb = clip.volumeTrack?.sample(
+                    at: f - clip.startFrame,
+                    fallback: staticDb
+                ) ?? staticDb
                 clip.upsertKeyframe(in: \.volumeTrack, frame: f, value: currentDb)
             }
         }

--- a/Sources/PalmierPro/Models/Keyframe.swift
+++ b/Sources/PalmierPro/Models/Keyframe.swift
@@ -132,8 +132,8 @@ enum AnimatableProperty: String, CaseIterable, Sendable {
     ]
 
     static func lanes(for track: Track) -> [AnimatableProperty] {
-        let order: [AnimatableProperty] = track.type == .audio ? [.volume] : visualLaneOrder
-        return order.filter { property in
+        guard track.type != .audio else { return [] }
+        return visualLaneOrder.filter { property in
             track.clips.contains { $0.supportsKeyframes(for: property) }
         }
     }

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -531,7 +531,7 @@ enum ClipRenderer {
         let half = volumeKeyframeSize / 2
 
         if showsVolumeKeyframes {
-            context.setFillColor(lineColor)
+            context.setFillColor(AppTheme.Accent.timecodeNSColor.cgColor)
             context.setStrokeColor(AppTheme.MediaOverlay.background.withAlphaComponent(0.5).cgColor)
             context.setLineWidth(0.5)
 

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -21,6 +21,10 @@ struct TimelineContainerView: NSViewRepresentable {
         let keyframeLaneState = TimelineKeyframeLaneState()
 
         let headerView = TimelineHeaderView(editor: editor, keyframeLaneState: keyframeLaneState)
+        headerView.updateAudioKeyframeButtonStates(
+            at: editor.activeFrame,
+            revision: editor.timelineRenderRevision
+        )
         headerView.frame = NSRect(x: 0, y: 0, width: headerWidth, height: 0)
         headerView.autoresizingMask = [.height]
         container.addSubview(headerView)
@@ -101,6 +105,10 @@ struct TimelineContainerView: NSViewRepresentable {
     }
 
     func updateNSView(_ container: NSView, context: Context) {
+        context.coordinator.headerView?.updateAudioKeyframeButtonStates(
+            at: editor.activeFrame,
+            revision: editor.timelineRenderRevision
+        )
         context.coordinator.keyframeLaneState?.update(
             timelineId: editor.activeTimelineId,
             revision: editor.timelineRenderRevision,

--- a/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineHeaderView.swift
@@ -23,12 +23,15 @@ final class TimelineHeaderView: NSView {
     private static let labelFont = NSFont.systemFont(ofSize: AppTheme.FontSize.sm, weight: .medium)
     private var labelAttrs: [NSAttributedString.Key: Any] = [:]
 
-    /// Rects for mute/hide/sync-lock buttons, indexed by track. Used for hit testing.
+    /// Track-header button hit areas indexed by track.
     var muteButtonRects: [Int: NSRect] = [:]
     var hideButtonRects: [Int: NSRect] = [:]
     var syncLockButtonRects: [Int: NSRect] = [:]
-    var keyframeLaneButtonRects: [Int: NSRect] = [:]
+    var keyframeButtonRects: [Int: NSRect] = [:]
     var dragHandleRects: [Int: NSRect] = [:]
+    private var audioTracksOnKeyframe: Set<String> = []
+    private var audioKeyframeStateFrame: Int?
+    private var audioKeyframeStateRevision: Int?
     private let agentTrackLayer = CAShapeLayer()
     private var displayedAgentTrackRevision = -1
     private var labelRects: [String: (hit: NSRect, edit: NSRect)] = [:]
@@ -104,7 +107,7 @@ final class TimelineHeaderView: NSView {
         muteButtonRects.removeAll()
         hideButtonRects.removeAll()
         syncLockButtonRects.removeAll()
-        keyframeLaneButtonRects.removeAll()
+        keyframeButtonRects.removeAll()
         dragHandleRects.removeAll()
         labelRects.removeAll()
         let stripWidth = AppTheme.ComponentSize.timelineTrackHeaderColorStripWidth
@@ -174,9 +177,17 @@ final class TimelineHeaderView: NSView {
                 x: syncX, y: iconY, size: iconSize, config: iconConfig,
                 active: track.syncLocked, onSymbol: "link", offSymbol: "personalhotspot.slash"
             )
-            if !AnimatableProperty.lanes(for: track).isEmpty {
+            if track.type == .audio,
+               track.clips.contains(where: { $0.supportsKeyframes(for: .volume) }) {
+                keyframeButtonRects[i] = drawToggleIcon(
+                    x: keyframeX, y: iconY, size: iconSize, config: iconConfig,
+                    active: audioTracksOnKeyframe.contains(track.id),
+                    onSymbol: "diamond.fill", offSymbol: "diamond",
+                    activeTint: AppTheme.Accent.timecodeNSColor
+                )
+            } else if !AnimatableProperty.lanes(for: track).isEmpty {
                 let expanded = keyframeLaneState.isExpanded(trackId: track.id)
-                keyframeLaneButtonRects[i] = drawToggleIcon(
+                keyframeButtonRects[i] = drawToggleIcon(
                     x: keyframeX, y: iconY, size: iconSize, config: iconConfig,
                     active: expanded, onSymbol: "diamond.fill", offSymbol: "diamond",
                     activeTint: AppTheme.Accent.timecodeNSColor
@@ -605,9 +616,14 @@ final class TimelineHeaderView: NSView {
                 return
             }
         }
-        for (ti, rect) in keyframeLaneButtonRects {
+        for (ti, rect) in keyframeButtonRects {
             if rect.contains(point), editor.timeline.tracks.indices.contains(ti) {
-                keyframeLaneState.toggle(trackId: editor.timeline.tracks[ti].id)
+                let track = editor.timeline.tracks[ti]
+                if track.type == .audio {
+                    toggleVolumeKeyframe(on: track)
+                } else {
+                    keyframeLaneState.toggle(trackId: track.id)
+                }
                 return
             }
         }
@@ -623,6 +639,50 @@ final class TimelineHeaderView: NSView {
         if let ti = hitTestResizeHandle(at: point) {
             resizeDrag = (ti, editor.timeline.tracks[ti].displayHeight)
         }
+    }
+
+    func updateAudioKeyframeButtonStates(at frame: Int, revision: Int) {
+        guard audioKeyframeStateFrame != frame
+            || audioKeyframeStateRevision != revision else { return }
+        audioKeyframeStateFrame = frame
+        audioKeyframeStateRevision = revision
+
+        let next = Set(editor.timeline.tracks.compactMap { track -> String? in
+            guard track.type == .audio,
+                  let clip = editor.keyframeLaneTarget(
+                      trackId: track.id,
+                      property: .volume,
+                      at: frame
+                  ),
+                  editor.hasKeyframe(
+                      clipId: clip.id,
+                      property: .volume,
+                      at: frame
+                  ) else {
+                return nil
+            }
+            return track.id
+        })
+        guard next != audioTracksOnKeyframe else { return }
+        audioTracksOnKeyframe = next
+        needsDisplay = true
+    }
+
+    private func toggleVolumeKeyframe(on track: Track) {
+        let frame = editor.activeFrame
+        guard let clip = editor.keyframeLaneTarget(
+            trackId: track.id,
+            property: .volume,
+            at: frame
+        ) else { return }
+        editor.selectedGap = nil
+        editor.selectedClipIds = [clip.id]
+        editor.toggleKeyframe(clipId: clip.id, property: .volume, at: frame)
+        updateAudioKeyframeButtonStates(
+            at: frame,
+            revision: editor.timelineRenderRevision
+        )
+        requestCanvasRedraw?()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -674,15 +734,36 @@ final class TimelineHeaderView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        if let trackIndex = keyframeLaneButtonRects.first(where: {
+        if let trackIndex = keyframeButtonRects.first(where: {
             $0.value.contains(point)
         })?.key,
            editor.timeline.tracks.indices.contains(trackIndex) {
-            let trackId = editor.timeline.tracks[trackIndex].id
-            updateToolTip(keyframeLaneState.isExpanded(trackId: trackId)
-                ? L10n.string("Hide clip keyframes")
-                : L10n.string("Show clip keyframes"))
-            NSCursor.pointingHand.set()
+            let track = editor.timeline.tracks[trackIndex]
+            if track.type == .audio {
+                let target = editor.keyframeLaneTarget(
+                    trackId: track.id,
+                    property: .volume
+                )
+                if let target {
+                    let onKeyframe = editor.hasKeyframe(
+                        clipId: target.id,
+                        property: .volume,
+                        at: editor.activeFrame
+                    )
+                    updateToolTip(onKeyframe
+                        ? L10n.string("Delete keyframe")
+                        : L10n.string("Add keyframe"))
+                    NSCursor.pointingHand.set()
+                } else {
+                    updateToolTip(L10n.string("Move playhead inside the clip"))
+                    NSCursor.arrow.set()
+                }
+            } else {
+                updateToolTip(keyframeLaneState.isExpanded(trackId: track.id)
+                    ? L10n.string("Hide clip keyframes")
+                    : L10n.string("Show clip keyframes"))
+                NSCursor.pointingHand.set()
+            }
         } else if dragHandleRects.values.contains(where: { $0.contains(point) }) {
             updateToolTip(nil)
             NSCursor.openHand.set()

--- a/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
@@ -39,10 +39,7 @@ struct TimelineKeyframeLaneTests {
         ])
     }
 
-    @Test func textOnlyAndAudioTracksExposeTheirOwnLaneSets() {
-        let textTrack = Fixtures.videoTrack(clips: [
-            Fixtures.clip(mediaType: .text, start: 0, duration: 30),
-        ])
+    @Test func audioTrackDoesNotExposeVolumeLane() {
         let audioTrack = Fixtures.audioTrack(clips: [
             Fixtures.clip(mediaType: .audio, start: 0, duration: 30),
         ])
@@ -50,7 +47,7 @@ struct TimelineKeyframeLaneTests {
         #expect(AnimatableProperty.lanes(for: textTrack) == [
             .position, .scale, .rotation, .opacity,
         ])
-        #expect(AnimatableProperty.lanes(for: audioTrack) == [.volume])
+        #expect(AnimatableProperty.lanes(for: audioTrack).isEmpty)
     }
 
     @Test func cropInsetsPreserveMinimumVisibleArea() {
@@ -94,6 +91,52 @@ struct TimelineKeyframeLaneTests {
         clip.rescaleKeyframes(by: 0.4)
 
         #expect(clip.opacityTrack?.keyframes.map(\.frame) == [3])
+    }
+
+    @MainActor
+    @Test func togglingFirstVolumeKeyframePreservesStaticClipLevel() throws {
+        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 10, duration: 30)
+        audio.volume = VolumeScale.linearFromDb(-8)
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        editor.toggleKeyframe(
+            clipId: audio.id,
+            property: .volume,
+            at: 15
+        )
+
+        let keyframe = try #require(editor.clipFor(id: audio.id)?.volumeTrack?.keyframes.first)
+        #expect(keyframe.frame == 5)
+        #expect(abs(keyframe.value - VolumeScale.dbFromLinear(audio.volume)) < 1e-12)
+    }
+
+    @MainActor
+    @Test func togglingExistingVolumeKeyframeRemovesIt() {
+        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 10, duration: 30)
+        audio.volumeTrack = KeyframeTrack(keyframes: [
+            Keyframe(frame: 5, value: -8, interpolationOut: .linear),
+        ])
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+        let undo = UndoManager()
+        editor.undo.attach(undo)
+        undo.removeAllActions()
+
+        editor.toggleKeyframe(
+            clipId: audio.id,
+            property: .volume,
+            at: 15
+        )
+
+        #expect(editor.clipFor(id: audio.id)?.volumeTrack == nil)
+        #expect(undo.canUndo)
+        undo.undo()
+        #expect(editor.clipFor(id: audio.id)?.volumeTrack == audio.volumeTrack)
     }
 
     @MainActor

--- a/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
@@ -39,7 +39,10 @@ struct TimelineKeyframeLaneTests {
         ])
     }
 
-    @Test func audioTrackDoesNotExposeVolumeLane() {
+    @Test func textOnlyAndAudioTracksExposeTheirOwnLaneSets() {
+        let textTrack = Fixtures.videoTrack(clips: [
+            Fixtures.clip(mediaType: .text, start: 0, duration: 30),
+        ])
         let audioTrack = Fixtures.audioTrack(clips: [
             Fixtures.clip(mediaType: .audio, start: 0, duration: 30),
         ])

--- a/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineKeyframeLaneTests.swift
@@ -97,26 +97,6 @@ struct TimelineKeyframeLaneTests {
     }
 
     @MainActor
-    @Test func togglingFirstVolumeKeyframePreservesStaticClipLevel() throws {
-        var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 10, duration: 30)
-        audio.volume = VolumeScale.linearFromDb(-8)
-        let editor = EditorViewModel()
-        editor.timeline = Fixtures.timeline(tracks: [
-            Fixtures.audioTrack(clips: [audio]),
-        ])
-
-        editor.toggleKeyframe(
-            clipId: audio.id,
-            property: .volume,
-            at: 15
-        )
-
-        let keyframe = try #require(editor.clipFor(id: audio.id)?.volumeTrack?.keyframes.first)
-        #expect(keyframe.frame == 5)
-        #expect(abs(keyframe.value - VolumeScale.dbFromLinear(audio.volume)) < 1e-12)
-    }
-
-    @MainActor
     @Test func togglingExistingVolumeKeyframeRemovesIt() {
         var audio = Fixtures.clip(id: "audio", mediaType: .audio, start: 10, duration: 30)
         audio.volumeTrack = KeyframeTrack(keyframes: [


### PR DESCRIPTION
## Summary
- Replace the redundant expanded volume lane on audio tracks with a track-header keyframe toggle at the playhead.
- Keep volume automation directly editable on audio clips and render inline keyframe diamonds in the timeline accent color.
- Match the Audio inspector interaction: add when the playhead is between keyframes, remove when it is on one, and fill the header diamond at an exact keyframe.

## Approach
- Exclude audio tracks from timeline keyframe-lane geometry while preserving visual-property lanes.
- Resolve the audio clip under the playhead and route header clicks through the existing keyframe toggle and undo path.
- Cache header keyframe state by playhead frame and timeline revision, redrawing only when the filled state changes.
- Preserve the existing 0 dB identity envelope when adding the first keyframe so static clip gain remains unchanged.

## Testing
- `swift build` — passed.
- `swift test --filter TimelineKeyframeLaneTests` — 16 tests passed.
- `swift test` — 1,562 tests passed.
- Manual UI review confirmed the neutral outline, filled playhead state, add/remove interaction, and orange inline keyframes.

## Change statistics
- Code logic: +105 / -16 lines.
- Tests: +27 / -1 lines.
- Total: +132 / -17 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeline UI and keyframe routing reuse existing editor APIs; no auth, persistence, or export pipeline changes.
> 
> **Overview**
> **Audio volume automation** no longer uses an expandable timeline keyframe lane. `AnimatableProperty.lanes(for:)` returns no lanes for audio tracks, so expanded lanes stay visual-only.
> 
> On audio tracks with volume-capable clips, the track-header diamond **adds or removes a volume keyframe at the playhead** via the existing `toggleKeyframe` / undo path (select clip, clear gap selection). The icon fills when the playhead sits on an exact volume keyframe; tooltips distinguish add, delete, and “move playhead inside clip.” Header state is refreshed from playhead frame and timeline revision in `TimelineContainerView`.
> 
> **Inline volume keyframe diamonds** on audio clips use the timeline accent color instead of the generic line color.
> 
> Tests expect empty lanes for audio tracks and cover toggling off an existing volume keyframe with undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e1d91b31d435fcc43e22256012c6e2c1322872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->