### PR TITLE
[fix] Prevent muted audio from stalling exports

### DIFF
--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -65,6 +65,7 @@ enum CompositionBuilder {
                 .filter { $0.mediaType != .text }
             guard !sortedClips.isEmpty else { continue }
             if track.type == .audio {
+                guard !track.muted else { continue }
                 try await insertAudioLane(clips: sortedClips, parentTrackIndex: trackIdx, nest: nil, depth: 0, ctx: ctx)
             } else {
                 try await insertVideoLane(clips: sortedClips, parentTrackIndex: trackIdx, nestCarrier: nil, depth: 0, ctx: ctx)

--- a/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
+++ b/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
@@ -301,6 +301,28 @@ struct CompositionBuildAudioTrackTests {
         #expect(audioMappings.first.flatMap(clipIds) == ["a1", "a2"])
     }
 
+    @Test func mutedAudioTrackIsExcludedFromComposition() async throws {
+        let audioURL = try makeSilentWav(durationSeconds: 1)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let clip = Fixtures.clip(
+            id: "muted", mediaRef: "audio", mediaType: .audio,
+            start: 0, duration: 24
+        )
+        var track = Fixtures.audioTrack(clips: [clip])
+        track.muted = true
+        let timeline = Fixtures.timeline(fps: 24, tracks: [track])
+
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { _ in audioURL },
+            renderSize: CGSize(width: 320, height: 180)
+        )
+
+        #expect(result.trackMappings.allSatisfy { $0.isVideo })
+        #expect(try await result.composition.loadTracks(withMediaType: .audio).isEmpty)
+    }
+
     @Test func unityAudioClipResetsVolumeAfterMutedClipOnSharedCompositionTrack() async throws {
         let audioURL = try makeSilentWav(durationSeconds: 3)
         defer { try? FileManager.default.removeItem(at: audioURL) }


### PR DESCRIPTION
## Summary
- Prevent muted audio tracks from entering AVFoundation preview and export compositions.
- Fix exports that could stop advancing while decoding a muted linked-audio lane with mixed source formats.
- Add regression coverage that verifies muted tracks produce no audio mapping or composition track.

## Approach
`CompositionBuilder` previously inserted every audio lane and relied on an `AVAudioMix` volume of zero for muted tracks. AVFoundation still decoded and mixed those sources, so a muted linked-audio lane could starve the offline mixer and stop video export progress. The builder now omits muted audio tracks before source loading and track insertion. This matches the existing nested-timeline behavior and preserves the single source of truth for composition construction.

## Testing
- `swift test --filter CompositionBuildAudioTrackTests` — passed.
- `swift test --filter ExportServiceRoundTripTests` — passed.
- `swift build` — passed.
- `swift test` — passed: 1,574 tests in 250 suites.
- Reproduced the original stall with the affected project, isolated it to the muted linked-audio lane, then exported the complete affected timeline through a temporary test harness after the fix — completed successfully in 2.608 seconds. The temporary harness and output were removed.

## Change statistics
- Code logic: +1 / -0
- Tests: +22 / -0
- Total: +23 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard in export/preview composition construction with targeted test coverage; behavior change only affects muted audio lanes.
> 
> **Overview**
> **Muted timeline audio lanes are no longer added to preview/export AVFoundation compositions**, instead of being inserted with zero volume in the audio mix.
> 
> `CompositionBuilder` now skips `insertAudioLane` when `track.muted` is true, so muted linked-audio lanes are not loaded or decoded during offline export. That addresses exports that could hang when a muted lane mixed incompatible source formats.
> 
> A regression test asserts muted tracks yield no audio `trackMappings` and an empty composition audio track list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ef7fc45ec99007c35ed0882526d961cae630f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->