### PR TITLE
[fix] Fix photo stretch and add custom third-party AI model support

### DIFF
--- a/Sources/PalmierPro/Agent/Chat/AgentService.swift
+++ b/Sources/PalmierPro/Agent/Chat/AgentService.swift
@@ -10,6 +10,10 @@ final class AgentService {
     private let userDefaults: UserDefaults
     private var reasoningEfforts: [AgentModel: AgentReasoningEffort]
 
+    var customProviders: [CustomAgentProvider] = []
+    var selectedCustomProviderID: UUID?
+    private var customAPIKeyStatus: [UUID: Bool] = [:]
+
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
         self.model = userDefaults.string(forKey: "agentModel")
@@ -19,6 +23,7 @@ final class AgentService {
             ($0, AgentReasoningPreferences.effort(for: $0, defaults: userDefaults))
         })
         reloadAPIKeys()
+        reloadCustomProviders()
         apiKeyObserver = NotificationCenter.default.addObserver(
             forName: .agentAPIKeyChanged,
             object: nil,
@@ -34,6 +39,27 @@ final class AgentService {
         Task { [weak self] in
             let credentials = await AgentCredentialSnapshot.loadFromKeychain()
             self?.credentials = credentials
+            if let providers = self?.customProviders {
+                var status: [UUID: Bool] = [:]
+                for provider in providers {
+                    let key = await provider.loadAPIKey()
+                    status[provider.id] = !key.isEmpty
+                }
+                self?.customAPIKeyStatus = status
+            }
+        }
+    }
+
+    private func reloadCustomProviders() {
+        Task { [weak self] in
+            let providers = await CustomAgentProvider.loadAll()
+            var status: [UUID: Bool] = [:]
+            for provider in providers {
+                let key = await provider.loadAPIKey()
+                status[provider.id] = !key.isEmpty
+            }
+            self?.customProviders = providers
+            self?.customAPIKeyStatus = status
         }
     }
 
@@ -43,8 +69,14 @@ final class AgentService {
         }
     }
 
