### PR TITLE
[fix] Prevent Google sign-in from hanging

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c80b49489eef7850fa92dd9d2f64d0fe49f300786831e32d9439f9efb1ef17ab",
+  "originHash" : "1c41338131a6fcbf5dc9354df9b2ff8ad6288c14b07f488862acada172550b23",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clerk/clerk-ios",
       "state" : {
-        "revision" : "9b6c83e780c48af3a5cb8c40305674d9d8cb0fc6",
-        "version" : "1.2.4"
+        "revision" : "32f7e0f08225845f086097e2a0a5d957557cf49b",
+        "version" : "1.3.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "9.21.0"),
         .package(url: "https://github.com/PostHog/posthog-ios.git", exact: "3.64.4"),
         .package(url: "https://github.com/clerk/clerk-convex-swift", from: "0.1.0"),
-        .package(url: "https://github.com/clerk/clerk-ios", from: "1.2.1"),
+        .package(url: "https://github.com/clerk/clerk-ios", from: "1.3.9"),
         .package(url: "https://github.com/get-convex/convex-swift", from: "0.8.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
         .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.5"),


### PR DESCRIPTION
## Summary
- Update Clerk from 1.2.4 to 1.3.9 to prevent Google sign-in from remaining stuck at “Opening Google…” when macOS fails to present the web-auth session.
- Include Clerk's corrected web-auth lifecycle, presentation-anchor, and cancellation handling.

## Approach
- Raise the Clerk package requirement to 1.3.9 and update its resolved revision.
- Keep all unrelated direct and transitive dependencies unchanged.
- Use the upstream SDK fix rather than adding a second OAuth implementation or customer-side cache workaround.

## Testing
- `swift build` — passed.
- `swift build --enable-all-traits` — passed.
- `swift build --force-resolved-versions` — passed.
- `swift test --force-resolved-versions` — 1,574 tests passed.
- [ ] Install a packaged build on the affected Mac.
- [ ] Click **Sign in with Google** and verify the browser opens immediately.
- [ ] Complete Google authentication and verify Palmier Pro receives the callback and displays the signed-in account.

## Change statistics
- Dependency configuration: +4 / -4
- Code logic: +0 / -0
- Tests: +0 / -0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication via a third-party SDK bump with no local code changes; regression risk is confined to sign-in/OAuth flows but that path is security-sensitive.
> 
> **Overview**
> Bumps the **Clerk iOS** dependency from **1.2.4** to **1.3.9** by raising the minimum in `Package.swift` and updating the pinned revision in `Package.resolved`. No Palmier Pro source or test changes.
> 
> The intent is to pick up upstream fixes for macOS web authentication so **Sign in with Google** no longer stalls on “Opening Google…” when the system fails to present the OAuth session. Behavior changes live entirely in the Clerk SDK (web-auth lifecycle, presentation anchor, cancellation handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4b290c922d0478f9c0221fd2378dbc9a3a2b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->