### PR TITLE
[fix/perf] Reuse source assets during composition builds

### DIFF
--- a/Sources/PalmierPro/Preview/AlphaVideoNormalizer.swift
+++ b/Sources/PalmierPro/Preview/AlphaVideoNormalizer.swift
@@ -6,10 +6,13 @@ import CoreVideo
 enum AlphaVideoNormalizer {
 
     /// Returns cached premultiplied-alpha video if source has straight alpha; else nil.
-    static func premultipliedVideo(for sourceURL: URL, mediaRef: String) async throws -> URL? {
-        let asset = AVURLAsset(url: sourceURL)
-        guard let track = try await asset.loadTracks(withMediaType: .video).first,
-              try await trackContainsAlpha(track) else { return nil }
+    static func premultipliedVideo(
+        for sourceURL: URL,
+        mediaRef: String,
+        asset: AVURLAsset,
+        track: AVAssetTrack
+    ) async throws -> URL? {
+        guard try await trackContainsAlpha(track) else { return nil }
 
         // Skip rotated/flipped sources since baking orientation would lose the original transform.
         let preferredTransform = (try? await track.load(.preferredTransform)) ?? .identity
@@ -23,12 +26,7 @@ enum AlphaVideoNormalizer {
         let outputURL = ImageVideoGenerator.cacheDirectory.appendingPathComponent(filename)
         if FileManager.default.fileExists(atPath: outputURL.path) { return outputURL }
 
-        do {
-            return try await transcode(asset: asset, track: track, size: size, to: outputURL)
-        } catch {
-            Log.preview.error("alpha premultiply failed mediaRef=\(mediaRef): \(error.localizedDescription)")
-            return nil
-        }
+        return try await transcode(asset: asset, track: track, size: size, to: outputURL)
     }
 
     private static func trackContainsAlpha(_ track: AVAssetTrack) async throws -> Bool {

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -41,7 +41,11 @@ enum CompositionBuilder {
         resolveSourceSize: @escaping @Sendable (String) -> CGSize? = { _ in nil },
         resolveTimeline: @escaping @Sendable (String) -> Timeline? = { _ in nil },
         missingMediaRefs: Set<String> = [],
-        renderSize: CGSize
+        renderSize: CGSize,
+        makeAsset: @escaping @Sendable (URL) -> AVURLAsset = { AVURLAsset(url: $0) },
+        loadTracks: @escaping @Sendable (AVURLAsset, AVMediaType) async throws -> [AVAssetTrack] = {
+            try await $0.loadTracks(withMediaType: $1)
+        }
     ) async throws -> CompositionResult {
         Log.preview.info("build fps=\(timeline.fps) size=\(timeline.width)x\(timeline.height) tracks=\(timeline.tracks.count)")
         guard timeline.fps > 0, timeline.width > 0, timeline.height > 0 else {
@@ -55,7 +59,9 @@ enum CompositionBuilder {
             resolveURL: resolveURL,
             resolveSourceSize: resolveSourceSize,
             resolveTimeline: resolveTimeline,
-            missingMediaRefs: missingMediaRefs
+            missingMediaRefs: missingMediaRefs,
+            makeAsset: makeAsset,
+            loadTracks: loadTracks
         )
 
         for (trackIdx, track) in timeline.tracks.enumerated() {
@@ -118,12 +124,17 @@ enum CompositionBuilder {
         let resolveSourceSize: @Sendable (String) -> CGSize?
         let resolveTimeline: @Sendable (String) -> Timeline?
         let missingMediaRefs: Set<String>
+        let makeAsset: @Sendable (URL) -> AVURLAsset
+        let loadTracks: @Sendable (AVURLAsset, AVMediaType) async throws -> [AVAssetTrack]
         var trackMappings: [TrackMapping] = []
         var clipNaturalSizes: [String: CGSize] = [:]
         var clipTransforms: [String: CGAffineTransform] = [:]
         var offlineMediaRefs: Set<String> = []
         var unprocessableMediaRefs: Set<String> = []
-        var failedLoadOutcomes: [SourceLoadKey: LoadOutcome] = [:]
+        var sourceAssetsByURL: [URL: AVURLAsset] = [:]
+        var trackLoadOutcomes: [TrackLoadKey: LoadOutcome] = [:]
+        var videoURLsBySourceURL: [URL: URL] = [:]
+        var loadOutcomesByMedia: [MediaLoadKey: LoadOutcome] = [:]
 
         init(
             composition: AVMutableComposition,
@@ -132,7 +143,9 @@ enum CompositionBuilder {
             resolveURL: @escaping @Sendable (String) -> URL?,
             resolveSourceSize: @escaping @Sendable (String) -> CGSize?,
             resolveTimeline: @escaping @Sendable (String) -> Timeline?,
-            missingMediaRefs: Set<String>
+            missingMediaRefs: Set<String>,
+            makeAsset: @escaping @Sendable (URL) -> AVURLAsset,
+            loadTracks: @escaping @Sendable (AVURLAsset, AVMediaType) async throws -> [AVAssetTrack]
         ) {
             self.composition = composition
             self.timescale = timescale
@@ -141,6 +154,123 @@ enum CompositionBuilder {
             self.resolveSourceSize = resolveSourceSize
             self.resolveTimeline = resolveTimeline
             self.missingMediaRefs = missingMediaRefs
+            self.makeAsset = makeAsset
+            self.loadTracks = loadTracks
+        }
+
+        private func sourceAsset(for url: URL) -> AVURLAsset {
+            if let asset = sourceAssetsByURL[url] { return asset }
+            let asset = makeAsset(url)
+            sourceAssetsByURL[url] = asset
+            return asset
+        }
+
+        func loadSource(for clip: Clip, mediaType: AVMediaType) async throws -> LoadOutcome {
+            try Task.checkCancellation()
+            let key = MediaLoadKey(mediaRef: clip.mediaRef, mediaType: mediaType)
+            if let outcome = loadOutcomesByMedia[key] { return outcome }
+            let outcome = try await prepareSource(for: clip, mediaType: mediaType)
+            loadOutcomesByMedia[key] = outcome
+            return outcome
+        }
+
+        private func prepareSource(for clip: Clip, mediaType: AVMediaType) async throws -> LoadOutcome {
+            guard !missingMediaRefs.contains(clip.mediaRef) else { return .offline }
+            guard let resolvedURL = resolveURL(clip.mediaRef) else { return .offline }
+
+            let mediaURL: URL
+            if clip.mediaType == .image {
+                let imageSize = resolveSourceSize(clip.mediaRef)
+                    ?? ImageVideoGenerator.imageNativeSize(url: resolvedURL)
+                    ?? renderSize
+                do {
+                    mediaURL = try await ImageVideoGenerator.stillVideo(
+                        for: resolvedURL,
+                        mediaRef: clip.mediaRef,
+                        size: imageSize
+                    )
+                } catch {
+                    Log.preview.error("stillVideo failed mediaRef=\(clip.mediaRef) size=\(Int(imageSize.width))x\(Int(imageSize.height)): \(Log.detail(error))")
+                    return FileManager.default.fileExists(atPath: resolvedURL.path) ? .unprocessable : .offline
+                }
+            } else if clip.mediaType == .lottie {
+                let lottieSize = resolveSourceSize(clip.mediaRef) ?? renderSize
+                do {
+                    mediaURL = try await LottieVideoGenerator.lottieVideo(
+                        for: resolvedURL,
+                        mediaRef: clip.mediaRef,
+                        size: lottieSize
+                    )
+                } catch {
+                    Log.preview.error("lottieVideo failed mediaRef=\(clip.mediaRef) size=\(Int(lottieSize.width))x\(Int(lottieSize.height)): \(Log.detail(error))")
+                    return FileManager.default.fileExists(atPath: resolvedURL.path) ? .unprocessable : .offline
+                }
+            } else if mediaType == .video {
+                return try await loadVideo(at: resolvedURL, clip: clip)
+            } else {
+                mediaURL = resolvedURL
+            }
+            return try await loadTrack(at: mediaURL, mediaType: mediaType, clip: clip)
+        }
+
+        private func loadTrack(
+            at url: URL,
+            mediaType: AVMediaType,
+            clip: Clip
+        ) async throws -> LoadOutcome {
+            try Task.checkCancellation()
+            let key = TrackLoadKey(url: url, mediaType: mediaType)
+            if let outcome = trackLoadOutcomes[key] { return outcome }
+            let asset = sourceAsset(for: key.url)
+            let outcome: LoadOutcome
+            do {
+                if let track = try await loadTracks(asset, mediaType).first {
+                    outcome = .loaded(asset: asset, track: track)
+                } else {
+                    outcome = .offline
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                Log.preview.warning(
+                    "loadTracks failed — skipping clip. clipId=\(clip.id) mediaRef=\(clip.mediaRef): \(error.localizedDescription)"
+                )
+                return .offline
+            }
+            trackLoadOutcomes[key] = outcome
+            return outcome
+        }
+
+        private func loadVideo(at url: URL, clip: Clip) async throws -> LoadOutcome {
+            let sourceURL = url.standardizedFileURL
+            let source = try await loadTrack(at: sourceURL, mediaType: .video, clip: clip)
+            guard case .loaded(let asset, let track) = source else { return source }
+
+            let videoURL: URL
+            if let cachedURL = videoURLsBySourceURL[sourceURL] {
+                videoURL = cachedURL
+            } else {
+                do {
+                    let normalizedURL = try await AlphaVideoNormalizer.premultipliedVideo(
+                        for: sourceURL,
+                        mediaRef: clip.mediaRef,
+                        asset: asset,
+                        track: track
+                    )
+                    try Task.checkCancellation()
+                    videoURL = (normalizedURL ?? sourceURL).standardizedFileURL
+                    videoURLsBySourceURL[sourceURL] = videoURL
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    Log.preview.warning(
+                        "alpha premultiply unavailable mediaRef=\(clip.mediaRef): \(error.localizedDescription)"
+                    )
+                    return source
+                }
+            }
+            guard videoURL != sourceURL else { return source }
+            return try await loadTrack(at: videoURL, mediaType: .video, clip: clip)
         }
     }
 
@@ -165,7 +295,7 @@ enum CompositionBuilder {
                 continue
             }
             let source: (asset: AVURLAsset, track: AVAssetTrack)
-            switch try await loadSource(clip: clip, mediaType: .video, ctx: ctx) {
+            switch try await ctx.loadSource(for: clip, mediaType: .video) {
             case .loaded(let asset, let track): source = (asset, track)
             case .offline: ctx.offlineMediaRefs.insert(clip.mediaRef); continue
             case .unprocessable: ctx.unprocessableMediaRefs.insert(clip.mediaRef); continue
@@ -221,7 +351,7 @@ enum CompositionBuilder {
             }
             if let nest { clip.volume *= nest.volumeScale }
             let source: (asset: AVURLAsset, track: AVAssetTrack)
-            switch try await loadSource(clip: clip, mediaType: .audio, ctx: ctx) {
+            switch try await ctx.loadSource(for: clip, mediaType: .audio) {
             case .loaded(let asset, let track): source = (asset, track)
             case .offline: ctx.offlineMediaRefs.insert(clip.mediaRef); continue
             case .unprocessable: ctx.unprocessableMediaRefs.insert(clip.mediaRef); continue
@@ -291,94 +421,24 @@ enum CompositionBuilder {
         ctx.clipTransforms[clip.id] = pt.concatenating(CGAffineTransform(translationX: -box.minX, y: -box.minY))
     }
 
-    private static func loadSource(clip: Clip, mediaType: AVMediaType, ctx: BuildContext) async throws -> LoadOutcome {
-        let key = SourceLoadKey(mediaRef: clip.mediaRef, mediaType: mediaType)
-        if let failedOutcome = ctx.failedLoadOutcomes[key] {
-            return failedOutcome
-        }
-        let outcome = try await loadSource(
-            clip: clip, mediaType: mediaType, resolveURL: ctx.resolveURL,
-            resolveSourceSize: ctx.resolveSourceSize, missingMediaRefs: ctx.missingMediaRefs,
-            renderSize: ctx.renderSize
-        )
-        switch outcome {
-        case .loaded:
-            break
-        case .offline, .unprocessable:
-            ctx.failedLoadOutcomes[key] = outcome
-        }
-        return outcome
-    }
-
     private enum LoadOutcome {
         case loaded(asset: AVURLAsset, track: AVAssetTrack)
         case offline
         case unprocessable
     }
 
-    private struct SourceLoadKey: Hashable {
+    private struct MediaLoadKey: Hashable {
         let mediaRef: String
-        let mediaType: String
-
-        init(mediaRef: String, mediaType: AVMediaType) {
-            self.mediaRef = mediaRef
-            self.mediaType = mediaType.rawValue
-        }
+        let mediaType: AVMediaType
     }
 
-    private static func loadSource(
-        clip: Clip,
-        mediaType: AVMediaType,
-        resolveURL: @Sendable (String) -> URL?,
-        resolveSourceSize: @Sendable (String) -> CGSize?,
-        missingMediaRefs: Set<String>,
-        renderSize: CGSize
-    ) async throws -> LoadOutcome {
-        let mediaURL: URL
-        guard !missingMediaRefs.contains(clip.mediaRef) else { return .offline }
-        guard let resolved = resolveURL(clip.mediaRef) else { return .offline }
-        if clip.mediaType == .image {
-            let imageSize = resolveSourceSize(clip.mediaRef)
-                ?? ImageVideoGenerator.imageNativeSize(url: resolved)
-                ?? renderSize
-            do {
-                mediaURL = try await ImageVideoGenerator.stillVideo(
-                    for: resolved,
-                    mediaRef: clip.mediaRef,
-                    size: imageSize
-                )
-            } catch {
-                Log.preview.error("stillVideo failed mediaRef=\(clip.mediaRef) size=\(Int(imageSize.width))x\(Int(imageSize.height)): \(Log.detail(error))")
-                return FileManager.default.fileExists(atPath: resolved.path) ? .unprocessable : .offline
-            }
-        } else if clip.mediaType == .lottie {
-            let lottieSize = resolveSourceSize(clip.mediaRef) ?? renderSize
-            do {
-                mediaURL = try await LottieVideoGenerator.lottieVideo(
-                    for: resolved,
-                    mediaRef: clip.mediaRef,
-                    size: lottieSize
-                )
-            } catch {
-                Log.preview.error("lottieVideo failed mediaRef=\(clip.mediaRef) size=\(Int(lottieSize.width))x\(Int(lottieSize.height)): \(Log.detail(error))")
-                return FileManager.default.fileExists(atPath: resolved.path) ? .unprocessable : .offline
-            }
-        } else if mediaType == .video {
-            mediaURL = (try? await AlphaVideoNormalizer.premultipliedVideo(for: resolved, mediaRef: clip.mediaRef)) ?? resolved
-        } else {
-            mediaURL = resolved
-        }
+    private struct TrackLoadKey: Hashable {
+        let url: URL
+        let mediaType: AVMediaType
 
-        guard !Task.isCancelled else { throw CancellationError() }
-        let sourceAsset = AVURLAsset(url: mediaURL)
-        do {
-            guard let sourceTrack = try await sourceAsset.loadTracks(withMediaType: mediaType).first else {
-                return .offline
-            }
-            return .loaded(asset: sourceAsset, track: sourceTrack)
-        } catch {
-            Log.preview.warning("loadTracks failed — skipping clip. clipId=\(clip.id) mediaRef=\(clip.mediaRef): \(error.localizedDescription)")
-            return .offline
+        init(url: URL, mediaType: AVMediaType) {
+            self.url = url.standardizedFileURL
+            self.mediaType = mediaType
         }
     }
 

--- a/Tests/PalmierProTests/Export/CompositionBuilderSourcePoolTests.swift
+++ b/Tests/PalmierProTests/Export/CompositionBuilderSourcePoolTests.swift
@@ -1,0 +1,206 @@
+import AVFoundation
+import Foundation
+import os
+import Testing
+@testable import PalmierPro
+
+@Suite("CompositionBuilder source pool")
+struct CompositionBuilderSourcePoolTests {
+
+    @Test func repeatedSourcesCreateOneAssetPerUniqueURL() async throws {
+        let sourceURLs = try await makeVideoSources(count: 8)
+        defer { sourceURLs.forEach { try? FileManager.default.removeItem(at: $0) } }
+        let mediaRefs = (0..<16).map { "source-\($0)" }
+        let urlsByRef = Dictionary(uniqueKeysWithValues: mediaRefs.enumerated().map {
+            ($0.element, sourceURLs[$0.offset % sourceURLs.count])
+        })
+        let timeline = makeTimeline(clipCount: 356, trackCount: 13, mediaRefs: mediaRefs)
+        let assetCreations = OSAllocatedUnfairLock(initialState: 0)
+        let started = ContinuousClock.now
+
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { urlsByRef[$0] },
+            renderSize: CGSize(width: 320, height: 180),
+            makeAsset: { url in
+                assetCreations.withLock { $0 += 1 }
+                return AVURLAsset(url: url)
+            }
+        )
+
+        let elapsed = started.duration(to: .now)
+        print("SOURCE_POOL_BENCHMARK clips=356 sources=8 elapsed=\(elapsed)")
+        #expect(result.offlineMediaRefs.isEmpty)
+        #expect(result.unprocessableMediaRefs.isEmpty)
+        #expect(assetCreations.withLock { $0 } == sourceURLs.count)
+    }
+
+    @Test func transientTrackFailureDoesNotPoisonURLAliases() async throws {
+        let sourceURL = try await makeVideoSource(index: 0)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+        let clips = [
+            Fixtures.clip(id: "first", mediaRef: "first-ref", start: 0, duration: 6),
+            Fixtures.clip(id: "second", mediaRef: "second-ref", start: 6, duration: 6),
+        ]
+        let timeline = Fixtures.timeline(fps: 30, tracks: [Fixtures.videoTrack(clips: clips)])
+        let assetCreations = OSAllocatedUnfairLock(initialState: 0)
+        let trackLoadAttempts = OSAllocatedUnfairLock(initialState: 0)
+
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { _ in sourceURL },
+            renderSize: CGSize(width: 320, height: 180),
+            makeAsset: { url in
+                assetCreations.withLock { $0 += 1 }
+                return AVURLAsset(url: url)
+            },
+            loadTracks: { asset, mediaType in
+                let attempt = trackLoadAttempts.withLock { count -> Int in
+                    count += 1
+                    return count
+                }
+                if attempt == 1 { throw NSError(domain: "transient", code: 1) }
+                return try await asset.loadTracks(withMediaType: mediaType)
+            }
+        )
+
+        let insertedIds = result.trackMappings.reduce(into: Set<String>()) { ids, mapping in
+            guard case .timeline(_, let clipIds) = mapping.kind, let clipIds else { return }
+            ids.formUnion(clipIds)
+        }
+        #expect(assetCreations.withLock { $0 } == 1)
+        #expect(trackLoadAttempts.withLock { $0 } == 2)
+        #expect(result.offlineMediaRefs == ["first-ref"])
+        #expect(insertedIds.contains("second"))
+    }
+
+    @Test func repeatedAlphaSourceUsesOneNormalizedAsset() async throws {
+        let sourceURL = try await makeAlphaSource()
+        let mediaRef = "alpha-\(UUID().uuidString)"
+        let normalizedURL = ImageVideoGenerator.cacheDirectory.appendingPathComponent(
+            "\(mediaRef)_\(DiskCache.sizeMtimeTag(for: sourceURL))_premul.mov"
+        )
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: normalizedURL)
+        }
+        let clips = [
+            Fixtures.clip(id: "first", mediaRef: mediaRef, start: 0, duration: 15),
+            Fixtures.clip(id: "second", mediaRef: mediaRef, start: 15, duration: 15),
+        ]
+        let timeline = Fixtures.timeline(fps: 30, tracks: [Fixtures.videoTrack(clips: clips)])
+        let assetCreations = OSAllocatedUnfairLock(initialState: 0)
+
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { _ in sourceURL },
+            renderSize: CGSize(width: 64, height: 64),
+            makeAsset: { url in
+                assetCreations.withLock { $0 += 1 }
+                return AVURLAsset(url: url)
+            }
+        )
+
+        #expect(result.offlineMediaRefs.isEmpty)
+        #expect(assetCreations.withLock { $0 } == 2)
+        #expect(FileManager.default.fileExists(atPath: normalizedURL.path))
+    }
+
+    @Test func cancellationStopsBeforeResolvingSources() async {
+        let clip = Fixtures.clip(id: "clip", mediaRef: "source", start: 0, duration: 6)
+        let timeline = Fixtures.timeline(fps: 30, tracks: [Fixtures.videoTrack(clips: [clip])])
+        let resolutions = OSAllocatedUnfairLock(initialState: 0)
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try await CompositionBuilder.build(
+                timeline: timeline,
+                resolveURL: { _ in
+                    resolutions.withLock { $0 += 1 }
+                    return URL(fileURLWithPath: "/unused.mov")
+                },
+                renderSize: CGSize(width: 320, height: 180)
+            )
+        }
+
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(resolutions.withLock { $0 } == 0)
+    }
+
+    private func makeVideoSources(count: Int) async throws -> [URL] {
+        var urls: [URL] = []
+        for index in 0..<count { urls.append(try await makeVideoSource(index: index)) }
+        return urls
+    }
+
+    private func makeVideoSource(index: Int) async throws -> URL {
+        try await FixtureVideo.write(
+            scenes: [FixtureVideo.Scene(rgb: (UInt8(truncatingIfNeeded: index * 20), 40, 80), seconds: 1)],
+            fps: 30,
+            size: 64,
+            fileType: .mov
+        )
+    }
+
+    private func makeTimeline(clipCount: Int, trackCount: Int, mediaRefs: [String]) -> Timeline {
+        let baseCount = clipCount / trackCount
+        let remainder = clipCount % trackCount
+        var globalIndex = 0
+        let tracks = (0..<trackCount).map { trackIndex in
+            let count = baseCount + (trackIndex < remainder ? 1 : 0)
+            let clips = (0..<count).map { localIndex in
+                defer { globalIndex += 1 }
+                return Fixtures.clip(
+                    id: "clip-\(globalIndex)",
+                    mediaRef: mediaRefs[globalIndex % mediaRefs.count],
+                    start: localIndex * 6,
+                    duration: 6
+                )
+            }
+            return Fixtures.videoTrack(id: "track-\(trackIndex)", clips: clips)
+        }
+        return Fixtures.timeline(fps: 30, tracks: tracks)
+    }
+
+    private func makeAlphaSource() async throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alpha-\(UUID().uuidString).mov")
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.proRes4444,
+            AVVideoWidthKey: 64,
+            AVVideoHeightKey: 64,
+        ])
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: 64,
+                kCVPixelBufferHeightKey as String: 64,
+            ]
+        )
+        writer.add(input)
+        try #require(writer.startWriting())
+        writer.startSession(atSourceTime: .zero)
+        let buffer = try alphaBuffer(pool: adaptor.pixelBufferPool)
+        try #require(adaptor.append(buffer, withPresentationTime: .zero))
+        try #require(adaptor.append(buffer, withPresentationTime: CMTime(value: 29, timescale: 30)))
+        input.markAsFinished()
+        await writer.finishWriting()
+        try #require(writer.status == .completed)
+        return url
+    }
+
+    private func alphaBuffer(pool: CVPixelBufferPool?) throws -> CVPixelBuffer {
+        var buffer: CVPixelBuffer?
+        if let pool {
+            CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buffer)
+        } else {
+            CVPixelBufferCreate(nil, 64, 64, kCVPixelFormatType_32BGRA, nil, &buffer)
+        }
+        let pixelBuffer = try #require(buffer)
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+        memset(CVPixelBufferGetBaseAddress(pixelBuffer), 128, CVPixelBufferGetDataSize(pixelBuffer))
+        return pixelBuffer
+    }
+}


### PR DESCRIPTION
## Summary
- Reuse one `AVURLAsset` per standardized source URL within each composition build.
- Prevent large previews and exports from constructing hundreds of duplicate assets for repeated clips and linked audio.
- Preserve cancellation, transient retry, offline-media reporting, and straight-alpha normalization behavior.

## Approach
`CompositionBuilder` now owns a build-scoped source pool. It memoizes media outcomes by stable media identity, track loads by standardized URL and media type, and normalized video URLs by source URL. Video and audio tracks share the same underlying asset when they reference the same file.

The pool is intentionally discarded after each build, avoiding stale cross-build state when users relink or externally replace media. Cancellation is checked before both cache layers. Thrown track and alpha-preflight failures are not cached, allowing aliases to retry; deterministic no-track results remain reusable. Alpha normalization receives the already-loaded asset and track instead of reopening the source.

Injected asset and track loaders provide deterministic regression coverage without changing production callers.

## Design
```mermaid
flowchart LR
    subgraph Before
        C1[Clip] --> A1[New AVURLAsset]
        C2[Clip] --> A2[New AVURLAsset]
        C3[Linked audio] --> A3[New AVURLAsset]
    end
    subgraph After
        D1[Clip] --> P[Build-scoped source pool]
        D2[Clip] --> P
        D3[Linked audio] --> P
        P --> A4[One asset per standardized URL]
    end
```

## Testing
- `swift test --filter CompositionBuilderSourcePoolTests` — passed.
- `swift build` — passed.
- `swift test` — passed: 1,578 tests in 251 suites.
- Synthetic regression covers URL aliases, transient track-load retry, cancellation before source resolution, and repeated straight-alpha normalization.
- User-reported large-project export smoke test succeeded.

### Benchmarks
- 356 clips / 13 tracks / 8 sources: asset constructions `356 → 8`; preparation `251 ms → 19 ms` (~13× faster).
- 356 clips / 20 tracks / 136 unique sources: 136 asset constructions; 90 ms preparation; representative export completed.
- 1,000 clips / 20 tracks / 1 source: one asset construction; 55 ms preparation.

## Change statistics
- Code logic: +152 / -94
- Tests: +206 / -0
- Total: +358 / -94 (net +264)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core preview/export composition loading and caching semantics; behavior is largely preserved but incorrect pooling could affect offline reporting or alpha video compositing.
> 
> **Overview**
> **Composition builds now reuse one `AVURLAsset` per standardized file URL** instead of opening a new asset for every clip, which cuts duplicate work on large previews/exports with repeated media.
> 
> `CompositionBuilder` gains a **build-scoped source pool** on `BuildContext`: memoized outcomes by `mediaRef` + media type, track loads by URL + type, shared assets via injectable `makeAsset` / `loadTracks`, and cached normalized video URLs per source. Video alpha handling runs through `loadVideo`, which calls `AlphaVideoNormalizer` with the **already-loaded asset and track**; normalization errors fall back to the original source with a warning instead of being swallowed inside the normalizer. **Thrown track-load failures are not cached** so a later clip pointing at the same URL can retry; deterministic offline outcomes still cache.
> 
> New **`CompositionBuilderSourcePoolTests`** cover one asset per unique URL under heavy clip counts, transient load retry across aliases, shared alpha normalization, and cancellation before URL resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afad6e78d13fafb81ff0f24676659960ed857ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->