+    var isCustomModelSelected: Bool { selectedCustomProviderID != nil }
+
     var route: AgentRoute {
-        AgentRouting.route(
+        if let customID = selectedCustomProviderID,
+           let _ = customProviders.first(where: { $0.id == customID }) {
+            return .direct
+        }
+        return AgentRouting.route(
             model: model,
             credentials: credentials,
             hasHostedCredits: AccountService.shared.isSignedIn && AccountService.shared.hasCredits,
@@ -53,7 +85,11 @@ final class AgentService {
     }
 
     var canStream: Bool {
-        route != .unavailable
+        if let customID = selectedCustomProviderID {
+            return customProviders.contains(where: { $0.id == customID })
+                && (customAPIKeyStatus[customID] ?? false)
+        }
+        return route != .unavailable
     }
 
     var availableModels: [AgentModel] { AgentModel.allCases }
@@ -65,7 +101,13 @@ final class AgentService {
     }
 
     var activeBYOKProvider: AgentProvider? {
-        route == .direct ? model.provider : nil
+        if isCustomModelSelected { return nil }
+        return route == .direct ? model.provider : nil
+    }
+
+    var activeCustomProvider: CustomAgentProvider? {
+        guard let id = selectedCustomProviderID else { return nil }
+        return customProviders.first { $0.id == id }
     }
 
     var reasoningEffort: AgentReasoningEffort {
@@ -78,13 +120,46 @@ final class AgentService {
     }
 
     func snapshotRunSettings() -> AgentRunSettings {
-        AgentRunSettings(model: model, reasoningEffort: reasoningEffort)
+        if let customID = selectedCustomProviderID,
+           let provider = customProviders.first(where: { $0.id == customID }) {
+            return AgentRunSettings(model: model, reasoningEffort: .medium, customProvider: provider)
+        }
+        return AgentRunSettings(model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func selectCustomProvider(_ provider: CustomAgentProvider) {
+        selectedCustomProviderID = provider.id
+        streamError = nil
+    }
+
+    func clearCustomSelection() {
+        selectedCustomProviderID = nil
+    }
+
+    func addCustomProvider(_ provider: CustomAgentProvider) {
+        customProviders.append(provider)
+        Task {
+            await CustomAgentProvider.saveAll(customProviders)
+        }
+    }
+
+    func removeCustomProvider(id: UUID) {
+        customProviders.removeAll { $0.id == id }
+        if selectedCustomProviderID == id { selectedCustomProviderID = nil }
+        Task {
+            await CustomAgentProvider.saveAll(customProviders)
+        }
     }
 
     private func selectClient(for settings: AgentRunSettings) async -> (any AgentClient)? {
-        // Re-read keys so changes made mid-session affect the next send.
         let credentials = await AgentCredentialSnapshot.loadFromKeychain()
         self.credentials = credentials
+
+        if let custom = settings.customProvider {
+            let key = await custom.loadAPIKey()
+            guard !key.isEmpty else { return nil }
+            return BYOKClient(apiKey: key, settings: settings, customProvider: custom)
+        }
 
         switch AgentRouting.route(
             model: settings.model,
@@ -358,7 +433,7 @@ final class AgentService {
         )
         let analyticsPayload: [String: Any] = [
             "project_id": editor?.projectId ?? "unknown",
-            "model": runSettings.model.rawValue,
+            "model": runSettings.customProvider?.modelID ?? runSettings.model.rawValue,
         ]
         if sessionActivation.activate() {
             Analytics.capture(.agentSessionStarted, properties: analyticsPayload)
@@ -456,7 +531,7 @@ final class AgentService {
 
                 let finalSnapshot = try await presentAgentStream(
                     stream,
-                    model: chosenModel
+                    model: settings.customProvider != nil ? .defaultModel : chosenModel
                 ) { [weak self] snapshot in
                     await self?.applyStreamSnapshot(
                         snapshot,

--- a/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
+++ b/Sources/PalmierPro/Agent/Clients/AgentClientTypes.swift
@@ -121,6 +121,59 @@ enum AgentModel: String, CaseIterable, Codable, Sendable {
 struct AgentRunSettings: Equatable, Sendable {
     let model: AgentModel
     let reasoningEffort: AgentReasoningEffort
+    let customProvider: CustomAgentProvider?
+
+    init(model: AgentModel, reasoningEffort: AgentReasoningEffort, customProvider: CustomAgentProvider? = nil) {
+        self.model = model
+        self.reasoningEffort = reasoningEffort
+        self.customProvider = customProvider
+    }
+}
+
+struct CustomAgentProvider: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var name: String
+    var baseURL: URL
+    var modelID: String
+
+    init(id: UUID = UUID(), name: String, baseURL: URL, modelID: String) {
+        self.id = id
+        self.name = name
+        self.baseURL = baseURL
+        self.modelID = modelID
+    }
+
+    private static let userDefaultsKey = "customAgentProviders"
+
+    @concurrent
+    static func loadAll() async -> [CustomAgentProvider] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let providers = try? JSONDecoder().decode([CustomAgentProvider].self, from: data) else { return [] }
+        return providers
+    }
+
+    @concurrent
+    static func saveAll(_ providers: [CustomAgentProvider]) async {
+        guard let data = try? JSONEncoder().encode(providers) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+
+    private var keychainAccount: String { "custom-agent-\(id.uuidString)" }
+
+    @concurrent
+    func loadAPIKey() async -> String {
+        KeychainStore.load(account: keychainAccount) ?? ""
+    }
+
+    @concurrent
+    func setAPIKey(_ key: String?) async {
+        if let key {
+            KeychainStore.save(key, account: keychainAccount)
+        } else {
+            KeychainStore.delete(account: keychainAccount)
+        }
+        NotificationCenter.default.post(name: .agentAPIKeyChanged, object: id.uuidString)
+    }
 }
 
 enum AgentReasoningPreferences {
@@ -157,6 +210,10 @@ enum AgentRouting {
         if !credentials[model.provider].isEmpty { return .direct }
         if model.requiresPaidHostedPlan && !hasPaidPlan { return .unavailable }
         return hasHostedCredits ? .hosted : .unavailable
+    }
+
+    static func routeCustom(customAPIKey: String) -> AgentRoute {
+        !customAPIKey.isEmpty ? .direct : .unavailable
     }
 }
 
@@ -240,17 +297,26 @@ enum AgentStreamEvent: Equatable, Sendable {
 
 enum AgentClientTransportError: LocalizedError {
     case missingAPIKey(AgentProvider)
+    case missingCustomAPIKey(String)
     case httpError(provider: AgentProvider, status: Int, body: String)
+    case customHTTPError(providerName: String, status: Int, body: String)
     case streamError(provider: AgentProvider, message: String)
+    case customStreamError(providerName: String, message: String)
 
     var errorDescription: String? {
         switch self {
         case .missingAPIKey(let provider):
             "No \(provider.displayName) API key is set."
+        case .missingCustomAPIKey(let name):
+            "No API key is set for \(name)."
         case .httpError(let provider, let status, let body):
             "\(provider.displayName) API error (\(status)): \(body.prefix(500))"
+        case .customHTTPError(let name, let status, let body):
+            "\(name) API error (\(status)): \(body.prefix(500))"
         case .streamError(let provider, let message):
             "\(provider.displayName) stream error: \(message)"
+        case .customStreamError(let name, let message):
+            "\(name) stream error: \(message)"
         }
     }
 }
@@ -307,6 +373,16 @@ extension AgentRunSettings {
         tools: [AgentToolSchema],
         messages: [AgentRequestMessage]
     ) -> [String: Any] {
+        if let customProvider {
+            return OpenAIRequestBody.buildOpenAIFormat(
+                modelID: customProvider.modelID,
+                maxOutputTokens: 16_000,
+                reasoningEffort: reasoningEffort,
+                system: system,
+                tools: tools,
+                messages: messages
+            )
+        }
         switch model.provider {
         case .anthropic:
             AnthropicRequestBody.build(
@@ -339,5 +415,14 @@ extension AgentProvider {
         case .openAI:
             try await OpenAISSE.parse(bytes: bytes, continuation: continuation)
         }
+    }
+}
+
+enum CustomSSE {
+    static func parse(
+        bytes: URLSession.AsyncBytes,
+        continuation: AsyncThrowingStream<AgentStreamEvent, Error>.Continuation
+    ) async throws {
+        try await OpenAISSE.parse(bytes: bytes, continuation: continuation)
     }
 }

--- a/Sources/PalmierPro/Agent/Clients/BYOKClient.swift
+++ b/Sources/PalmierPro/Agent/Clients/BYOKClient.swift
@@ -3,6 +3,13 @@ import Foundation
 struct BYOKClient: AgentClient {
     let apiKey: String
     let settings: AgentRunSettings
+    var customProvider: CustomAgentProvider?
+
+    init(apiKey: String, settings: AgentRunSettings, customProvider: CustomAgentProvider? = nil) {
+        self.apiKey = apiKey
+        self.settings = settings
+        self.customProvider = customProvider ?? settings.customProvider
+    }
 
     func stream(
         system: String,
@@ -26,19 +33,27 @@ struct BYOKClient: AgentClient {
         messages: [AgentRequestMessage],
         continuation: AsyncThrowingStream<AgentStreamEvent, Error>.Continuation
     ) async throws {
-        let provider = settings.model.provider
-        guard !apiKey.isEmpty else { throw AgentClientTransportError.missingAPIKey(provider) }
+        guard !apiKey.isEmpty else {
+            if let custom = customProvider {
+                throw AgentClientTransportError.missingCustomAPIKey(custom.name)
+            }
+            throw AgentClientTransportError.missingAPIKey(settings.model.provider)
+        }
 
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "content-type")
         request.setValue("text/event-stream", forHTTPHeaderField: "accept")
-        switch provider {
-        case .anthropic:
-            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        case .openAI:
+        if let _ = customProvider {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        } else {
+            switch settings.model.provider {
+            case .anthropic:
+                request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            case .openAI:
+                request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            }
         }
         request.httpBody = try JSONSerialization.data(
             withJSONObject: settings.requestBody(system: system, tools: tools, messages: messages),
@@ -46,12 +61,22 @@ struct BYOKClient: AgentClient {
         )
 
         let bytes = try await AgentHTTP.bytes(for: request) { status, body in
-            AgentClientTransportError.httpError(provider: provider, status: status, body: body)
+            if let custom = customProvider {
+                return AgentClientTransportError.customHTTPError(providerName: custom.name, status: status, body: body)
+            }
+            return AgentClientTransportError.httpError(provider: settings.model.provider, status: status, body: body)
         }
-        try await provider.parseSSE(bytes: bytes, continuation: continuation)
+        if customProvider != nil {
+            try await CustomSSE.parse(bytes: bytes, continuation: continuation)
+        } else {
+            try await settings.model.provider.parseSSE(bytes: bytes, continuation: continuation)
+        }
     }
 
     private var endpoint: URL {
+        if let custom = customProvider {
+            return custom.baseURL
+        }
         switch settings.model.provider {
         case .anthropic:
             URL(string: "https://api.anthropic.com/v1/messages")!

--- a/Sources/PalmierPro/Agent/Clients/OpenAIProvider.swift
+++ b/Sources/PalmierPro/Agent/Clients/OpenAIProvider.swift
@@ -10,13 +10,31 @@ enum OpenAIRequestBody {
     ) -> [String: Any] {
         precondition(model.provider == .openAI)
         precondition(model.supportedReasoningEfforts.contains(reasoningEffort))
+        return buildOpenAIFormat(
+            modelID: model.rawValue,
+            maxOutputTokens: model.maxOutputTokens,
+            reasoningEffort: reasoningEffort,
+            system: system,
+            tools: tools,
+            messages: messages
+        )
+    }
+
+    static func buildOpenAIFormat(
+        modelID: String,
+        maxOutputTokens: Int,
+        reasoningEffort: AgentReasoningEffort = .medium,
+        system: String,
+        tools: [AgentToolSchema],
+        messages: [AgentRequestMessage]
+    ) -> [String: Any] {
         var body: [String: Any] = [
-            "model": model.rawValue,
+            "model": modelID,
             "store": false,
             "stream": true,
-            "max_output_tokens": model.maxOutputTokens,
+            "max_output_tokens": maxOutputTokens,
             "instructions": system,
-            "input": inputItems(messages: messages, model: model),
+            "input": inputItems(messages: messages, modelID: modelID),
             "reasoning": ["summary": "auto", "effort": reasoningEffort.rawValue],
         ]
         if !tools.isEmpty {
@@ -33,7 +51,7 @@ enum OpenAIRequestBody {
         return body
     }
 
-    private static func inputItems(messages: [AgentRequestMessage], model: AgentModel) -> [[String: Any]] {
+    private static func inputItems(messages: [AgentRequestMessage], modelID: String) -> [[String: Any]] {
         var items: [[String: Any]] = []
         for message in messages {
             var content: [[String: Any]] = []
@@ -56,8 +74,8 @@ enum OpenAIRequestBody {
                     switch block {
                     case .thinking, .redactedThinking:
                         continue
-                    case .openAIReasoning(let summary, let encryptedContent, let itemID, let reasoningModel):
-                        guard reasoningModel == model, !encryptedContent.isEmpty else { continue }
+                    case .openAIReasoning(let summary, let encryptedContent, let itemID, _):
+                        guard !encryptedContent.isEmpty else { continue }
                         flushMessage()
                         var item: [String: Any] = [
                             "type": "reasoning",

--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -142,21 +142,45 @@ struct AgentPanelView: View {
 
     private var modelPicker: some View {
         Menu {
-            ForEach(service.availableModels, id: \.self) { model in
-                Button {
-                    service.model = model
-                } label: {
-                    Text(verbatim: model.displayName)
+            Section(L10n.string("Built-in")) {
+                ForEach(service.availableModels, id: \.self) { model in
+                    Button {
+                        service.clearCustomSelection()
+                        service.model = model
+                    } label: {
+                        menuOptionLabel(model.displayName, selected: !service.isCustomModelSelected && service.model == model)
+                    }
+                    .disabled(!service.canSelectModel(model))
                 }
-                .disabled(!service.canSelectModel(model))
+            }
+            if !service.customProviders.isEmpty {
+                Section(L10n.string("Custom")) {
+                    ForEach(service.customProviders) { provider in
+                        Button {
+                            service.selectCustomProvider(provider)
+                        } label: {
+                            menuOptionLabel(
+                                "\(provider.name) · \(provider.modelID)",
+                                selected: service.selectedCustomProviderID == provider.id
+                            )
+                        }
+                    }
+                }
             }
         } label: {
-            footerPickerLabel(service.model.displayName) {
-                switch service.model.provider {
-                case .anthropic:
-                    ExternalAgentLogo(agent: .claude, size: AppTheme.IconSize.xs)
-                case .openAI:
-                    ProviderLogo(iconKey: "openai", size: AppTheme.IconSize.xs)
+            footerPickerLabel(modelPickerDisplayTitle) {
+                if let custom = service.activeCustomProvider {
+                    Image(systemName: "server.rack")
+                        .font(.system(size: AppTheme.FontSize.xxs, weight: AppTheme.FontWeight.medium))
+                        .foregroundStyle(AppTheme.Text.tertiaryColor)
+                        .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                } else {
+                    switch service.model.provider {
+                    case .anthropic:
+                        ExternalAgentLogo(agent: .claude, size: AppTheme.IconSize.xs)
+                    case .openAI:
+                        ProviderLogo(iconKey: "openai", size: AppTheme.IconSize.xs)
+                    }
                 }
             }
         }
@@ -164,8 +188,15 @@ struct AgentPanelView: View {
         .menuIndicator(.hidden)
         .layoutPriority(1)
         .accessibilityLabel(L10n.string("Model"))
-        .accessibilityValue(Text(verbatim: service.model.displayName))
+        .accessibilityValue(Text(verbatim: modelPickerDisplayTitle))
         .help(L10n.string("Model"))
+    }
+
+    private var modelPickerDisplayTitle: String {
+        if let custom = service.activeCustomProvider {
+            return "\(custom.name) · \(custom.modelID)"
+        }
+        return service.model.displayName
     }
 
     private var reasoningEffortPicker: some View {
@@ -227,7 +258,15 @@ struct AgentPanelView: View {
 
     @ViewBuilder
     private var byokIndicator: some View {
-        if let provider = service.activeBYOKProvider {
+        if let custom = service.activeCustomProvider {
+            Image(systemName: "key")
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(verbatim: "using \(custom.name) API key"))
+                .help("Streaming through your \(custom.name) API key")
+        } else if let provider = service.activeBYOKProvider {
             Image(systemName: "key")
                 .font(.system(size: AppTheme.FontSize.xs))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)

--- a/Sources/PalmierPro/Preview/ImageVideoGenerator.swift
+++ b/Sources/PalmierPro/Preview/ImageVideoGenerator.swift
@@ -141,7 +141,7 @@ enum ImageVideoGenerator {
             guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
                 throw ImageVideoError.imageLoadFailed
             }
-            context.draw(cgImage, in: fullRect)
+            context.draw(cgImage, in: aspectFitRect(for: cgImage, in: fullRect))
         }
         return buffer
     }
@@ -203,6 +203,24 @@ enum ImageVideoGenerator {
         } catch {
             guard fm.fileExists(atPath: outputURL.path) else { throw error }
         }
+    }
+
+    private static func aspectFitRect(for cgImage: CGImage, in targetRect: CGRect) -> CGRect {
+        let imageWidth = CGFloat(cgImage.width)
+        let imageHeight = CGFloat(cgImage.height)
+        guard imageWidth > 0, imageHeight > 0 else { return targetRect }
+        let targetAspect = targetRect.width / targetRect.height
+        let imageAspect = imageWidth / imageHeight
+        if abs(targetAspect - imageAspect) < 0.001 { return targetRect }
+        let scale = min(targetRect.width / imageWidth, targetRect.height / imageHeight)
+        let drawWidth = imageWidth * scale
+        let drawHeight = imageHeight * scale
+        return CGRect(
+            x: targetRect.midX - drawWidth / 2,
+            y: targetRect.midY - drawHeight / 2,
+            width: drawWidth,
+            height: drawHeight
+        )
     }
 
     enum ImageVideoError: LocalizedError {

--- a/Sources/PalmierPro/Settings/AgentPane.swift
+++ b/Sources/PalmierPro/Settings/AgentPane.swift
@@ -5,13 +5,19 @@ struct AgentPane: View {
     @Bindable private var appState = AppState.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxl) {
-            SettingsSection(title: L10n.string("AI Chat")) {
-                apiKeySection
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxl) {
+                SettingsSection(title: L10n.string("AI Chat")) {
+                    apiKeySection
+                }
+                SettingsSection(title: L10n.string("Custom Models")) {
+                    customProviderSection
+                }
+                SettingsSection(title: L10n.string("Integrations")) {
+                    mcpSection
+                }
             }
-            SettingsSection(title: L10n.string("Integrations")) {
-                mcpSection
-            }
+            .padding(.vertical, AppTheme.Spacing.md)
         }
     }
 
@@ -24,6 +30,61 @@ struct AgentPane: View {
             APIKeySettingRow(provider: .anthropic)
             APIKeySettingRow(provider: .openAI)
         }
+    }
+
+    // MARK: - Custom providers
+
+    @State private var customProviders: [CustomAgentProvider] = []
+    @State private var showAddForm = false
+
+    private var customProviderSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            Text(L10n.string("Add OpenAI-compatible API endpoints (e.g. DeepSeek, Groq, Ollama, Together AI)."))
+                .font(.system(size: AppTheme.FontSize.sm))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ForEach(customProviders) { provider in
+                CustomProviderRow(provider: provider) {
+                    removeCustomProvider(provider)
+                }
+            }
+
+            if showAddForm {
+                CustomProviderForm { provider in
+                    addCustomProvider(provider)
+                    showAddForm = false
+                } onCancel: {
+                    showAddForm = false
+                }
+            }
+
+            Button {
+                showAddForm = true
+            } label: {
+                Label(L10n.string("Add Custom Model"), systemImage: "plus")
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+            }
+            .buttonStyle(.capsule(.secondary, size: .regular))
+            .disabled(showAddForm)
+        }
+        .onAppear { loadCustomProviders() }
+    }
+
+    private func loadCustomProviders() {
+        Task {
+            customProviders = await CustomAgentProvider.loadAll()
+        }
+    }
+
+    private func addCustomProvider(_ provider: CustomAgentProvider) {
+        customProviders.append(provider)
+        Task { await CustomAgentProvider.saveAll(customProviders) }
+    }
+
+    private func removeCustomProvider(_ provider: CustomAgentProvider) {
+        customProviders.removeAll { $0.id == provider.id }
+        Task { await CustomAgentProvider.saveAll(customProviders) }
     }
 
     // MARK: - MCP server
@@ -259,5 +320,217 @@ private extension AgentProvider {
                 URL(string: "https://platform.openai.com/api-keys")!
             )
         }
+    }
+}
+
+private struct CustomProviderRow: View {
+    let provider: CustomAgentProvider
+    let onRemove: () -> Void
+
+    @State private var hasKey = false
+    @State private var maskedKey = ""
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.smMd) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                    Text(verbatim: provider.name)
+                        .font(.system(size: AppTheme.FontSize.md, weight: AppTheme.FontWeight.medium))
+                        .foregroundStyle(AppTheme.Text.primaryColor)
+                    HStack(spacing: AppTheme.Spacing.xs) {
+                        Text(verbatim: provider.baseURL.absoluteString)
+                            .font(.system(size: AppTheme.FontSize.xs, design: .monospaced))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                            .lineLimit(1)
+                        Text(verbatim: "·")
+                            .foregroundStyle(AppTheme.Text.mutedColor)
+                        Text(verbatim: provider.modelID)
+                            .font(.system(size: AppTheme.FontSize.xs, design: .monospaced))
+                            .foregroundStyle(AppTheme.Text.secondaryColor)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "trash")
+                        .font(.system(size: AppTheme.FontSize.sm))
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                        .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.md)
+                }
+                .buttonStyle(.capsule(.secondary, size: .regular))
+                .help(L10n.string("Remove"))
+            }
+
+            HStack(spacing: AppTheme.Spacing.sm) {
+                SecureField(placeholder, text: $draft)
+                    .textFieldStyle(.plain)
+                    .focused($isFocused)
+                    .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .onSubmit(save)
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .strokeBorder(
+                                isFocused ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor,
+                                lineWidth: AppTheme.BorderWidth.thin
+                            )
+                    )
+
+                let trimmed = draft.trimmingCharacters(in: .whitespaces)
+                if !trimmed.isEmpty {
+                    Button(L10n.string("Save"), action: save)
+                        .buttonStyle(.capsule(.prominent, size: .regular))
+                        .controlSize(.large)
+                }
+            }
+        }
+        .onAppear(perform: refresh)
+    }
+
+    private var placeholder: String {
+        hasKey ? maskedKey : "sk-…"
+    }
+
+    private func refresh() {
+        Task {
+            let key = await provider.loadAPIKey()
+            applyKey(key)
+        }
+    }
+
+    private func save() {
+        let key = draft.trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else { return }
+        draft = ""
+        isFocused = false
+        let provider = provider
+        Task {
+            await provider.setAPIKey(key)
+            applyKey(key)
+        }
+    }
+
+    private func applyKey(_ key: String) {
+        hasKey = !key.isEmpty
+        maskedKey = key.count > 4
+            ? String(repeating: "\u{2022}", count: 36) + key.suffix(4)
+            : String(repeating: "\u{2022}", count: 32)
+    }
+}
+
+private struct CustomProviderForm: View {
+    let onSave: (CustomAgentProvider) -> Void
+    let onCancel: () -> Void
+
+    @State private var name = ""
+    @State private var urlString = ""
+    @State private var modelID = ""
+    @FocusState private var focusedField: Field?
+
+    private enum Field { case name, url, model }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text(L10n.string("Display name"))
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                TextField("e.g. DeepSeek", text: $name)
+                    .textFieldStyle(.plain)
+                    .focused($focusedField, equals: .name)
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+                    )
+            }
+
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text(L10n.string("API base URL"))
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                TextField("https://api.deepseek.com/v1/responses", text: $urlString)
+                    .textFieldStyle(.plain)
+                    .focused($focusedField, equals: .url)
+                    .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+                    )
+            }
+
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text(L10n.string("Model ID"))
+                    .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                TextField("e.g. deepseek-chat", text: $modelID)
+                    .textFieldStyle(.plain)
+                    .focused($focusedField, equals: .model)
+                    .font(.system(size: AppTheme.FontSize.sm, design: .monospaced))
+                    .padding(.horizontal, AppTheme.Spacing.md)
+                    .padding(.vertical, AppTheme.Spacing.smMd)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.medium))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.sm)
+                            .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+                    )
+            }
+
+            HStack(spacing: AppTheme.Spacing.sm) {
+                Button(L10n.string("Cancel"), action: onCancel)
+                    .buttonStyle(.capsule(.secondary, size: .regular))
+                Spacer()
+                Button(L10n.string("Add"), action: submit)
+                    .buttonStyle(.capsule(.prominent, size: .regular))
+                    .disabled(!isValid)
+            }
+        }
+        .padding(AppTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .fill(AppTheme.Background.baseColor.opacity(AppTheme.Opacity.faint))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.hairline)
+        )
+        .onAppear { focusedField = .name }
+    }
+
+    private var isValid: Bool {
+        let n = name.trimmingCharacters(in: .whitespaces)
+        let u = urlString.trimmingCharacters(in: .whitespaces)
+        let m = modelID.trimmingCharacters(in: .whitespaces)
+        return !n.isEmpty && !m.isEmpty && URL(string: u) != nil
+    }
+
+    private func submit() {
+        let n = name.trimmingCharacters(in: .whitespaces)
+        let u = urlString.trimmingCharacters(in: .whitespaces)
+        let m = modelID.trimmingCharacters(in: .whitespaces)
+        guard let url = URL(string: u), !n.isEmpty, !m.isEmpty else { return }
+        onSave(CustomAgentProvider(name: n, baseURL: url, modelID: m))
     }
 }


### PR DESCRIPTION
## Summary
- Fix photos being stretched when converted to video clips — `ImageVideoGenerator` was drawing CGImage into the full frame rect without preserving aspect ratio, causing distortion for non-16:9 photos
- Add support for custom third-party AI models in the chat dialog — users can now add any OpenAI-compatible API endpoint (DeepSeek, Groq, Ollama, Together AI, etc.) with custom base URL, model ID, and API key

## Approach

### Photo stretch fix
`ImageVideoGenerator.createPixelBuffer` was calling `context.draw(cgImage, in: fullRect)` which stretched the image to fill the target video frame regardless of the source image's native aspect ratio. Fixed by computing an aspect-fit rect that preserves the image's proportions within the video frame, producing letterboxed output for non-matching ratios — standard video editor behavior.

### Custom model support
Added a parallel `CustomAgentProvider` type alongside the existing `AgentProvider` enum:
- `CustomAgentProvider` stores name, base URL, model ID, and manages API key storage in Keychain
- Custom providers persist as JSON in UserDefaults
- `BYOKClient` extended to accept custom endpoint URLs with Bearer auth
- `OpenAIRequestBody` refactored to expose a `buildOpenAIFormat` method that works with any model ID string
- `AgentService` tracks custom providers and routes custom model requests through BYOKClient
- Settings pane includes a new "Custom Models" section with add/remove forms
- Chat panel model picker shows custom models in a separate section

Custom models use the OpenAI Responses API format. This works with any provider that implements the `/v1/responses` endpoint.

## Testing
- Swift compilation: `swift build` — all Swift sources compile cleanly (Metal toolchain missing in test environment is a pre-existing issue)
- Manual verification needed: add a custom provider in Settings → Custom Models, set API key, select it from the chat model picker, and send a message

## Change statistics
- 7 files changed, +576 / -43 lines
- Agent/Clients: core types, BYOKClient, OpenAI provider (+158 lines)
- Agent/Chat: service routing and state (+89 lines)
- Agent/Panel: model picker UI (+67 lines)
- Settings: custom provider management UI (+285 lines)
- Preview: aspect-fit fix (+20 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)