### PR TITLE
[feat] Add timeline markers

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -20,6 +20,9 @@ enum AgentInstructions {
           re-read). create_timeline makes a new empty timeline or duplicates via from= — use \
           that for alternate versions instead of editing over the original. A nested timeline \
           appears as a clip with mediaType 'sequence'.
+        - Markers are timeline-owned (no clipId) or attached to one timeline clip (clipId). \
+          Clip markers use sourceStartFrame; timeline markers use startFrame. Use \
+          manage_markers and stable markerId values.
         - IDs are short prefixes — pass them back exactly as given, never padded or completed. \
           Folders have no ids: they are paths ('B-roll/Sunset'), created on demand.
 

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -20,9 +20,8 @@ enum AgentInstructions {
           re-read). create_timeline makes a new empty timeline or duplicates via from= — use \
           that for alternate versions instead of editing over the original. A nested timeline \
           appears as a clip with mediaType 'sequence'.
-        - Markers are timeline-owned (no clipId) or attached to one timeline clip (clipId). \
-          Clip markers use sourceStartFrame; timeline markers use startFrame. Use \
-          manage_markers and stable markerId values.
+        - Markers are persistent timeline notes. Use manage_markers and stable markerId values; \
+          point markers have zero duration and ranges are half-open.
         - IDs are short prefixes — pass them back exactly as given, never padded or completed. \
           Folders have no ids: they are paths ('B-roll/Sunset'), created on demand.
 

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -127,14 +127,13 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .manageMarkers,
-            description: "Creates, updates, or deletes one persistent marker. Omit clipId for a timeline marker or set it for one timeline clip instance. Clip marker frames are source frames in the project frame-rate timebase; timeline marker frames are sequence time. A zero duration marks one frame; a positive duration is half-open.",
+            description: "Creates, updates, or deletes one persistent timeline marker. A zero duration marks one frame; a positive duration is half-open.",
             inputSchema: objectSchema(
                 properties: [
                     "action": ["type": "string", "enum": ["create", "update", "delete"]],
                     "markerId": ["type": "string", "description": "Required for update/delete. From get_timeline."],
-                    "clipId": ["type": "string", "description": "Create only. Omit for a timeline marker."],
                     "name": ["type": "string"],
-                    "startFrame": ["type": "integer", "description": "Timeline frame, or source frame for a clip marker."],
+                    "startFrame": ["type": "integer", "description": "Timeline frame."],
                     "durationFrames": ["type": "integer", "description": "0 for a point; positive for a range."],
                     "color": ["type": "string", "description": "#RGB, #RRGGBB, or #RRGGBBAA."],
                     "comment": ["type": "string"],

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -10,6 +10,7 @@ enum ToolName: String, CaseIterable, Sendable {
     case inspectTimeline = "inspect_timeline"
     case createTimeline = "create_timeline"
     case setActiveTimeline = "set_active_timeline"
+    case manageMarkers = "manage_markers"
     case setProjectSettings = "set_project_settings"
     case exportProject = "export_project"
     case manageExports = "manage_exports"
@@ -84,7 +85,7 @@ enum ToolDefinitions {
     static let all: [AgentTool] = [
         AgentTool(
             name: .getTimeline,
-            description: "Always call at the start of a session. Returns project settings (fps, resolution, totalFrames, durationSeconds), tracks with a stable trackId, their current index (what every trackIndex parameter takes), type, and clips, plus canGenerate (if false, generation/upscale tools will fail — tell the user to sign in to Palmier and subscribe before attempting them). Clip ids are accepted by clip mutation tools; trackId is accepted by manage_tracks.\n\nEvery clip occupies frames: [start, end) — timeline frames, end exclusive, duration = end − start. gaps on a track lists its empty [start, end) spans; no gaps key means contiguous. A video clip's linked audio partner is folded into it as audio: {id, track, …} carrying only what deviates (volumeDb, effects, differing trims); the partner is not repeated on its own track, which instead reports linkedClips (its folded count). Address the audio side by its nested id.\n\nFields equal to their defaults are omitted: mediaType 'video', sourceClipType = mediaType, speed 1, volumeDb 0, opacity 1, edgeRounding 0, edgeSoftness 0, trims/fades 0, identity transform/crop, default textStyle, track muted/hidden false. Text clips never report trims. Keyframe tracks that animate nothing are shown as what they are: identity tracks are dropped, constant ones appear as the static field (e.g. crop: {left: 0.31}). A graded clip carries `color` — its grade in apply_color's own vocabulary, pasteable to other clips via apply_color's color parameter. Other effects appear as effects: [{type, params}], the exact shape apply_effect accepts.\n\nCaption clips (sharing a captionGroupId) come back per track as captionGroups summaries: clipCount, frameRange, shared style, and a textPreview — individual caption clips and their ids are NOT listed. That summary is all you need to restyle (update_text with captionGroupId) or judge coverage; the spoken words live in get_transcript. Only when you must touch individual caption clips (retime one, delete one, fix one word's style), re-read with captionDetail:true — ideally windowed — to get [clipId, startFrame, endFrame, text] rows, capped at 200 per group. Caption clips whose properties deviate from the group always appear individually in clips.",
+            description: "Always call at the start of a session. Returns project settings (fps, resolution, totalFrames, durationSeconds), tracks with a stable trackId, their current index (what every trackIndex parameter takes), type, and clips, plus canGenerate (if false, generation/upscale tools will fail — tell the user to sign in to Palmier and subscribe before attempting them). Clip ids are accepted by clip mutation tools; trackId is accepted by manage_tracks.\n\nEvery clip occupies frames: [start, end) — timeline frames, end exclusive, duration = end − start. gaps on a track lists its empty [start, end) spans; no gaps key means contiguous. A video clip's linked audio partner is folded into it as audio: {id, track, …} carrying only what deviates (volumeDb, effects, differing trims); the partner is not repeated on its own track, which instead reports linkedClips (its folded count). Address the audio side by its nested id.\n\nFields equal to their defaults are omitted: mediaType 'video', sourceClipType = mediaType, speed 1, volumeDb 0, opacity 1, edgeRounding 0, edgeSoftness 0, trims/fades 0, identity transform/crop, default textStyle, track muted/hidden false. Text clips never report trims. Keyframe tracks that animate nothing are shown as what they are: identity tracks are dropped, constant ones appear as the static field (e.g. crop: {left: 0.31}). A graded clip carries `color` — its grade in apply_color's own vocabulary, pasteable to other clips via apply_color's color parameter. Other effects appear as effects: [{type, params}], the exact shape apply_effect accepts.\n\nCaption clips (sharing a captionGroupId) come back per track as captionGroups summaries: clipCount, frameRange, shared style, and a textPreview — individual caption clips and their ids are NOT listed. That summary is all you need to restyle (update_text with captionGroupId) or judge coverage; the spoken words live in get_transcript. Only when you must touch individual caption clips (retime one, delete one, fix one word's style), re-read with captionDetail:true — ideally windowed — to get [clipId, startFrame, endFrame, text] rows, capped at 200 per group. Caption clips whose properties deviate from the group always appear individually in clips.\n\nmarkers contains persistent review notes with markerId, name, comment, color, startFrame, endFrame, and durationFrames. Point markers have durationFrames 0; range markers use half-open [startFrame, endFrame). Windowed reads include only markers in or intersecting the window.",
             inputSchema: objectSchema(
                 properties: [
                     "startFrame": ["type": "integer", "description": "Optional. Window start (inclusive); only clips intersecting [startFrame, endFrame) are returned. Omit both startFrame and endFrame for the whole timeline — never pass a zero-width window. Tracks report totalClips when the window hides some."],
@@ -122,6 +123,23 @@ enum ToolDefinitions {
                     "timelineId": ["type": "string", "description": "Timeline id from get_media's timelines list (or a sequence clip's mediaRef)."],
                 ],
                 required: ["timelineId"]
+            )
+        ),
+        AgentTool(
+            name: .manageMarkers,
+            description: "Creates, updates, or deletes one persistent marker. Omit clipId for a timeline marker or set it for one timeline clip instance. Clip marker frames are source frames in the project frame-rate timebase; timeline marker frames are sequence time. A zero duration marks one frame; a positive duration is half-open.",
+            inputSchema: objectSchema(
+                properties: [
+                    "action": ["type": "string", "enum": ["create", "update", "delete"]],
+                    "markerId": ["type": "string", "description": "Required for update/delete. From get_timeline."],
+                    "clipId": ["type": "string", "description": "Create only. Omit for a timeline marker."],
+                    "name": ["type": "string"],
+                    "startFrame": ["type": "integer", "description": "Timeline frame, or source frame for a clip marker."],
+                    "durationFrames": ["type": "integer", "description": "0 for a point; positive for a range."],
+                    "color": ["type": "string", "description": "#RGB, #RRGGBB, or #RRGGBBAA."],
+                    "comment": ["type": "string"],
+                ],
+                required: ["action"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
@@ -3,14 +3,13 @@ import Foundation
 private struct ManageMarkersInput: DecodableToolArgs {
     let action: String
     let markerId: String?
-    let clipId: String?
     let name: String?
     let startFrame: Int?
     let durationFrames: Int?
     let color: String?
     let comment: String?
     static let allowedKeys: Set<String> = [
-        "action", "markerId", "clipId", "name", "startFrame", "durationFrames", "color", "comment",
+        "action", "markerId", "name", "startFrame", "durationFrames", "color", "comment",
     ]
     var hasPatch: Bool {
         name != nil || startFrame != nil || durationFrames != nil || color != nil || comment != nil
@@ -28,7 +27,7 @@ extension ToolExecutor {
                     throw ToolError("create requires name and startFrame.")
                 }
                 let marker = TimelineMarker(
-                    clipId: input.clipId, name: name, startFrame: start,
+                    name: name, startFrame: start,
                     durationFrames: input.durationFrames ?? 0,
                     color: try parseColorHex(input.color, path: "color") ?? TimelineMarker.defaultColor,
                     comment: input.comment ?? ""
@@ -40,14 +39,16 @@ extension ToolExecutor {
                 guard let id = input.markerId, input.hasPatch else {
                     throw ToolError("update requires markerId and at least one field to change.")
                 }
-                let update = TimelineMarkerUpdateRequest(
-                    id: id, name: input.name, startFrame: input.startFrame,
-                    durationFrames: input.durationFrames,
-                    color: try parseColorHex(input.color, path: "color"),
-                    comment: input.comment
-                )
+                guard var marker = editor.timelineMarker(id: id) else {
+                    throw ToolError("Unknown markerId '\(id)'.")
+                }
+                if let value = input.name { marker.name = value }
+                if let value = input.startFrame { marker.startFrame = value }
+                if let value = input.durationFrames { marker.durationFrames = value }
+                if let value = try parseColorHex(input.color, path: "color") { marker.color = value }
+                if let value = input.comment { marker.comment = value }
                 receipt = try editor.changeTimelineMarkers(
-                    updates: [update], actionName: "Change Marker (Agent)"
+                    updates: [marker], actionName: "Change Marker (Agent)"
                 )
             case "delete":
                 guard let id = input.markerId else { throw ToolError("delete requires markerId.") }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+private struct ManageMarkersInput: DecodableToolArgs {
+    let action: String
+    let markerId: String?
+    let clipId: String?
+    let name: String?
+    let startFrame: Int?
+    let durationFrames: Int?
+    let color: String?
+    let comment: String?
+    static let allowedKeys: Set<String> = [
+        "action", "markerId", "clipId", "name", "startFrame", "durationFrames", "color", "comment",
+    ]
+    var hasPatch: Bool {
+        name != nil || startFrame != nil || durationFrames != nil || color != nil || comment != nil
+    }
+}
+
+extension ToolExecutor {
+    func manageMarkers(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        let input: ManageMarkersInput = try decodeToolArgs(args, path: "manage_markers")
+        let receipt: TimelineMarkerChangeReceipt
+        do {
+            switch input.action {
+            case "create":
+                guard let name = input.name, let start = input.startFrame else {
+                    throw ToolError("create requires name and startFrame.")
+                }
+                let marker = TimelineMarker(
+                    clipId: input.clipId, name: name, startFrame: start,
+                    durationFrames: input.durationFrames ?? 0,
+                    color: try parseColorHex(input.color, path: "color") ?? TimelineMarker.defaultColor,
+                    comment: input.comment ?? ""
+                )
+                receipt = try editor.changeTimelineMarkers(
+                    creates: [marker], actionName: "Add Marker (Agent)"
+                )
+            case "update":
+                guard let id = input.markerId, input.hasPatch else {
+                    throw ToolError("update requires markerId and at least one field to change.")
+                }
+                let update = TimelineMarkerUpdateRequest(
+                    id: id, name: input.name, startFrame: input.startFrame,
+                    durationFrames: input.durationFrames,
+                    color: try parseColorHex(input.color, path: "color"),
+                    comment: input.comment
+                )
+                receipt = try editor.changeTimelineMarkers(
+                    updates: [update], actionName: "Change Marker (Agent)"
+                )
+            case "delete":
+                guard let id = input.markerId else { throw ToolError("delete requires markerId.") }
+                receipt = try editor.changeTimelineMarkers(
+                    deleteIds: [id], actionName: "Delete Marker (Agent)"
+                )
+            default:
+                throw ToolError("action must be create, update, or delete.")
+            }
+        } catch TimelineMarkerValidationError.invalidName {
+            throw ToolError("Marker names must be non-empty single lines of at most \(TimelineMarker.maximumNameLength) characters.")
+        } catch TimelineMarkerValidationError.invalidComment {
+            throw ToolError("Marker comments must be at most \(TimelineMarker.maximumCommentLength) characters.")
+        } catch let error as ToolError {
+            throw error
+        } catch {
+            throw ToolError("Marker frames must be non-negative integer ranges and every ID must exist.")
+        }
+        var payload: [String: Any] = [:]
+        if let marker = receipt.created.first { payload["created"] = Self.timelineMarkerDict(marker) }
+        if let marker = receipt.updated.first { payload["updated"] = Self.timelineMarkerDict(marker) }
+        if let id = receipt.deletedIds.first { payload["deletedMarkerId"] = id }
+        if payload.isEmpty { payload["noOp"] = true }
+        return .ok(Self.jsonString(payload) ?? "{}")
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
@@ -9,7 +9,7 @@ extension ToolExecutor {
         "mediaRef", "startFrameMediaRef", "endFrameMediaRef",
         "sourceVideoMediaRef", "videoSourceMediaRef", "sourceMediaRef", "subtitleMediaRef",
         "captionGroupId", "timelineId", "trackId", "item", "from", "reference",
-        "groupId", "memberId",
+        "groupId", "memberId", "markerId",
     ]
     private static let arrayIdKeys: Set<String> = [
         "clipIds", "targetClipIds", "items", "ids", "deletes",
@@ -29,6 +29,7 @@ extension ToolExecutor {
                 if let linkGroupId = clip.linkGroupId { ids.insert(linkGroupId) }
             }
         }
+        for marker in editor.timeline.markers { ids.insert(marker.id) }
         for asset in editor.mediaAssets { ids.insert(asset.id) }
         for group in editor.multicamGroups {
             ids.insert(group.id)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -20,9 +20,7 @@ extension ToolExecutor {
         if markers.isEmpty {
             dict.removeValue(forKey: "markers")
         } else {
-            dict["markers"] = markers.map {
-                Self.timelineMarkerDict($0, source: editor.timelineMarker(id: $0.id))
-            }
+            dict["markers"] = markers.map(Self.timelineMarkerDict)
         }
         dict["totalFrames"] = editor.timeline.totalFrames
         dict["durationSeconds"] = Double(editor.timeline.totalFrames) / Double(max(editor.timeline.fps, 1))
@@ -90,8 +88,8 @@ extension ToolExecutor {
         try? JSONSerialization.jsonObject(with: JSONEncoder().encode(clip)) as? [String: Any]
     }
 
-    static func timelineMarkerDict(_ marker: TimelineMarker, source: TimelineMarker? = nil) -> [String: Any] {
-        var result: [String: Any] = [
+    static func timelineMarkerDict(_ marker: TimelineMarker) -> [String: Any] {
+        [
             "markerId": marker.id,
             "name": marker.name,
             "startFrame": marker.startFrame,
@@ -100,12 +98,6 @@ extension ToolExecutor {
             "color": marker.color.hexString,
             "comment": marker.comment,
         ]
-        if let clipId = marker.clipId {
-            result["clipId"] = clipId
-            result["sourceStartFrame"] = source?.startFrame ?? marker.startFrame
-            result["sourceDurationFrames"] = source?.durationFrames ?? marker.durationFrames
-        }
-        return result
     }
 
     func timelineEntries(_ editor: EditorViewModel, detailed: Bool = false) -> [[String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -14,6 +14,16 @@ extension ToolExecutor {
         if let tracks = dict["tracks"] as? [[String: Any]] {
             dict["tracks"] = Self.compactTracks(tracks, editor: editor, window: window, captionDetail: captionDetail)
         }
+        let markers = editor.displayedTimelineMarkers().filter { marker in
+            window.map(marker.intersects) ?? true
+        }
+        if markers.isEmpty {
+            dict.removeValue(forKey: "markers")
+        } else {
+            dict["markers"] = markers.map {
+                Self.timelineMarkerDict($0, source: editor.timelineMarker(id: $0.id))
+            }
+        }
         dict["totalFrames"] = editor.timeline.totalFrames
         dict["durationSeconds"] = Double(editor.timeline.totalFrames) / Double(max(editor.timeline.fps, 1))
         if let window {
@@ -78,6 +88,24 @@ extension ToolExecutor {
 
     private static func rawClipDict(_ clip: Clip) -> [String: Any]? {
         try? JSONSerialization.jsonObject(with: JSONEncoder().encode(clip)) as? [String: Any]
+    }
+
+    static func timelineMarkerDict(_ marker: TimelineMarker, source: TimelineMarker? = nil) -> [String: Any] {
+        var result: [String: Any] = [
+            "markerId": marker.id,
+            "name": marker.name,
+            "startFrame": marker.startFrame,
+            "endFrame": marker.endFrame,
+            "durationFrames": marker.durationFrames,
+            "color": marker.color.hexString,
+            "comment": marker.comment,
+        ]
+        if let clipId = marker.clipId {
+            result["clipId"] = clipId
+            result["sourceStartFrame"] = source?.startFrame ?? marker.startFrame
+            result["sourceDurationFrames"] = source?.durationFrames ?? marker.durationFrames
+        }
+        return result
     }
 
     func timelineEntries(_ editor: EditorViewModel, detailed: Bool = false) -> [[String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -362,6 +362,7 @@ final class ToolExecutor {
         case .setProjectSettings: return try setProjectSettings(editor, args)
         case .createTimeline:     return try createTimeline(editor, args)
         case .setActiveTimeline:  return try setActiveTimeline(editor, args)
+        case .manageMarkers:      return try manageMarkers(editor, args)
         case .readSkill:     return readSkill(args)
         case .manageSkills:  return try await manageSkills(args)
         case .manageProject:

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -110,6 +110,8 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         case 51: // Delete/Backspace
             if handlesMediaPanelCommands, !editorViewModel.mediaPanelSelectedKeys().isEmpty {
                 editorViewModel.deleteMediaPanelItems()
+            } else if !editorViewModel.selectedTimelineMarkerIds.isEmpty {
+                editorViewModel.deleteSelectedTimelineMarker()
             } else if shift {
                 if editorViewModel.selectedGap != nil {
                     editorViewModel.rippleDeleteSelectedGap()
@@ -120,6 +122,13 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
                 editorViewModel.deleteSelectedClips()
             }
             return true
+
+        case 46: // M key
+            if mods.intersection([.command, .option, .control]).isEmpty {
+                _ = editorViewModel.addTimelineMarkerAtSelection()
+                return true
+            }
+            return false
 
         case 8: // C key
             if !cmd {
@@ -205,6 +214,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             editorViewModel.slipPreview = nil
             editorViewModel.selectedClipIds.removeAll()
             editorViewModel.clearTimelineRange()
+            editorViewModel.selectedTimelineMarkerIds = []
             editorViewModel.toolMode = .pointer
             return true
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -134,6 +134,7 @@ extension EditorViewModel {
 
         timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = left
         timeline.tracks[loc.trackIndex].clips.append(right)
+        timeline.copyMarkers(from: clip.id, to: right.id)
         sortClips(trackIndex: loc.trackIndex)
 
         registerTimelineUndo("Split Clip") { vm in
@@ -257,6 +258,8 @@ extension EditorViewModel {
     func withTimelineSwap(actionName: String, refreshVisuals: Bool = true, _ work: () -> Void) {
         let before = timeline
         undo.withoutRegistration(work)
+        let liveClipIds = Set(timeline.tracks.flatMap(\.clips).map(\.id))
+        timeline.markers.removeAll { $0.clipId.map { !liveClipIds.contains($0) } ?? false }
         let after = timeline
         guard before != after else { return }
         guard undo.isRegistrationEnabled else { return }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -134,7 +134,6 @@ extension EditorViewModel {
 
         timeline.tracks[loc.trackIndex].clips[loc.clipIndex] = left
         timeline.tracks[loc.trackIndex].clips.append(right)
-        timeline.copyMarkers(from: clip.id, to: right.id)
         sortClips(trackIndex: loc.trackIndex)
 
         registerTimelineUndo("Split Clip") { vm in
@@ -258,8 +257,6 @@ extension EditorViewModel {
     func withTimelineSwap(actionName: String, refreshVisuals: Bool = true, _ work: () -> Void) {
         let before = timeline
         undo.withoutRegistration(work)
-        let liveClipIds = Set(timeline.tracks.flatMap(\.clips).map(\.id))
-        timeline.markers.removeAll { $0.clipId.map { !liveClipIds.contains($0) } ?? false }
         let after = timeline
         guard before != after else { return }
         guard undo.isRegistrationEnabled else { return }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
@@ -153,7 +153,6 @@ private extension EditorViewModel {
                     clone.linkGroupId = nil
                 }
                 timeline.tracks[ti].clips.append(clone)
-                timeline.copyMarkers(from: p.source.id, to: clone.id)
                 newIds.append(clone.id)
             }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Clipboard.swift
@@ -153,6 +153,7 @@ private extension EditorViewModel {
                     clone.linkGroupId = nil
                 }
                 timeline.tracks[ti].clips.append(clone)
+                timeline.copyMarkers(from: p.source.id, to: clone.id)
                 newIds.append(clone.id)
             }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
@@ -76,6 +76,7 @@ extension EditorViewModel {
                 return c
             })
         }
+        child.markers = timeline.markers.filter { $0.clipId.map(ids.contains) == true }
         child.regenerateIds()
 
         undo.perform("Nest Clips") {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Nesting.swift
@@ -76,7 +76,6 @@ extension EditorViewModel {
                 return c
             })
         }
-        child.markers = timeline.markers.filter { $0.clipId.map(ids.contains) == true }
         child.regenerateIds()
 
         undo.perform("Nest Clips") {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+PreviewTabs.swift
@@ -10,7 +10,7 @@ extension EditorViewModel {
 
     /// Minimum zoom scale that fits the entire timeline with end padding.
     var minZoomScale: Double {
-        let totalFrames = timeline.totalFrames
+        let totalFrames = timeline.displayFrames
         guard totalFrames > 0, timelineVisibleWidth > 0 else { return Zoom.min }
         let fitAll = timelineVisibleWidth / (Double(totalFrames) * Zoom.fitAllBuffer)
         return min(Zoom.max, max(Zoom.floor, fitAll))
@@ -102,6 +102,7 @@ extension EditorViewModel {
             pruneMediaPanelSelectionAnchor()
         case .mediaAsset(let id, _, _):
             selectedClipIds.removeAll()
+            selectedTimelineMarkerIds = []
             selectedFolderIds.removeAll()
             selectedMediaAssetIds = [id]
             mediaPanelSelectionAnchor = id

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ProjectSettings.swift
@@ -180,6 +180,7 @@ extension EditorViewModel {
 
 extension Timeline {
     mutating func rescaleFrames(by scale: Double) {
+        for i in markers.indices { markers[i].rescaleFrames(by: scale) }
         for ti in tracks.indices {
             let clipIndices = tracks[ti].clips.indices.sorted {
                 tracks[ti].clips[$0].startFrame < tracks[ti].clips[$1].startFrame

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
@@ -30,6 +30,7 @@ extension EditorViewModel {
         selectedClipIds = expandToLinkGroup(ids)
         selectedGap = nil
         selectedTimelineRange = nil
+        selectedTimelineMarkerIds = []
     }
 
     private func forwardSelectionAnchorId() -> String? {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Selection.swift
@@ -6,6 +6,7 @@ extension EditorViewModel {
 
     func selectPreviewClip(_ clipId: String) {
         selectedGap = nil
+        selectedTimelineMarkerIds = []
         guard !selectedClipIds.contains(clipId) else { return }
         selectedClipIds = expandToLinkGroup([clipId])
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
@@ -1,12 +1,4 @@
 import Foundation
-struct TimelineMarkerUpdateRequest {
-    var id: String
-    var name: String?
-    var startFrame: Int?
-    var durationFrames: Int?
-    var color: TextStyle.RGBA?
-    var comment: String?
-}
 struct TimelineMarkerChangeReceipt {
     var created: [TimelineMarker]
     var updated: [TimelineMarker]
@@ -18,47 +10,15 @@ extension EditorViewModel {
     }
 
     func displayedTimelineMarkers(preview: TimelineMarker? = nil) -> [TimelineMarker] {
-        var markers = timeline.markers
-        if let preview, let index = markers.firstIndex(where: { $0.id == preview.id }) {
-            markers[index] = preview
-        }
-        var displayed: [TimelineMarker] = []
-        for marker in markers {
-            guard let clipId = marker.clipId else { displayed.append(marker); continue }
-            guard let clip = clipFor(id: clipId), let copy = projected(marker, on: clip) else { continue }
-            displayed.append(copy)
-        }
-        return displayed.sorted { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
+        timeline.markers
+            .map { $0.id == preview?.id ? preview ?? $0 : $0 }
+            .sorted { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
     }
-    func timelineMarkerSnapFrames(
-        excludingClipIds: Set<String> = [],
-        excludingMarkerIds: Set<String> = []
-    ) -> [Int] {
-        var frames = Set<Int>()
-        for marker in displayedTimelineMarkers()
-        where !excludingMarkerIds.contains(marker.id)
-            && (marker.clipId.map({ !excludingClipIds.contains($0) }) ?? true) {
-            frames.insert(marker.startFrame)
-            if marker.isRange { frames.insert(marker.endFrame) }
-        }
-        return frames.sorted()
-    }
-    private func projected(_ marker: TimelineMarker, on clip: Clip) -> TimelineMarker? {
-        let sourceStart = clip.trimStartFrame
-        let sourceEnd = sourceStart + clip.sourceFramesConsumed
-        var copy = marker
-        if marker.isRange {
-            let start = max(sourceStart, marker.startFrame)
-            let end = min(sourceEnd, marker.endFrame)
-            guard start < end else { return nil }
-            copy.startFrame = clip.markerTimelineFrame(at: start)
-            let timelineEnd = clip.markerTimelineFrame(at: end)
-            copy.durationFrames = max(1, timelineEnd - copy.startFrame)
-        } else {
-            guard marker.startFrame >= sourceStart, marker.startFrame < sourceEnd else { return nil }
-            copy.startFrame = clip.markerTimelineFrame(at: marker.startFrame)
-        }
-        return copy
+    func timelineMarkerSnapFrames(excludingMarkerIds: Set<String> = []) -> [Int] {
+        let frames = displayedTimelineMarkers()
+            .filter { !excludingMarkerIds.contains($0.id) }
+            .flatMap { $0.isRange ? [$0.startFrame, $0.endFrame] : [$0.startFrame] }
+        return Set(frames).sorted()
     }
 
     @discardableResult
@@ -68,23 +28,10 @@ extension EditorViewModel {
             return nil
         }
         let range = validSelectedTimelineRange
-        let selected = timeline.tracks.flatMap(\.clips).filter { selectedClipIds.contains($0.id) }
-        let selectedAtPlayhead = selected.filter {
-            $0.contains(timelineFrame: activeFrame)
-        }
-        let sourceClip = Set(selectedAtPlayhead.map(\.mediaRef)).count == 1
-            ? selectedAtPlayhead.first(where: { $0.mediaType != .audio }) ?? selectedAtPlayhead.first
-            : nil
-        guard selected.isEmpty || sourceClip != nil else {
-            refuseWithToast(L10n.string("Move the playhead over the selected clip to add a marker."))
-            return nil
-        }
-        let sourceFrame = sourceClip.map { $0.markerSourceFrame(at: activeFrame) }
         let marker = TimelineMarker(
-            clipId: sourceClip?.id,
             name: L10n.string("Marker"),
-            startFrame: sourceFrame ?? range?.startFrame ?? activeFrame,
-            durationFrames: sourceClip == nil ? range.map { $0.endFrame - $0.startFrame } ?? 0 : 0
+            startFrame: range?.startFrame ?? activeFrame,
+            durationFrames: range.map { $0.endFrame - $0.startFrame } ?? 0
         )
         do {
             let created = try changeTimelineMarkers(
@@ -106,7 +53,7 @@ extension EditorViewModel {
     @discardableResult
     func changeTimelineMarkers(
         creates: [TimelineMarker] = [],
-        updates: [TimelineMarkerUpdateRequest] = [],
+        updates: [TimelineMarker] = [],
         deleteIds: [String] = [],
         actionName: String
     ) throws -> TimelineMarkerChangeReceipt {
@@ -119,14 +66,13 @@ extension EditorViewModel {
         }
 
         var updated: [TimelineMarker] = []
-        for request in updates {
-            guard !deleteSet.contains(request.id) else {
+        for marker in try updates.map(validatedTimelineMarker) {
+            guard !deleteSet.contains(marker.id) else {
                 throw TimelineMarkerValidationError.invalidRange
             }
-            guard let index = next.firstIndex(where: { $0.id == request.id }) else {
+            guard let index = next.firstIndex(where: { $0.id == marker.id }) else {
                 throw TimelineMarkerValidationError.invalidRange
             }
-            let marker = try applying(request, to: next[index])
             if marker != next[index] { next[index] = marker; updated.append(marker) }
         }
 
@@ -156,16 +102,6 @@ extension EditorViewModel {
         }
     }
 
-    private func applying(_ request: TimelineMarkerUpdateRequest, to original: TimelineMarker) throws -> TimelineMarker {
-        var marker = original
-        if let name = request.name { marker.name = name }
-        if let startFrame = request.startFrame { marker.startFrame = startFrame }
-        if let durationFrames = request.durationFrames { marker.durationFrames = durationFrames }
-        if let color = request.color { marker.color = color }
-        if let comment = request.comment { marker.comment = comment }
-        return try validatedTimelineMarker(marker)
-    }
-
     private func validatedTimelineMarker(_ marker: TimelineMarker) throws -> TimelineMarker {
         let name = marker.name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty,
@@ -179,8 +115,7 @@ extension EditorViewModel {
         let end = marker.startFrame.addingReportingOverflow(marker.durationFrames)
         let components = [marker.color.r, marker.color.g, marker.color.b, marker.color.a]
         guard marker.startFrame >= 0, marker.durationFrames >= 0, !end.overflow,
-              components.allSatisfy({ $0.isFinite && (0...1).contains($0) }),
-              marker.clipId.map({ clipFor(id: $0) != nil }) ?? true else {
+              components.allSatisfy({ $0.isFinite && (0...1).contains($0) }) else {
             throw TimelineMarkerValidationError.invalidRange
         }
         var marker = marker

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
@@ -29,7 +29,7 @@ extension EditorViewModel {
         }
         let range = validSelectedTimelineRange
         let marker = TimelineMarker(
-            name: L10n.string("Marker"),
+            name: nextMarkerName(),
             startFrame: range?.startFrame ?? activeFrame,
             durationFrames: range.map { $0.endFrame - $0.startFrame } ?? 0
         )
@@ -48,6 +48,13 @@ extension EditorViewModel {
             refuseWithToast(L10n.string("Couldn't add marker."))
             return nil
         }
+    }
+
+    private func nextMarkerName() -> String {
+        let names = Set(timeline.markers.map(\.name))
+        var number = 1
+        while names.contains(L10n.string("Marker \(number)")) { number += 1 }
+        return L10n.string("Marker \(number)")
     }
 
     @discardableResult

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
@@ -1,0 +1,205 @@
+import Foundation
+struct TimelineMarkerUpdateRequest {
+    var id: String
+    var name: String?
+    var startFrame: Int?
+    var durationFrames: Int?
+    var color: TextStyle.RGBA?
+    var comment: String?
+}
+struct TimelineMarkerChangeReceipt {
+    var created: [TimelineMarker]
+    var updated: [TimelineMarker]
+    var deletedIds: [String]
+}
+extension EditorViewModel {
+    func timelineMarker(id: String) -> TimelineMarker? {
+        timeline.markers.first { $0.id == id }
+    }
+
+    func displayedTimelineMarkers(preview: TimelineMarker? = nil) -> [TimelineMarker] {
+        var markers = timeline.markers
+        if let preview, let index = markers.firstIndex(where: { $0.id == preview.id }) {
+            markers[index] = preview
+        }
+        var displayed: [TimelineMarker] = []
+        for marker in markers {
+            guard let clipId = marker.clipId else { displayed.append(marker); continue }
+            guard let clip = clipFor(id: clipId), let copy = projected(marker, on: clip) else { continue }
+            displayed.append(copy)
+        }
+        return displayed.sorted { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
+    }
+    func timelineMarkerSnapFrames(
+        excludingClipIds: Set<String> = [],
+        excludingMarkerIds: Set<String> = []
+    ) -> [Int] {
+        var frames = Set<Int>()
+        for marker in displayedTimelineMarkers()
+        where !excludingMarkerIds.contains(marker.id)
+            && (marker.clipId.map({ !excludingClipIds.contains($0) }) ?? true) {
+            frames.insert(marker.startFrame)
+            if marker.isRange { frames.insert(marker.endFrame) }
+        }
+        return frames.sorted()
+    }
+    private func projected(_ marker: TimelineMarker, on clip: Clip) -> TimelineMarker? {
+        let sourceStart = clip.trimStartFrame
+        let sourceEnd = sourceStart + clip.sourceFramesConsumed
+        var copy = marker
+        if marker.isRange {
+            let start = max(sourceStart, marker.startFrame)
+            let end = min(sourceEnd, marker.endFrame)
+            guard start < end else { return nil }
+            copy.startFrame = clip.markerTimelineFrame(at: start)
+            let timelineEnd = clip.markerTimelineFrame(at: end)
+            copy.durationFrames = max(1, timelineEnd - copy.startFrame)
+        } else {
+            guard marker.startFrame >= sourceStart, marker.startFrame < sourceEnd else { return nil }
+            copy.startFrame = clip.markerTimelineFrame(at: marker.startFrame)
+        }
+        return copy
+    }
+
+    @discardableResult
+    func addTimelineMarkerAtSelection() -> TimelineMarker? {
+        guard case .timeline = activePreviewTab else {
+            refuseWithToast(L10n.string("Select the timeline to add a marker."))
+            return nil
+        }
+        let range = validSelectedTimelineRange
+        let selected = timeline.tracks.flatMap(\.clips).filter { selectedClipIds.contains($0.id) }
+        let selectedAtPlayhead = selected.filter {
+            $0.contains(timelineFrame: activeFrame)
+        }
+        let sourceClip = Set(selectedAtPlayhead.map(\.mediaRef)).count == 1
+            ? selectedAtPlayhead.first(where: { $0.mediaType != .audio }) ?? selectedAtPlayhead.first
+            : nil
+        guard selected.isEmpty || sourceClip != nil else {
+            refuseWithToast(L10n.string("Move the playhead over the selected clip to add a marker."))
+            return nil
+        }
+        let sourceFrame = sourceClip.map { $0.markerSourceFrame(at: activeFrame) }
+        let marker = TimelineMarker(
+            clipId: sourceClip?.id,
+            name: L10n.string("Marker"),
+            startFrame: sourceFrame ?? range?.startFrame ?? activeFrame,
+            durationFrames: sourceClip == nil ? range.map { $0.endFrame - $0.startFrame } ?? 0 : 0
+        )
+        do {
+            let created = try changeTimelineMarkers(
+                creates: [marker],
+                actionName: "Add Marker"
+            ).created.first
+            selectedTimelineMarkerIds = Set(created.map { [$0.id] } ?? [])
+            selectedClipIds.removeAll()
+            selectedGap = nil
+            selectedTimelineRange = nil
+            if let id = created?.id { onPresentTimelineMarkerEditor?(id) }
+            return created
+        } catch {
+            refuseWithToast(L10n.string("Couldn't add marker."))
+            return nil
+        }
+    }
+
+    @discardableResult
+    func changeTimelineMarkers(
+        creates: [TimelineMarker] = [],
+        updates: [TimelineMarkerUpdateRequest] = [],
+        deleteIds: [String] = [],
+        actionName: String
+    ) throws -> TimelineMarkerChangeReceipt {
+        let deleteSet = Set(deleteIds)
+        guard deleteSet.count == deleteIds.count else { throw TimelineMarkerValidationError.invalidRange }
+        let before = timeline.markers
+        var next = before
+        guard deleteSet.isSubset(of: Set(next.map(\.id))) else {
+            throw TimelineMarkerValidationError.invalidRange
+        }
+
+        var updated: [TimelineMarker] = []
+        for request in updates {
+            guard !deleteSet.contains(request.id) else {
+                throw TimelineMarkerValidationError.invalidRange
+            }
+            guard let index = next.firstIndex(where: { $0.id == request.id }) else {
+                throw TimelineMarkerValidationError.invalidRange
+            }
+            let marker = try applying(request, to: next[index])
+            if marker != next[index] { next[index] = marker; updated.append(marker) }
+        }
+
+        next.removeAll { deleteSet.contains($0.id) }
+        let created = try creates.map(validatedTimelineMarker)
+        next += created
+        next.sort { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
+        guard next != before else {
+            return TimelineMarkerChangeReceipt(created: [], updated: [], deletedIds: [])
+        }
+
+        timeline.markers = next
+        registerTimelineMarkerSwap(undoMarkers: before, redoMarkers: next, actionName: actionName)
+        selectedTimelineMarkerIds.subtract(deleteSet)
+        return TimelineMarkerChangeReceipt(created: created, updated: updated, deletedIds: deleteIds)
+    }
+
+    func deleteSelectedTimelineMarker() {
+        guard !selectedTimelineMarkerIds.isEmpty else { return }
+        do {
+            _ = try changeTimelineMarkers(
+                deleteIds: Array(selectedTimelineMarkerIds),
+                actionName: selectedTimelineMarkerIds.count == 1 ? "Delete Marker" : "Delete Markers"
+            )
+        } catch {
+            refuseWithToast(L10n.string("Couldn't delete marker."))
+        }
+    }
+
+    private func applying(_ request: TimelineMarkerUpdateRequest, to original: TimelineMarker) throws -> TimelineMarker {
+        var marker = original
+        if let name = request.name { marker.name = name }
+        if let startFrame = request.startFrame { marker.startFrame = startFrame }
+        if let durationFrames = request.durationFrames { marker.durationFrames = durationFrames }
+        if let color = request.color { marker.color = color }
+        if let comment = request.comment { marker.comment = comment }
+        return try validatedTimelineMarker(marker)
+    }
+
+    private func validatedTimelineMarker(_ marker: TimelineMarker) throws -> TimelineMarker {
+        let name = marker.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty,
+              name.count <= TimelineMarker.maximumNameLength,
+              name.rangeOfCharacter(from: .controlCharacters.union(.newlines)) == nil else {
+            throw TimelineMarkerValidationError.invalidName
+        }
+        guard marker.comment.count <= TimelineMarker.maximumCommentLength else {
+            throw TimelineMarkerValidationError.invalidComment
+        }
+        let end = marker.startFrame.addingReportingOverflow(marker.durationFrames)
+        let components = [marker.color.r, marker.color.g, marker.color.b, marker.color.a]
+        guard marker.startFrame >= 0, marker.durationFrames >= 0, !end.overflow,
+              components.allSatisfy({ $0.isFinite && (0...1).contains($0) }),
+              marker.clipId.map({ clipFor(id: $0) != nil }) ?? true else {
+            throw TimelineMarkerValidationError.invalidRange
+        }
+        var marker = marker
+        marker.name = name
+        return marker
+    }
+
+    private func registerTimelineMarkerSwap(
+        undoMarkers: [TimelineMarker],
+        redoMarkers: [TimelineMarker],
+        actionName: String
+    ) {
+        registerTimelineUndo(actionName) { vm in
+            vm.timeline.markers = undoMarkers
+            vm.selectedTimelineMarkerIds.formIntersection(undoMarkers.map(\.id))
+            vm.registerTimelineMarkerSwap(
+                undoMarkers: redoMarkers, redoMarkers: undoMarkers,
+                actionName: actionName
+            )
+        }
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineRange.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineRange.swift
@@ -6,21 +6,16 @@ extension EditorViewModel {
 
     func markTimelineRangeStart(atFrame frame: Int? = nil) {
         let start = max(0, frame ?? activeFrame)
-        selectedTimelineRange = TimelineRangeSelection(
-            startFrame: start,
-            endFrame: selectedTimelineRange?.endFrame ?? start
-        )
+        setTimelineRange(startFrame: start, endFrame: selectedTimelineRange?.endFrame ?? start)
     }
 
     func markTimelineRangeEnd(atFrame frame: Int? = nil) {
         let end = max(0, frame ?? activeFrame)
-        selectedTimelineRange = TimelineRangeSelection(
-            startFrame: selectedTimelineRange?.startFrame ?? end,
-            endFrame: end
-        )
+        setTimelineRange(startFrame: selectedTimelineRange?.startFrame ?? end, endFrame: end)
     }
 
     func setTimelineRange(startFrame: Int, endFrame: Int) {
+        selectedTimelineMarkerIds = []
         selectedTimelineRange = TimelineRangeSelection(
             startFrame: max(0, startFrame),
             endFrame: max(0, endFrame)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -94,6 +94,7 @@ extension EditorViewModel {
         selectedClipIds = []
         selectedGap = nil
         selectedTimelineRange = nil
+        selectedTimelineMarkerIds = []
         pendingSwapClipId = nil
         pendingSwapTargetClipIds = []
         clearAgentActivity()
@@ -264,11 +265,18 @@ extension Timeline {
     /// Fresh track/clip/group ids for a duplicated timeline so ids stay unique project-wide.
     mutating func regenerateIds() {
         var groups: [String: String] = [:]
+        var clipIds: [String: String] = [:]
         for ti in tracks.indices {
             tracks[ti].id = UUID().uuidString
             for ci in tracks[ti].clips.indices {
+                let oldId = tracks[ti].clips[ci].id
                 tracks[ti].clips[ci].freshenIds(groups: &groups)
+                clipIds[oldId] = tracks[ti].clips[ci].id
             }
+        }
+        for i in markers.indices {
+            markers[i].id = UUID().uuidString
+            if let clipId = markers[i].clipId { markers[i].clipId = clipIds[clipId] }
         }
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -265,18 +265,12 @@ extension Timeline {
     /// Fresh track/clip/group ids for a duplicated timeline so ids stay unique project-wide.
     mutating func regenerateIds() {
         var groups: [String: String] = [:]
-        var clipIds: [String: String] = [:]
         for ti in tracks.indices {
             tracks[ti].id = UUID().uuidString
             for ci in tracks[ti].clips.indices {
-                let oldId = tracks[ti].clips[ci].id
                 tracks[ti].clips[ci].freshenIds(groups: &groups)
-                clipIds[oldId] = tracks[ti].clips[ci].id
             }
         }
-        for i in markers.indices {
-            markers[i].id = UUID().uuidString
-            if let clipId = markers[i].clipId { markers[i].clipId = clipIds[clipId] }
-        }
+        for i in markers.indices { markers[i].id = UUID().uuidString }
     }
 }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Tracks.swift
@@ -55,6 +55,7 @@ extension EditorViewModel {
         guard let track = timeline.tracks.first(where: { $0.id == trackId }),
               !track.clips.isEmpty else { return false }
         selectedGap = nil
+        selectedTimelineMarkerIds = []
         selectedClipIds = Set(track.clips.map(\.id))
         return true
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -118,6 +118,7 @@ final class EditorViewModel {
     var isMarqueeSelecting: Bool = false
     var selectedGap: GapSelection?
     var selectedTimelineRange: TimelineRangeSelection?
+    var selectedTimelineMarkerIds: Set<String> = []
     var selectedMediaAssetIds: Set<String> = []
     var selectedFolderIds: Set<String> = []
     var selectedTimelineIds: Set<String> = []
@@ -341,6 +342,7 @@ final class EditorViewModel {
     @ObservationIgnored let projectPackageCoordinator = ProjectPackageCoordinator()
     @ObservationIgnored var onProjectCheckpointRequired: (() -> Void)?
     @ObservationIgnored var onCancelTimelineDrag: (() -> Void)?
+    @ObservationIgnored var onPresentTimelineMarkerEditor: ((String) -> Void)?
     var isDocumentEdited: Bool = false
 
     func telemetrySnapshot() -> [String: Any] {
@@ -478,6 +480,7 @@ final class EditorViewModel {
     var pendingRebuildTask: Task<Void, Never>?
 
     func notifyTimelineChanged(refreshVisuals: Bool = true) {
+        selectedTimelineMarkerIds.formIntersection(timeline.markers.map(\.id))
         guard undo.isRegistrationEnabled else { return }
         enhancePendingDenoises()
         pendingRebuildTask?.cancel()
@@ -730,6 +733,7 @@ final class EditorViewModel {
         for i in timeline.tracks.indices {
             timeline.tracks[i].clips.removeAll { $0.id == id }
         }
+        timeline.markers.removeAll { $0.clipId == id }
         pendingReplacements.remove(id)
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -733,7 +733,6 @@ final class EditorViewModel {
         for i in timeline.tracks.indices {
             timeline.tracks[i].clips.removeAll { $0.id == id }
         }
-        timeline.markers.removeAll { $0.clipId == id }
         pendingReplacements.remove(id)
     }
 

--- a/Sources/PalmierPro/Inspector/Components/ScrubbableNumberField.swift
+++ b/Sources/PalmierPro/Inspector/Components/ScrubbableNumberField.swift
@@ -11,11 +11,13 @@ struct ScrubbableNumberField: View {
     var dragSensitivity: Double = 1
     var fieldWidth: CGFloat = AppTheme.EditorPanel.numericFieldWidth
     var fieldHeight: CGFloat = AppTheme.EditorPanel.fieldMinHeight
+    var fieldFill: Color = AppTheme.Background.baseColor
     var valueFontSize: CGFloat = AppTheme.FontSize.sm
     var dragValueAdjustment: (Double) -> Double = { $0 }
     var trailingLabel: String? = nil
     var trailingLabelFontSize: CGFloat = AppTheme.FontSize.xs
     var displayTextOverride: ((Double) -> String?)? = nil
+    var parseTextOverride: ((String) -> Double?)? = nil
     var onDraggingValue: ((Double) -> Void)? = nil
     var onChanged: ((Double) -> Void)? = nil
     var onInteractionStart: (() -> Void)? = nil
@@ -41,7 +43,8 @@ struct ScrubbableNumberField: View {
         return String(format: format, displayValue) + valueSuffix
     }
     private var editingText: String {
-        isMixed ? "" : String(format: format, displayValue)
+        if isMixed { return "" }
+        return displayTextOverride?(sourceValue) ?? String(format: format, displayValue)
     }
 
     var body: some View {
@@ -81,7 +84,8 @@ struct ScrubbableNumberField: View {
             .padding(.vertical, AppTheme.Spacing.xxs)
             .editorValueField(
                 active: isEditing || isDragging,
-                minHeight: fieldHeight
+                minHeight: fieldHeight,
+                fill: fieldFill
             )
             .overlay(scrubOverlay)
         }
@@ -148,14 +152,13 @@ struct ScrubbableNumberField: View {
     }
 
     private func commitEdit() {
-        guard let raw = Self.committedValue(
-            from: editText,
-            suffix: valueSuffix,
-            displayMultiplier: displayMultiplier,
-            range: range
-        ) else { return }
-        liveValue = raw
-        onCommit(raw)
+        let parsed = parseTextOverride?(editText) ?? Self.committedValue(
+            from: editText, suffix: valueSuffix,
+            displayMultiplier: displayMultiplier, range: range
+        )
+        guard let raw = parsed else { return }
+        liveValue = raw.clamped(to: range)
+        onCommit(liveValue)
     }
 
     private func beginInteraction() {

--- a/Sources/PalmierPro/Models/TextStyle.swift
+++ b/Sources/PalmierPro/Models/TextStyle.swift
@@ -212,6 +212,11 @@ extension TextStyle.RGBA {
         Color(.sRGB, red: r, green: g, blue: b, opacity: a)
     }
 
+    var hexString: String {
+        let bytes = [r, g, b, a].map { Int((min(max($0, 0), 1) * 255).rounded()) }
+        return String(format: "#%02X%02X%02X%02X", bytes[0], bytes[1], bytes[2], bytes[3])
+    }
+
     init(_ color: Color) {
         let ns = NSColor(color).usingColorSpace(.sRGB) ?? .black
         self.init(

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -33,7 +33,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     }
 
     var displayFrames: Int {
-        markers.filter { $0.clipId == nil }.reduce(totalFrames) { result, marker in
+        markers.reduce(totalFrames) { result, marker in
             max(result, marker.startFrame + max(1, marker.durationFrames))
         }
     }

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -22,6 +22,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     var settingsConfigured: Bool = false
     var folderId: String?
     var tracks: [Track] = []
+    var markers: [TimelineMarker] = []
 
     var totalFrames: Int {
         var maxFrame = 0
@@ -29,6 +30,12 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
             maxFrame = max(maxFrame, track.endFrame)
         }
         return maxFrame
+    }
+
+    var displayFrames: Int {
+        markers.filter { $0.clipId == nil }.reduce(totalFrames) { result, marker in
+            max(result, marker.startFrame + max(1, marker.durationFrames))
+        }
     }
 
     var hasAudioClips: Bool {
@@ -60,7 +67,7 @@ struct Timeline: Codable, Sendable, Equatable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, fps, width, height, settingsConfigured, folderId, tracks
+        case id, name, fps, width, height, settingsConfigured, folderId, tracks, markers
     }
 }
 
@@ -75,7 +82,8 @@ extension Timeline {
             height: try c.decode(Int.self, forKey: .height),
             settingsConfigured: (try? c.decode(Bool.self, forKey: .settingsConfigured)) ?? false,
             folderId: try? c.decode(String.self, forKey: .folderId),
-            tracks: try c.decode([Track].self, forKey: .tracks)
+            tracks: try c.decode([Track].self, forKey: .tracks),
+            markers: (try? c.decode([TimelineMarker].self, forKey: .markers)) ?? []
         )
     }
 }

--- a/Sources/PalmierPro/Models/TimelineMarker.swift
+++ b/Sources/PalmierPro/Models/TimelineMarker.swift
@@ -6,7 +6,6 @@ struct TimelineMarker: Codable, Sendable, Equatable, Hashable, Identifiable {
     static let defaultColor = TextStyle.RGBA(r: 0, g: 0.478, b: 1, a: 1)
 
     var id: String = UUID().uuidString
-    var clipId: String?
     var name: String
     var startFrame: Int
     var durationFrames: Int = 0
@@ -33,25 +32,4 @@ enum TimelineMarkerValidationError: Error, Equatable {
     case invalidName
     case invalidComment
     case invalidRange
-}
-
-extension Timeline {
-    mutating func copyMarkers(from sourceClipId: String, to clipId: String) {
-        markers += markers.filter { $0.clipId == sourceClipId }.map {
-            var copy = $0
-            copy.id = UUID().uuidString
-            copy.clipId = clipId
-            return copy
-        }
-    }
-}
-
-extension Clip {
-    func markerSourceFrame(at timelineFrame: Int) -> Int {
-        trimStartFrame + Int((Double(timelineFrame - startFrame) * speed).rounded())
-    }
-
-    func markerTimelineFrame(at sourceFrame: Int) -> Int {
-        startFrame + Int((Double(sourceFrame - trimStartFrame) / speed).rounded())
-    }
 }

--- a/Sources/PalmierPro/Models/TimelineMarker.swift
+++ b/Sources/PalmierPro/Models/TimelineMarker.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct TimelineMarker: Codable, Sendable, Equatable, Hashable, Identifiable {
+    static let maximumNameLength = 120
+    static let maximumCommentLength = 4_000
+    static let defaultColor = TextStyle.RGBA(r: 0, g: 0.478, b: 1, a: 1)
+
+    var id: String = UUID().uuidString
+    var clipId: String?
+    var name: String
+    var startFrame: Int
+    var durationFrames: Int = 0
+    var color: TextStyle.RGBA = defaultColor
+    var comment: String = ""
+
+    var endFrame: Int { startFrame + durationFrames }
+    var isRange: Bool { durationFrames > 0 }
+
+    func intersects(_ range: Range<Int>) -> Bool {
+        isRange
+            ? startFrame < range.upperBound && endFrame > range.lowerBound
+            : range.contains(startFrame)
+    }
+
+    mutating func rescaleFrames(by scale: Double) {
+        let scaledEnd = Int((Double(endFrame) * scale).rounded())
+        startFrame = max(0, Int((Double(startFrame) * scale).rounded()))
+        durationFrames = isRange ? max(1, scaledEnd - startFrame) : 0
+    }
+}
+
+enum TimelineMarkerValidationError: Error, Equatable {
+    case invalidName
+    case invalidComment
+    case invalidRange
+}
+
+extension Timeline {
+    mutating func copyMarkers(from sourceClipId: String, to clipId: String) {
+        markers += markers.filter { $0.clipId == sourceClipId }.map {
+            var copy = $0
+            copy.id = UUID().uuidString
+            copy.clipId = clipId
+            return copy
+        }
+    }
+}
+
+extension Clip {
+    func markerSourceFrame(at timelineFrame: Int) -> Int {
+        trimStartFrame + Int((Double(timelineFrame - startFrame) * speed).rounded())
+    }
+
+    func markerTimelineFrame(at sourceFrame: Int) -> Int {
+        startFrame + Int((Double(sourceFrame - trimStartFrame) / speed).rounded())
+    }
+}

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -242,7 +242,6 @@
 "Couldn't align %lld clips." = "Couldn't align %lld clips.";
 "Couldn't change marker." = "Couldn't change marker.";
 "Couldn't delete marker." = "Couldn't delete marker.";
-"Couldn't delete markers." = "Couldn't delete markers.";
 "Couldn't switch angle." = "Couldn't switch angle.";
 "Couldn’t move %@ to the Trash." = "Couldn’t move %@ to the Trash.";
 "Count" = "Count";
@@ -568,7 +567,7 @@
 "Mark Range Start" = "Mark Range Start";
 "Mark Silence" = "Mark Silence";
 "Mark Speakers" = "Mark Speakers";
-"Marker" = "Marker";
+"Marker %lld" = "Marker %lld";
 "Marker name" = "Marker name";
 "Marketer" = "Marketer";
 "Master Audio Meter" = "Master Audio Meter";
@@ -606,7 +605,6 @@
 "Motion Blur" = "Motion Blur";
 "Move Clip to New Track" = "Move Clip to New Track";
 "Move playhead inside the clip" = "Move playhead inside the clip";
-"Move the playhead over the selected clip to add a marker." = "Move the playhead over the selected clip to add a marker.";
 "Move to Folder" = "Move to Folder";
 "Multicam" = "Multicam";
 "Multilingual" = "Multilingual";
@@ -755,7 +753,6 @@
 "Remove" = "Remove";
 "Remove %@" = "Remove %@";
 "Remove API key" = "Remove API key";
-"Remove All" = "Remove All";
 "Remove Dead Air" = "Remove Dead Air";
 "Remove Marker" = "Remove Marker";
 "Remove background sound and keep speech" = "Remove background sound and keep speech";

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -67,6 +67,7 @@
 "Account settings" = "Account settings";
 "Action Safe" = "Action Safe";
 "Activity unavailable" = "Activity unavailable";
+"Add Marker (M)" = "Add Marker (M)";
 "Add Range to Chat" = "Add Range to Chat";
 "Add Text" = "Add Text";
 "Add an Anthropic API key or credits to use this model." = "Add an Anthropic API key or credits to use this model.";
@@ -173,6 +174,7 @@
 "Chat history" = "Chat history";
 "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key." = "Chat with your agent! It can generate content, edit clips, organize your assets, and much more. Start by signing in, or bring your own Anthropic API key.";
 "Check for Updates…" = "Check for Updates…";
+"Check the marker name, position, and duration." = "Check the marker name, position, and duration.";
 "Choose a .cube LUT file" = "Choose a .cube LUT file";
 "Choose a crop aspect" = "Choose a crop aspect";
 "Choose animation clip color" = "Choose animation clip color";
@@ -236,7 +238,11 @@
 "Could not install the on-device speech model: %@" = "Could not install the on-device speech model: %@";
 "Could not parse transcription result." = "Could not parse transcription result.";
 "Couldn't Prepare Media" = "Couldn't Prepare Media";
+"Couldn't add marker." = "Couldn't add marker.";
 "Couldn't align %lld clips." = "Couldn't align %lld clips.";
+"Couldn't change marker." = "Couldn't change marker.";
+"Couldn't delete marker." = "Couldn't delete marker.";
+"Couldn't delete markers." = "Couldn't delete markers.";
 "Couldn't switch angle." = "Couldn't switch angle.";
 "Couldn’t move %@ to the Trash." = "Couldn’t move %@ to the Trash.";
 "Count" = "Count";
@@ -562,6 +568,8 @@
 "Mark Range Start" = "Mark Range Start";
 "Mark Silence" = "Mark Silence";
 "Mark Speakers" = "Mark Speakers";
+"Marker" = "Marker";
+"Marker name" = "Marker name";
 "Marketer" = "Marketer";
 "Master Audio Meter" = "Master Audio Meter";
 "Master — defines the group's clock and transcript." = "Master — defines the group's clock and transcript.";
@@ -598,6 +606,7 @@
 "Motion Blur" = "Motion Blur";
 "Move Clip to New Track" = "Move Clip to New Track";
 "Move playhead inside the clip" = "Move playhead inside the clip";
+"Move the playhead over the selected clip to add a marker." = "Move the playhead over the selected clip to add a marker.";
 "Move to Folder" = "Move to Folder";
 "Multicam" = "Multicam";
 "Multilingual" = "Multilingual";
@@ -646,6 +655,7 @@
 "Normal" = "Normal";
 "Not selected" = "Not selected";
 "Not synced — unusable as an angle." = "Not synced — unusable as an angle.";
+"Notes" = "Notes";
 "Notifications" = "Notifications";
 "OK" = "OK";
 "Off" = "Off";
@@ -745,7 +755,9 @@
 "Remove" = "Remove";
 "Remove %@" = "Remove %@";
 "Remove API key" = "Remove API key";
+"Remove All" = "Remove All";
 "Remove Dead Air" = "Remove Dead Air";
+"Remove Marker" = "Remove Marker";
 "Remove background sound and keep speech" = "Remove background sound and keep speech";
 "Remove filler words" = "Remove filler words";
 "Remove from Queue" = "Remove from Queue";
@@ -822,6 +834,7 @@
 "Select Range" = "Select Range";
 "Select compatible clips and paste settings again." = "Select compatible clips and paste settings again.";
 "Select media files or folders to import" = "Select media files or folders to import";
+"Select the timeline to add a marker." = "Select the timeline to add a marker.";
 "Selected" = "Selected";
 "Selected Clips · %lld" = "Selected Clips · %lld";
 "Selection Tool" = "Selection Tool";
@@ -957,6 +970,7 @@
 "Threshold" = "Threshold";
 "Thumbnail Size" = "Thumbnail Size";
 "Tilt" = "Tilt";
+"Time" = "Time";
 "Timecode" = "Timecode";
 "Timeline" = "Timeline";
 "Timeline Format" = "Timeline Format";

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -883,10 +883,7 @@ enum ClipRenderer {
             .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs, weight: .medium),
             .foregroundColor: clip.sourceClipType.themeForegroundColor,
         ]
-        let attributed = NSMutableAttributedString(string: text, attributes: baseAttrs)
-        if clip.linkGroupId != nil {
-            attributed.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: (name as NSString).length))
-        }
+        let attributed = NSAttributedString(string: text, attributes: baseAttrs)
         let size = attributed.size()
         let inset = AppTheme.Spacing.sm
         let origin = NSPoint(

--- a/Sources/PalmierPro/Timeline/DragState.swift
+++ b/Sources/PalmierPro/Timeline/DragState.swift
@@ -12,6 +12,7 @@ enum DragState {
     case fadeKnee(FadeKneeDrag)
     case marquee(MarqueeDrag)
     case timelineRange(TimelineRangeDrag)
+    case timelineMarker(TimelineMarkerDrag)
 
     struct KeyframeDrag {
         let clipId: String
@@ -108,9 +109,19 @@ enum DragState {
         let origin: NSPoint
         var current: NSRect = .zero
         var baseSelection: Set<String> = []
+        var baseMarkerSelection: Set<String> = []
     }
 
     struct TimelineRangeDrag {
         let anchorFrame: Int
+    }
+
+    struct TimelineMarkerDrag {
+        let original: TimelineMarker
+        let displayed: TimelineMarker
+        let adjustsDuration: Bool
+        let grabFrame: Int
+        var value: TimelineMarker
+        var displayedValue: TimelineMarker
     }
 }

--- a/Sources/PalmierPro/Timeline/DragState.swift
+++ b/Sources/PalmierPro/Timeline/DragState.swift
@@ -118,10 +118,8 @@ enum DragState {
 
     struct TimelineMarkerDrag {
         let original: TimelineMarker
-        let displayed: TimelineMarker
         let adjustsDuration: Bool
         let grabFrame: Int
         var value: TimelineMarker
-        var displayedValue: TimelineMarker
     }
 }

--- a/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
+++ b/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
@@ -6,6 +6,7 @@ struct MarkerEditorPopover: View {
     let onPreview: (TimelineMarker) -> Void
     let onDismiss: () -> Void
     @State private var draft: TimelineMarker
+    @FocusState private var notesFocused: Bool
     init(
         marker: TimelineMarker,
         fps: Int,
@@ -39,6 +40,7 @@ struct MarkerEditorPopover: View {
                     fieldLabel(L10n.string("Notes"))
                     TextField(String(), text: $draft.comment, axis: .vertical)
                         .textFieldStyle(.plain)
+                        .focused($notesFocused)
                         .font(.system(size: AppTheme.FontSize.sm))
                         .lineLimit(3, reservesSpace: true)
                         .frame(height: AppTheme.TimelineMarker.notesHeight)
@@ -85,11 +87,12 @@ struct MarkerEditorPopover: View {
                 Spacer()
                 Button(L10n.string("Done")) { apply() }
                     .buttonStyle(.capsule(.prominent, size: .small))
-                    .keyboardShortcut(.defaultAction)
+                    .keyboardShortcut(.return, modifiers: .command)
             }
         }
         .padding(AppTheme.Spacing.md)
         .frame(width: AppTheme.TimelineMarker.editorWidth)
+        .task { notesFocused = true }
     }
     private func fieldLabel(_ label: String) -> some View {
         Text(label)

--- a/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
+++ b/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
@@ -5,11 +5,7 @@ struct MarkerEditorPopover: View {
     let fps: Int
     let onPreview: (TimelineMarker) -> Void
     let onDismiss: () -> Void
-    @State private var name: String
-    @State private var comment: String
-    @State private var startFrame: Int
-    @State private var durationFrames: Int
-    @State private var color: TextStyle.RGBA
+    @State private var draft: TimelineMarker
     init(
         marker: TimelineMarker,
         fps: Int,
@@ -20,24 +16,20 @@ struct MarkerEditorPopover: View {
         self.fps = fps
         self.onPreview = onPreview
         self.onDismiss = onDismiss
-        _name = State(initialValue: marker.name)
-        _comment = State(initialValue: marker.comment)
-        _startFrame = State(initialValue: marker.startFrame)
-        _durationFrames = State(initialValue: marker.durationFrames)
-        _color = State(initialValue: marker.color)
+        _draft = State(initialValue: marker)
     }
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
             Grid(alignment: .topLeading, horizontalSpacing: AppTheme.Spacing.sm, verticalSpacing: AppTheme.Spacing.md) {
                 GridRow {
                     fieldLabel(L10n.string("Time"))
-                    timeField($startFrame, isDuration: false)
+                    timeField(\.startFrame)
                     fieldLabel(L10n.string("Duration"))
-                    timeField($durationFrames, isDuration: true)
+                    timeField(\.durationFrames)
                 }
                 GridRow {
                     fieldLabel(L10n.string("Name"))
-                    TextField(L10n.string("Marker name"), text: $name)
+                    TextField(L10n.string("Marker name"), text: $draft.name)
                         .textFieldStyle(.plain)
                         .padding(.horizontal, AppTheme.Spacing.sm)
                         .editorValueField(fill: AppTheme.Background.raisedColor)
@@ -45,7 +37,7 @@ struct MarkerEditorPopover: View {
                 }
                 GridRow {
                     fieldLabel(L10n.string("Notes"))
-                    TextField(String(), text: $comment, axis: .vertical)
+                    TextField(String(), text: $draft.comment, axis: .vertical)
                         .textFieldStyle(.plain)
                         .font(.system(size: AppTheme.FontSize.sm))
                         .lineLimit(3, reservesSpace: true)
@@ -62,13 +54,13 @@ struct MarkerEditorPopover: View {
                     HStack(spacing: AppTheme.Spacing.xxs) {
                         ForEach(Array(AppTheme.TimelineMarker.presetColors.enumerated()), id: \.offset) { _, preset in
                             Button {
-                                color = preset
-                                preview { $0.color = preset }
+                                draft.color = preset
+                                onPreview(draft)
                             } label: {
                                 ZStack {
                                     RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
                                         .stroke(
-                                            color == preset ? AppTheme.Text.primaryColor : .clear,
+                                            draft.color == preset ? AppTheme.Text.primaryColor : .clear,
                                             lineWidth: AppTheme.BorderWidth.medium
                                         )
                                     TimelineMarkerShape()
@@ -107,16 +99,13 @@ struct MarkerEditorPopover: View {
             .fixedSize(horizontal: true, vertical: false)
             .frame(height: AppTheme.EditorPanel.fieldMinHeight)
     }
-    private func timeField(_ value: Binding<Int>, isDuration: Bool) -> some View {
+    private func timeField(_ keyPath: WritableKeyPath<TimelineMarker, Int>) -> some View {
         let update: (Double) -> Void = {
-            let next = Int($0)
-            value.wrappedValue = next
-            preview {
-                if isDuration { $0.durationFrames = next } else { $0.startFrame = next }
-            }
+            draft[keyPath: keyPath] = Int($0)
+            onPreview(draft)
         }
         return ScrubbableNumberField(
-            value: Double(value.wrappedValue),
+            value: Double(draft[keyPath: keyPath]),
             range: 0...Double(Int32.max),
             dragSensitivity: 1,
             fieldWidth: AppTheme.TimelineMarker.timeFieldWidth,
@@ -128,25 +117,10 @@ struct MarkerEditorPopover: View {
             onCommit: update
         )
     }
-    private func preview(_ change: (inout TimelineMarker) -> Void) {
-        var preview = marker
-        preview.startFrame = startFrame
-        preview.durationFrames = durationFrames
-        preview.color = color
-        change(&preview)
-        onPreview(preview)
-    }
     private func apply() {
         do {
             _ = try editor.changeTimelineMarkers(
-                updates: [TimelineMarkerUpdateRequest(
-                    id: marker.id,
-                    name: name,
-                    startFrame: startFrame,
-                    durationFrames: durationFrames,
-                    color: color,
-                    comment: comment
-                )],
+                updates: [draft],
                 actionName: "Edit Marker"
             )
             editor.selectedTimelineMarkerIds = []

--- a/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
+++ b/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+struct MarkerEditorPopover: View {
+    @Environment(EditorViewModel.self) private var editor
+    let marker: TimelineMarker
+    let fps: Int
+    let onPreview: (TimelineMarker) -> Void
+    let onDismiss: () -> Void
+    @State private var name: String
+    @State private var comment: String
+    @State private var startFrame: Int
+    @State private var durationFrames: Int
+    @State private var color: TextStyle.RGBA
+    init(
+        marker: TimelineMarker,
+        fps: Int,
+        onPreview: @escaping (TimelineMarker) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.marker = marker
+        self.fps = fps
+        self.onPreview = onPreview
+        self.onDismiss = onDismiss
+        _name = State(initialValue: marker.name)
+        _comment = State(initialValue: marker.comment)
+        _startFrame = State(initialValue: marker.startFrame)
+        _durationFrames = State(initialValue: marker.durationFrames)
+        _color = State(initialValue: marker.color)
+    }
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            Grid(alignment: .topLeading, horizontalSpacing: AppTheme.Spacing.sm, verticalSpacing: AppTheme.Spacing.md) {
+                GridRow {
+                    fieldLabel(L10n.string("Time"))
+                    timeField($startFrame, isDuration: false)
+                    fieldLabel(L10n.string("Duration"))
+                    timeField($durationFrames, isDuration: true)
+                }
+                GridRow {
+                    fieldLabel(L10n.string("Name"))
+                    TextField(L10n.string("Marker name"), text: $name)
+                        .textFieldStyle(.plain)
+                        .padding(.horizontal, AppTheme.Spacing.sm)
+                        .editorValueField(fill: AppTheme.Background.raisedColor)
+                        .gridCellColumns(3)
+                }
+                GridRow {
+                    fieldLabel(L10n.string("Notes"))
+                    TextField(String(), text: $comment, axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: AppTheme.FontSize.sm))
+                        .lineLimit(3, reservesSpace: true)
+                        .frame(height: AppTheme.TimelineMarker.notesHeight)
+                        .padding(.horizontal, AppTheme.Spacing.sm)
+                        .editorValueField(
+                            minHeight: AppTheme.TimelineMarker.notesHeight,
+                            fill: AppTheme.Background.raisedColor
+                        )
+                        .gridCellColumns(3)
+                }
+                GridRow {
+                    fieldLabel(L10n.string("Color"))
+                    HStack(spacing: AppTheme.Spacing.xxs) {
+                        ForEach(Array(AppTheme.TimelineMarker.presetColors.enumerated()), id: \.offset) { _, preset in
+                            Button {
+                                color = preset
+                                preview { $0.color = preset }
+                            } label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                                        .stroke(
+                                            color == preset ? AppTheme.Text.primaryColor : .clear,
+                                            lineWidth: AppTheme.BorderWidth.medium
+                                        )
+                                    TimelineMarkerShape()
+                                        .fill(preset.swiftUIColor)
+                                        .padding(AppTheme.Spacing.xxs)
+                                }
+                                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(Text(verbatim: preset.hexString))
+                        }
+                    }
+                    .gridCellColumns(3)
+                }
+            }
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Button(L10n.string("Remove Marker"), role: .destructive) {
+                    editor.deleteSelectedTimelineMarker()
+                    onDismiss()
+                }
+                .buttonStyle(.capsule(.secondary, size: .small))
+                Spacer()
+                Button(L10n.string("Done")) { apply() }
+                    .buttonStyle(.capsule(.prominent, size: .small))
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(AppTheme.Spacing.md)
+        .frame(width: AppTheme.TimelineMarker.editorWidth)
+    }
+    private func fieldLabel(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: AppTheme.FontSize.xs))
+            .foregroundStyle(AppTheme.Text.tertiaryColor)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .frame(height: AppTheme.EditorPanel.fieldMinHeight)
+    }
+    private func timeField(_ value: Binding<Int>, isDuration: Bool) -> some View {
+        let update: (Double) -> Void = {
+            let next = Int($0)
+            value.wrappedValue = next
+            preview {
+                if isDuration { $0.durationFrames = next } else { $0.startFrame = next }
+            }
+        }
+        return ScrubbableNumberField(
+            value: Double(value.wrappedValue),
+            range: 0...Double(Int32.max),
+            dragSensitivity: 1,
+            fieldWidth: AppTheme.TimelineMarker.timeFieldWidth,
+            fieldFill: AppTheme.Background.raisedColor,
+            dragValueAdjustment: { $0.rounded() },
+            displayTextOverride: { formatTimecode(frame: Int($0), fps: fps) },
+            parseTextOverride: { parseTimecode($0, fps: fps).map(Double.init) },
+            onChanged: update,
+            onCommit: update
+        )
+    }
+    private func preview(_ change: (inout TimelineMarker) -> Void) {
+        var preview = marker
+        preview.startFrame = startFrame
+        preview.durationFrames = durationFrames
+        preview.color = color
+        change(&preview)
+        onPreview(preview)
+    }
+    private func apply() {
+        do {
+            _ = try editor.changeTimelineMarkers(
+                updates: [TimelineMarkerUpdateRequest(
+                    id: marker.id,
+                    name: name,
+                    startFrame: startFrame,
+                    durationFrames: durationFrames,
+                    color: color,
+                    comment: comment
+                )],
+                actionName: "Edit Marker"
+            )
+            editor.selectedTimelineMarkerIds = []
+            onDismiss()
+        } catch {
+            editor.refuseWithToast(L10n.string("Check the marker name, position, and duration."))
+        }
+    }
+}

--- a/Sources/PalmierPro/Timeline/SnapEngine.swift
+++ b/Sources/PalmierPro/Timeline/SnapEngine.swift
@@ -8,7 +8,7 @@ enum SnapEngine {
     struct SnapTarget {
         let frame: Int
         let kind: Kind
-        enum Kind { case playhead, clipEdge, beat }
+        enum Kind { case playhead, clipEdge, beat, marker }
     }
 
     struct SnapResult {
@@ -33,6 +33,7 @@ enum SnapEngine {
         playheadFrame: Int = 0,
         excludeClipIds: Set<String> = [],
         includePlayhead: Bool = false,
+        markerFrames: [Int] = [],
         beatFrames: ((Clip) -> [Int])? = nil,
         includeExcludedClipBeats: Bool = false
     ) -> [SnapTarget] {
@@ -40,6 +41,7 @@ enum SnapEngine {
         if includePlayhead {
             targets.append(SnapTarget(frame: playheadFrame, kind: .playhead))
         }
+        targets += markerFrames.map { SnapTarget(frame: $0, kind: .marker) }
         for track in tracks {
             for clip in track.clips {
                 let excluded = excludeClipIds.contains(clip.id)
@@ -90,7 +92,7 @@ enum SnapEngine {
             for target in targets {
                 let threshold: Double = switch target.kind {
                 case .playhead: baseFrameThreshold * Snap.playheadMultiplier
-                case .clipEdge, .beat: baseFrameThreshold
+                case .clipEdge, .beat, .marker: baseFrameThreshold
                 }
                 let dist = abs(Double(probePos - target.frame))
                 if dist <= threshold, dist < (best?.distance ?? .infinity) {

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -112,6 +112,7 @@ struct TimelineContainerView: NSViewRepresentable {
             keyframeLaneRevision: context.coordinator.keyframeLaneState?.revision ?? 0,
             selectedClipIds: editor.selectedClipIds,
             selectedTimelineRange: editor.selectedTimelineRange,
+            selectedTimelineMarkerIds: editor.selectedTimelineMarkerIds,
             pendingReplacements: editor.pendingReplacements,
             generatingAssetIds: Set(editor.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
         )
@@ -160,6 +161,7 @@ struct TimelineContainerView: NSViewRepresentable {
         let keyframeLaneRevision: Int
         let selectedClipIds: Set<String>
         let selectedTimelineRange: TimelineRangeSelection?
+        let selectedTimelineMarkerIds: Set<String>
         let pendingReplacements: Set<String>
         let generatingAssetIds: Set<String>
     }

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -122,8 +122,7 @@ final class TimelineInputController {
             at: point,
             markers: editor.displayedTimelineMarkers(),
             geometry: geometry,
-            rulerMinY: scrollOffsetY,
-            clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+            rulerMinY: scrollOffsetY
         ) {
             beginMarkerDrag(
                 marker,
@@ -429,37 +428,13 @@ final class TimelineInputController {
                 return snap.frame - snap.probeOffset
             }
             if drag.adjustsDuration {
-                let candidateEnd = max(drag.displayed.startFrame, snapped(frame))
-                if let clipId = drag.original.clipId, let clip = editor.clipFor(id: clipId) {
-                    let displayEnd = min(clip.endFrame, candidateEnd)
-                    let sourceEnd = clip.markerSourceFrame(at: displayEnd)
-                    drag.value.durationFrames = displayEnd == drag.displayed.startFrame
-                        ? 0
-                        : max(1, sourceEnd - drag.original.startFrame)
-                    drag.displayedValue.durationFrames = displayEnd - drag.displayed.startFrame
-                    if displayEnd != candidateEnd { snapIndicatorX = nil; snapState = .init() }
-                } else {
-                    drag.value.durationFrames = candidateEnd - drag.displayed.startFrame
-                    drag.displayedValue.durationFrames = drag.value.durationFrames
-                }
+                let end = max(drag.original.startFrame, snapped(frame))
+                drag.value.durationFrames = end - drag.original.startFrame
             } else {
-                let raw = drag.displayed.startFrame + frame - drag.grabFrame
-                let candidate = max(0, snapped(
-                    raw, probes: [0, drag.displayedValue.durationFrames]
+                let raw = drag.original.startFrame + frame - drag.grabFrame
+                drag.value.startFrame = max(0, snapped(
+                    raw, probes: [0, drag.value.durationFrames]
                 ))
-                if let clipId = drag.original.clipId, let clip = editor.clipFor(id: clipId) {
-                    let visibleEnd = clip.trimStartFrame + clip.sourceFramesConsumed
-                    let maxSource = max(clip.trimStartFrame, visibleEnd - max(1, drag.original.durationFrames))
-                    drag.value.startFrame = min(
-                        maxSource,
-                        max(clip.trimStartFrame, clip.markerSourceFrame(at: candidate))
-                    )
-                    drag.displayedValue.startFrame = clip.markerTimelineFrame(at: drag.value.startFrame)
-                    if drag.displayedValue.startFrame != candidate { snapIndicatorX = nil; snapState = .init() }
-                } else {
-                    drag.value.startFrame = candidate
-                    drag.displayedValue.startFrame = candidate
-                }
             }
             dragState = .timelineMarker(drag)
 
@@ -471,7 +446,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: allDraggedIds,
                 includePlayhead: true,
-                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: allDraggedIds),
+                markerFrames: editor.timelineMarkerSnapFrames(),
                 beatFrames: editor.beatSnapFrames(for:)
             )
 
@@ -519,7 +494,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
                 includePlayhead: true,
-                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: [drag.clipId]),
+                markerFrames: editor.timelineMarkerSnapFrames(),
                 beatFrames: editor.beatSnapFrames(for:),
                 includeExcludedClipBeats: true
             )
@@ -551,7 +526,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
                 includePlayhead: true,
-                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: [drag.clipId]),
+                markerFrames: editor.timelineMarkerSnapFrames(),
                 beatFrames: editor.beatSnapFrames(for:),
                 includeExcludedClipBeats: true
             )
@@ -632,8 +607,7 @@ final class TimelineInputController {
                 intersecting: marq.current,
                 markers: editor.displayedTimelineMarkers(),
                 geometry: geometry,
-                rulerMinY: rulerY,
-                clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+                rulerMinY: rulerY
             )
             editor.selectedTimelineMarkerIds = marq.baseMarkerSelection.union(markerIds)
             dragState = .marquee(marq)
@@ -823,11 +797,7 @@ final class TimelineInputController {
             if changed {
                 do {
                     _ = try editor.changeTimelineMarkers(
-                        updates: [TimelineMarkerUpdateRequest(
-                            id: drag.original.id,
-                            startFrame: drag.adjustsDuration ? nil : drag.value.startFrame,
-                            durationFrames: drag.adjustsDuration ? drag.value.durationFrames : nil
-                        )],
+                        updates: [drag.value],
                         actionName: drag.adjustsDuration ? "Change Marker Duration" : "Move Marker"
                     )
                 } catch {
@@ -879,8 +849,7 @@ final class TimelineInputController {
             at: point,
             markers: editor.displayedTimelineMarkers(),
             geometry: geometry,
-            rulerMinY: scrollOffsetY,
-            clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+            rulerMinY: scrollOffsetY
         ) != nil {
             if event.modifierFlags.contains(.option) {
                 NSCursor.resizeLeftRight.set()
@@ -1353,12 +1322,6 @@ final class TimelineInputController {
 
     // MARK: - Hit testing
 
-    private func markerClipRect(for id: String, geometry: TimelineGeometry) -> NSRect? {
-        guard let location = editor.findClip(id: id) else { return nil }
-        let clip = editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
-        return geometry.clipRect(for: clip, trackIndex: location.trackIndex)
-    }
-
     func hitTestClip(
         at point: NSPoint,
         trackIndex: Int,
@@ -1518,11 +1481,9 @@ final class TimelineInputController {
         if adjustsDuration { NSCursor.resizeLeftRight.set() } else { NSCursor.closedHand.set() }
         dragState = .timelineMarker(DragState.TimelineMarkerDrag(
             original: original,
-            displayed: marker,
             adjustsDuration: adjustsDuration,
             grabFrame: grabFrame,
-            value: original,
-            displayedValue: marker
+            value: original
         ))
         if clickCount >= 2 { view.presentMarkerEditor(id: marker.id) }
     }

--- a/Sources/PalmierPro/Timeline/TimelineInputController.swift
+++ b/Sources/PalmierPro/Timeline/TimelineInputController.swift
@@ -115,8 +115,27 @@ final class TimelineInputController {
         let point = view.convert(event.locationInWindow, from: nil)
         let scrollOffsetY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
 
-        if event.clickCount == 2,
-           point.y >= scrollOffsetY + geometry.rulerHeight {
+        if editor.activePreviewTab != .timeline {
+            editor.selectPreviewTab(id: PreviewTab.timeline.id)
+        }
+        if let marker = TimelineMarkerRenderer.marker(
+            at: point,
+            markers: editor.displayedTimelineMarkers(),
+            geometry: geometry,
+            rulerMinY: scrollOffsetY,
+            clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+        ) {
+            beginMarkerDrag(
+                marker,
+                grabFrame: geometry.frameAt(x: point.x),
+                adjustsDuration: event.modifierFlags.contains(.option),
+                clickCount: event.clickCount
+            )
+            view.needsDisplay = true
+            return
+        }
+
+        if event.clickCount == 2, point.y >= scrollOffsetY + geometry.rulerHeight {
             let ti = geometry.trackAt(y: point.y)
             if let hit = hitTestClip(at: point, trackIndex: ti, geometry: geometry) {
                 let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
@@ -135,10 +154,6 @@ final class TimelineInputController {
             }
         }
 
-        if editor.activePreviewTab != .timeline {
-            editor.selectPreviewTab(id: PreviewTab.timeline.id)
-        }
-
         if point.y >= scrollOffsetY && point.y < scrollOffsetY + geometry.rulerHeight {
             view.setHoveredClipId(nil)
             let frame = geometry.frameAt(x: point.x)
@@ -147,12 +162,14 @@ final class TimelineInputController {
             } else if event.modifierFlags.contains(.shift) {
                 beginTimelineRangeSelection(at: frame)
             } else {
+                editor.selectedTimelineMarkerIds = []
                 beginPlayheadScrub(at: frame)
             }
             return
         }
 
         if case .keyframeLane(let trackIndex, let property) = geometry.rowLocation(atY: point.y) {
+            editor.selectedTimelineMarkerIds = []
             editor.selectedGap = nil
             snapState = SnapEngine.SnapState()
             snapIndicatorX = nil
@@ -196,6 +213,7 @@ final class TimelineInputController {
         editor.selectedGap = nil // re-selected below if this lands in a gap
 
         if editor.toolMode == .razor {
+            editor.selectedTimelineMarkerIds = []
             if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
                 let clickFrame = razorPreviewFrame ?? geometry.frameAt(x: point.x)
                 let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
@@ -206,6 +224,7 @@ final class TimelineInputController {
         }
 
         if let hit = hitTestClip(at: point, trackIndex: trackIndex, geometry: geometry) {
+            editor.selectedTimelineMarkerIds = []
             let clip = editor.timeline.tracks[hit.trackIndex].clips[hit.clipIndex]
             let rect = geometry.clipRect(for: clip, trackIndex: hit.trackIndex)
             view.setHoveredClipId(ClipRenderer.supportsPrecisionControls(in: rect) ? clip.id : nil)
@@ -335,9 +354,14 @@ final class TimelineInputController {
             editor.isMarqueeSelecting = true
             if !event.modifierFlags.contains(.shift) {
                 editor.selectedClipIds.removeAll()
+                editor.selectedTimelineMarkerIds.removeAll()
             }
             editor.selectedGap = hitTestGap(at: point, trackIndex: trackIndex, geometry: geometry)
-            dragState = .marquee(DragState.MarqueeDrag(origin: point, baseSelection: editor.selectedClipIds))
+            dragState = .marquee(DragState.MarqueeDrag(
+                origin: point,
+                baseSelection: editor.selectedClipIds,
+                baseMarkerSelection: editor.selectedTimelineMarkerIds
+            ))
         }
 
         snapState = SnapEngine.SnapState()
@@ -365,6 +389,7 @@ final class TimelineInputController {
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
                 includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(),
                 beatFrames: editor.beatSnapFrames(for:)
             )
             let rangeEndFrame: Int
@@ -383,6 +408,61 @@ final class TimelineInputController {
             }
             editor.setTimelineRange(startFrame: drag.anchorFrame, endFrame: rangeEndFrame)
 
+        case .timelineMarker(var drag):
+            let targets = SnapEngine.collectTargets(
+                tracks: editor.timeline.tracks,
+                playheadFrame: editor.currentFrame,
+                includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(excludingMarkerIds: [drag.original.id]),
+                beatFrames: editor.beatSnapFrames(for:)
+            )
+            func snapped(_ position: Int, probes: [Int] = [0]) -> Int {
+                guard let snap = SnapEngine.findSnap(
+                    position: position, probeOffsets: probes, targets: targets,
+                    state: &snapState, baseThreshold: Snap.thresholdPixels,
+                    pixelsPerFrame: geometry.pixelsPerFrame
+                ) else {
+                    snapIndicatorX = nil
+                    return position
+                }
+                snapIndicatorX = snap.x
+                return snap.frame - snap.probeOffset
+            }
+            if drag.adjustsDuration {
+                let candidateEnd = max(drag.displayed.startFrame, snapped(frame))
+                if let clipId = drag.original.clipId, let clip = editor.clipFor(id: clipId) {
+                    let displayEnd = min(clip.endFrame, candidateEnd)
+                    let sourceEnd = clip.markerSourceFrame(at: displayEnd)
+                    drag.value.durationFrames = displayEnd == drag.displayed.startFrame
+                        ? 0
+                        : max(1, sourceEnd - drag.original.startFrame)
+                    drag.displayedValue.durationFrames = displayEnd - drag.displayed.startFrame
+                    if displayEnd != candidateEnd { snapIndicatorX = nil; snapState = .init() }
+                } else {
+                    drag.value.durationFrames = candidateEnd - drag.displayed.startFrame
+                    drag.displayedValue.durationFrames = drag.value.durationFrames
+                }
+            } else {
+                let raw = drag.displayed.startFrame + frame - drag.grabFrame
+                let candidate = max(0, snapped(
+                    raw, probes: [0, drag.displayedValue.durationFrames]
+                ))
+                if let clipId = drag.original.clipId, let clip = editor.clipFor(id: clipId) {
+                    let visibleEnd = clip.trimStartFrame + clip.sourceFramesConsumed
+                    let maxSource = max(clip.trimStartFrame, visibleEnd - max(1, drag.original.durationFrames))
+                    drag.value.startFrame = min(
+                        maxSource,
+                        max(clip.trimStartFrame, clip.markerSourceFrame(at: candidate))
+                    )
+                    drag.displayedValue.startFrame = clip.markerTimelineFrame(at: drag.value.startFrame)
+                    if drag.displayedValue.startFrame != candidate { snapIndicatorX = nil; snapState = .init() }
+                } else {
+                    drag.value.startFrame = candidate
+                    drag.displayedValue.startFrame = candidate
+                }
+            }
+            dragState = .timelineMarker(drag)
+
         case .moveClip(var drag):
             let candidateFrame = frame - drag.grabOffsetFrames
             let allDraggedIds = Set(drag.all.map(\.clipId))
@@ -391,6 +471,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: allDraggedIds,
                 includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: allDraggedIds),
                 beatFrames: editor.beatSnapFrames(for:)
             )
 
@@ -438,6 +519,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
                 includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: [drag.clipId]),
                 beatFrames: editor.beatSnapFrames(for:),
                 includeExcludedClipBeats: true
             )
@@ -469,6 +551,7 @@ final class TimelineInputController {
                 playheadFrame: editor.currentFrame,
                 excludeClipIds: [drag.clipId],
                 includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(excludingClipIds: [drag.clipId]),
                 beatFrames: editor.beatSnapFrames(for:),
                 includeExcludedClipBeats: true
             )
@@ -544,6 +627,15 @@ final class TimelineInputController {
             if !event.modifierFlags.contains(.option) {
                 selected = editor.expandToLinkGroup(selected)
             }
+            let rulerY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
+            let markerIds = TimelineMarkerRenderer.markerIds(
+                intersecting: marq.current,
+                markers: editor.displayedTimelineMarkers(),
+                geometry: geometry,
+                rulerMinY: rulerY,
+                clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+            )
+            editor.selectedTimelineMarkerIds = marq.baseMarkerSelection.union(markerIds)
             dragState = .marquee(marq)
             // Touch only what changed.
             let padding = AppTheme.BorderWidth.thick
@@ -724,6 +816,26 @@ final class TimelineInputController {
         case .timelineRange:
             editor.keepValidTimelineRangeOrClear()
 
+        case .timelineMarker(let drag):
+            let changed = drag.adjustsDuration
+                ? drag.value.durationFrames != drag.original.durationFrames
+                : drag.value.startFrame != drag.original.startFrame
+            if changed {
+                do {
+                    _ = try editor.changeTimelineMarkers(
+                        updates: [TimelineMarkerUpdateRequest(
+                            id: drag.original.id,
+                            startFrame: drag.adjustsDuration ? nil : drag.value.startFrame,
+                            durationFrames: drag.adjustsDuration ? drag.value.durationFrames : nil
+                        )],
+                        actionName: drag.adjustsDuration ? "Change Marker Duration" : "Move Marker"
+                    )
+                } catch {
+                    editor.refuseWithToast(L10n.string("Couldn't change marker."))
+                }
+            }
+            NSCursor.openHand.set()
+
         case .idle:
             break
         }
@@ -745,6 +857,8 @@ final class TimelineInputController {
         case .keyframe(let drag):
             editor.currentFrame = drag.originalFrame
             editor.revertClipProperty(clipId: drag.clipId)
+        case .timelineMarker:
+            NSCursor.openHand.set()
         default:
             return
         }
@@ -760,6 +874,23 @@ final class TimelineInputController {
     func mouseMoved(with event: NSEvent, geometry: TimelineGeometry) {
         let point = view.convert(event.locationInWindow, from: nil)
         let scrollOffsetY = view.enclosingScrollView?.contentView.bounds.origin.y ?? 0
+
+        if TimelineMarkerRenderer.marker(
+            at: point,
+            markers: editor.displayedTimelineMarkers(),
+            geometry: geometry,
+            rulerMinY: scrollOffsetY,
+            clipRect: { self.markerClipRect(for: $0, geometry: geometry) }
+        ) != nil {
+            if event.modifierFlags.contains(.option) {
+                NSCursor.resizeLeftRight.set()
+            } else {
+                NSCursor.openHand.set()
+            }
+            razorPreviewFrame = nil
+            razorSnapState = SnapEngine.SnapState()
+            return
+        }
 
         if point.y >= scrollOffsetY && point.y < scrollOffsetY + geometry.rulerHeight {
             view.setHoveredClipId(nil)
@@ -799,6 +930,7 @@ final class TimelineInputController {
                 tracks: editor.timeline.tracks,
                 playheadFrame: editor.currentFrame,
                 includePlayhead: true,
+                markerFrames: editor.timelineMarkerSnapFrames(),
                 beatFrames: editor.beatSnapFrames(for:)
             )
             if let snap = SnapEngine.findSnap(
@@ -1221,6 +1353,12 @@ final class TimelineInputController {
 
     // MARK: - Hit testing
 
+    private func markerClipRect(for id: String, geometry: TimelineGeometry) -> NSRect? {
+        guard let location = editor.findClip(id: id) else { return nil }
+        let clip = editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
+        return geometry.clipRect(for: clip, trackIndex: location.trackIndex)
+    }
+
     func hitTestClip(
         at point: NSPoint,
         trackIndex: Int,
@@ -1362,6 +1500,31 @@ final class TimelineInputController {
         editor.selectedClipIds.removeAll()
         editor.selectedGap = nil
         editor.setTimelineRange(startFrame: frame, endFrame: frame)
+    }
+
+    private func beginMarkerDrag(
+        _ marker: TimelineMarker,
+        grabFrame: Int,
+        adjustsDuration: Bool,
+        clickCount: Int
+    ) {
+        guard let original = editor.timelineMarker(id: marker.id) else { return }
+        editor.selectedTimelineMarkerIds = [marker.id]
+        editor.selectedClipIds.removeAll()
+        editor.selectedGap = nil
+        editor.selectedTimelineRange = nil
+        snapState = SnapEngine.SnapState()
+        snapIndicatorX = nil
+        if adjustsDuration { NSCursor.resizeLeftRight.set() } else { NSCursor.closedHand.set() }
+        dragState = .timelineMarker(DragState.TimelineMarkerDrag(
+            original: original,
+            displayed: marker,
+            adjustsDuration: adjustsDuration,
+            grabFrame: grabFrame,
+            value: original,
+            displayedValue: marker
+        ))
+        if clickCount >= 2 { view.presentMarkerEditor(id: marker.id) }
     }
 
     private func scrubToFrame(_ frame: Int) {

--- a/Sources/PalmierPro/Timeline/TimelineMarkerRenderer.swift
+++ b/Sources/PalmierPro/Timeline/TimelineMarkerRenderer.swift
@@ -32,57 +32,43 @@ struct TimelineMarkerShape: Shape {
 }
 
 enum TimelineMarkerRenderer {
-    typealias ClipRect = (String) -> NSRect?
     private typealias Lane = (minY: CGFloat, height: CGFloat)
 
     static func draw(
         _ markers: [TimelineMarker], selectedIds: Set<String>, geometry: TimelineGeometry,
-        rulerMinY: CGFloat, clipRect: ClipRect, context: CGContext
+        rulerMinY: CGFloat, context: CGContext
     ) {
+        let lane = (rulerMinY, geometry.rulerHeight)
         for marker in markers {
-            guard let lane = lane(for: marker, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { continue }
             draw(marker, selected: selectedIds.contains(marker.id), geometry: geometry, lane: lane, context: context)
         }
     }
 
     static func marker(
         at point: NSPoint, markers: [TimelineMarker], geometry: TimelineGeometry,
-        rulerMinY: CGFloat, clipRect: ClipRect
+        rulerMinY: CGFloat
     ) -> TimelineMarker? {
-        markers.reversed().first {
-            guard let lane = lane(for: $0, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { return false }
+        let lane = (rulerMinY, geometry.rulerHeight)
+        return markers.reversed().first {
             return endpointRects(for: $0, geometry: geometry, lane: lane).contains { $0.contains(point) }
         }
     }
 
     static func markerIds(
         intersecting selection: NSRect, markers: [TimelineMarker], geometry: TimelineGeometry,
-        rulerMinY: CGFloat, clipRect: ClipRect
+        rulerMinY: CGFloat
     ) -> Set<String> {
-        Set(markers.compactMap {
-            guard let lane = lane(for: $0, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { return nil }
+        let lane = (rulerMinY, geometry.rulerHeight)
+        return Set(markers.compactMap {
             return endpointRects(for: $0, geometry: geometry, lane: lane)
                 .contains { $0.intersects(selection) } ? $0.id : nil
         })
     }
 
     static func anchorRect(
-        for marker: TimelineMarker, geometry: TimelineGeometry, rulerMinY: CGFloat,
-        clipRect: ClipRect
-    ) -> NSRect? {
-        guard let lane = lane(
-            for: marker, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect
-        ) else { return nil }
-        return flagRect(for: marker, geometry: geometry, lane: lane)
-    }
-
-    private static func lane(
-        for marker: TimelineMarker, geometry: TimelineGeometry,
-        rulerMinY: CGFloat, clipRect: ClipRect
-    ) -> Lane? {
-        guard let clipId = marker.clipId else { return (rulerMinY, geometry.rulerHeight) }
-        guard let rect = clipRect(clipId) else { return nil }
-        return (rect.maxY - AppTheme.TimelineMarker.flagHeight, AppTheme.TimelineMarker.flagHeight)
+        for marker: TimelineMarker, geometry: TimelineGeometry, rulerMinY: CGFloat
+    ) -> NSRect {
+        flagRect(for: marker, geometry: geometry, lane: (rulerMinY, geometry.rulerHeight))
     }
 
     private static func draw(

--- a/Sources/PalmierPro/Timeline/TimelineMarkerRenderer.swift
+++ b/Sources/PalmierPro/Timeline/TimelineMarkerRenderer.swift
@@ -1,0 +1,149 @@
+import AppKit
+import SwiftUI
+
+private enum MarkerHalf { case start, end }
+
+private func markerPath(in rect: CGRect, half: MarkerHalf? = nil) -> CGPath {
+    let mid = rect.midX
+    let tip = CGPoint(x: mid, y: rect.maxY)
+    let points: [CGPoint] = switch half {
+    case .start: [
+        CGPoint(x: rect.minX, y: rect.minY), CGPoint(x: mid, y: rect.minY),
+        tip, CGPoint(x: rect.minX, y: rect.maxY - rect.width / 2),
+    ]
+    case .end: [
+        CGPoint(x: mid, y: rect.minY), CGPoint(x: rect.maxX, y: rect.minY),
+        CGPoint(x: rect.maxX, y: rect.maxY - rect.width / 2), tip,
+    ]
+    case nil: [
+        CGPoint(x: rect.minX, y: rect.minY), CGPoint(x: rect.maxX, y: rect.minY),
+        CGPoint(x: rect.maxX, y: rect.maxY - rect.width / 2), tip,
+        CGPoint(x: rect.minX, y: rect.maxY - rect.width / 2),
+    ]
+    }
+    let path = CGMutablePath()
+    path.addLines(between: points)
+    path.closeSubpath()
+    return path
+}
+
+struct TimelineMarkerShape: Shape {
+    func path(in rect: CGRect) -> Path { Path(markerPath(in: rect)) }
+}
+
+enum TimelineMarkerRenderer {
+    typealias ClipRect = (String) -> NSRect?
+    private typealias Lane = (minY: CGFloat, height: CGFloat)
+
+    static func draw(
+        _ markers: [TimelineMarker], selectedIds: Set<String>, geometry: TimelineGeometry,
+        rulerMinY: CGFloat, clipRect: ClipRect, context: CGContext
+    ) {
+        for marker in markers {
+            guard let lane = lane(for: marker, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { continue }
+            draw(marker, selected: selectedIds.contains(marker.id), geometry: geometry, lane: lane, context: context)
+        }
+    }
+
+    static func marker(
+        at point: NSPoint, markers: [TimelineMarker], geometry: TimelineGeometry,
+        rulerMinY: CGFloat, clipRect: ClipRect
+    ) -> TimelineMarker? {
+        markers.reversed().first {
+            guard let lane = lane(for: $0, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { return false }
+            return endpointRects(for: $0, geometry: geometry, lane: lane).contains { $0.contains(point) }
+        }
+    }
+
+    static func markerIds(
+        intersecting selection: NSRect, markers: [TimelineMarker], geometry: TimelineGeometry,
+        rulerMinY: CGFloat, clipRect: ClipRect
+    ) -> Set<String> {
+        Set(markers.compactMap {
+            guard let lane = lane(for: $0, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect) else { return nil }
+            return endpointRects(for: $0, geometry: geometry, lane: lane)
+                .contains { $0.intersects(selection) } ? $0.id : nil
+        })
+    }
+
+    static func anchorRect(
+        for marker: TimelineMarker, geometry: TimelineGeometry, rulerMinY: CGFloat,
+        clipRect: ClipRect
+    ) -> NSRect? {
+        guard let lane = lane(
+            for: marker, geometry: geometry, rulerMinY: rulerMinY, clipRect: clipRect
+        ) else { return nil }
+        return flagRect(for: marker, geometry: geometry, lane: lane)
+    }
+
+    private static func lane(
+        for marker: TimelineMarker, geometry: TimelineGeometry,
+        rulerMinY: CGFloat, clipRect: ClipRect
+    ) -> Lane? {
+        guard let clipId = marker.clipId else { return (rulerMinY, geometry.rulerHeight) }
+        guard let rect = clipRect(clipId) else { return nil }
+        return (rect.maxY - AppTheme.TimelineMarker.flagHeight, AppTheme.TimelineMarker.flagHeight)
+    }
+
+    private static func draw(
+        _ marker: TimelineMarker, selected: Bool, geometry: TimelineGeometry,
+        lane: Lane, context: CGContext
+    ) {
+        let startX = geometry.xForFrame(marker.startFrame)
+        let flag = flagRect(for: marker, geometry: geometry, lane: lane)
+        let color = marker.color.nsColor
+        let paths: [CGPath]
+        if marker.isRange {
+            let endX = geometry.xForFrame(marker.endFrame)
+            context.setFillColor(color.withAlphaComponent(
+                color.alphaComponent * AppTheme.Opacity.strong
+            ).cgColor)
+            context.fill(CGRect(
+                x: startX, y: lane.minY + lane.height - AppTheme.TimelineMarker.rangeBarHeight,
+                width: max(0, endX - startX), height: AppTheme.TimelineMarker.rangeBarHeight
+            ))
+            paths = [
+                markerPath(in: flag, half: .start),
+                markerPath(in: flag.offsetBy(dx: endX - startX, dy: 0), half: .end),
+            ]
+        } else {
+            paths = [markerPath(in: flag)]
+        }
+        for path in paths {
+            context.setFillColor(color.cgColor)
+            context.addPath(path); context.fillPath()
+            context.setStrokeColor(
+                (selected ? AppTheme.Border.timelineMarkerSelected : AppTheme.Border.timelineMarker).cgColor
+            )
+            context.setLineWidth(selected ? AppTheme.BorderWidth.medium : AppTheme.BorderWidth.thin)
+            context.addPath(path); context.strokePath()
+        }
+    }
+
+    private static func flagRect(
+        for marker: TimelineMarker, geometry: TimelineGeometry, lane: Lane
+    ) -> NSRect {
+        NSRect(
+            x: geometry.xForFrame(marker.startFrame) - AppTheme.TimelineMarker.flagWidth / 2,
+            y: lane.minY + lane.height - AppTheme.TimelineMarker.flagHeight,
+            width: AppTheme.TimelineMarker.flagWidth,
+            height: AppTheme.TimelineMarker.flagHeight
+        )
+    }
+
+    private static func endpointRects(
+        for marker: TimelineMarker, geometry: TimelineGeometry, lane: Lane
+    ) -> [NSRect] {
+        let flag = flagRect(for: marker, geometry: geometry, lane: lane)
+        var rects = marker.isRange
+            ? [
+                NSRect(x: flag.minX, y: flag.minY, width: flag.width / 2, height: flag.height),
+                NSRect(x: geometry.xForFrame(marker.endFrame), y: flag.minY,
+                       width: flag.width / 2, height: flag.height),
+            ]
+            : [flag]
+        return rects.map {
+            $0.insetBy(dx: -AppTheme.TimelineMarker.hitSlop, dy: -AppTheme.TimelineMarker.hitSlop)
+        }
+    }
+}

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -315,25 +315,9 @@ final class TimelineView: NSView, NSPopoverDelegate {
         }
         drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx, rippleInsertPreview: rippleInsertPreview)
         var displayedMarkers = editor.displayedTimelineMarkers(preview: markerEditorPreview)
-        if let rippleInsertPreview {
-            for index in displayedMarkers.indices {
-                guard let clipId = displayedMarkers[index].clipId,
-                      let delta = rippleInsertPreview.shiftDeltasByClipId[clipId] else { continue }
-                displayedMarkers[index].startFrame += delta
-            }
-        }
-        if case .moveClip(let drag) = inputController.dragState {
-            let draggedIds = Set(drag.all.map(\.clipId))
-            for index in displayedMarkers.indices
-            where displayedMarkers[index].clipId.map(draggedIds.contains) == true {
-                displayedMarkers[index].startFrame += drag.deltaFrames
-            }
-        }
         if case .timelineMarker(let drag) = inputController.dragState,
-           let index = displayedMarkers.firstIndex(where: {
-               $0.id == drag.original.id && $0.clipId == drag.original.clipId
-           }) {
-            displayedMarkers[index] = drag.displayedValue
+           let index = displayedMarkers.firstIndex(where: { $0.id == drag.original.id }) {
+            displayedMarkers[index] = drag.value
         }
         syncAgentActivityLayers()
         drawGapSelection(geometry: geo, context: ctx)
@@ -398,7 +382,6 @@ final class TimelineView: NSView, NSPopoverDelegate {
             selectedIds: editor.selectedTimelineMarkerIds,
             geometry: geo,
             rulerMinY: scrollOffset.y,
-            clipRect: { clipDisplayRects[$0] },
             context: ctx
         )
     }
@@ -410,14 +393,9 @@ final class TimelineView: NSView, NSPopoverDelegate {
         guard let marker = editor.timelineMarker(id: id),
               let displayed = editor.displayedTimelineMarkers().first(where: { $0.id == id }) else { return }
         let rulerY = enclosingScrollView?.contentView.bounds.origin.y ?? 0
-        guard let anchor = TimelineMarkerRenderer.anchorRect(
-            for: displayed, geometry: geometry, rulerMinY: rulerY,
-            clipRect: { id in
-                guard let location = editor.findClip(id: id) else { return nil }
-                let clip = editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
-                return geometry.clipRect(for: clip, trackIndex: location.trackIndex)
-            }
-        ) else { return }
+        let anchor = TimelineMarkerRenderer.anchorRect(
+            for: displayed, geometry: geometry, rulerMinY: rulerY
+        )
         dismissMarkerEditor()
         let popover = NSPopover()
         popover.behavior = .transient

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 /// AppKit drawing view; input is delegated to TimelineInputController.
-final class TimelineView: NSView {
+final class TimelineView: NSView, NSPopoverDelegate {
     unowned var editor: EditorViewModel
     let keyframeLaneState: TimelineKeyframeLaneState
     private(set) var inputController: TimelineInputController!
@@ -21,6 +21,8 @@ final class TimelineView: NSView {
     private var cachedAngleLabels: [String: [String: String]] = [:]
     private(set) var hoveredClipId: String?
     private let canvas = TimelineCanvasView()
+    private var markerPopover: NSPopover?
+    private var markerEditorPreview: TimelineMarker?
 
     // MARK: - Init
 
@@ -31,6 +33,7 @@ final class TimelineView: NSView {
         self.inputController = TimelineInputController(editor: editor, view: self)
         editor.mediaVisualCache.timelineView = self
         editor.onCancelTimelineDrag = { [weak self] in self?.inputController.cancelActiveDrag() }
+        editor.onPresentTimelineMarkerEditor = { [weak self] in self?.presentMarkerEditor(id: $0) }
         wantsLayer = true
         configureAgentActivityLayers()
         updateAppearanceColors()
@@ -185,7 +188,7 @@ final class TimelineView: NSView {
                     editor.timelineVisibleWidth = newVisibleWidth
                     let minZoom = editor.minZoomScale
                     if isFirstLayout {
-                        editor.zoomScale = editor.timeline.totalFrames == 0
+                        editor.zoomScale = editor.timeline.displayFrames == 0
                             ? Defaults.pixelsPerFrame
                             : minZoom
                     } else if editor.zoomScale < minZoom {
@@ -195,7 +198,7 @@ final class TimelineView: NSView {
             }
         }
 
-        let totalFrames = editor.timeline.totalFrames
+        let totalFrames = editor.timeline.displayFrames
         let contentWidth = editor.zoomScale * Double(totalFrames) + visibleSize.width * 0.5
         let geo = geometry
         let contentHeight: CGFloat
@@ -311,6 +314,27 @@ final class TimelineView: NSView {
             drawRippleInsertGapBand(preview: rippleInsertPreview, geometry: geo, context: ctx)
         }
         drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx, rippleInsertPreview: rippleInsertPreview)
+        var displayedMarkers = editor.displayedTimelineMarkers(preview: markerEditorPreview)
+        if let rippleInsertPreview {
+            for index in displayedMarkers.indices {
+                guard let clipId = displayedMarkers[index].clipId,
+                      let delta = rippleInsertPreview.shiftDeltasByClipId[clipId] else { continue }
+                displayedMarkers[index].startFrame += delta
+            }
+        }
+        if case .moveClip(let drag) = inputController.dragState {
+            let draggedIds = Set(drag.all.map(\.clipId))
+            for index in displayedMarkers.indices
+            where displayedMarkers[index].clipId.map(draggedIds.contains) == true {
+                displayedMarkers[index].startFrame += drag.deltaFrames
+            }
+        }
+        if case .timelineMarker(let drag) = inputController.dragState,
+           let index = displayedMarkers.firstIndex(where: {
+               $0.id == drag.original.id && $0.clipId == drag.original.clipId
+           }) {
+            displayedMarkers[index] = drag.displayedValue
+        }
         syncAgentActivityLayers()
         drawGapSelection(geometry: geo, context: ctx)
         syncGeneratingClipOverlays(geometry: geo)
@@ -369,10 +393,63 @@ final class TimelineView: NSView {
         )
         drawTimelineRangeSelectionRulerFill(geometry: geo, scrollOffset: scrollOffset, context: ctx)
         drawTimelineRangeSelectionEdges(geometry: geo, scrollOffset: scrollOffset, context: ctx)
+        TimelineMarkerRenderer.draw(
+            displayedMarkers,
+            selectedIds: editor.selectedTimelineMarkerIds,
+            geometry: geo,
+            rulerMinY: scrollOffset.y,
+            clipRect: { clipDisplayRects[$0] },
+            context: ctx
+        )
     }
 
     func updatePlayheadLayer() { playheadOverlay.update() }
     func updateAgentActivityOverlay() { syncAgentActivityLayers() }
+
+    func presentMarkerEditor(id: String) {
+        guard let marker = editor.timelineMarker(id: id),
+              let displayed = editor.displayedTimelineMarkers().first(where: { $0.id == id }) else { return }
+        let rulerY = enclosingScrollView?.contentView.bounds.origin.y ?? 0
+        guard let anchor = TimelineMarkerRenderer.anchorRect(
+            for: displayed, geometry: geometry, rulerMinY: rulerY,
+            clipRect: { id in
+                guard let location = editor.findClip(id: id) else { return nil }
+                let clip = editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
+                return geometry.clipRect(for: clip, trackIndex: location.trackIndex)
+            }
+        ) else { return }
+        dismissMarkerEditor()
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.delegate = self
+        popover.contentViewController = NSHostingController(rootView:
+            MarkerEditorPopover(
+                marker: marker,
+                fps: editor.timeline.fps,
+                onPreview: { [weak self] marker in
+                    self?.markerEditorPreview = marker
+                    self?.needsDisplay = true
+                },
+                onDismiss: { [weak self] in self?.dismissMarkerEditor() }
+            )
+            .environment(editor)
+        )
+        markerPopover = popover
+        popover.show(relativeTo: anchor, of: self, preferredEdge: .minY)
+    }
+
+    private func dismissMarkerEditor() {
+        markerEditorPreview = nil
+        markerPopover?.performClose(nil)
+        markerPopover = nil
+        needsDisplay = true
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        markerEditorPreview = nil
+        markerPopover = nil
+        needsDisplay = true
+    }
 
     // MARK: - Clip drawing with ghost support
 
@@ -1898,6 +1975,7 @@ final class TimelineView: NSView {
             .reduce(0) { $0 + editor.clipDurationFrames(for: $1, segment: externalDragSegments[$1.id]) }
         let targets = SnapEngine.collectTargets(
             tracks: editor.timeline.tracks,
+            markerFrames: editor.timelineMarkerSnapFrames(),
             beatFrames: editor.beatSnapFrames(for:)
         )
         if let snap = SnapEngine.findSnap(

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -418,12 +418,13 @@ final class TimelineView: NSView, NSPopoverDelegate {
 
     private func dismissMarkerEditor() {
         markerEditorPreview = nil
-        markerPopover?.performClose(nil)
-        markerPopover = nil
+        markerPopover?.close()
         needsDisplay = true
     }
 
     func popoverDidClose(_ notification: Notification) {
+        guard let closed = notification.object as? NSPopover,
+              closed === markerPopover else { return }
         markerEditorPreview = nil
         markerPopover = nil
         needsDisplay = true

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -38,6 +38,7 @@ struct ToolbarView: View {
             // Add content
             HStack(spacing: AppTheme.Spacing.md) {
                 textGlyphButton("T", help: L10n.string("Add Text"), action: { _ = editor.addTextClip() })
+                markerButton
             }
 
             Spacer()
@@ -69,6 +70,21 @@ struct ToolbarView: View {
         }
         .padding(.horizontal, AppTheme.Spacing.md)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var markerButton: some View {
+        Button { _ = editor.addTimelineMarkerAtSelection() } label: {
+            TimelineMarkerShape()
+                .fill(AppTheme.Text.secondaryColor)
+                .frame(
+                    width: AppTheme.TimelineMarker.flagWidth,
+                    height: AppTheme.TimelineMarker.flagHeight
+                )
+                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
+                .hoverHighlight()
+        }
+        .buttonStyle(.plain)
+        .help(L10n.string("Add Marker (M)"))
     }
 
     private func toolbarButton(_ systemName: String, help: String, action: @escaping () -> Void) -> some View {

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -58,6 +58,8 @@ enum AppTheme {
         )
         static let timelineClip = AppTheme.adaptive(light: .white, dark: .black)
         static let timelineClipSelected = AppTheme.adaptive(light: .black, dark: .white)
+        static let timelineMarker = AppTheme.adaptive(light: .white, dark: .black)
+        static let timelineMarkerSelected = AppTheme.adaptive(light: .black, dark: .white)
 
         static var primaryColor: Color { Color(primary) }
         static var subtleColor: Color { Color(subtle) }
@@ -204,6 +206,20 @@ enum AppTheme {
         static let changeGlowRadius: CGFloat = 8
         static let readGlowOpacity: Float = 0.35
         static let readGlowRadius: CGFloat = 4
+    }
+
+    enum TimelineMarker {
+        static let flagWidth: CGFloat = 10
+        static let flagHeight: CGFloat = 12
+        static let rangeBarHeight: CGFloat = 4
+        static let hitSlop: CGFloat = 3
+        static let editorWidth: CGFloat = 320
+        static let timeFieldWidth: CGFloat = 82
+        static let notesHeight: CGFloat = 54
+        static let presetColors = [
+            "#4094FF", "#40CCE6", "#40BF5C", "#F2C72E", "#FF8C26", "#E64040", "#F259A6",
+            "#A666F2", "#8CBFFF", "#73E6B8", "#A6D936", "#C79E6B", "#D1D1D1",
+        ].compactMap(TextStyle.RGBA.init(hex:))
     }
 
     // MARK: - Text

--- a/Sources/PalmierPro/UI/EditorPanel/EditorPanelControls.swift
+++ b/Sources/PalmierPro/UI/EditorPanel/EditorPanelControls.swift
@@ -3,6 +3,7 @@ import SwiftUI
 private struct EditorValueFieldModifier: ViewModifier {
     var active = false
     var minHeight = AppTheme.EditorPanel.fieldMinHeight
+    var fill = AppTheme.Background.baseColor
     @Environment(\.isEnabled) private var isEnabled
     @State private var isHovered = false
 
@@ -11,7 +12,7 @@ private struct EditorValueFieldModifier: ViewModifier {
             .frame(minHeight: minHeight)
             .background(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.xsSm, style: .continuous)
-                    .fill(AppTheme.Background.baseColor)
+                    .fill(fill)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: AppTheme.Radius.xsSm, style: .continuous)
@@ -32,9 +33,10 @@ private struct EditorValueFieldModifier: ViewModifier {
 extension View {
     func editorValueField(
         active: Bool = false,
-        minHeight: CGFloat = AppTheme.EditorPanel.fieldMinHeight
+        minHeight: CGFloat = AppTheme.EditorPanel.fieldMinHeight,
+        fill: Color = AppTheme.Background.baseColor
     ) -> some View {
-        modifier(EditorValueFieldModifier(active: active, minHeight: minHeight))
+        modifier(EditorValueFieldModifier(active: active, minHeight: minHeight, fill: fill))
     }
 }
 

--- a/Sources/PalmierPro/Utilities/TimeFormatting.swift
+++ b/Sources/PalmierPro/Utilities/TimeFormatting.swift
@@ -12,6 +12,16 @@ func formatTimecode(frame: Int, fps: Int) -> String {
     return "\(sign)\(twoDigit(hh)):\(twoDigit(mm)):\(twoDigit(ss)):\(twoDigit(ff))"
 }
 
+func parseTimecode(_ value: String, fps: Int) -> Int? {
+    let fields = value.split(separator: ":", omittingEmptySubsequences: false)
+    guard (1...1_000).contains(fps), fields.count == 4,
+          let hours = Int(fields[0]), let minutes = Int(fields[1]),
+          let seconds = Int(fields[2]), let frames = Int(fields[3]),
+          (0..<1_000).contains(hours), (0..<60).contains(minutes), (0..<60).contains(seconds),
+          (0..<fps).contains(frames) else { return nil }
+    return (hours * 3_600 + minutes * 60 + seconds) * fps + frames
+}
+
 private func twoDigit(_ value: Int) -> String {
     guard value >= 0 && value < 10 else { return "\(value)" }
     return "0\(value)"

--- a/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MCP
+import Testing
+@testable import PalmierPro
+
+@Suite("MCP timeline markers")
+@MainActor
+struct MCPMarkerTests {
+    @Test func discoversCreatesReadsUpdatesAndUndoesMarker() async throws {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 100)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [clip])
+        ]))
+        let undo = UndoManager()
+        harness.editor.undo.attach(undo)
+        let server = Server(
+            name: "marker-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "marker-test", version: "1.0.0")
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let (tools, _) = try await client.listTools()
+            #expect(tools.contains { $0.name == "manage_markers" })
+            let create = try json(try await client.callTool(name: "manage_markers", arguments: [
+                "action": .string("create"),
+                "clipId": .string(clip.id),
+                "name": .string("Instance note"),
+                "startFrame": .int(20),
+                "durationFrames": .int(10),
+                "color": .string("#FF9500"),
+                "comment": .string("Move subject left"),
+            ]))
+            let markerId = try #require((create["created"] as? [String: Any])?["markerId"] as? String)
+            let timeline = try json(try await client.callTool(name: "get_timeline", arguments: [
+                "startFrame": .int(15),
+                "endFrame": .int(25),
+            ]))
+            let markers = try #require(timeline["markers"] as? [[String: Any]])
+            let marker = try #require(markers.first { $0["clipId"] as? String == clip.id })
+            #expect(marker["name"] as? String == "Instance note")
+            #expect(marker["endFrame"] as? Int == 30)
+            #expect(marker["color"] as? String == "#FF9500FF")
+            #expect(marker["sourceStartFrame"] as? Int == 20)
+            _ = try json(try await client.callTool(name: "manage_markers", arguments: [
+                "action": .string("update"),
+                "markerId": .string(markerId),
+                "startFrame": .int(40),
+                "color": .string("#34C759"),
+                "comment": .string("Addressed"),
+            ]))
+            #expect(harness.editor.timeline.markers.first?.startFrame == 40)
+            #expect(harness.editor.timeline.markers.first?.comment == "Addressed")
+            #expect((try await client.callTool(name: "undo")).isError != true)
+            #expect(harness.editor.timeline.markers.first?.startFrame == 20)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+    private func json(_ result: (content: [Tool.Content], isError: Bool?)) throws -> [String: Any] {
+        guard case .text(let text, _, _) = result.content.first else {
+            throw CocoaError(.coderReadCorrupt)
+        }
+        return try #require(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+}

--- a/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
@@ -28,8 +28,7 @@ struct MCPMarkerTests {
             #expect(tools.contains { $0.name == "manage_markers" })
             let create = try json(try await client.callTool(name: "manage_markers", arguments: [
                 "action": .string("create"),
-                "clipId": .string(clip.id),
-                "name": .string("Instance note"),
+                "name": .string("Timeline note"),
                 "startFrame": .int(20),
                 "durationFrames": .int(10),
                 "color": .string("#FF9500"),
@@ -41,11 +40,10 @@ struct MCPMarkerTests {
                 "endFrame": .int(25),
             ]))
             let markers = try #require(timeline["markers"] as? [[String: Any]])
-            let marker = try #require(markers.first { $0["clipId"] as? String == clip.id })
-            #expect(marker["name"] as? String == "Instance note")
+            let marker = try #require(markers.first)
+            #expect(marker["name"] as? String == "Timeline note")
             #expect(marker["endFrame"] as? Int == 30)
             #expect(marker["color"] as? String == "#FF9500FF")
-            #expect(marker["sourceStartFrame"] as? Int == 20)
             _ = try json(try await client.callTool(name: "manage_markers", arguments: [
                 "action": .string("update"),
                 "markerId": .string(markerId),

--- a/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
+++ b/Tests/PalmierProTests/Editor/PreviewSelectionTests.swift
@@ -11,11 +11,13 @@ struct PreviewSelectionTests {
             Fixtures.videoTrack(clips: [Fixtures.clip(id: "clip", start: 0, duration: 20)]),
         ])
         editor.selectedGap = GapSelection(trackIndex: 0, range: FrameRange(start: 50, end: 100))
+        editor.selectedTimelineMarkerIds = ["marker"]
 
         editor.selectPreviewClip("clip")
 
         #expect(editor.selectedClipIds == ["clip"])
         #expect(editor.selectedGap == nil)
+        #expect(editor.selectedTimelineMarkerIds.isEmpty)
     }
 
     @Test func selectingSelectedClipPreservesMultiSelection() {
@@ -27,10 +29,12 @@ struct PreviewSelectionTests {
             ]),
         ])
         editor.selectedClipIds = ["first", "second"]
+        editor.selectedTimelineMarkerIds = ["marker"]
 
         editor.selectPreviewClip("first")
 
         #expect(editor.selectedClipIds == ["first", "second"])
+        #expect(editor.selectedTimelineMarkerIds.isEmpty)
     }
 
     @Test func rotatedTextUsesRotatedHitTarget() {

--- a/Tests/PalmierProTests/TimeFormattingTests.swift
+++ b/Tests/PalmierProTests/TimeFormattingTests.swift
@@ -36,6 +36,12 @@ struct FormatTimecodeTests {
         #expect(formatTimecode(frame: 23, fps: 24) == "00:00:00:23")
         #expect(formatTimecode(frame: 24, fps: 24) == "00:00:01:00")
     }
+
+    @Test func timecodeParsingValidatesFields() {
+        #expect(parseTimecode("01:02:03:04", fps: 30) == 111_694)
+        #expect(parseTimecode("00:00:00:30", fps: 30) == nil)
+        #expect(parseTimecode("invalid", fps: 30) == nil)
+    }
 }
 
 @Suite("frame/seconds conversion")

--- a/Tests/PalmierProTests/Timeline/SnapEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/SnapEngineTests.swift
@@ -14,6 +14,12 @@ struct SnapEngineTests {
         #expect(SnapEngine.collectTargets(tracks: [], includePlayhead: false).isEmpty)
     }
 
+    @Test func collectTargetsIncludesMarkerFrames() {
+        let targets = SnapEngine.collectTargets(tracks: [], markerFrames: [12, 30])
+        #expect(targets.map(\.frame) == [12, 30])
+        #expect(targets.allSatisfy { $0.kind == .marker })
+    }
+
     @Test func collectTargetsIncludesPlayheadOnlyWhenRequested() {
         let withPlayhead = SnapEngine.collectTargets(tracks: [], playheadFrame: 75, includePlayhead: true)
         #expect(withPlayhead.count == 1)

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Timeline markers")
+@MainActor
+struct TimelineMarkerTests {
+    @Test func markersPersistWithoutChangingContentDuration() throws {
+        var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])])
+        timeline.markers = [TimelineMarker(name: "Review", startFrame: 40, durationFrames: 10, color: .init(r: 1, g: 0, b: 0), comment: "Tighten")]
+        let file = ProjectFile(timelines: [timeline])
+        let decoded = try JSONDecoder().decode(ProjectFile.self, from: JSONEncoder().encode(file))
+        #expect(decoded.timelines[0].markers == timeline.markers)
+        #expect(decoded.timelines[0].totalFrames == 30)
+        #expect(decoded.timelines[0].displayFrames == 50)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(timeline)) as? [String: Any])
+        object.removeValue(forKey: "markers")
+        let withoutMarkers = try JSONSerialization.data(withJSONObject: object)
+        #expect(try JSONDecoder().decode(Timeline.self, from: withoutMarkers).markers.isEmpty)
+    }
+    @Test func duplicateTimelineFreshensMarkerIds() throws {
+        let editor = EditorViewModel()
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
+        editor.timeline.tracks = [Fixtures.videoTrack(clips: [clip])]
+        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Note", startFrame: 4)]
+        let originalId = try #require(editor.timeline.markers.first?.id)
+        let copyId = try #require(editor.duplicateTimeline(editor.activeTimelineId))
+        let copy = try #require(editor.timeline(for: copyId))
+        let copiedMarker = try #require(copy.markers.first)
+        #expect(copiedMarker.id != originalId)
+        #expect(copiedMarker.clipId == copy.tracks[0].clips[0].id)
+    }
+    @Test func markerChangesUndoAsOneAction() throws {
+        let editor = EditorViewModel()
+        let undo = UndoManager()
+        editor.undo.attach(undo)
+        let created = try #require(try editor.changeTimelineMarkers(
+            creates: [TimelineMarker(
+                name: "Audio note",
+                startFrame: 12,
+                durationFrames: 8,
+                color: .init(r: 1, g: 1, b: 0),
+                comment: "Lower this"
+            )],
+            actionName: "Add Marker"
+        ).created.first)
+        #expect(editor.timeline.markers == [created])
+        undo.undo()
+        #expect(editor.timeline.markers.isEmpty)
+        undo.redo()
+        #expect(editor.timeline.markers == [created])
+    }
+    @Test func clipMarkerProjectsThroughTrimAndSpeed() {
+        var clip = Fixtures.clip(mediaRef: "source", start: 100, duration: 20, trimStart: 10, speed: 2)
+        clip.trimEndFrame = 10
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Clip note", startFrame: 30)]
+        #expect(editor.displayedTimelineMarkers().first {
+            $0.clipId == clip.id
+        }?.startFrame == 110)
+        #expect(editor.timelineMarkerSnapFrames() == [110])
+        #expect(editor.timelineMarkerSnapFrames(excludingClipIds: [clip.id]).isEmpty)
+        #expect(editor.timelineMarkerSnapFrames(
+            excludingMarkerIds: [editor.timeline.markers[0].id]
+        ).isEmpty)
+    }
+    @Test func deletingClipRemovesItsMarkerInTheSameUndo() {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
+        let editor = EditorViewModel()
+        let undo = UndoManager()
+        editor.undo.attach(undo)
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Note", startFrame: 4)]
+        editor.removeClips(ids: [clip.id])
+        #expect(editor.timeline.markers.isEmpty)
+        undo.undo()
+        #expect(editor.timeline.markers.first?.clipId == clip.id)
+    }
+    @Test func selectedClipCreatesClipMarkerAtPlayhead() {
+        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
+        let editor = EditorViewModel()
+        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        editor.selectedClipIds = [clip.id]
+        editor.currentFrame = 10
+        #expect(editor.addTimelineMarkerAtSelection()?.clipId == clip.id)
+    }
+    @Test func marqueeCrossingRulerSelectsTimelineAndClipMarkers() {
+        let geometry = TimelineGeometry(pixelsPerFrame: 1, trackHeights: [50])
+        let markers = [
+            TimelineMarker(id: "timeline", name: "Timeline", startFrame: 10),
+            TimelineMarker(id: "clip", clipId: "clip", name: "Clip", startFrame: 20),
+        ]
+        let selected = TimelineMarkerRenderer.markerIds(
+            intersecting: NSRect(x: 0, y: 0, width: 30, height: 100),
+            markers: markers, geometry: geometry, rulerMinY: 0,
+            clipRect: { _ in NSRect(x: 0, y: geometry.rulerHeight, width: 100, height: 50) }
+        )
+        #expect(selected == ["timeline", "clip"])
+    }
+    @Test func durationBarIsNotAMarkerHitTarget() {
+        let geometry = TimelineGeometry(pixelsPerFrame: 1, trackHeights: [])
+        let marker = TimelineMarker(id: "range", name: "Range", startFrame: 10, durationFrames: 30)
+        let selected = TimelineMarkerRenderer.markerIds(
+            intersecting: NSRect(x: 20, y: geometry.rulerHeight - 4, width: 5, height: 2),
+            markers: [marker], geometry: geometry, rulerMinY: 0,
+            clipRect: { _ in nil }
+        )
+        #expect(selected.isEmpty)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -20,15 +20,12 @@ struct TimelineMarkerTests {
     }
     @Test func duplicateTimelineFreshensMarkerIds() throws {
         let editor = EditorViewModel()
-        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
-        editor.timeline.tracks = [Fixtures.videoTrack(clips: [clip])]
-        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Note", startFrame: 4)]
+        editor.timeline.markers = [TimelineMarker(name: "Note", startFrame: 4)]
         let originalId = try #require(editor.timeline.markers.first?.id)
         let copyId = try #require(editor.duplicateTimeline(editor.activeTimelineId))
         let copy = try #require(editor.timeline(for: copyId))
         let copiedMarker = try #require(copy.markers.first)
         #expect(copiedMarker.id != originalId)
-        #expect(copiedMarker.clipId == copy.tracks[0].clips[0].id)
     }
     @Test func markerChangesUndoAsOneAction() throws {
         let editor = EditorViewModel()
@@ -49,62 +46,35 @@ struct TimelineMarkerTests {
         #expect(editor.timeline.markers.isEmpty)
         undo.redo()
         #expect(editor.timeline.markers == [created])
-    }
-    @Test func clipMarkerProjectsThroughTrimAndSpeed() {
-        var clip = Fixtures.clip(mediaRef: "source", start: 100, duration: 20, trimStart: 10, speed: 2)
-        clip.trimEndFrame = 10
-        let editor = EditorViewModel()
-        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
-        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Clip note", startFrame: 30)]
-        #expect(editor.displayedTimelineMarkers().first {
-            $0.clipId == clip.id
-        }?.startFrame == 110)
-        #expect(editor.timelineMarkerSnapFrames() == [110])
-        #expect(editor.timelineMarkerSnapFrames(excludingClipIds: [clip.id]).isEmpty)
+        #expect(editor.timelineMarkerSnapFrames() == [12, 20])
         #expect(editor.timelineMarkerSnapFrames(
-            excludingMarkerIds: [editor.timeline.markers[0].id]
+            excludingMarkerIds: [created.id]
         ).isEmpty)
     }
-    @Test func deletingClipRemovesItsMarkerInTheSameUndo() {
-        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
+    @Test func selectedClipStillCreatesTimelineMarkerAtPlayhead() {
         let editor = EditorViewModel()
-        let undo = UndoManager()
-        editor.undo.attach(undo)
-        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
-        editor.timeline.markers = [TimelineMarker(clipId: clip.id, name: "Note", startFrame: 4)]
-        editor.removeClips(ids: [clip.id])
-        #expect(editor.timeline.markers.isEmpty)
-        undo.undo()
-        #expect(editor.timeline.markers.first?.clipId == clip.id)
-    }
-    @Test func selectedClipCreatesClipMarkerAtPlayhead() {
-        let clip = Fixtures.clip(id: "clip", start: 0, duration: 20)
-        let editor = EditorViewModel()
-        editor.timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
-        editor.selectedClipIds = [clip.id]
+        editor.selectedClipIds = ["clip"]
         editor.currentFrame = 10
-        #expect(editor.addTimelineMarkerAtSelection()?.clipId == clip.id)
+        #expect(editor.addTimelineMarkerAtSelection()?.startFrame == 10)
     }
-    @Test func marqueeCrossingRulerSelectsTimelineAndClipMarkers() {
+    @Test func marqueeCrossingRulerSelectsMarkers() {
         let geometry = TimelineGeometry(pixelsPerFrame: 1, trackHeights: [50])
         let markers = [
-            TimelineMarker(id: "timeline", name: "Timeline", startFrame: 10),
-            TimelineMarker(id: "clip", clipId: "clip", name: "Clip", startFrame: 20),
+            TimelineMarker(id: "first", name: "First", startFrame: 10),
+            TimelineMarker(id: "second", name: "Second", startFrame: 20),
         ]
         let selected = TimelineMarkerRenderer.markerIds(
             intersecting: NSRect(x: 0, y: 0, width: 30, height: 100),
-            markers: markers, geometry: geometry, rulerMinY: 0,
-            clipRect: { _ in NSRect(x: 0, y: geometry.rulerHeight, width: 100, height: 50) }
+            markers: markers, geometry: geometry, rulerMinY: 0
         )
-        #expect(selected == ["timeline", "clip"])
+        #expect(selected == ["first", "second"])
     }
     @Test func durationBarIsNotAMarkerHitTarget() {
         let geometry = TimelineGeometry(pixelsPerFrame: 1, trackHeights: [])
         let marker = TimelineMarker(id: "range", name: "Range", startFrame: 10, durationFrames: 30)
         let selected = TimelineMarkerRenderer.markerIds(
             intersecting: NSRect(x: 20, y: geometry.rulerHeight - 4, width: 5, height: 2),
-            markers: [marker], geometry: geometry, rulerMinY: 0,
-            clipRect: { _ in nil }
+            markers: [marker], geometry: geometry, rulerMinY: 0
         )
         #expect(selected.isEmpty)
     }

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -51,11 +51,15 @@ struct TimelineMarkerTests {
             excludingMarkerIds: [created.id]
         ).isEmpty)
     }
-    @Test func selectedClipStillCreatesTimelineMarkerAtPlayhead() {
+    @Test func defaultMarkerNamesUseNextNumber() {
         let editor = EditorViewModel()
         editor.selectedClipIds = ["clip"]
         editor.currentFrame = 10
-        #expect(editor.addTimelineMarkerAtSelection()?.startFrame == 10)
+        let first = editor.addTimelineMarkerAtSelection()
+        editor.currentFrame = 11
+        let second = editor.addTimelineMarkerAtSelection()
+        #expect((first?.startFrame, first?.name) == (10, L10n.string("Marker 1")))
+        #expect(second?.name == L10n.string("Marker 2"))
     }
     @Test func marqueeCrossingRulerSelectsMarkers() {
         let geometry = TimelineGeometry(pixelsPerFrame: 1, trackHeights: [50])

--- a/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
+++ b/Tests/PalmierProTests/Timeline/TrackSelectionTests.swift
@@ -16,6 +16,7 @@ struct TrackSelectionTests {
             ]),
         ])
         editor.selectedClipIds = ["audio"]
+        editor.selectedTimelineMarkerIds = ["marker"]
         editor.selectedGap = GapSelection(
             trackIndex: 1,
             range: FrameRange(start: 60, end: 90)
@@ -24,6 +25,7 @@ struct TrackSelectionTests {
         #expect(editor.selectAllClips(onTrack: "target"))
         #expect(editor.selectedClipIds == ["video", "title"])
         #expect(editor.selectedGap == nil)
+        #expect(editor.selectedTimelineMarkerIds.isEmpty)
     }
 
     @Test func unavailableTrackPreservesSelection() {


### PR DESCRIPTION
## Summary

- add persistent point and range markers for timeline review notes, names, colors, and exact timing
- add marker rendering, editing, selection, dragging, duration adjustment, snapping, and undo across the timeline UI
- expose stable marker reads and mutations through the Agent and MCP boundary

## Approach

- store markers on `Timeline` as the single source of truth; `durationFrames == 0` represents a point and positive durations represent half-open ranges
- route UI and Agent changes through one validated `EditorViewModel` mutation path so no-ops avoid undo entries and each intent commits atomically
- keep popup edits transient for live Time, Duration, and Color previews; Done commits once while Escape or dismissal restores persisted state
- centralize marker drawing, endpoint-only hit testing, marquee selection, popup anchoring, and adaptive borders in the timeline renderer
- intentionally limit this PR to timeline markers; clip-attached and source-media markers remain out of scope

## Design

```mermaid
flowchart LR
    Toolbar[Toolbar / M shortcut] --> Mutation[Shared marker mutation]
    Popup[Marker editor popup] --> Mutation
    Agent[Agent manage_markers] --> Mutation
    Mutation --> Timeline[(Timeline.markers)]
    Timeline --> Renderer[Timeline renderer and hit testing]
    Timeline --> Read[get_timeline]
    Renderer --> Interactions[Drag / Option-drag / marquee / snap]
```

## Testing

- `swift build` — passed
- `swift test` — passed, 1,568 tests across 250 suites
- MCP coverage discovers `manage_markers`, creates and reads a marker independently, updates it by stable ID, and verifies undo

Manual UI verification still required:

- [ ] create point/range markers with the toolbar and `M`
- [ ] verify the popup anchors above the marker and Done/Escape dismissal behavior
- [ ] verify live Time, Duration, and preset Color previews
- [ ] drag markers and Option-drag ranges in both directions, including collapse to zero duration
- [ ] verify clip, playhead, beat, and marker snapping plus marquee selection across the ruler
- [ ] verify light/dark borders, selected contrast, compact controls, and keyboard focus

## Change statistics

- production code: +876 / -42
- tests: +169 / -0
- localization: +11 / -0
- total: +1,056 / -42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches timeline model persistence, selection/drag input, and agent tools, but changes are additive with dedicated validation and test coverage rather than altering clip edit paths.
> 
> **Overview**
> Adds **persistent point and range markers** on the timeline for review notes (name, color, comment, frame timing), stored on `Timeline` and serialized with the project.
> 
> **UI:** Ruler rendering, selection, drag/Option-drag duration, marquee, snapping (including marker frames), toolbar and **M** shortcut, popover editor with live preview, and Delete handling. Timeline zoom/layout uses `displayFrames` so markers past clip content still fit. Clip/gap/range selection clears marker selection and vice versa.
> 
> **Agent/MCP:** `get_timeline` returns windowed `markers`; new **`manage_markers`** (create/update/delete) shares the same validated `changeTimelineMarkers` path as the editor, with `markerId` in the short-ID universe.
> 
> **Project ops:** Markers rescale on FPS changes, get new IDs on timeline duplicate, and undo as atomic marker-list swaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787abef876e18e123002059843f7d5bb40fdb05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->