### PR TITLE
[POC] Preview media in claude

### DIFF
--- a/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPHTTPServer.swift
@@ -12,6 +12,7 @@ actor MCPHTTPServer {
 
     private let port: UInt16
     private let makeServer: @Sendable () async -> MCPServerInstance
+    private let previewMedia: @Sendable (String) async -> (url: URL, mimeType: String)?
     private nonisolated(unsafe) var listener: NWListener?
 
     private struct Session {
@@ -28,9 +29,11 @@ actor MCPHTTPServer {
 
     init(
         port: UInt16,
+        previewMedia: @escaping @Sendable (String) async -> (url: URL, mimeType: String)? = { _ in nil },
         makeServer: @escaping @Sendable () async -> MCPServerInstance
     ) {
         self.port = port
+        self.previewMedia = previewMedia
         self.makeServer = makeServer
     }
 
@@ -53,6 +56,25 @@ actor MCPHTTPServer {
         }
 
         listener?.start(queue: .global(qos: .userInitiated))
+    }
+
+    func notifyResourceUpdated(uri: String) async {
+        let servers = sessions.values.map(\.server)
+        let fallbackServer = fallback?.server
+        for server in servers {
+            do {
+                try await server.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
+            } catch {
+                Log.mcp.warning("resource updated notify failed uri=\(uri): \(error.localizedDescription)")
+            }
+        }
+        if let fallbackServer {
+            do {
+                try await fallbackServer.notify(ResourceUpdatedNotification.message(.init(uri: uri)))
+            } catch {
+                Log.mcp.warning("resource updated notify failed uri=\(uri): \(error.localizedDescription)")
+            }
+        }
     }
 
     func stop() {
@@ -124,6 +146,11 @@ actor MCPHTTPServer {
             let body = "{\"resource\":\"http://127.0.0.1:\(port)\"}"
             sendRaw("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(body.utf8.count)\r\n\r\n\(body)", on: connection, keepAlive: true)
             receive(on: connection)
+            return
+        }
+
+        if let path = request.path, path.hasPrefix(MCPPreviewApp.previewHTTPPathPrefix) {
+            await servePreview(request: request, connection: connection)
             return
         }
 
@@ -301,9 +328,85 @@ actor MCPHTTPServer {
         })
     }
 
+    private func servePreview(request: HTTPRequest, connection: NWConnection) async {
+        let mediaRef = String((request.path ?? "").dropFirst(MCPPreviewApp.previewHTTPPathPrefix.count))
+        let method = request.method.uppercased()
+        if method == "OPTIONS" {
+            sendRaw(
+                "HTTP/1.1 204 No Content\r\n\(Self.previewCORSHeaders)Content-Length: 0\r\n\r\n",
+                on: connection,
+                keepAlive: true
+            )
+            receive(on: connection)
+            return
+        }
+        guard method == "GET" || method == "HEAD", MCPPreviewApp.isPreviewMediaRef(mediaRef) else {
+            sendRaw("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: false)
+            return
+        }
+        guard let file = await previewMedia(mediaRef) else {
+            sendRaw("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: false)
+            return
+        }
+        let loaded = await Task.detached(priority: .userInitiated) { () -> (Data, Int)? in
+            let values = try? file.url.resourceValues(forKeys: [.fileSizeKey])
+            let size = values?.fileSize ?? 0
+            guard size > 0, size <= MCPPreviewApp.maxHTTPMediaBytes else { return nil }
+            guard let data = try? Data(contentsOf: file.url) else { return nil }
+            return (data, data.count)
+        }.value
+        guard let (data, size) = loaded else {
+            sendRaw("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", on: connection, keepAlive: false)
+            return
+        }
+        let range = Self.byteRange(from: request.header("Range"), size: size)
+        let body: Data
+        let status: Int
+        var extra = ""
+        if let range {
+            body = data.subdata(in: range)
+            status = 206
+            extra = "Content-Range: bytes \(range.lowerBound)-\(range.upperBound - 1)/\(size)\r\n"
+        } else {
+            body = data
+            status = 200
+        }
+        var head = "HTTP/1.1 \(status) \(statusText(status))\r\n"
+        head += Self.previewCORSHeaders
+        head += "Content-Type: \(file.mimeType)\r\n"
+        head += "Accept-Ranges: bytes\r\n"
+        head += extra
+        head += "Content-Length: \(method == "HEAD" ? 0 : body.count)\r\nConnection: close\r\n\r\n"
+        var response = head.data(using: .utf8) ?? Data()
+        if method != "HEAD" { response.append(body) }
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.send(content: nil, contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        })
+    }
+
+    private static let previewCORSHeaders =
+        "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, HEAD, OPTIONS\r\nAccess-Control-Allow-Headers: Range\r\n"
+
+    private nonisolated static func byteRange(from header: String?, size: Int) -> Range<Int>? {
+        guard let header, header.hasPrefix("bytes="), size > 0 else { return nil }
+        let spec = header.dropFirst("bytes=".count)
+        let parts = spec.split(separator: "-", maxSplits: 1)
+        guard let start = Int(parts.first ?? ""), start >= 0, start < size else { return nil }
+        let end: Int
+        if parts.count == 2, !parts[1].isEmpty {
+            guard let parsed = Int(parts[1]), parsed >= start else { return nil }
+            end = min(parsed + 1, size)
+        } else {
+            end = size
+        }
+        return start..<end
+    }
+
     private nonisolated func statusText(_ code: Int) -> String {
         switch code {
-        case 200: "OK"; case 202: "Accepted"; case 400: "Bad Request"
+        case 200: "OK"; case 202: "Accepted"; case 206: "Partial Content"; case 400: "Bad Request"
         case 404: "Not Found"; case 405: "Method Not Allowed"; case 409: "Conflict"
         case 500: "Internal Server Error"
         default: "Unknown"

--- a/Sources/PalmierPro/Agent/MCP/MCPPreviewApp.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPPreviewApp.swift
@@ -1,0 +1,1109 @@
+import Foundation
+import MCP
+
+enum MCPPreviewApp {
+    static let resourceURI = "ui://palmier/MCPPreviewApp.html"
+    static let mimeType = "text/html;profile=mcp-app"
+    static let pollerToolName = "get_generation_preview"
+    static let revealToolName = "reveal_generation_media"
+    static let previewResourcePrefix = "palmier://generation-preview/"
+    static let generationMediaPrefix = "palmier://generation-media/"
+    static let modelIconPrefix = "palmier://model-icon/"
+    static let previewHTTPPathPrefix = "/preview/"
+    static let previewMaxPixelSize = 512
+    static let maxAudioPreviewBytes = 1_500_000
+    static let maxHTTPMediaBytes = 80_000_000
+    static let maxInlineMediaBytes = 24_000_000
+    static let html = htmlSource
+
+    static var previewOrigin: String { "http://127.0.0.1:\(MCPService.port)" }
+
+    static func httpMediaURL(mediaRef: String) -> String {
+        previewOrigin + previewHTTPPathPrefix + mediaRef
+    }
+
+    static func isPreviewMediaRef(_ value: String) -> Bool {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        return (8...80).contains(value.count) && value.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+
+    static func httpMediaMIMEType(url: URL, type: ClipType) -> String {
+        switch url.pathExtension.lowercased() {
+        case "jpg", "jpeg": "image/jpeg"
+        case "png": "image/png"
+        case "webp": "image/webp"
+        case "heic": "image/heic"
+        case "gif": "image/gif"
+        case "mp4", "m4v": "video/mp4"
+        case "mov": "video/quicktime"
+        case "mp3": "audio/mpeg"
+        case "wav": "audio/wav"
+        case "m4a", "aac": "audio/mp4"
+        case "aiff", "aif", "aifc": "audio/aiff"
+        case "caf": "audio/x-caf"
+        case "flac": "audio/flac"
+        case "ogg": "audio/ogg"
+        default:
+            switch type {
+            case .image: "image/jpeg"
+            case .video, .sequence: "video/mp4"
+            case .audio: "audio/mpeg"
+            case .text, .subtitle: "application/octet-stream"
+            case .lottie: "application/json"
+            }
+        }
+    }
+
+    static var toolMeta: Metadata {
+        Metadata(additionalFields: [
+            "ui": .object(["resourceUri": .string(resourceURI)]),
+        ])
+    }
+
+    static var pollerMeta: Metadata {
+        Metadata(additionalFields: [
+            "ui": .object(["visibility": .array([.string("app")])]),
+        ])
+    }
+
+    static var resourceMeta: Metadata {
+        let origin = Value.string(previewOrigin)
+        return Metadata(additionalFields: [
+            "ui": .object([
+                "prefersBorder": .bool(false),
+                "csp": .object([
+                    "connectDomains": .array([origin]),
+                    "resourceDomains": .array([origin, .string("blob:"), .string("data:")]),
+                ]),
+            ]),
+        ])
+    }
+
+    static var resource: Resource {
+        Resource(
+            name: "Generated Media Preview",
+            uri: resourceURI,
+            description: "Inline preview card for generate_image, generate_video, and generate_audio",
+            mimeType: mimeType,
+            _meta: resourceMeta
+        )
+    }
+
+    static func meta(for name: ToolName) -> Metadata? {
+        switch name {
+        case .generateImage, .generateVideo, .generateAudio, .showTimeline:
+            toolMeta
+        case .getGenerationPreview, .revealGenerationMedia, .revealTimeline:
+            pollerMeta
+        default:
+            nil
+        }
+    }
+
+    static func previewResourceURI(mediaRef: String) -> String {
+        previewResourcePrefix + mediaRef
+    }
+
+    static func previewResourceMediaRef(_ uri: String) -> String? {
+        guard uri.hasPrefix(previewResourcePrefix) else { return nil }
+        let mediaRef = String(uri.dropFirst(previewResourcePrefix.count))
+        return mediaRef.isEmpty ? nil : mediaRef
+    }
+
+    static func generationMediaURI(mediaRef: String) -> String {
+        generationMediaPrefix + mediaRef
+    }
+
+    static func generationMediaRef(_ uri: String) -> String? {
+        guard uri.hasPrefix(generationMediaPrefix) else { return nil }
+        let mediaRef = String(uri.dropFirst(generationMediaPrefix.count))
+        return isPreviewMediaRef(mediaRef) ? mediaRef : nil
+    }
+
+    static func modelIconKey(_ uri: String) -> String? {
+        guard uri.hasPrefix(modelIconPrefix) else { return nil }
+        let key = String(uri.dropFirst(modelIconPrefix.count))
+        return key.isEmpty ? nil : key
+    }
+
+    nonisolated static func modelIconPNG(iconKey: String) -> Data? {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        guard iconKey.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        guard let url = BundledResource.url("Images/LabLogos/logo-\(iconKey).png") else { return nil }
+        return try? Data(contentsOf: url)
+    }
+}
+
+extension MCPPreviewApp {
+    private static let htmlSource = #"""
+    <!doctype html>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Generated media</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: var(--color-background-primary, light-dark(#f4f4f5, #18181b));
+        --elev: var(--color-background-secondary, light-dark(#ffffff, #27272a));
+        --text: var(--color-text-primary, light-dark(#18181b, #fafafa));
+        --muted: var(--color-text-secondary, light-dark(#71717a, #a1a1aa));
+        --border: var(--color-border-primary, light-dark(#e4e4e7, #3f3f46));
+        --fill: var(--color-background-tertiary, light-dark(#e4e4e7, #3f3f46));
+      }
+      html, body {
+        margin: 0;
+        background: transparent;
+        color: var(--text);
+        font: 12.5px/1.45 ui-sans-serif, system-ui, sans-serif;
+      }
+      .card { overflow: hidden; }
+      .stage {
+        position: relative;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        background: color-mix(in srgb, var(--text) 6%, transparent);
+        border-radius: 10px;
+        aspect-ratio: var(--preview-aspect, 16 / 9);
+      }
+      .stage.portrait {
+        max-height: 360px;
+        width: min(100%, calc(360px * var(--preview-aspect)));
+        margin-inline: auto;
+      }
+      .stage.audio { aspect-ratio: 16 / 6; }
+      .stage img, .stage video {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      .stage img { object-fit: contain; }
+      .stage video { object-fit: cover; }
+      .status { color: var(--muted); }
+      .bars {
+        display: flex;
+        align-items: flex-end;
+        gap: 4px;
+        height: 28px;
+      }
+      .bars span {
+        width: 4px;
+        border-radius: 2px;
+        background: var(--muted);
+        animation: eq 1s ease-in-out infinite;
+      }
+      .bars span:nth-child(1) { height: 10px; animation-delay: 0s; }
+      .bars span:nth-child(2) { height: 22px; animation-delay: 0.12s; }
+      .bars span:nth-child(3) { height: 14px; animation-delay: 0.24s; }
+      .bars span:nth-child(4) { height: 26px; animation-delay: 0.08s; }
+      .bars span:nth-child(5) { height: 12px; animation-delay: 0.2s; }
+      .bars.idle span { animation: none; opacity: 0.7; }
+      @keyframes eq {
+        0%, 100% { transform: scaleY(0.45); }
+        50% { transform: scaleY(1); }
+      }
+      .shimmer {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(110deg, transparent 25%, color-mix(in srgb, var(--text) 10%, transparent) 50%, transparent 75%);
+        background-size: 200% 100%;
+        animation: shine 1.6s linear infinite;
+      }
+      @keyframes shine {
+        from { background-position: 200% 0; }
+        to { background-position: -200% 0; }
+      }
+      audio { width: 100%; }
+      .bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px 10px;
+        padding-top: 8px;
+        min-height: 22px;
+      }
+      .model {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        font-weight: 600;
+        font-size: 12px;
+      }
+      .model img, .glyph {
+        width: 14px;
+        height: 14px;
+        border-radius: 3px;
+        flex: none;
+      }
+      .glyph {
+        display: grid;
+        place-items: center;
+        color: var(--muted);
+        font-size: 9px;
+      }
+      .model span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .meta {
+        display: flex;
+        flex: 1 0 100%;
+        align-items: center;
+        gap: 6px 10px;
+        min-width: 0;
+      }
+      .facts {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        min-width: 0;
+        color: var(--muted);
+        font-size: 11px;
+        font-variant-numeric: tabular-nums;
+      }
+      .facts span + span::before {
+        content: "·";
+        margin: 0 6px;
+        opacity: 0.55;
+      }
+      .prompt-drop {
+        flex: 1 0 100%;
+        min-width: 0;
+      }
+      .icon-btn {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        color: var(--muted);
+        padding: 2px;
+        margin-left: auto;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        border-radius: 4px;
+        flex: none;
+      }
+      .icon-btn:hover { color: var(--text); }
+      .icon-btn[hidden] { display: none; }
+      .prompt-drop summary {
+        cursor: pointer;
+        color: var(--muted);
+        font-size: 11px;
+        list-style: none;
+        user-select: none;
+      }
+      .prompt-drop summary::-webkit-details-marker { display: none; }
+      .prompt-drop summary::after { content: " ▾"; }
+      .prompt-drop[open] summary::after { content: " ▴"; }
+      .prompt-drop p {
+        margin: 6px 0 0;
+        color: var(--muted);
+        white-space: pre-wrap;
+      }
+      .error { color: var(--muted); }
+      html.collapsed, html.collapsed body {
+        height: 0 !important;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+      }
+      html.collapsed .card, html.collapsed .gallery { display: none; }
+      .gallery {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 8px;
+      }
+      .gallery .card { min-width: 0; }
+    </style>
+    <div id="single">
+    <div class="card">
+      <div class="stage" id="stage">
+        <div class="shimmer" id="shimmer"></div>
+        <span class="status" id="status">Generating…</span>
+      </div>
+      <div class="bar">
+        <div class="meta">
+          <div class="model" id="modelRow" hidden>
+            <span id="iconSlot"><span class="glyph" id="glyph">◆</span></span>
+            <span id="modelName"></span>
+          </div>
+          <div class="facts" id="chips"></div>
+          <button type="button" class="icon-btn" id="finderBtn" hidden title="Show in Finder" aria-label="Show in Finder">
+            <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+              <path fill="currentColor" d="M3.5 2.5h4v1h-4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-4h1v4a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2zm5.8.5h4.2V7h-1V4.2L7.85 8.85l-.7-.7L11.8 3.5H9.3z"/>
+            </svg>
+          </button>
+        </div>
+        <details class="prompt-drop" id="promptDrop" hidden>
+          <summary>Prompt</summary>
+          <p id="prompt"></p>
+        </details>
+      </div>
+    </div>
+    </div>
+    <div class="gallery" id="gallery" hidden></div>
+    <script>
+    (() => {
+      const single = document.getElementById("single");
+      const gallery = document.getElementById("gallery");
+      const stage = document.getElementById("stage");
+      const status = document.getElementById("status");
+      const shimmer = document.getElementById("shimmer");
+      const modelRow = document.getElementById("modelRow");
+      const modelName = document.getElementById("modelName");
+      const iconSlot = document.getElementById("iconSlot");
+      const promptEl = document.getElementById("prompt");
+      const promptDrop = document.getElementById("promptDrop");
+      const chips = document.getElementById("chips");
+      const finderBtn = document.getElementById("finderBtn");
+      const finderIcon = `<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M3.5 2.5h4v1h-4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-4h1v4a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2zm5.8.5h4.2V7h-1V4.2L7.85 8.85l-.7-.7L11.8 3.5H9.3z"/></svg>`;
+      let nextId = 1;
+      const pending = new Map();
+      let alive = true;
+      let mediaRef = null;
+      let previewUri = null;
+      let kind = "image";
+      let timelineId = null;
+      let groupRole = "host";
+      let groupMembers = [];
+      let pollTimer = 0;
+      let keepPolling = false;
+      let objectUrl = null;
+      let loadedPlayableRef = null;
+      const objectUrls = new Map();
+      let imageBurstUntil = 0;
+
+      function post(payload) { window.parent.postMessage(payload, "*"); }
+      function request(method, params) {
+        const id = nextId++;
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          post({ jsonrpc: "2.0", id, method, params });
+        });
+      }
+      function notify(method, params) { post({ jsonrpc: "2.0", method, params }); }
+      function reportSize() {
+        if (document.documentElement.classList.contains("collapsed")) {
+          notify("ui/notifications/size-changed", { width: 0, height: 0 });
+          return;
+        }
+        const rect = document.documentElement.getBoundingClientRect();
+        notify("ui/notifications/size-changed", {
+          width: Math.ceil(rect.width),
+          height: Math.ceil(rect.height),
+        });
+      }
+      function setAspectOn(el, value) {
+        if (!el || typeof value !== "string" || !value.includes(":")) return;
+        const [w, h] = value.split(":").map(Number);
+        if (!w || !h) return;
+        el.style.setProperty("--preview-aspect", `${w} / ${h}`);
+        el.classList.toggle("portrait", h > w);
+      }
+      function setAspect(value) { setAspectOn(stage, value); }
+      function formatDuration(seconds) {
+        const n = Number(seconds);
+        if (!n || n < 0) return null;
+        if (n < 60) return `${Math.round(n)}s`;
+        const m = Math.floor(n / 60);
+        const s = Math.round(n % 60);
+        return `${m}:${String(s).padStart(2, "0")}`;
+      }
+      function creditLabel(credits) {
+        if (typeof credits !== "number" || !Number.isFinite(credits)) return null;
+        if (credits === 1) return "1 credit";
+        return `${credits} credits`;
+      }
+      function chipLabels(data) {
+        const items = [];
+        if (data.aspectRatio) items.push(data.aspectRatio);
+        if (data.resolution) items.push(data.resolution);
+        if ((data.kind || kind) !== "image") {
+          const duration = formatDuration(data.duration);
+          if (duration) items.push(duration);
+        }
+        const credits = creditLabel(data.credits);
+        if (credits) items.push(credits);
+        return items;
+      }
+      function makeChips(data) {
+        return chipLabels(data).map((label) => {
+          const chip = document.createElement("span");
+          chip.textContent = label;
+          return chip;
+        });
+      }
+      function setPrompt(elDrop, elText, text) {
+        const value = typeof text === "string" ? text.trim() : "";
+        if (!elDrop || !elText) return;
+        if (!value) {
+          elDrop.hidden = true;
+          elText.textContent = "";
+          return;
+        }
+        elText.textContent = value;
+        elDrop.hidden = false;
+      }
+      function revokeObjectUrl() {
+        for (const url of objectUrls.values()) URL.revokeObjectURL(url);
+        objectUrls.clear();
+        objectUrl = null;
+        loadedPlayableRef = null;
+      }
+      function blobUrlFromBase64(b64, mime, ref) {
+        const prev = ref && objectUrls.get(ref);
+        if (prev) URL.revokeObjectURL(prev);
+        else if (!ref && objectUrl) URL.revokeObjectURL(objectUrl);
+        const url = URL.createObjectURL(new Blob([base64ToBytes(b64)], { type: mime }));
+        if (ref) objectUrls.set(ref, url);
+        objectUrl = url;
+        return url;
+      }
+      function setFinderVisible(visible) {
+        if (finderBtn) finderBtn.hidden = !visible;
+      }
+      function syncActionButton() {
+        if (!finderBtn) return;
+        if (kind === "timeline") {
+          finderBtn.title = "View in Palmier";
+          finderBtn.setAttribute("aria-label", "View in Palmier");
+          setFinderVisible(!!timelineId);
+        } else {
+          finderBtn.title = "Show in Finder";
+          finderBtn.setAttribute("aria-label", "Show in Finder");
+        }
+      }
+      async function revealInFinder(ref) {
+        if (!ref) return;
+        try {
+          await request("tools/call", {
+            name: "reveal_generation_media",
+            arguments: { mediaRef: ref },
+          });
+        } catch {}
+      }
+      async function revealTimeline(id) {
+        if (!id) return;
+        try {
+          await request("tools/call", {
+            name: "reveal_timeline",
+            arguments: { timelineId: id },
+          });
+        } catch {}
+      }
+      function makeFinderButton(ref) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-btn";
+        btn.title = "Show in Finder";
+        btn.setAttribute("aria-label", "Show in Finder");
+        btn.innerHTML = finderIcon;
+        btn.addEventListener("click", (event) => {
+          event.preventDefault();
+          revealInFinder(ref);
+        });
+        return btn;
+      }
+      function makePalmierButton(id) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-btn";
+        btn.title = "View in Palmier";
+        btn.setAttribute("aria-label", "View in Palmier");
+        btn.innerHTML = finderIcon;
+        btn.addEventListener("click", (event) => {
+          event.preventDefault();
+          revealTimeline(id);
+        });
+        return btn;
+      }
+      function collapse() {
+        stopPolling();
+        document.documentElement.classList.add("collapsed");
+        single.hidden = true;
+        gallery.hidden = true;
+        reportSize();
+      }
+      function clearMedia() {
+        for (const node of [...stage.querySelectorAll("img, video, audio, .badge, .play, .bars")]) {
+          node.remove();
+        }
+      }
+      function showGenerating(phase) {
+        if (kind === "timeline") syncActionButton();
+        else setFinderVisible(false);
+        stage.classList.remove("ready");
+        shimmer.hidden = false;
+        status.hidden = false;
+        status.textContent = phase || (kind === "timeline" ? "Rendering…" : "Generating…");
+        status.classList.remove("error");
+        if (!status.isConnected) stage.append(status);
+        if (kind === "audio") {
+          stage.classList.add("audio");
+          if (!stage.querySelector(".bars")) {
+            const bars = document.createElement("div");
+            bars.className = "bars";
+            bars.innerHTML = "<span></span><span></span><span></span><span></span><span></span>";
+            stage.append(bars);
+          }
+        } else {
+          stage.classList.remove("audio");
+        }
+        reportSize();
+      }
+      function showError(message) {
+        if (!isBurstKind(kind) && kind !== "timeline") stopPolling();
+        setFinderVisible(false);
+        stage.classList.remove("ready");
+        shimmer.hidden = true;
+        clearMedia();
+        status.hidden = false;
+        status.classList.add("error");
+        status.textContent = message || "Generation failed";
+        if (!status.isConnected) stage.append(status);
+        reportSize();
+      }
+      function applyMeta(data) {
+        if (!data) return;
+        if (data.kind) kind = data.kind;
+        if (data.timelineId) timelineId = data.timelineId;
+        if (data.aspectRatio) setAspect(data.aspectRatio);
+        if (kind === "timeline") {
+          modelName.textContent = data.timelineName || data.name || "";
+          modelRow.hidden = !modelName.textContent;
+          iconSlot.replaceChildren();
+          iconSlot.hidden = true;
+          setPrompt(promptDrop, promptEl, "");
+          chips.replaceChildren();
+        } else {
+          iconSlot.hidden = false;
+          if (data.model) {
+            modelName.textContent = data.model;
+            modelRow.hidden = false;
+          }
+          if (data.modelIconKey) loadIcon(data.modelIconKey, iconSlot);
+          setPrompt(promptDrop, promptEl, data.prompt);
+          chips.replaceChildren(...makeChips(data));
+        }
+        syncActionButton();
+        if (kind === "audio") stage.classList.add("audio");
+        reportSize();
+      }
+      async function loadIcon(key, slot) {
+        if (!slot) return;
+        try {
+          const result = await request("resources/read", { uri: "palmier://model-icon/" + key });
+          const blob = result && result.contents && result.contents[0];
+          let src = null;
+          if (blob && blob.blob) src = `data:${blob.mimeType || "image/png"};base64,${blob.blob}`;
+          else if (blob && blob.text && blob.text.startsWith("data:")) src = blob.text;
+          if (!src) return;
+          const img = document.createElement("img");
+          img.alt = "";
+          img.src = src;
+          slot.replaceChildren(img);
+        } catch {}
+      }
+      function showImage(src) {
+        shimmer.hidden = true;
+        if (status.isConnected) status.remove();
+        clearMedia();
+        const img = document.createElement("img");
+        img.alt = kind === "video" ? "Generated video" : "Generated image";
+        img.onload = reportSize;
+        img.src = src;
+        stage.append(img);
+        stage.classList.add("ready");
+        reportSize();
+      }
+      function showVideo(src, poster) {
+        shimmer.hidden = true;
+        if (status.isConnected) status.remove();
+        let video = stage.querySelector("video");
+        if (!video) {
+          clearMedia();
+          video = document.createElement("video");
+          video.controls = true;
+          video.playsInline = true;
+          video.preload = "metadata";
+          video.onloadedmetadata = () => {
+            if (video.videoWidth && video.videoHeight) {
+              video.width = video.videoWidth;
+              video.height = video.videoHeight;
+              setAspectOn(stage, `${video.videoWidth}:${video.videoHeight}`);
+            }
+            reportSize();
+          };
+          stage.append(video);
+        }
+        if (poster && video.poster !== poster) video.poster = poster;
+        if (src && video.getAttribute("src") !== src) video.src = src;
+        stage.classList.add("ready");
+        reportSize();
+      }
+      function showAudio(src) {
+        shimmer.hidden = true;
+        if (status.isConnected) status.remove();
+        clearMedia();
+        stage.classList.add("audio", "ready");
+        if (src) {
+          const audio = document.createElement("audio");
+          audio.controls = true;
+          audio.src = src;
+          audio.onerror = () => showAudio(null);
+          stage.append(audio);
+        } else {
+          const bars = document.createElement("div");
+          bars.className = "bars idle";
+          bars.innerHTML = "<span></span><span></span><span></span><span></span><span></span>";
+          stage.append(bars);
+          const ready = document.createElement("span");
+          ready.className = "status";
+          ready.textContent = "Ready in Palmier";
+          stage.append(ready);
+        }
+        reportSize();
+      }
+      function previewSrc(payload) {
+        const preview = payload && payload.preview;
+        if (preview && preview.data) {
+          return `data:${preview.mimeType || "image/jpeg"};base64,${preview.data}`;
+        }
+        return null;
+      }
+      function audioSrc(payload) {
+        if (payload && payload.mediaUrl) return payload.mediaUrl;
+        const audio = payload && payload.audio;
+        if (audio && audio.data) {
+          return `data:${audio.mimeType || "audio/mpeg"};base64,${audio.data}`;
+        }
+        return null;
+      }
+      function base64ToBytes(b64) {
+        const bin = atob(b64);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        return bytes;
+      }
+      async function loadPlayableUrl(payload) {
+        const mime = (payload && payload.mimeType) || (kind === "audio" ? "audio/mpeg" : "video/mp4");
+        const ref = (payload && payload.mediaRef) || mediaRef;
+        if (objectUrls.has(ref)) return objectUrls.get(ref);
+        if (objectUrl && loadedPlayableRef === ref) return objectUrl;
+        const inline = payload && payload.media;
+        if (inline && inline.data) {
+          const url = blobUrlFromBase64(inline.data, inline.mimeType || mime, ref);
+          loadedPlayableRef = ref;
+          return url;
+        }
+        if (ref) {
+          try {
+            const full = parsePayload(await request("tools/call", {
+              name: "get_generation_preview",
+              arguments: { mediaRef: ref, includeMedia: true },
+            }));
+            if (full && full.media && full.media.data) {
+              const url = blobUrlFromBase64(full.media.data, full.media.mimeType || mime, ref);
+              loadedPlayableRef = ref;
+              return url;
+            }
+          } catch {}
+        }
+        const uri = payload && payload.mediaResourceUri;
+        if (uri) {
+          try {
+            const result = await request("resources/read", { uri });
+            const block = result && result.contents && result.contents[0];
+            if (block && block.blob) {
+              const url = blobUrlFromBase64(block.blob, block.mimeType || mime, ref);
+              loadedPlayableRef = ref;
+              return url;
+            }
+          } catch {}
+        }
+        return (payload && payload.mediaUrl) || null;
+      }
+      async function applyReady(payload) {
+        applyMeta(payload);
+        setFinderVisible(kind === "timeline" ? !!timelineId : !!((payload && payload.mediaRef) || mediaRef));
+        if (kind === "audio") {
+          showAudio(await loadPlayableUrl(payload) || audioSrc(payload));
+          return;
+        }
+        if (kind === "video" || kind === "timeline") {
+          const poster = previewSrc(payload);
+          showVideo(null, poster);
+          const src = await loadPlayableUrl(payload);
+          if (src) showVideo(src, poster);
+          return;
+        }
+        const src = previewSrc(payload);
+        if (src) showImage(src);
+        else showGenerating("Ready in Palmier");
+        shimmer.hidden = true;
+      }
+      function parsePayload(result) {
+        if (!result) return null;
+        if (result.structuredContent && typeof result.structuredContent === "object") {
+          return result.structuredContent;
+        }
+        const blocks = result.content || result.contents || [];
+        for (const block of blocks) {
+          const text = block && (block.text || (block.type === "text" && block.text));
+          if (typeof text !== "string") continue;
+          const trimmed = text.trim();
+          if (!trimmed.startsWith("{")) continue;
+          try { return JSON.parse(trimmed); } catch {}
+        }
+        if (typeof result.text === "string" && result.text.trim().startsWith("{")) {
+          try { return JSON.parse(result.text); } catch {}
+        }
+        return null;
+      }
+      function rememberGroup(payload) {
+        if (Array.isArray(payload.groupMembers) && payload.groupMembers.length) {
+          groupMembers = payload.groupMembers;
+        }
+        if (groupRole === "host" && mediaRef && payload.groupRole === "member") {
+          return;
+        }
+        if (payload.groupRole) groupRole = payload.groupRole;
+      }
+      function isBurstKind(k) {
+        return k === "image" || k === "video";
+      }
+      function previewMembers(payload) {
+        const members = Array.isArray(payload.groupMembers) && payload.groupMembers.length
+          ? payload.groupMembers
+          : groupMembers;
+        const k = payload.kind || kind;
+        if ((isBurstKind(k) || k === "timeline") && members.length > 1) return members;
+        return null;
+      }
+      async function fillTileStage(stageEl, data) {
+        stageEl.replaceChildren();
+        setAspectOn(stageEl, data.aspectRatio);
+        if (data.status === "failed") {
+          const err = document.createElement("span");
+          err.className = "status error";
+          err.textContent = data.error || "Generation failed";
+          stageEl.append(err);
+          return;
+        }
+        if (data.status === "ready" && (data.kind === "timeline" || data.kind === "video")) {
+          const src = await loadPlayableUrl(data);
+          if (src) {
+            const video = document.createElement("video");
+            video.controls = true;
+            video.playsInline = true;
+            video.preload = "metadata";
+            video.src = src;
+            video.onloadedmetadata = () => {
+              if (video.videoWidth && video.videoHeight) {
+                setAspectOn(stageEl, `${video.videoWidth}:${video.videoHeight}`);
+              }
+              reportSize();
+            };
+            stageEl.append(video);
+            stageEl.classList.add("ready");
+            return;
+          }
+        }
+        const src = previewSrc(data);
+        if (data.status === "ready" && src) {
+          const img = document.createElement("img");
+          img.alt = "Generated image";
+          img.onload = reportSize;
+          img.src = src;
+          stageEl.append(img);
+          stageEl.classList.add("ready");
+          return;
+        }
+        stageEl.classList.remove("ready");
+        const shine = document.createElement("div");
+        shine.className = "shimmer";
+        stageEl.append(shine);
+        const label = document.createElement("span");
+        label.className = "status";
+        label.textContent = data.phase === "downloading" ? "Downloading…"
+          : data.phase === "preparing" ? "Preparing…"
+          : data.phase === "rendering" ? "Rendering…"
+          : data.kind === "timeline" ? "Rendering…"
+          : "Generating…";
+        stageEl.append(label);
+      }
+      async function makeTile(data) {
+        const card = document.createElement("div");
+        card.className = "card";
+        const stageEl = document.createElement("div");
+        stageEl.className = "stage";
+        await fillTileStage(stageEl, data);
+        const bar = document.createElement("div");
+        bar.className = "bar";
+        const model = document.createElement("div");
+        model.className = "model";
+        const name = document.createElement("span");
+        const meta = document.createElement("div");
+        meta.className = "meta";
+        if (data.kind === "timeline") {
+          name.textContent = data.timelineName || data.name || "";
+          model.append(name);
+          meta.append(model);
+          if (data.timelineId) meta.append(makePalmierButton(data.timelineId));
+          bar.append(meta);
+        } else {
+          const slot = document.createElement("span");
+          const icon = document.createElement("span");
+          icon.className = "glyph";
+          icon.textContent = "◆";
+          slot.append(icon);
+          name.textContent = data.model || "";
+          model.append(slot, name);
+          if (data.modelIconKey) loadIcon(data.modelIconKey, slot);
+          const facts = document.createElement("div");
+          facts.className = "facts";
+          facts.append(...makeChips(data));
+          const drop = document.createElement("details");
+          drop.className = "prompt-drop";
+          const summary = document.createElement("summary");
+          summary.textContent = "Prompt";
+          const body = document.createElement("p");
+          drop.append(summary, body);
+          drop.addEventListener("toggle", reportSize);
+          setPrompt(drop, body, data.prompt);
+          meta.append(model, facts);
+          if (data.status === "ready" && data.mediaRef) {
+            meta.append(makeFinderButton(data.mediaRef));
+          }
+          bar.append(meta, drop);
+        }
+        card.append(stageEl, bar);
+        return card;
+      }
+      async function renderGallery(refs) {
+        document.documentElement.classList.remove("collapsed");
+        const payloads = [];
+        for (const ref of refs) {
+          payloads.push(await loadPreview(ref));
+        }
+        const cards = [];
+        for (let index = 0; index < payloads.length; index++) {
+          cards.push(await makeTile(payloads[index] || {
+            status: "generating",
+            mediaRef: refs[index],
+            kind: kind,
+          }));
+        }
+        gallery.replaceChildren(...cards);
+        gallery.hidden = false;
+        single.hidden = true;
+        reportSize();
+        return payloads.some((item) => !item || item.status === "generating");
+      }
+      async function loadPreview(ref) {
+        try {
+          return parsePayload(await request("tools/call", {
+            name: "get_generation_preview",
+            arguments: { mediaRef: ref },
+          }));
+        } catch {
+          return null;
+        }
+      }
+      async function fetchPreview() {
+        if (!mediaRef || groupRole === "member") return;
+        const payload = await loadPreview(mediaRef);
+        if (!payload) return;
+        rememberGroup(payload);
+        if (groupRole === "member" && previewMembers(payload)) {
+          collapse();
+          return;
+        }
+        const members = previewMembers(payload);
+        if (members) {
+          groupMembers = members;
+          let pendingWork = true;
+          try {
+            pendingWork = await renderGallery(members);
+          } catch {
+            single.hidden = false;
+            gallery.hidden = true;
+            reportSize();
+          }
+          if (pendingWork) {
+            imageBurstUntil = 0;
+          } else if (!imageBurstUntil) {
+            imageBurstUntil = Date.now() + 8000;
+          } else if (Date.now() >= imageBurstUntil) {
+            stopPolling();
+          }
+          return;
+        }
+        applyMeta(payload);
+        if (payload.status === "ready") {
+          await applyReady(payload);
+          if (!isBurstKind(kind)) {
+            stopPolling();
+          } else if (!imageBurstUntil) {
+            imageBurstUntil = Date.now() + 8000;
+          } else if (Date.now() >= imageBurstUntil) {
+            stopPolling();
+          }
+        } else if (payload.status === "failed") {
+          showError(payload.error);
+        } else {
+          imageBurstUntil = 0;
+          const phase = payload.phase === "downloading" ? "Downloading…"
+            : payload.phase === "preparing" ? "Preparing…"
+            : payload.phase === "rendering" ? "Rendering…"
+            : "Generating…";
+          showGenerating(phase);
+        }
+      }
+      function stopPolling() {
+        keepPolling = false;
+        if (pollTimer) {
+          clearTimeout(pollTimer);
+          pollTimer = 0;
+        }
+      }
+      function startPolling() {
+        stopPolling();
+        keepPolling = true;
+        let delay = 800;
+        const tick = async () => {
+          if (!alive || !keepPolling || !mediaRef || groupRole === "member") return;
+          await fetchPreview();
+          if (!alive || !keepPolling || !mediaRef || groupRole === "member") return;
+          delay = Math.min(delay + 400, 2000);
+          pollTimer = setTimeout(tick, delay);
+        };
+        pollTimer = setTimeout(tick, 400);
+      }
+      function showPlaceholder(args) {
+        applyMeta({
+          kind: kind,
+          prompt: args && args.prompt,
+          aspectRatio: args && args.aspectRatio,
+          resolution: args && args.resolution,
+          duration: args && args.duration,
+          model: args && args.model,
+        });
+        showGenerating();
+      }
+      async function showResult(result) {
+        if (!result) return;
+        if (result.isError) {
+          const text = (result.content || []).find((block) => block.type === "text");
+          showError(text && text.text);
+          return;
+        }
+        const payload = parsePayload(result);
+        if (payload) {
+          rememberGroup(payload);
+          if (groupRole === "member" && previewMembers(payload)) {
+            collapse();
+            return;
+          }
+          if (!mediaRef && payload.mediaRef) mediaRef = payload.mediaRef;
+          if (!previewUri && payload.previewUri) previewUri = payload.previewUri;
+          applyMeta(payload);
+          if (previewMembers(payload)) {
+            startPolling();
+            fetchPreview();
+            return;
+          }
+          if (payload.status === "ready") {
+            await applyReady(payload);
+            if (isBurstKind(kind)) startPolling();
+            return;
+          }
+          if (payload.status === "failed") {
+            showError(payload.error);
+            return;
+          }
+          showGenerating();
+          startPolling();
+          return;
+        }
+        const blocks = result.content || [];
+        for (const block of blocks) {
+          if (block && block.type === "image" && block.data) {
+            showImage(`data:${block.mimeType || "image/jpeg"};base64,${block.data}`);
+            return;
+          }
+        }
+        showGenerating();
+      }
+      function handleHostNotification(msg) {
+        const uri = msg.params && msg.params.uri;
+        if (!uri || groupRole === "member") return;
+        if (previewUri && uri === previewUri) fetchPreview();
+        else if (mediaRef && uri.endsWith(mediaRef)) fetchPreview();
+        else if (groupMembers.some((ref) => uri.endsWith(ref))) fetchPreview();
+      }
+
+      window.addEventListener("message", (event) => {
+        const msg = event.data;
+        if (!msg || msg.jsonrpc !== "2.0") return;
+        if (Object.prototype.hasOwnProperty.call(msg, "id") && pending.has(msg.id)) {
+          const waiter = pending.get(msg.id);
+          pending.delete(msg.id);
+          if (msg.error) waiter.reject(msg.error);
+          else waiter.resolve(msg.result);
+          return;
+        }
+        if (msg.method === "ping") {
+          post({ jsonrpc: "2.0", id: msg.id, result: {} });
+          return;
+        }
+        if (msg.method === "ui/resource-teardown") {
+          alive = false;
+          stopPolling();
+          revokeObjectUrl();
+          post({ jsonrpc: "2.0", id: msg.id, result: {} });
+          return;
+        }
+        if (msg.method === "ui/notifications/tool-input") {
+          showPlaceholder(msg.params && msg.params.arguments);
+          return;
+        }
+        if (msg.method === "ui/notifications/tool-result") {
+          showResult(msg.params);
+          return;
+        }
+        if (msg.method === "ui/notifications/tool-cancelled") {
+          showError("Generation cancelled");
+          return;
+        }
+        if (msg.method === "notifications/resources/updated"
+            || msg.method === "ui/notifications/resources/updated") {
+          handleHostNotification(msg);
+        }
+      });
+
+      promptDrop.addEventListener("toggle", reportSize);
+      finderBtn.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (kind === "timeline") revealTimeline(timelineId);
+        else revealInFinder(mediaRef);
+      });
+      new ResizeObserver(reportSize).observe(document.documentElement);
+
+      (async () => {
+        await request("ui/initialize", {
+          protocolVersion: "2026-01-26",
+          appInfo: { name: "MCPPreviewApp", version: "1.6.1" },
+          appCapabilities: { availableDisplayModes: ["inline"] },
+        });
+        notify("ui/notifications/initialized", {});
+        reportSize();
+      })();
+    })();
+    </script>
+    """#
+}

--- a/Sources/PalmierPro/Agent/MCP/MCPService.swift
+++ b/Sources/PalmierPro/Agent/MCP/MCPService.swift
@@ -6,7 +6,7 @@ import MCP
 @MainActor
 final class MCPService {
 
-    static let port: UInt16 = 19789
+    nonisolated static let port: UInt16 = 19789
 
     private static let enabledKey = "io.palmier.pro.mcp.enabled"
 
@@ -27,30 +27,46 @@ final class MCPService {
     private let projectProvider: () -> VideoProject?
     @ObservationIgnored
     private var httpServer: MCPHTTPServer?
+    @ObservationIgnored
+    private var previewNotifyTask: Task<Void, Never>?
 
     init(projectProvider: @escaping () -> VideoProject?) {
         self.projectProvider = projectProvider
     }
 
     func start() {
-        let httpServer = MCPHTTPServer(port: Self.port) { [self] in
+        let httpServer = MCPHTTPServer(
+            port: Self.port,
+            previewMedia: { mediaRef in
+                await MainActor.run { Self.previewMediaFile(mediaRef: mediaRef) }
+            }
+        ) { [self] in
             let toolExecutor = await makeSessionToolExecutor()
             let server = Server(
                 name: "palmier-pro",
                 version: "1.0.0",
                 instructions: AgentInstructions.serverInstructions + AgentInstructions.projectNavigation,
                 capabilities: .init(
-                    resources: .init(subscribe: false, listChanged: false),
+                    resources: .init(subscribe: true, listChanged: false),
                     tools: .init(listChanged: true)
                 )
             )
             await Self.registerTools(on: server, executor: toolExecutor)
-            await Self.registerResources(on: server)
+            await Self.registerResources(on: server, executor: toolExecutor)
             return MCPServerInstance(server: server) { clientInfo in
                 await toolExecutor.setMCPClientInfo(MCPClientInfo(clientInfo))
             }
         }
         self.httpServer = httpServer
+        previewNotifyTask?.cancel()
+        previewNotifyTask = Task { [weak self] in
+            for await note in NotificationCenter.default.notifications(named: .generationAssetDidChange) {
+                guard !Task.isCancelled, let mediaRef = note.object as? String else { continue }
+                await self?.httpServer?.notifyResourceUpdated(
+                    uri: MCPPreviewApp.previewResourceURI(mediaRef: mediaRef)
+                )
+            }
+        }
         Task { @MainActor [weak self] in
             do {
                 try await httpServer.start()
@@ -68,6 +84,8 @@ final class MCPService {
     }
 
     func stop() {
+        previewNotifyTask?.cancel()
+        previewNotifyTask = nil
         if let server = httpServer {
             Task { await server.stop() }
         }
@@ -78,7 +96,12 @@ final class MCPService {
 
     nonisolated static func registerTools(on server: Server, executor: ToolExecutor) async {
         let tools: [Tool] = ToolDefinitions.mcpServer.map { def in
-            Tool(name: def.name.rawValue, description: def.description, inputSchema: def.mcpSchemaValue)
+            Tool(
+                name: def.name.rawValue,
+                description: def.description,
+                inputSchema: def.mcpSchemaValue,
+                _meta: MCPPreviewApp.meta(for: def.name)
+            )
         }
 
         await server.withMethodHandler(ListTools.self) { _ in
@@ -97,7 +120,7 @@ final class MCPService {
         return result.toMCPResult()
     }
 
-    private nonisolated static func registerResources(on server: Server) async {
+    private nonisolated static func registerResources(on server: Server, executor: ToolExecutor) async {
         let resources = [
             Resource(
                 name: "Video Models",
@@ -111,6 +134,7 @@ final class MCPService {
                 description: "Available AI image generation models and their capabilities",
                 mimeType: "application/json"
             ),
+            MCPPreviewApp.resource,
         ]
 
         await server.withMethodHandler(ListResources.self) { _ in
@@ -118,12 +142,19 @@ final class MCPService {
         }
 
         await server.withMethodHandler(ReadResource.self) { params in
-            await Self.readResource(uri: params.uri)
+            await Self.readResource(uri: params.uri, executor: executor)
+        }
+
+        await server.withMethodHandler(ResourceSubscribe.self) { _ in
+            Empty()
+        }
+        await server.withMethodHandler(ResourceUnsubscribe.self) { _ in
+            Empty()
         }
     }
 
     @MainActor
-    private static func readResource(uri: String) -> ReadResource.Result {
+    private static func readResource(uri: String, executor: ToolExecutor) async -> ReadResource.Result {
         switch uri {
         case "palmier://models/video":
             let json = ToolExecutor.jsonString(VideoModelConfig.allModels.map { ToolExecutor.videoModelInfo($0) }) ?? "[]"
@@ -131,9 +162,60 @@ final class MCPService {
         case "palmier://models/image":
             let json = ToolExecutor.jsonString(ImageModelConfig.allModels.map { ToolExecutor.imageModelInfo($0) }) ?? "[]"
             return .init(contents: [.text(json, uri: uri, mimeType: "application/json")])
+        case MCPPreviewApp.resourceURI:
+            return .init(contents: [
+                .text(MCPPreviewApp.html, uri: uri, mimeType: MCPPreviewApp.mimeType, _meta: MCPPreviewApp.resourceMeta)
+            ])
         default:
+            if let mediaRef = MCPPreviewApp.previewResourceMediaRef(uri) {
+                let json = await executor.generationPreviewJSON(mediaRef: mediaRef)
+                return .init(contents: [.text(json, uri: uri, mimeType: "application/json")])
+            }
+            if let mediaRef = MCPPreviewApp.generationMediaRef(uri) {
+                return await Self.readGenerationMedia(uri: uri, mediaRef: mediaRef)
+            }
+            if let iconKey = MCPPreviewApp.modelIconKey(uri) {
+                let png = await Task.detached(priority: .utility) {
+                    MCPPreviewApp.modelIconPNG(iconKey: iconKey)
+                }.value
+                if let png {
+                    return .init(contents: [
+                        .binary(png, uri: uri, mimeType: "image/png")
+                    ])
+                }
+            }
             return .init(contents: [.text("Unknown resource: \(uri)", uri: uri)])
         }
+    }
+
+    @MainActor
+    private static func readGenerationMedia(uri: String, mediaRef: String) async -> ReadResource.Result {
+        guard let file = previewMediaFile(mediaRef: mediaRef) else {
+            return .init(contents: [])
+        }
+        let loaded = await Task.detached(priority: .userInitiated) { () -> Data? in
+            let values = try? file.url.resourceValues(forKeys: [.fileSizeKey])
+            let size = values?.fileSize ?? 0
+            guard size > 0, size <= MCPPreviewApp.maxHTTPMediaBytes else { return nil }
+            return try? Data(contentsOf: file.url)
+        }.value
+        guard let data = loaded else {
+            return .init(contents: [])
+        }
+        return .init(contents: [.binary(data, uri: uri, mimeType: file.mimeType)])
+    }
+
+    @MainActor
+    private static func previewMediaFile(mediaRef: String) -> (url: URL, mimeType: String)? {
+        guard MCPPreviewApp.isPreviewMediaRef(mediaRef) else { return nil }
+        for project in AppState.shared.openProjects {
+            guard let asset = project.editorViewModel.mediaAssets.first(where: { $0.id == mediaRef }) else {
+                continue
+            }
+            guard asset.generationStatus == .none else { return nil }
+            return (asset.url, MCPPreviewApp.httpMediaMIMEType(url: asset.url, type: asset.type))
+        }
+        return nil
     }
 
 }

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -34,7 +34,8 @@ enum AgentInstructions {
           summaries — restyle whole groups from that alone; captionDetail=true (windowed) \
           only to touch individual caption clips.
         - After a batch of edits, spot-check the result: get_timeline for structure, \
-          inspect_timeline when placement, layout, captions, or stacking matter.
+          inspect_timeline for stills at a frame, show_timeline to play the cut (pass \
+          startFrame/endFrame on long timelines; several timelineIds to compare variants).
         - Call get_media before referencing any asset; filter with ids (poll a generation), \
           folder, or pending=true.
         - Call list_models before any generate_* or upscale call. If get_timeline says \

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -10,6 +10,8 @@ enum ToolName: String, CaseIterable, Sendable {
     case inspectTimeline = "inspect_timeline"
     case createTimeline = "create_timeline"
     case setActiveTimeline = "set_active_timeline"
+    case showTimeline = "show_timeline"
+    case revealTimeline = "reveal_timeline"
     case manageMarkers = "manage_markers"
     case setProjectSettings = "set_project_settings"
     case exportProject = "export_project"
@@ -67,6 +69,8 @@ enum ToolName: String, CaseIterable, Sendable {
     case generateVideo = "generate_video"
     case generateImage = "generate_image"
     case generateAudio = "generate_audio"
+    case getGenerationPreview = "get_generation_preview"
+    case revealGenerationMedia = "reveal_generation_media"
     case upscaleMedia = "upscale_media"
 
     // Meta
@@ -112,6 +116,22 @@ enum ToolDefinitions {
                 properties: [
                     "name": ["type": "string", "description": "Optional display name. Defaults to 'Timeline N', or '<source> copy' when duplicating."],
                     "from": ["type": "string", "description": "Optional timelineId to duplicate instead of creating empty."],
+                ]
+            )
+        ),
+        AgentTool(
+            name: .showTimeline,
+            description: "Plays the composited timeline as video in the conversation — what the user would see in Palmier's preview, including stacked tracks, transforms, text, and captions. Use this after a batch of edits, or to compare variants, so the user can watch the cut without leaving chat. inspect_timeline is stills at specific frames; this is the moving picture.\n\nOmit timelineIds to show the active timeline. Pass several timelineIds (variant A/B/C) to show them side by side in one call. startFrame/endFrame (half-open timeline frames from get_timeline) select a range; do that on long timelines — the preview is capped at 20 seconds and reports the window it actually rendered. Returns immediately; the card fills in when Palmier finishes rendering.",
+            inputSchema: objectSchema(
+                properties: [
+                    "timelineIds": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description": "Optional. Timeline ids from get_media. Default: the active timeline. Max 6.",
+                    ],
+                    "timelineId": ["type": "string", "description": "Optional. Single timeline id; same as timelineIds with one entry."],
+                    "startFrame": ["type": "integer", "description": "Optional. Range start (inclusive). Default 0."],
+                    "endFrame": ["type": "integer", "description": "Optional. Range end (exclusive). Default: end of that timeline, capped at 20 seconds from startFrame."],
                 ]
             )
         ),
@@ -1059,7 +1079,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .generateVideo,
-            description: "Starts an async AI video generation. Returns a placeholder asset ID immediately; generation runs in the background and the asset becomes usable in add_clips once ready. Costs real money and is not undoable.",
+            description: "Starts an async AI video generation and returns a placeholder asset ID immediately so multiple generations can run at once. In MCP Apps hosts, an inline preview card appears and fills in when Palmier finishes. Costs real money and is not undoable.",
             inputSchema: objectSchema(
                 properties: [
                     "prompt": ["type": "string", "description": "Text description of the video to generate. Optional for transforms such as lip sync that do not use a prompt."],
@@ -1083,7 +1103,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .generateImage,
-            description: "Starts an async AI image generation. Returns a placeholder asset ID immediately; generation runs in the background. Costs real money and is not undoable.",
+            description: "Starts an async AI image generation and returns a placeholder asset ID immediately so multiple generations can run at once. In MCP Apps hosts, an inline preview card appears and fills in when Palmier finishes. Costs real money and is not undoable.",
             inputSchema: objectSchema(
                 properties: [
                     "prompt": ["type": "string", "description": "Text description of the image to generate"],
@@ -1100,7 +1120,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .generateAudio,
-            description: "Starts an async AI audio generation or transformation. Returns a placeholder asset ID immediately; the asset appears in get_media and becomes usable in add_clips once ready. TTS converts text into speech. Generative audio models create dialogue, music, or sound effects from a prompt, video, or supported image/audio references. Voice Cleanup isolates speech from background audio. Dubbing translates source speech while preserving speaker delivery; pass targetLanguage. For models whose inputs include audio or video, provide sourceMediaRef. Video-to-audio scoring models also accept videoSourceStartFrame+videoSourceEndFrame and place the result on the timeline automatically. Other results land in the media library for placement with add_clips. Use list_models with type='audio' to inspect inputs, category, voices, reference caps, and limits. Costs real money and is not undoable.",
+            description: "Starts an async AI audio generation or transformation and returns a placeholder asset ID immediately so multiple generations can run at once. In MCP Apps hosts, an inline preview card appears and fills in when Palmier finishes. TTS converts text into speech. Generative audio models create dialogue, music, or sound effects from a prompt, video, or supported image/audio references. Voice Cleanup isolates speech from background audio. Dubbing translates source speech while preserving speaker delivery; pass targetLanguage. For models whose inputs include audio or video, provide sourceMediaRef. Video-to-audio scoring models also accept videoSourceStartFrame+videoSourceEndFrame and place the result on the timeline automatically. Other results land in the media library for placement with add_clips. Use list_models with type='audio' to inspect inputs, category, voices, reference caps, and limits. Costs real money and is not undoable.",
             inputSchema: objectSchema(
                 properties: [
                     "prompt": ["type": "string", "description": "Required for text-driven models. TTS uses it as spoken text; generative audio models use it as the scene, music, or sound description. Omit for Voice Cleanup and Dubbing."],
@@ -1241,7 +1261,44 @@ enum ToolDefinitions {
         )
     )
 
-    static var mcpServer: [AgentTool] { all + [manageProject] }
+    /// MCP Apps preview poller. Hidden from the model.
+    static let getGenerationPreview = AgentTool(
+        name: .getGenerationPreview,
+        description: "Called by the generation preview UI to load a thumbnail or playable media once Palmier finishes generating. Do not call this from the conversation.",
+        inputSchema: objectSchema(
+            properties: [
+                "mediaRef": ["type": "string", "description": "Placeholder asset ID returned by generate_image, generate_video, or generate_audio."],
+                "includeMedia": ["type": "boolean", "description": "When true, include playable video or audio bytes once the file is ready."],
+            ],
+            required: ["mediaRef"]
+        )
+    )
+
+    /// MCP Apps Finder control. Hidden from the model.
+    static let revealGenerationMedia = AgentTool(
+        name: .revealGenerationMedia,
+        description: "Called by the generation preview UI to reveal the generated file in Finder. Do not call this from the conversation.",
+        inputSchema: objectSchema(
+            properties: [
+                "mediaRef": ["type": "string", "description": "Asset ID from generate_image, generate_video, or generate_audio."],
+            ],
+            required: ["mediaRef"]
+        )
+    )
+
+    /// MCP Apps "View in Palmier" control. Hidden from the model.
+    static let revealTimeline = AgentTool(
+        name: .revealTimeline,
+        description: "Called by the timeline preview UI to activate that timeline in Palmier Pro. Do not call this from the conversation.",
+        inputSchema: objectSchema(
+            properties: [
+                "timelineId": ["type": "string", "description": "Timeline id from show_timeline."],
+            ],
+            required: ["timelineId"]
+        )
+    )
+
+    static var mcpServer: [AgentTool] { all + [manageProject, getGenerationPreview, revealGenerationMedia, revealTimeline] }
     static var inAppAgent: [AgentTool] { all + [readSkill, manageSkills] }
 
     private static func textTransformProperties() -> [String: [String: Any]] {

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Generate.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 import Foundation
 
@@ -52,7 +53,20 @@ extension ToolExecutor {
                 ) else {
                     throw ToolError("Asset '\(mediaRef)' is not a completed enhanceable draft.")
                 }
-                return .ok("Draft enhancement started. Placeholder asset ID: \(placeholderId)")
+                let input = draft.generationInput
+                let model = input.flatMap { id in VideoModelConfig.allModels.first { $0.id == id.model } }
+                return generationPreviewReceipt(
+                    message: "Draft enhancement started. Placeholder asset ID: \(placeholderId)",
+                    mediaRef: placeholderId,
+                    kind: "video",
+                    prompt: input?.prompt ?? "",
+                    displayName: model?.displayName ?? "Enhance draft",
+                    iconKey: model?.entry.providerIconKey,
+                    aspectRatio: input?.aspectRatio,
+                    duration: input?.duration,
+                    resolution: input?.resolution,
+                    credits: input.flatMap { CostEstimator.cost(for: $0) }
+                )
             }
             let modelId = try args.string("model") ?? defaultModelId(
                 VideoModelConfig.allModels.map { (id: $0.id, paidOnly: $0.paidOnly) }, kind: "video")
@@ -160,7 +174,18 @@ extension ToolExecutor {
             editor: editor
         )
         let draftSummary = draft ? ", draft: true" : ""
-        return .ok("Edit started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), source: \(sourceAsset.name)\(draftSummary)")
+        return generationPreviewReceipt(
+            message: "Edit started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), source: \(sourceAsset.name)\(draftSummary)",
+            mediaRef: placeholderId,
+            kind: "video",
+            prompt: prompt,
+            displayName: model.displayName,
+            iconKey: model.entry.providerIconKey,
+            aspectRatio: aspectRatio,
+            duration: duration,
+            resolution: resolution,
+            credits: CostEstimator.cost(for: genInput)
+        )
     }
 
     private func generateVideoText(
@@ -238,7 +263,18 @@ extension ToolExecutor {
             ? ", refs: \(imageRefCount)img/\(videoRefCount)vid/\(audioRefCount)aud"
             : ""
         let draftSummary = draft ? ", draft: true" : ""
-        return .ok("Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), duration: \(duration)s, aspect: \(aspectRatio)\(refSummary)\(draftSummary)")
+        return generationPreviewReceipt(
+            message: "Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), duration: \(duration)s, aspect: \(aspectRatio)\(refSummary)\(draftSummary)",
+            mediaRef: placeholderId,
+            kind: "video",
+            prompt: prompt,
+            displayName: model.displayName,
+            iconKey: model.entry.providerIconKey,
+            aspectRatio: aspectRatio,
+            duration: duration,
+            resolution: resolution,
+            credits: CostEstimator.cost(for: genInput)
+        )
     }
 
     private func referenceAssets(
@@ -296,7 +332,17 @@ extension ToolExecutor {
             projectURL: editor.projectURL,
             editor: editor
         )
-        return .ok("Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), aspect: \(aspectRatio)")
+        return generationPreviewReceipt(
+            message: "Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), aspect: \(aspectRatio)",
+            mediaRef: placeholderId,
+            kind: "image",
+            prompt: prompt,
+            displayName: model.displayName,
+            iconKey: model.entry.providerIconKey,
+            aspectRatio: aspectRatio,
+            resolution: resolution,
+            credits: CostEstimator.cost(for: genInput)
+        )
     }
 
     func generateAudio(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
@@ -462,7 +508,16 @@ extension ToolExecutor {
                 )
                 return placeholderId
             }
-            return .ok("Generation started and placed on the timeline at frame \(startFrame). Placeholder asset ID: \(placeholderId). Model: \(model.displayName), \(model.category.label) (scored from video).")
+            return generationPreviewReceipt(
+                message: "Generation started and placed on the timeline at frame \(startFrame). Placeholder asset ID: \(placeholderId). Model: \(model.displayName), \(model.category.label) (scored from video).",
+                mediaRef: placeholderId,
+                kind: "audio",
+                prompt: prompt,
+                displayName: model.displayName,
+                iconKey: model.entry.providerIconKey,
+                duration: durationSeconds,
+                credits: CostEstimator.cost(for: genInput)
+            )
         }
 
         let placeholderId = submission.submit(
@@ -471,7 +526,16 @@ extension ToolExecutor {
             editor: editor
         )
         let sourceNote = sourceAsset != nil || videoURL != nil ? " (from source media)" : ""
-        return .ok("Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), \(model.category.label)\(sourceNote). Place it with add_clips.")
+        return generationPreviewReceipt(
+            message: "Generation started. Placeholder asset ID: \(placeholderId). Model: \(model.displayName), \(model.category.label)\(sourceNote). Place it with add_clips.",
+            mediaRef: placeholderId,
+            kind: "audio",
+            prompt: prompt,
+            displayName: model.displayName,
+            iconKey: model.entry.providerIconKey,
+            duration: durationSeconds,
+            credits: CostEstimator.cost(for: genInput)
+        )
     }
 
     func upscaleMedia(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
@@ -749,5 +813,299 @@ extension ToolExecutor {
         }
         info["settings"] = selects + numbers + toggles
         return info
+    }
+
+    private func generationPreviewReceipt(
+        message: String,
+        mediaRef: String,
+        kind: String,
+        prompt: String,
+        displayName: String,
+        iconKey: String?,
+        aspectRatio: String? = nil,
+        duration: Int? = nil,
+        resolution: String? = nil,
+        credits: Int? = nil
+    ) -> ToolResult {
+        guard Analytics.origin?.source == "mcp" else { return .ok(message) }
+        let group = registerMCPPreviewBurst(kind: kind, mediaRef: mediaRef)
+        var payload: [String: Any] = [
+            "kind": kind,
+            "mediaRef": mediaRef,
+            "message": message,
+            "model": displayName,
+            "previewUri": MCPPreviewApp.previewResourceURI(mediaRef: mediaRef),
+            "prompt": prompt,
+            "status": "generating",
+            "groupRole": group.role,
+            "groupMembers": group.members,
+        ]
+        if let iconKey, !iconKey.isEmpty { payload["modelIconKey"] = iconKey }
+        if let aspectRatio, !aspectRatio.isEmpty { payload["aspectRatio"] = aspectRatio }
+        if let duration, duration > 0 { payload["duration"] = duration }
+        if let resolution, !resolution.isEmpty { payload["resolution"] = resolution }
+        if let credits { payload["credits"] = credits }
+        return .ok(Self.jsonString(payload) ?? message)
+    }
+
+    static let groupedPreviewKinds: Set<String> = ["image", "video"]
+
+    func registerMCPPreviewBurst(kind: String, mediaRef: String) -> (role: String, members: [String]) {
+        if Self.groupedPreviewKinds.contains(kind), mcpPreviewBurstKind == kind {
+            mcpPreviewBurstMediaRefs.append(mediaRef)
+        } else {
+            mcpPreviewBurstKind = kind
+            mcpPreviewBurstMediaRefs = [mediaRef]
+        }
+        let members = mcpPreviewBurstMediaRefs
+        let isMember = Self.groupedPreviewKinds.contains(kind)
+            && members.count > 1
+            && mediaRef != members.first
+        if isMember, let host = members.first {
+            NotificationCenter.default.post(name: .generationAssetDidChange, object: host)
+        }
+        return (isMember ? "member" : "host", members)
+    }
+
+    func mcpPreviewGroup(for mediaRef: String) -> (role: String, members: [String])? {
+        guard let index = mcpPreviewBurstMediaRefs.firstIndex(of: mediaRef) else { return nil }
+        let groups = mcpPreviewBurstKind.map { Self.groupedPreviewKinds.contains($0) } ?? false
+        let members = groups ? mcpPreviewBurstMediaRefs : [mediaRef]
+        let isMember = groups && members.count > 1 && index > 0
+        return (isMember ? "member" : "host", members)
+    }
+
+    func getGenerationPreview(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["mediaRef", "includeMedia"], path: "get_generation_preview")
+        let mediaRef = try args.requireString("mediaRef")
+        let includeMedia = args.bool("includeMedia") ?? false
+        return .ok(await generationPreviewJSON(mediaRef: mediaRef, includeMedia: includeMedia, editor: editor))
+    }
+
+    func revealGenerationMedia(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["mediaRef"], path: "reveal_generation_media")
+        let mediaRef = try args.requireString("mediaRef")
+        let asset = try asset(mediaRef, editor: editor)
+        let url = asset.url
+        let exists = await Task.detached(priority: .userInitiated) {
+            FileManager.default.fileExists(atPath: url.path)
+        }.value
+        guard exists else {
+            throw ToolError("Generated file is not on disk yet.")
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+        return .ok(#"{"revealed":true}"#)
+    }
+
+    func generationPreviewJSON(
+        mediaRef: String,
+        includeMedia: Bool = false,
+        editor: EditorViewModel? = nil
+    ) async -> String {
+        if let json = await timelinePreviewJSON(mediaRef: mediaRef, includeMedia: includeMedia) {
+            return json
+        }
+        let payload = await generationPreviewPayload(
+            mediaRef: mediaRef,
+            includeMedia: includeMedia,
+            editor: editor ?? self.editor
+        )
+        return Self.jsonString(payload) ?? #"{"status":"missing"}"#
+    }
+
+    private func generationPreviewPayload(
+        mediaRef: String,
+        includeMedia: Bool,
+        editor: EditorViewModel?
+    ) async -> [String: Any] {
+        guard let editor, let asset = editor.mediaAssets.first(where: { $0.id == mediaRef }) else {
+            return ["mediaRef": mediaRef, "status": "missing"]
+        }
+        var payload: [String: Any] = [
+            "kind": asset.type.rawValue,
+            "mediaRef": mediaRef,
+        ]
+        if let group = mcpPreviewGroup(for: mediaRef) {
+            payload["groupRole"] = group.role
+            payload["groupMembers"] = group.members
+        }
+        if let input = asset.generationInput {
+            if !input.prompt.isEmpty { payload["prompt"] = input.prompt }
+            if !input.aspectRatio.isEmpty { payload["aspectRatio"] = input.aspectRatio }
+            if let resolution = input.resolution, !resolution.isEmpty {
+                payload["resolution"] = resolution
+            }
+            payload["model"] = ModelRegistry.displayName(for: input.model)
+            if let iconKey = providerIconKey(for: input.model), !iconKey.isEmpty {
+                payload["modelIconKey"] = iconKey
+            }
+            if let credits = CostEstimator.cost(for: input) {
+                payload["credits"] = credits
+            }
+        }
+        let duration = asset.resolvedDuration
+        if (asset.type == .video || asset.type == .audio), duration > 0 {
+            payload["duration"] = duration
+        }
+
+        switch asset.generationStatus {
+        case .failed(let message):
+            payload["status"] = "failed"
+            payload["error"] = message
+            return payload
+        case .preparing:
+            payload["status"] = "generating"
+            payload["phase"] = "preparing"
+            return payload
+        case .generating:
+            payload["status"] = "generating"
+            payload["phase"] = "generating"
+            return payload
+        case .downloading:
+            payload["status"] = "generating"
+            payload["phase"] = "downloading"
+            return payload
+        case .rendering:
+            payload["status"] = "generating"
+            payload["phase"] = "rendering"
+            return payload
+        case .none:
+            break
+        }
+
+        let url = asset.url
+        let type = asset.type
+        let encoded = await Task.detached(priority: .userInitiated) {
+            await Self.encodeGenerationPreview(url: url, type: type, includeMedia: includeMedia)
+        }.value
+        payload["status"] = encoded.fileExists ? "ready" : "generating"
+        if encoded.fileExists, asset.type == .video || asset.type == .audio {
+            payload["mediaUrl"] = MCPPreviewApp.httpMediaURL(mediaRef: mediaRef)
+            payload["mediaResourceUri"] = MCPPreviewApp.generationMediaURI(mediaRef: mediaRef)
+            payload["mimeType"] = MCPPreviewApp.httpMediaMIMEType(url: url, type: type)
+        }
+        if let preview = encoded.preview {
+            payload["preview"] = preview
+        }
+        if let audio = encoded.audio {
+            payload["audio"] = audio
+        }
+        if let media = encoded.media {
+            payload["media"] = media
+        }
+        return payload
+    }
+
+    private func providerIconKey(for modelId: String) -> String? {
+        switch ModelRegistry.byId[modelId] {
+        case .video(let model): model.entry.providerIconKey
+        case .image(let model): model.entry.providerIconKey
+        case .audio(let model): model.entry.providerIconKey
+        case .upscale(let model): model.entry.providerIconKey
+        case .none: nil
+        }
+    }
+
+    private struct EncodedGenerationPreview: Sendable {
+        var fileExists: Bool
+        var preview: [String: String]?
+        var audio: [String: String]?
+        var media: [String: String]?
+    }
+
+    private nonisolated static func encodeGenerationPreview(
+        url: URL,
+        type: ClipType,
+        includeMedia: Bool
+    ) async -> EncodedGenerationPreview {
+        let exists = FileManager.default.fileExists(atPath: url.path)
+        guard exists else {
+            return EncodedGenerationPreview(fileExists: false, preview: nil, audio: nil, media: nil)
+        }
+        let media = includeMedia ? inlinePlayableMedia(url: url, type: type) : nil
+        switch type {
+        case .image:
+            guard let image = ImageEncoder.thumbnail(url: url, maxPixelSize: MCPPreviewApp.previewMaxPixelSize),
+                  let data = ImageEncoder.encodeJPEG(image, quality: 0.7)
+            else {
+                return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: nil)
+            }
+            return EncodedGenerationPreview(
+                fileExists: true,
+                preview: ["mimeType": "image/jpeg", "data": data.base64EncodedString()],
+                audio: nil,
+                media: nil
+            )
+        case .video:
+            if includeMedia {
+                return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: media)
+            }
+            guard let data = await videoPosterJPEG(url: url) else {
+                return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: nil)
+            }
+            return EncodedGenerationPreview(
+                fileExists: true,
+                preview: ["mimeType": "image/jpeg", "data": data.base64EncodedString()],
+                audio: nil,
+                media: nil
+            )
+        case .audio:
+            if includeMedia {
+                return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: media)
+            }
+            guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+                  let size = values.fileSize,
+                  size > 0,
+                  size <= MCPPreviewApp.maxAudioPreviewBytes,
+                  let data = try? Data(contentsOf: url)
+            else {
+                return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: nil)
+            }
+            return EncodedGenerationPreview(
+                fileExists: true,
+                preview: nil,
+                audio: ["mimeType": audioMIMEType(url: url), "data": data.base64EncodedString()],
+                media: nil
+            )
+        default:
+            return EncodedGenerationPreview(fileExists: true, preview: nil, audio: nil, media: nil)
+        }
+    }
+
+    private nonisolated static func inlinePlayableMedia(url: URL, type: ClipType) -> [String: String]? {
+        guard type == .video || type == .audio else { return nil }
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+              let size = values.fileSize,
+              size > 0,
+              size <= MCPPreviewApp.maxInlineMediaBytes,
+              let data = try? Data(contentsOf: url)
+        else { return nil }
+        return [
+            "mimeType": MCPPreviewApp.httpMediaMIMEType(url: url, type: type),
+            "data": data.base64EncodedString(),
+        ]
+    }
+
+    private nonisolated static func videoPosterJPEG(url: URL) async -> Data? {
+        let asset = AVURLAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(
+            width: MCPPreviewApp.previewMaxPixelSize,
+            height: MCPPreviewApp.previewMaxPixelSize
+        )
+        let time = CMTime(seconds: 0.1, preferredTimescale: 600)
+        guard let cgImage = try? await generator.image(at: time).image else { return nil }
+        return ImageEncoder.encodeJPEG(cgImage, quality: 0.7)
+    }
+
+    private nonisolated static func audioMIMEType(url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "wav": "audio/wav"
+        case "m4a", "aac": "audio/mp4"
+        case "ogg": "audio/ogg"
+        case "flac": "audio/flac"
+        default: "audio/mpeg"
+        }
     }
 }

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShortId.swift
@@ -12,7 +12,7 @@ extension ToolExecutor {
         "groupId", "memberId", "markerId",
     ]
     private static let arrayIdKeys: Set<String> = [
-        "clipIds", "targetClipIds", "items", "ids", "deletes",
+        "clipIds", "targetClipIds", "items", "ids", "deletes", "timelineIds",
         "referenceMediaRefs", "referenceImageMediaRefs",
         "referenceVideoMediaRefs", "referenceAudioMediaRefs",
     ]
@@ -57,7 +57,7 @@ extension ToolExecutor {
         guard !map.isEmpty else { return result }
         let uuidRegex = /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/
         let content = result.content.map { block -> ToolResult.Block in
-            guard case .text(let s) = block else { return block }
+            guard case .text(let s) = block, s.count < 250_000 else { return block }
             return .text(s.replacing(uuidRegex) { map[String($0.output)] ?? String($0.output) })
         }
         return ToolResult(content: content, isError: result.isError)

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShowTimeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+ShowTimeline.swift
@@ -1,0 +1,288 @@
+import AppKit
+import Foundation
+
+struct TimelinePreviewJob {
+    var id: String
+    var timelineId: String
+    var timelineName: String
+    var startFrame: Int
+    var endFrame: Int
+    var fps: Int
+    var width: Int
+    var height: Int
+    var windowed: Bool
+    var groupMembers: [String]
+    var status: String
+    var error: String?
+    var fileURL: URL?
+}
+
+extension ToolExecutor {
+    static let timelinePreviewMaxSeconds = 20
+    static let timelinePreviewMaxCount = 6
+    static let timelinePreviewShortSide = 720
+    private static let timelinePreviewJobCap = 24
+
+    struct TimelinePreviewWindow: Equatable {
+        var startFrame: Int
+        var endFrame: Int
+        var windowed: Bool
+    }
+
+    static func timelinePreviewWindow(
+        totalFrames: Int,
+        fps: Int,
+        startFrame: Int?,
+        endFrame: Int?
+    ) throws -> TimelinePreviewWindow {
+        guard totalFrames > 0 else {
+            throw ToolError("Timeline is empty.")
+        }
+        let start = startFrame ?? 0
+        guard start >= 0 else {
+            throw ToolError("startFrame must be >= 0.")
+        }
+        guard start < totalFrames else {
+            throw ToolError("startFrame \(start) is past the end of the timeline (\(totalFrames) frames).")
+        }
+        let requestedEnd = endFrame ?? totalFrames
+        guard requestedEnd > start else {
+            throw ToolError("endFrame must be greater than startFrame.")
+        }
+        let clampedEnd = min(requestedEnd, totalFrames)
+        let maxFrames = max(1, fps) * timelinePreviewMaxSeconds
+        if clampedEnd - start > maxFrames {
+            return TimelinePreviewWindow(startFrame: start, endFrame: start + maxFrames, windowed: true)
+        }
+        return TimelinePreviewWindow(startFrame: start, endFrame: clampedEnd, windowed: false)
+    }
+
+    static func aspectRatioLabel(width: Int, height: Int) -> String {
+        let d = gcd(max(width, 1), max(height, 1))
+        return "\(width / d):\(height / d)"
+    }
+
+    func showTimeline(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(
+            args,
+            allowed: ["timelineIds", "timelineId", "startFrame", "endFrame"],
+            path: "show_timeline"
+        )
+        let ids = try resolvedShowTimelineIds(args, editor: editor)
+        let requestedStart = args.int("startFrame")
+        let requestedEnd = args.int("endFrame")
+
+        var jobs: [TimelinePreviewJob] = []
+        var warnings: [String] = []
+        for timelineId in ids {
+            guard let timeline = editor.timeline(for: timelineId) else {
+                throw ToolError("No timeline with id '\(timelineId)'. get_media lists the project's timelines.")
+            }
+            let window: TimelinePreviewWindow
+            do {
+                window = try Self.timelinePreviewWindow(
+                    totalFrames: timeline.totalFrames,
+                    fps: timeline.fps,
+                    startFrame: requestedStart,
+                    endFrame: requestedEnd
+                )
+            } catch let error as ToolError {
+                throw ToolError("\"\(timeline.name)\": \(error.message)")
+            }
+            if window.windowed {
+                warnings.append(
+                    "\"\(timeline.name)\" previewed frames [\(window.startFrame), \(window.endFrame)) (max \(Self.timelinePreviewMaxSeconds)s). Pass a smaller range to choose a different span."
+                )
+            }
+            jobs.append(
+                TimelinePreviewJob(
+                    id: UUID().uuidString,
+                    timelineId: timeline.id,
+                    timelineName: timeline.name,
+                    startFrame: window.startFrame,
+                    endFrame: window.endFrame,
+                    fps: max(1, timeline.fps),
+                    width: timeline.width,
+                    height: timeline.height,
+                    windowed: window.windowed,
+                    groupMembers: [],
+                    status: "generating",
+                    error: nil,
+                    fileURL: nil
+                )
+            )
+        }
+        let members = jobs.map(\.id)
+        for i in jobs.indices {
+            jobs[i].groupMembers = members
+            rememberTimelinePreview(jobs[i])
+        }
+        startTimelinePreviewRenders(jobs, editor: editor)
+
+        let host = jobs[0]
+        var payload = timelinePreviewPayload(host)
+        payload["message"] = jobs.count == 1
+            ? "Rendering \"\(host.timelineName)\"."
+            : "Rendering \(jobs.count) timelines."
+        payload["previews"] = jobs.map { timelinePreviewPayload($0) }
+        if !warnings.isEmpty { payload["warnings"] = warnings }
+        let json = Self.jsonString(payload) ?? "{}"
+        return .ok(json)
+    }
+
+    func revealTimeline(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: ["timelineId"], path: "reveal_timeline")
+        let timelineId = try args.requireString("timelineId")
+        guard editor.timeline(for: timelineId) != nil else {
+            throw ToolError("No timeline with id '\(timelineId)'.")
+        }
+        if editor.activeTimelineId != timelineId {
+            editor.activateTimeline(timelineId)
+        }
+        if let project = project(for: editor) {
+            AppState.shared.showEditor(for: project)
+            project.windowControllers.first?.window?.makeKeyAndOrderFront(nil)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        return .ok(#"{"activated":true}"#)
+    }
+
+    func timelinePreviewJSON(mediaRef: String, includeMedia: Bool) async -> String? {
+        guard let job = timelinePreviewJobs[mediaRef] else { return nil }
+        var payload = timelinePreviewPayload(job)
+        if includeMedia, job.status == "ready", let url = job.fileURL {
+            let media = await Task.detached(priority: .userInitiated) {
+                Self.inlinePlayableFile(url: url, mimeType: "video/mp4")
+            }.value
+            if let media { payload["media"] = media }
+        }
+        return Self.jsonString(payload)
+    }
+
+    private func resolvedShowTimelineIds(_ args: [String: Any], editor: EditorViewModel) throws -> [String] {
+        var ids = args.stringArray("timelineIds")
+        if let one = args.string("timelineId") { ids.insert(one, at: 0) }
+        if ids.isEmpty { ids = [editor.activeTimelineId] }
+        var seen = Set<String>()
+        ids = ids.filter { seen.insert($0).inserted }
+        guard !ids.isEmpty else {
+            throw ToolError("No timeline to show.")
+        }
+        if ids.count > Self.timelinePreviewMaxCount {
+            throw ToolError("show_timeline accepts at most \(Self.timelinePreviewMaxCount) timelines.")
+        }
+        return ids
+    }
+
+    private func rememberTimelinePreview(_ job: TimelinePreviewJob) {
+        timelinePreviewJobs[job.id] = job
+        timelinePreviewOrder.append(job.id)
+        while timelinePreviewOrder.count > Self.timelinePreviewJobCap {
+            let evicted = timelinePreviewOrder.removeFirst()
+            if let url = timelinePreviewJobs[evicted]?.fileURL {
+                let stale = url
+                Task.detached { try? FileManager.default.removeItem(at: stale) }
+            }
+            timelinePreviewJobs.removeValue(forKey: evicted)
+        }
+    }
+
+    private func startTimelinePreviewRenders(_ jobs: [TimelinePreviewJob], editor: EditorViewModel) {
+        let requests: [(job: TimelinePreviewJob, timeline: Timeline)] = jobs.compactMap { job in
+            guard let timeline = editor.timeline(for: job.timelineId) else { return nil }
+            return (job, timeline)
+        }
+        let resolver = editor.mediaResolver
+        let resolveTimeline = editor.timelineResolver()
+        let missing = editor.missingMediaRefs
+        timelinePreviewRenderTask = Task { @MainActor [weak self] in
+            for request in requests {
+                guard let self, !Task.isCancelled else { return }
+                do {
+                    let url = try await TimelineRenderer.render(
+                        timeline: request.timeline,
+                        resolver: resolver,
+                        resolveTimeline: resolveTimeline,
+                        missingMediaRefs: missing,
+                        startFrame: request.job.startFrame,
+                        frameCount: request.job.endFrame - request.job.startFrame,
+                        shortSide: Self.timelinePreviewShortSide
+                    )
+                    guard !Task.isCancelled else {
+                        try? FileManager.default.removeItem(at: url)
+                        return
+                    }
+                    self.completeTimelinePreview(id: request.job.id, url: url)
+                } catch is CancellationError {
+                    self.failTimelinePreview(id: request.job.id, message: "Cancelled")
+                } catch {
+                    self.failTimelinePreview(id: request.job.id, message: error.localizedDescription)
+                }
+                NotificationCenter.default.post(name: .generationAssetDidChange, object: request.job.id)
+            }
+        }
+    }
+
+    private func completeTimelinePreview(id: String, url: URL) {
+        guard var job = timelinePreviewJobs[id] else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+        if let previous = job.fileURL, previous != url {
+            let stale = previous
+            Task.detached { try? FileManager.default.removeItem(at: stale) }
+        }
+        job.status = "ready"
+        job.error = nil
+        job.fileURL = url
+        timelinePreviewJobs[id] = job
+    }
+
+    private func failTimelinePreview(id: String, message: String) {
+        guard var job = timelinePreviewJobs[id] else { return }
+        job.status = "failed"
+        job.error = message
+        timelinePreviewJobs[id] = job
+    }
+
+    private func timelinePreviewPayload(_ job: TimelinePreviewJob) -> [String: Any] {
+        let duration = Double(job.endFrame - job.startFrame) / Double(max(1, job.fps))
+        var payload: [String: Any] = [
+            "kind": "timeline",
+            "mediaRef": job.id,
+            "timelineId": job.timelineId,
+            "timelineName": job.timelineName,
+            "name": job.timelineName,
+            "status": job.status,
+            "phase": job.status == "generating" ? "rendering" : job.status,
+            "startFrame": job.startFrame,
+            "endFrame": job.endFrame,
+            "duration": duration,
+            "aspectRatio": Self.aspectRatioLabel(width: job.width, height: job.height),
+            "previewUri": MCPPreviewApp.previewResourceURI(mediaRef: job.id),
+            "groupRole": job.id == job.groupMembers.first ? "host" : "member",
+            "groupMembers": job.groupMembers,
+            "mimeType": "video/mp4",
+        ]
+        if job.windowed { payload["windowed"] = true }
+        if let error = job.error { payload["error"] = error }
+        return payload
+    }
+
+    private func project(for editor: EditorViewModel) -> VideoProject? {
+        if let sessionProject, sessionProject.editorViewModel === editor {
+            return sessionProject
+        }
+        return AppState.shared.openProjects.first { $0.editorViewModel === editor }
+    }
+
+    private nonisolated static func inlinePlayableFile(url: URL, mimeType: String) -> [String: String]? {
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+              let size = values.fileSize,
+              size > 0,
+              size <= MCPPreviewApp.maxInlineMediaBytes,
+              let data = try? Data(contentsOf: url)
+        else { return nil }
+        return ["mimeType": mimeType, "data": data.base64EncodedString()]
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -67,6 +67,11 @@ final class ToolExecutor {
 
     var feedbackState = FeedbackState()
     var lastTranscriptSession: TranscriptSession?
+    var mcpPreviewBurstKind: String?
+    var mcpPreviewBurstMediaRefs: [String] = []
+    var timelinePreviewJobs: [String: TimelinePreviewJob] = [:]
+    var timelinePreviewOrder: [String] = []
+    var timelinePreviewRenderTask: Task<Void, Never>?
 
     func execute(
         name: String,
@@ -249,7 +254,8 @@ final class ToolExecutor {
     private static func canReadInactiveProject(_ tool: ToolName) -> Bool {
         switch tool {
         case .getTimeline, .inspectTimeline, .getMedia, .inspectMedia, .searchMedia,
-             .getMulticam, .getTranscript, .detectBeats, .inspectColor, .listModels, .sendFeedback:
+             .getMulticam, .getTranscript, .detectBeats, .inspectColor, .listModels, .sendFeedback,
+             .getGenerationPreview, .revealGenerationMedia, .showTimeline, .revealTimeline:
             true
         default:
             false
@@ -354,6 +360,8 @@ final class ToolExecutor {
         case .generateVideo: return try generate(editor, args, type: .video)
         case .generateImage: return try generate(editor, args, type: .image)
         case .generateAudio: return try await generateAudio(editor, args)
+        case .getGenerationPreview: return try await getGenerationPreview(editor, args)
+        case .revealGenerationMedia: return try await revealGenerationMedia(editor, args)
         case .upscaleMedia:  return try upscaleMedia(editor, args)
         case .importMedia:   return try await importMedia(editor, args)
         case .listModels:    return listModels(args)
@@ -362,6 +370,8 @@ final class ToolExecutor {
         case .setProjectSettings: return try setProjectSettings(editor, args)
         case .createTimeline:     return try createTimeline(editor, args)
         case .setActiveTimeline:  return try setActiveTimeline(editor, args)
+        case .showTimeline:       return try showTimeline(editor, args)
+        case .revealTimeline:     return try revealTimeline(editor, args)
         case .manageMarkers:      return try manageMarkers(editor, args)
         case .readSkill:     return readSkill(args)
         case .manageSkills:  return try await manageSkills(args)

--- a/Sources/PalmierPro/App/AppNotifications.swift
+++ b/Sources/PalmierPro/App/AppNotifications.swift
@@ -2,6 +2,10 @@ import AppKit
 import Foundation
 import UserNotifications
 
+extension Notification.Name {
+    static let generationAssetDidChange = Notification.Name("io.palmier.pro.generationAssetDidChange")
+}
+
 @MainActor
 enum AppNotifications {
     private static let enabledKey = "io.palmier.pro.notifications.enabled"

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -407,6 +407,9 @@ final class GenerationService {
     ) {
         if let status {
             asset.generationStatus = status
+            if case .failed = status {
+                NotificationCenter.default.post(name: .generationAssetDidChange, object: asset.id)
+            }
         }
         if let mutateInput, var input = asset.generationInput {
             mutateInput(&input)
@@ -711,6 +714,7 @@ final class GenerationService {
             if await downloadAndFinalize(asset: placeholder, remoteURL: remote, editor: editor) {
                 onComplete?(placeholder)
                 finalized.append(placeholder)
+                NotificationCenter.default.post(name: .generationAssetDidChange, object: placeholder.id)
             }
         }
 

--- a/Tests/PalmierProTests/Agent/MCPPreviewAppTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPPreviewAppTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import PalmierPro
+
+struct MCPPreviewAppTests {
+    @Test func generateToolsDeclarePreviewResource() {
+        for name in [ToolName.generateImage, .generateVideo, .generateAudio, .showTimeline] {
+            guard case .object(let ui)? = MCPPreviewApp.meta(for: name)?["ui"] else {
+                Issue.record("\(name.rawValue) must declare _meta.ui")
+                continue
+            }
+            #expect(ui["resourceUri"] == .string(MCPPreviewApp.resourceURI))
+        }
+        #expect(MCPPreviewApp.resourceURI.hasPrefix("ui://"))
+        #expect(MCPPreviewApp.mimeType == "text/html;profile=mcp-app")
+    }
+
+    @Test func previewPollerIsAppVisibleOnly() {
+        guard case .object(let ui)? = MCPPreviewApp.meta(for: .getGenerationPreview)?["ui"] else {
+            Issue.record("get_generation_preview must declare app visibility")
+            return
+        }
+        #expect(ui["visibility"] == .array([.string("app")]))
+        #expect(ToolDefinitions.mcpServer.contains(where: { $0.name == .getGenerationPreview }))
+        #expect(!ToolDefinitions.inAppAgent.contains(where: { $0.name == .getGenerationPreview }))
+        #expect(!ToolDefinitions.all.contains(where: { $0.name == .getGenerationPreview }))
+        guard case .object(let revealUI)? = MCPPreviewApp.meta(for: .revealGenerationMedia)?["ui"] else {
+            Issue.record("reveal_generation_media must declare app visibility")
+            return
+        }
+        #expect(revealUI["visibility"] == .array([.string("app")]))
+        #expect(ToolDefinitions.mcpServer.contains(where: { $0.name == .revealGenerationMedia }))
+        #expect(!ToolDefinitions.inAppAgent.contains(where: { $0.name == .revealGenerationMedia }))
+        #expect(!ToolDefinitions.all.contains(where: { $0.name == .revealGenerationMedia }))
+        guard case .object(let timelineUI)? = MCPPreviewApp.meta(for: .revealTimeline)?["ui"] else {
+            Issue.record("reveal_timeline must declare app visibility")
+            return
+        }
+        #expect(timelineUI["visibility"] == .array([.string("app")]))
+        #expect(ToolDefinitions.mcpServer.contains(where: { $0.name == .revealTimeline }))
+        #expect(!ToolDefinitions.inAppAgent.contains(where: { $0.name == .revealTimeline }))
+        #expect(!ToolDefinitions.all.contains(where: { $0.name == .revealTimeline }))
+        #expect(ToolDefinitions.all.contains(where: { $0.name == .showTimeline }))
+    }
+
+    @Test func htmlWaitsForPalmierCompletion() {
+        let html = MCPPreviewApp.html
+        #expect(html.contains("ui/initialize"))
+        #expect(html.contains("get_generation_preview"))
+        #expect(html.contains("notifications/resources/updated"))
+        #expect(html.contains("modelIconKey"))
+        #expect(html.contains("aspectRatio"))
+        #expect(html.contains("duration"))
+        #expect(html.contains("resolution"))
+        #expect(html.contains("kind === \"audio\""))
+        #expect(html.contains("kind === \"video\""))
+        #expect(html.contains("mediaUrl"))
+        #expect(html.contains("credits"))
+        #expect(html.contains("groupRole"))
+        #expect(html.contains("groupMembers"))
+        #expect(html.contains("async function showResult"))
+        #expect(html.contains("async function applyReady"))
+        #expect(html.contains("mediaResourceUri"))
+        #expect(html.contains("prompt-drop"))
+        #expect(html.contains("<details"))
+        #expect(html.contains("includeMedia"))
+        #expect(html.contains("reveal_generation_media"))
+        #expect(html.contains("video.controls = true"))
+        #expect(html.contains("Show in Finder"))
+        #expect(html.contains("View in Palmier"))
+        #expect(html.contains("reveal_timeline"))
+        #expect(html.contains("kind === \"timeline\""))
+        #expect(html.contains("isBurstKind"))
+        #expect(html.contains("stage.portrait"))
+        #expect(html.contains("groupRole === \"host\" && mediaRef"))
+        #expect(html.contains("gallery"))
+        #expect(html.contains("collapsed"))
+    }
+
+    @Test func previewMediaRefRejectsUnsafePaths() {
+        #expect(MCPPreviewApp.isPreviewMediaRef("A1B2C3D4-E5F6-7890-ABCD-EF1234567890"))
+        #expect(!MCPPreviewApp.isPreviewMediaRef("../secret"))
+        #expect(!MCPPreviewApp.isPreviewMediaRef("short"))
+        #expect(!MCPPreviewApp.isPreviewMediaRef("has space-xxxxxxxx"))
+        #expect(!MCPPreviewApp.isPreviewMediaRef(""))
+    }
+
+    @Test func previewResourceAllowsLocalhostMedia() {
+        guard case .object(let ui) = MCPPreviewApp.resourceMeta["ui"],
+              case .object(let csp) = ui["csp"],
+              case .array(let connect) = csp["connectDomains"],
+              case .array(let resources) = csp["resourceDomains"]
+        else {
+            Issue.record("preview HTML must declare localhost CSP")
+            return
+        }
+        let origin = Value.string(MCPPreviewApp.previewOrigin)
+        #expect(connect == [origin])
+        #expect(resources.contains(origin))
+        #expect(resources.contains(.string("blob:")))
+        #expect(resources.contains(.string("data:")))
+        #expect(MCPPreviewApp.httpMediaURL(mediaRef: "asset-id").hasPrefix("http://127.0.0.1:19789/preview/"))
+        #expect(MCPPreviewApp.httpMediaMIMEType(url: URL(fileURLWithPath: "/tmp/clip.mp4"), type: .video) == "video/mp4")
+        #expect(MCPPreviewApp.httpMediaMIMEType(url: URL(fileURLWithPath: "/tmp/clip.mov"), type: .video) == "video/quicktime")
+        #expect(MCPPreviewApp.httpMediaMIMEType(url: URL(fileURLWithPath: "/tmp/clip.m4a"), type: .audio) == "audio/mp4")
+    }
+}

--- a/Tests/PalmierProTests/Agent/ShowTimelineToolTests.swift
+++ b/Tests/PalmierProTests/Agent/ShowTimelineToolTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+struct ShowTimelineToolTests {
+    @Test func emptyTimelineIsRejected() async {
+        let harness = ToolHarness()
+        let result = await harness.runRaw("show_timeline")
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).localizedCaseInsensitiveContains("empty"))
+    }
+
+    @Test func unknownTimelineIdIsRejected() async {
+        let clip = Fixtures.clip(start: 0, duration: 30)
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])]))
+        defer { harness.executor.timelinePreviewRenderTask?.cancel() }
+        let result = await harness.runRaw("show_timeline", args: ["timelineId": "missing-timeline-id"])
+        #expect(result.isError)
+        #expect(ToolHarness.textOf(result).localizedCaseInsensitiveContains("no timeline"))
+    }
+
+    @Test func windowCapsLongTimelinesAndReportsTheSpan() throws {
+        let window = try ToolExecutor.timelinePreviewWindow(
+            totalFrames: 30 * 60,
+            fps: 30,
+            startFrame: 0,
+            endFrame: nil
+        )
+        #expect(window.startFrame == 0)
+        #expect(window.endFrame == 30 * ToolExecutor.timelinePreviewMaxSeconds)
+        #expect(window.windowed)
+    }
+
+    @Test func requestedRangeIsPreservedWhenShort() throws {
+        let window = try ToolExecutor.timelinePreviewWindow(
+            totalFrames: 900,
+            fps: 30,
+            startFrame: 90,
+            endFrame: 150
+        )
+        #expect(window.startFrame == 90)
+        #expect(window.endFrame == 150)
+        #expect(!window.windowed)
+    }
+
+    @Test func aspectRatioUsesLowestTerms() {
+        #expect(ToolExecutor.aspectRatioLabel(width: 1920, height: 1080) == "16:9")
+        #expect(ToolExecutor.aspectRatioLabel(width: 1080, height: 1920) == "9:16")
+    }
+
+    @Test func returnsGeneratingReceiptForActiveTimeline() async throws {
+        let clip = Fixtures.clip(start: 0, duration: 45)
+        var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        timeline.name = "Variant A"
+        let harness = ToolHarness(timeline: timeline)
+        defer { harness.executor.timelinePreviewRenderTask?.cancel() }
+
+        let payload = try await harness.runOK("show_timeline") as? [String: Any]
+        #expect(payload?["kind"] as? String == "timeline")
+        #expect(payload?["status"] as? String == "generating")
+        #expect(payload?["timelineName"] as? String == "Variant A")
+        let timelineId = try #require(payload?["timelineId"] as? String)
+        #expect(harness.editor.activeTimelineId.hasPrefix(timelineId))
+        #expect((payload?["mediaRef"] as? String)?.isEmpty == false)
+    }
+
+    @Test func multipleTimelineIdsShareOneGroup() async throws {
+        let clip = Fixtures.clip(start: 0, duration: 30)
+        var first = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [clip])])
+        first.name = "A"
+        let harness = ToolHarness(timeline: first)
+        defer { harness.executor.timelinePreviewRenderTask?.cancel() }
+        let secondId = harness.editor.createTimeline(name: "B")
+        harness.editor.timeline = {
+            var copy = harness.editor.timeline
+            copy.tracks = [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])]
+            return copy
+        }()
+
+        let payload = try await harness.runOK("show_timeline", args: [
+            "timelineIds": [first.id, secondId],
+        ]) as? [String: Any]
+        let members = payload?["groupMembers"] as? [String]
+        #expect(members?.count == 2)
+        #expect(payload?["kind"] as? String == "timeline")
+        let previews = payload?["previews"] as? [[String: Any]]
+        #expect(previews?.count == 2)
+        let names = Set(previews?.compactMap { $0["timelineName"] as? String } ?? [])
+        #expect(names == ["A", "B"])
+    }
+
+    @Test func consecutiveVideoGensShareOneBurst() {
+        let harness = ToolHarness()
+        let first = harness.executor.registerMCPPreviewBurst(kind: "video", mediaRef: "v1")
+        #expect(first.role == "host")
+        #expect(first.members == ["v1"])
+        let second = harness.executor.registerMCPPreviewBurst(kind: "video", mediaRef: "v2")
+        #expect(second.role == "member")
+        #expect(second.members == ["v1", "v2"])
+        #expect(harness.executor.mcpPreviewGroup(for: "v1")?.role == "host")
+        #expect(harness.executor.mcpPreviewGroup(for: "v1")?.members == ["v1", "v2"])
+        let image = harness.executor.registerMCPPreviewBurst(kind: "image", mediaRef: "i1")
+        #expect(image.role == "host")
+        #expect(image.members == ["i1"])
+    }
+
+    @Test func audioDoesNotJoinAVideoBurst() {
+        let harness = ToolHarness()
+        _ = harness.executor.registerMCPPreviewBurst(kind: "video", mediaRef: "v1")
+        let audio = harness.executor.registerMCPPreviewBurst(kind: "audio", mediaRef: "a1")
+        #expect(audio.role == "host")
+        #expect(audio.members == ["a1"])
+    }
+}


### PR DESCRIPTION
Idea: most edits won't require you to context switch between claude <> timeline. But if you need to make finer grain edits, you can always go into the timeline.

AI Gen: see the generting in the chat and associated metadata. one click to go the media in finder
Real footage: preview timelines and segments of timeline

I.e. "Create four different UGC ads and then assemble them in the timeline and show me them"
1. Create characters and videos

https://github.com/user-attachments/assets/4b06b7a1-c761-49b7-815b-464cc4865762


3. Autonomously assemble multiple timelines and then presetn all four versions for review.

https://github.com/user-attachments/assets/bacc8325-b0f8-48e2-9fcc-9afcc8991040

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new MCP surface (localhost media HTTP, resource subscriptions, async renders) though bound to 127.0.0.1 with validated refs and size limits; generation tool receipts change MCP response shape.
> 
> **Overview**
> Adds **MCP Apps** inline preview cards in MCP chat hosts so users can watch AI generations and rendered timelines without leaving the conversation.
> 
> **Generation previews:** `generate_image`, `generate_video`, and `generate_audio` now attach UI metadata and return structured JSON (model, prompt, credits, `previewUri`) when the call originates from MCP. A bundled HTML app polls `get_generation_preview`, reacts to resource-update notifications, and shows progress, thumbnails, and playback. Helper tools **`reveal_generation_media`** (Finder) and burst **gallery** grouping for back-to-back image/video gens collapse member cards into one grid.
> 
> **Timeline previews:** New **`show_timeline`** renders up to six timelines (optional frame window, 20s cap) via `TimelineRenderer` and uses the same preview UI; **`reveal_timeline`** focuses that timeline in Palmier Pro.
> 
> **MCP server plumbing:** Registers the preview HTML resource plus per-asset `palmier://` URIs; enables resource subscribe; posts **`generationAssetDidChange`** when gens finish or timeline renders complete to push **`ResourceUpdatedNotification`**. Loopback **`/preview/{mediaRef}`** serves finished media with CORS and byte-range support (size-capped, ref-validated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ed563014e3bbf3a83a8761d6b3a9be943e43af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->