### PR TITLE
[ui/agent] Add marker review workflow to timeline index

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -21,7 +21,9 @@ enum AgentInstructions {
           that for alternate versions instead of editing over the original. A nested timeline \
           appears as a clip with mediaType 'sequence'.
         - Markers are persistent timeline notes. Use manage_markers and stable markerId values; \
-          point markers have zero duration and ranges are half-open.
+          point markers have zero duration and ranges are half-open. Leave failed or ambiguous \
+          work open, set review only after applying and verifying the edit, and set resolved only \
+          when the user explicitly approves or requests it.
         - IDs are short prefixes — pass them back exactly as given, never padded or completed. \
           Folders have no ids: they are paths ('B-roll/Sunset'), created on demand.
 

--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -127,7 +127,7 @@ enum ToolDefinitions {
         ),
         AgentTool(
             name: .manageMarkers,
-            description: "Creates, updates, or deletes one persistent timeline marker. A zero duration marks one frame; a positive duration is half-open.",
+            description: "Creates, updates, or deletes one persistent timeline marker. A zero duration marks one frame; a positive duration is half-open. Status tracks the review workflow: open is awaiting work, review is ready for user approval, and resolved is accepted. Set review only after applying and verifying the requested edit. Set resolved only when the user explicitly approves or requests it.",
             inputSchema: objectSchema(
                 properties: [
                     "action": ["type": "string", "enum": ["create", "update", "delete"]],
@@ -137,6 +137,7 @@ enum ToolDefinitions {
                     "durationFrames": ["type": "integer", "description": "0 for a point; positive for a range."],
                     "color": ["type": "string", "description": "#RGB, #RRGGBB, or #RRGGBBAA."],
                     "comment": ["type": "string"],
+                    "status": ["type": "string", "enum": ["open", "review", "resolved"]],
                 ],
                 required: ["action"]
             )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Markers.swift
@@ -8,17 +8,26 @@ private struct ManageMarkersInput: DecodableToolArgs {
     let durationFrames: Int?
     let color: String?
     let comment: String?
+    let status: String?
     static let allowedKeys: Set<String> = [
         "action", "markerId", "name", "startFrame", "durationFrames", "color", "comment",
+        "status",
     ]
     var hasPatch: Bool {
-        name != nil || startFrame != nil || durationFrames != nil || color != nil || comment != nil
+        name != nil || startFrame != nil || durationFrames != nil || color != nil
+            || comment != nil || status != nil
     }
 }
 
 extension ToolExecutor {
     func manageMarkers(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
         let input: ManageMarkersInput = try decodeToolArgs(args, path: "manage_markers")
+        let status: TimelineMarker.Status? = try input.status.map {
+            guard let status = TimelineMarker.Status(rawValue: $0) else {
+                throw ToolError("status must be open, review, or resolved.")
+            }
+            return status
+        }
         let receipt: TimelineMarkerChangeReceipt
         do {
             switch input.action {
@@ -30,7 +39,8 @@ extension ToolExecutor {
                     name: name, startFrame: start,
                     durationFrames: input.durationFrames ?? 0,
                     color: try parseColorHex(input.color, path: "color") ?? TimelineMarker.defaultColor,
-                    comment: input.comment ?? ""
+                    comment: input.comment ?? "",
+                    status: status ?? .open
                 )
                 receipt = try editor.changeTimelineMarkers(
                     creates: [marker], actionName: "Add Marker (Agent)"
@@ -47,6 +57,7 @@ extension ToolExecutor {
                 if let value = input.durationFrames { marker.durationFrames = value }
                 if let value = try parseColorHex(input.color, path: "color") { marker.color = value }
                 if let value = input.comment { marker.comment = value }
+                if let status { marker.status = status }
                 receipt = try editor.changeTimelineMarkers(
                     updates: [marker], actionName: "Change Marker (Agent)"
                 )

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Timeline.swift
@@ -97,6 +97,7 @@ extension ToolExecutor {
             "durationFrames": marker.durationFrames,
             "color": marker.color.hexString,
             "comment": marker.comment,
+            "status": marker.status.rawValue,
         ]
     }
 

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TimelineMarkers.swift
@@ -65,6 +65,7 @@ extension EditorViewModel {
         actionName: String
     ) throws -> TimelineMarkerChangeReceipt {
         let deleteSet = Set(deleteIds)
+        let affectedIds = deleteSet.union(updates.map(\.id))
         guard deleteSet.count == deleteIds.count else { throw TimelineMarkerValidationError.invalidRange }
         let before = timeline.markers
         var next = before
@@ -87,10 +88,12 @@ extension EditorViewModel {
         let created = try creates.map(validatedTimelineMarker)
         next += created
         next.sort { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
+        if let preview = timelineMarkerPreview, affectedIds.contains(preview.id) {
+            timelineMarkerPreview = nil
+        }
         guard next != before else {
             return TimelineMarkerChangeReceipt(created: [], updated: [], deletedIds: [])
         }
-
         timeline.markers = next
         registerTimelineMarkerSwap(undoMarkers: before, redoMarkers: next, actionName: actionName)
         selectedTimelineMarkerIds.subtract(deleteSet)
@@ -136,6 +139,7 @@ extension EditorViewModel {
         actionName: String
     ) {
         registerTimelineUndo(actionName) { vm in
+            vm.timelineMarkerPreview = nil
             vm.timeline.markers = undoMarkers
             vm.selectedTimelineMarkerIds.formIntersection(undoMarkers.map(\.id))
             vm.registerTimelineMarkerSwap(

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Timelines.swift
@@ -106,6 +106,7 @@ extension EditorViewModel {
         selectedGap = nil
         selectedTimelineRange = nil
         selectedTimelineMarkerIds = []
+        timelineMarkerPreview = nil
         pendingSwapClipId = nil
         pendingSwapTargetClipIds = []
         clearAgentActivity()

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -139,6 +139,7 @@ final class EditorViewModel {
     var selectedGap: GapSelection?
     var selectedTimelineRange: TimelineRangeSelection?
     var selectedTimelineMarkerIds: Set<String> = []
+    var timelineMarkerPreview: TimelineMarker?
     var selectedMediaAssetIds: Set<String> = []
     var selectedFolderIds: Set<String> = []
     var selectedTimelineIds: Set<String> = []
@@ -155,6 +156,7 @@ final class EditorViewModel {
     var rotationSnapGuidesVisible: Bool = false
     var timelineVisibleWidth: Double = 0
     var timelineRenderRevision: Int = 0
+    var timelineCompositionGeneration: Int = 0
     @ObservationIgnored private var clipLocationIndexCache: (revision: Int, timelineId: String, index: [String: ClipLocation])?
     @ObservationIgnored var keyframeNavigationCache: [
         KeyframeNavigationCacheKey: [KeyframeLaneNavigationTarget]

--- a/Sources/PalmierPro/MediaPanel/IndexTab/CaptionBrowser.swift
+++ b/Sources/PalmierPro/MediaPanel/IndexTab/CaptionBrowser.swift
@@ -18,6 +18,7 @@ struct CaptionBrowser: View {
     let groups: [CaptionBrowserGroup]
     let fps: Int
     @Binding var selectedGroupId: String?
+    @Binding var indexSection: IndexBrowserSection
 
     @State private var searchQuery = ""
     @State private var jumpTargetId: String?
@@ -101,24 +102,15 @@ struct CaptionBrowser: View {
     ) -> some View {
         HStack(spacing: AppTheme.Spacing.xs) {
             if editor.isMediaPanelSearchExpanded {
-                ExpandablePanelSearch(
-                    text: $searchQuery,
-                    focus: $isSearchFocused
-                )
+                ExpandablePanelSearch(text: $searchQuery, focus: $isSearchFocused)
                     .layoutPriority(1)
             } else {
-                if let activeGroup {
-                    if groups.count > 1 {
-                        groupPicker(activeGroup: activeGroup)
-                    } else {
-                        groupTitle(activeGroup)
-                    }
-                }
+                IndexModeTabs(selection: $indexSection)
                 Spacer(minLength: AppTheme.Spacing.zero)
-                ExpandablePanelSearch(
-                    text: $searchQuery,
-                    focus: $isSearchFocused
-                )
+                if groups.count > 1, let activeGroup {
+                    groupPicker(activeGroup: activeGroup)
+                }
+                ExpandablePanelSearch(text: $searchQuery, focus: $isSearchFocused)
                 CaptionJumpToPlayheadButton(
                     timelineIndex: timelineIndex,
                     playheadState: editor.playheadState,
@@ -127,26 +119,13 @@ struct CaptionBrowser: View {
             }
         }
         .padding(.horizontal, AppTheme.Spacing.sm)
-        .padding(.vertical, AppTheme.Spacing.sm)
+        .padding(.vertical, AppTheme.Spacing.xxs)
         .fixedSize(horizontal: false, vertical: true)
         .background(AppTheme.Background.surfaceColor)
         .animation(
             .easeInOut(duration: AppTheme.Anim.transition),
             value: editor.isMediaPanelSearchExpanded
         )
-    }
-
-    private func groupTitle(_ group: CaptionBrowserGroup) -> some View {
-        Text(verbatim: groupLabel(group))
-            .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.regular))
-            .foregroundStyle(AppTheme.Text.secondaryColor)
-            .lineLimit(1)
-            .truncationMode(.middle)
-            .frame(
-                maxWidth: AppTheme.MediaPanel.captionIndexGroupMenuWidth,
-                alignment: .leading
-            )
-            .layoutPriority(2)
     }
 
     private func groupPicker(activeGroup: CaptionBrowserGroup) -> some View {
@@ -167,8 +146,8 @@ struct CaptionBrowser: View {
         .menuStyle(.button)
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
-        .frame(width: AppTheme.MediaPanel.captionIndexGroupMenuWidth)
-        .layoutPriority(2)
+        .frame(maxWidth: AppTheme.MediaPanel.captionIndexGroupMenuWidth)
+        .layoutPriority(1)
         .focusable(false)
     }
 
@@ -178,7 +157,7 @@ struct CaptionBrowser: View {
             code: editor.timelineTrackDisplayLabel(at: group.trackIndex),
             name: editor.timeline.tracks[group.trackIndex].name
         )
-        return L10n.string("Track: \(title)")
+        return title
     }
 }
 

--- a/Sources/PalmierPro/MediaPanel/IndexTab/IndexTab.swift
+++ b/Sources/PalmierPro/MediaPanel/IndexTab/IndexTab.swift
@@ -1,8 +1,54 @@
 import SwiftUI
 
+enum IndexBrowserSection: String, CaseIterable {
+    case captions = "Captions"
+    case markers = "Markers"
+    var titleKey: String { self == .captions ? L10n.key("Captions") : L10n.key("Markers") }
+}
+
+struct IndexModeTabs: View {
+    @Binding var selection: IndexBrowserSection
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.md) {
+            ForEach(IndexBrowserSection.allCases, id: \.self) { section in
+                let selected = selection == section
+                Button { selection = section } label: {
+                    Text(L10n.string(key: section.titleKey))
+                        .font(.system(
+                            size: AppTheme.FontSize.sm,
+                            weight: selected
+                                ? AppTheme.FontWeight.semibold
+                                : AppTheme.FontWeight.regular
+                        ))
+                        .foregroundStyle(
+                            selected
+                                ? AppTheme.Text.primaryColor
+                                : AppTheme.Text.tertiaryColor
+                        )
+                        .frame(height: AppTheme.IconSize.md)
+                        .overlay(alignment: .bottom) {
+                            Rectangle()
+                                .fill(selected
+                                    ? AppTheme.Text.primaryColor
+                                    : Color.clear)
+                                .frame(height: AppTheme.BorderWidth.thin)
+                        }
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .focusable(false)
+                .accessibilityAddTraits(selected ? .isSelected : [])
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
 struct IndexTab: View {
     @Environment(EditorViewModel.self) private var editor
     @Binding var selectedCaptionGroupId: String?
+    @Binding var section: IndexBrowserSection
     @State private var emptySearchQuery = ""
     @FocusState private var isSearchFocused: Bool
 
@@ -11,39 +57,46 @@ struct IndexTab: View {
         let captionGroups = CaptionBrowserNavigation.groups(in: timeline)
 
         Group {
-            if captionGroups.isEmpty {
-                emptyState
-            } else {
-                CaptionBrowser(
-                    groups: captionGroups,
-                    fps: timeline.fps,
-                    selectedGroupId: $selectedCaptionGroupId
+            switch section {
+            case .captions:
+                if captionGroups.isEmpty {
+                    captionEmptyState
+                } else {
+                    CaptionBrowser(
+                        groups: captionGroups,
+                        fps: timeline.fps,
+                        selectedGroupId: $selectedCaptionGroupId,
+                        indexSection: $section
+                    )
+                }
+            case .markers:
+                MarkerBrowser(
+                    timeline: timeline,
+                    indexSection: $section
                 )
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(AppTheme.Background.surfaceColor)
+        .onChange(of: section) { _, _ in
+            editor.collapseMediaPanelSearch()
+        }
     }
 
-    private var emptyState: some View {
+    private var captionEmptyState: some View {
         VStack(spacing: AppTheme.Spacing.zero) {
             HStack {
                 if editor.isMediaPanelSearchExpanded {
-                    ExpandablePanelSearch(
-                        text: $emptySearchQuery,
-                        focus: $isSearchFocused
-                    )
+                    ExpandablePanelSearch(text: $emptySearchQuery, focus: $isSearchFocused)
                         .layoutPriority(1)
                 } else {
+                    IndexModeTabs(selection: $section)
                     Spacer(minLength: AppTheme.Spacing.zero)
-                    ExpandablePanelSearch(
-                        text: $emptySearchQuery,
-                        focus: $isSearchFocused
-                    )
+                    ExpandablePanelSearch(text: $emptySearchQuery, focus: $isSearchFocused)
                 }
             }
             .padding(.horizontal, AppTheme.Spacing.sm)
-            .padding(.vertical, AppTheme.Spacing.sm)
+            .padding(.vertical, AppTheme.Spacing.xxs)
 
             Rectangle()
                 .fill(AppTheme.Border.primaryColor)

--- a/Sources/PalmierPro/MediaPanel/IndexTab/MarkerBrowser.swift
+++ b/Sources/PalmierPro/MediaPanel/IndexTab/MarkerBrowser.swift
@@ -1,0 +1,468 @@
+import SwiftUI
+
+private extension TimelineMarker.Status {
+    var titleKey: String {
+        switch self {
+        case .open: L10n.key("Open")
+        case .review: L10n.key("Review")
+        case .resolved: L10n.key("Resolved")
+        }
+    }
+    var color: Color {
+        switch self {
+        case .open: AppTheme.Status.pendingColor
+        case .review: AppTheme.Status.warningColor
+        case .resolved: AppTheme.Status.successColor
+        }
+    }
+}
+
+@MainActor @ViewBuilder
+private func markerStatusButtons(selected: TimelineMarker.Status?, includesAll: Bool = false,
+                                 action: @escaping (TimelineMarker.Status?) -> Void) -> some View {
+    if includesAll {
+        Button { action(nil) } label: {
+            Label(L10n.string("All Statuses"), systemImage: selected == nil ? "checkmark" : "circle")
+        }
+        Divider()
+    }
+    ForEach(TimelineMarker.Status.allCases, id: \.self) { status in
+        Button { action(status) } label: {
+            Label(L10n.string(key: status.titleKey),
+                  systemImage: selected == status ? "checkmark" : "circle.fill")
+        }
+    }
+}
+
+struct MarkerBrowser: View {
+    @Environment(EditorViewModel.self) private var editor
+    let timeline: Timeline
+    @Binding var indexSection: IndexBrowserSection
+    @State private var searchQuery = ""
+    @State private var statusFilter: TimelineMarker.Status?
+    @FocusState private var isSearchFocused: Bool
+
+    var body: some View {
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let markers = MarkerBrowserNavigation.sortedMarkers(
+            timeline.markers, matching: query, status: statusFilter)
+        VStack(spacing: AppTheme.Spacing.zero) {
+            toolbar
+            Rectangle().fill(AppTheme.Border.primaryColor)
+                .frame(height: AppTheme.BorderWidth.hairline)
+            if timeline.markers.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    if markers.isEmpty {
+                        Text(query.isEmpty
+                            ? L10n.string("No markers match this filter.")
+                            : L10n.string("No matches for “\(query)”"))
+                            .font(.system(size: AppTheme.FontSize.sm))
+                            .foregroundStyle(AppTheme.Text.tertiaryColor)
+                            .frame(maxWidth: .infinity).padding(.top, AppTheme.Spacing.xl)
+                    } else {
+                        LazyVStack(alignment: .leading, spacing: AppTheme.Spacing.zero) {
+                            ForEach(markers) {
+                                MarkerBrowserRow(marker: $0, fps: timeline.fps,
+                                                 thumbnailSize: thumbnailSize,
+                                                 timelineId: timeline.id)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear { editor.selectPreviewTab(id: PreviewTab.timeline.id) }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            if editor.isMediaPanelSearchExpanded {
+                ExpandablePanelSearch(text: $searchQuery, focus: $isSearchFocused)
+                    .layoutPriority(1)
+            } else {
+                IndexModeTabs(selection: $indexSection)
+                Spacer(minLength: AppTheme.Spacing.zero)
+                ExpandablePanelSearch(text: $searchQuery, focus: $isSearchFocused)
+                statusFilterMenu
+            }
+        }
+        .padding(.horizontal, AppTheme.Spacing.sm)
+        .padding(.vertical, AppTheme.Spacing.xxs)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(AppTheme.Background.surfaceColor)
+        .animation(.easeInOut(duration: AppTheme.Anim.transition),
+                   value: editor.isMediaPanelSearchExpanded)
+    }
+
+    private var thumbnailSize: CGSize {
+        MarkerThumbnailMetrics.size(
+            canvas: CGSize(width: timeline.width, height: timeline.height),
+            height: AppTheme.MediaPanel.markerIndexThumbnailHeight)
+    }
+
+    private var statusFilterMenu: some View {
+        Menu {
+            markerStatusButtons(selected: statusFilter, includesAll: true) { statusFilter = $0 }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(statusFilter?.color ?? AppTheme.Text.tertiaryColor)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+                .contentShape(Rectangle())
+                .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+        }
+        .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).focusable(false)
+        .accessibilityLabel(L10n.string("Status Filter"))
+        .accessibilityValue(statusFilter.map { L10n.string(key: $0.titleKey) }
+            ?? L10n.string("All Statuses"))
+        .help(L10n.string("Filter markers by status"))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: AppTheme.Spacing.sm) {
+            Spacer()
+            TimelineMarkerShape().fill(AppTheme.Text.mutedColor)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.smMd)
+            Text(L10n.string("No markers"))
+                .font(.system(size: AppTheme.FontSize.sm, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+            Text(L10n.string("Press M in the timeline to add a marker."))
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.mutedColor)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct MarkerBrowserRow: View {
+    private enum TimingField { case time, duration }
+    @Environment(EditorViewModel.self) private var editor
+    let marker: TimelineMarker
+    let fps: Int
+    let thumbnailSize: CGSize
+    let timelineId: String
+    @State private var comment: String
+    @State private var commentBaseline: String
+    @State private var isColorPickerPresented = false
+    @State private var isRemoving = false
+    @FocusState private var commentFocused: Bool
+
+    init(marker: TimelineMarker, fps: Int, thumbnailSize: CGSize, timelineId: String) {
+        self.marker = marker
+        self.fps = fps
+        self.thumbnailSize = thumbnailSize
+        self.timelineId = timelineId
+        _comment = State(initialValue: marker.comment)
+        _commentBaseline = State(initialValue: marker.comment)
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: AppTheme.Spacing.sm) {
+            MarkerThumbnailView(
+                timelineId: timelineId, frame: marker.startFrame, size: thumbnailSize)
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+                HStack(spacing: AppTheme.Spacing.sm) {
+                    HStack(spacing: AppTheme.Spacing.xxs) {
+                        markerColorButton
+                        Text(verbatim: marker.name)
+                            .font(.system(size: AppTheme.FontSize.sm)).italic()
+                            .foregroundStyle(AppTheme.Text.secondaryColor).lineLimit(1)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    HStack(spacing: AppTheme.Spacing.xxs) {
+                        timingField(.time)
+                        timingField(.duration)
+                        statusButton
+                        deleteButton
+                    }
+                    .fixedSize()
+                }
+                commentField
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(AppTheme.Spacing.sm).frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle()).onTapGesture { select() }
+        .hoverHighlight(
+            cornerRadius: AppTheme.Radius.xs,
+            isActive: editor.selectedTimelineMarkerIds.contains(marker.id)
+        )
+        .padding(.horizontal, AppTheme.Spacing.xxs)
+        .onChange(of: marker) { _, updated in
+            guard !commentFocused else { return }
+            comment = updated.comment
+            commentBaseline = updated.comment
+        }
+        .onDisappear {
+            if commentFocused, !isRemoving { commitComment() }
+            clearPreview()
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityAction { select() }
+    }
+
+    private var markerColorButton: some View {
+        Button {
+            select(seek: false)
+            isColorPickerPresented = true
+        } label: {
+            TimelineMarkerShape().fill(marker.color.swiftUIColor)
+                .overlay {
+                    TimelineMarkerShape().stroke(
+                        Color(nsColor: AppTheme.Border.timelineMarker),
+                        lineWidth: AppTheme.BorderWidth.thin
+                    )
+                }
+                .frame(width: AppTheme.TimelineMarker.flagWidth,
+                       height: AppTheme.TimelineMarker.flagHeight)
+                .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+        }
+        .buttonStyle(.plain).focusable(false)
+        .accessibilityLabel(L10n.string("Color"))
+        .popover(isPresented: $isColorPickerPresented, arrowEdge: .bottom) {
+            MarkerColorPicker(selection: marker.color) { color in
+                change(actionName: "Change Marker Color") { $0.color = color }
+                isColorPickerPresented = false
+            }
+            .padding(AppTheme.Spacing.md)
+        }
+    }
+
+    private var deleteButton: some View {
+        Button(role: .destructive, action: remove) {
+            actionIcon("trash", color: AppTheme.Text.tertiaryColor)
+        }
+        .buttonStyle(.plain).focusable(false)
+        .help(L10n.string("Delete Marker"))
+    }
+
+    private var statusButton: some View {
+        Menu {
+            markerStatusButtons(selected: marker.status) {
+                guard let status = $0 else { return }
+                change(actionName: "Change Marker Status") { $0.status = status }
+            }
+        } label: {
+            actionIcon("circle.fill", color: marker.status.color)
+        }
+        .menuStyle(.button).buttonStyle(.plain).menuIndicator(.hidden).focusable(false)
+        .help(L10n.string("Status: \(L10n.string(key: marker.status.titleKey))"))
+    }
+
+    private func actionIcon(_ systemName: String, color: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+            .foregroundStyle(color)
+            .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+            .contentShape(Rectangle())
+            .hoverHighlight(cornerRadius: AppTheme.Radius.sm)
+    }
+
+    private func timingField(_ field: TimingField) -> some View {
+        let isDuration = field == .duration
+        let keyPath: WritableKeyPath<TimelineMarker, Int> =
+            isDuration ? \.durationFrames : \.startFrame
+        let secondsPerFrame = fps > 0 ? 1 / Double(fps) : 1
+        let label = isDuration ? L10n.string("Duration") : L10n.string("Time")
+        return ScrubbableNumberField(
+            value: Double(marker[keyPath: keyPath]),
+            range: 0...Double(Int32.max),
+            displayMultiplier: isDuration ? secondsPerFrame : 1,
+            format: isDuration ? "%.1f" : "%.0f",
+            valueSuffix: isDuration ? "s" : "",
+            dragSensitivity: isDuration ? secondsPerFrame : 1,
+            fieldWidth: isDuration ? AppTheme.MediaPanel.markerIndexDurationFieldWidth
+                : AppTheme.MediaPanel.markerIndexTimeFieldWidth,
+            fieldFill: AppTheme.Background.raisedColor,
+            valueFontSize: AppTheme.FontSize.xs,
+            dragValueAdjustment: { $0.rounded() },
+            displayTextOverride: {
+                if isDuration { return $0 == 0 ? "-" : nil }
+                return formatTimecode(frame: Int($0), fps: fps)
+            },
+            parseTextOverride: isDuration ? nil
+                : { parseTimecode($0, fps: fps).map(Double.init) },
+            onChanged: { preview($0, at: keyPath) },
+            onInteractionStart: { select(seek: false) },
+            onInteractionEnd: clearPreview,
+            onCommit: {
+                commit($0, at: keyPath,
+                       actionName: isDuration ? "Change Marker Duration" : "Move Marker")
+            }
+        )
+        .accessibilityLabel(label).help(label)
+    }
+
+    private var commentField: some View {
+        TextField(L10n.string("Add a comment"), text: $comment, axis: .vertical)
+            .textFieldStyle(.plain).font(.system(size: AppTheme.FontSize.smMd))
+            .foregroundStyle(AppTheme.Text.primaryColor)
+            .lineLimit(2, reservesSpace: true).frame(height: AppTheme.MediaPanel.markerIndexCommentHeight)
+            .padding(.horizontal, AppTheme.Spacing.sm)
+            .editorValueField(minHeight: AppTheme.MediaPanel.markerIndexCommentHeight,
+                              fill: AppTheme.Background.raisedColor)
+            .focused($commentFocused).accessibilityLabel(L10n.string("Comments")).help(comment)
+            .onChange(of: commentFocused) { _, focused in
+                if focused {
+                    syncCommentFromModel()
+                    select()
+                } else if !isRemoving {
+                    commitComment()
+                }
+            }
+            .onExitCommand {
+                syncCommentFromModel()
+                commentFocused = false
+            }
+            .onKeyPress(.return, phases: .down) {
+                guard $0.modifiers.contains(.command) else { return .ignored }
+                commitComment()
+                commentFocused = false
+                return .handled
+            }
+    }
+
+    private func select(seek: Bool = true) {
+        guard let marker = editor.timelineMarker(id: marker.id) else { return }
+        editor.selectPreviewTab(id: PreviewTab.timeline.id)
+        editor.selectedClipIds.removeAll()
+        editor.selectedGap = nil
+        editor.selectedTimelineRange = nil
+        editor.selectedTimelineMarkerIds = [marker.id]
+        if seek { editor.seekToFrame(marker.startFrame) }
+    }
+    private func preview(_ value: Double, at keyPath: WritableKeyPath<TimelineMarker, Int>) {
+        let value = Int(value)
+        guard var preview = editor.timelineMarker(id: marker.id) else { return }
+        preview[keyPath: keyPath] = value
+        editor.timelineMarkerPreview = preview
+    }
+    private func commit(
+        _ value: Double,
+        at keyPath: WritableKeyPath<TimelineMarker, Int>,
+        actionName: String
+    ) {
+        let value = Int(value)
+        change(actionName: actionName) { $0[keyPath: keyPath] = value }
+    }
+    private func clearPreview() {
+        if editor.timelineMarkerPreview?.id == marker.id { editor.timelineMarkerPreview = nil }
+    }
+    private func syncCommentFromModel() {
+        comment = editor.timelineMarker(id: marker.id)?.comment ?? marker.comment
+        commentBaseline = comment
+    }
+    private func commitComment() {
+        guard let current = editor.timelineMarker(id: marker.id) else { return }
+        guard current.comment == commentBaseline else {
+            syncCommentFromModel()
+            editor.refuseWithToast(L10n.string(
+                "The marker comment changed while you were editing. Review it and try again."
+            ))
+            return
+        }
+        guard current.comment != comment else { return }
+        let updatedComment = comment
+        change(actionName: "Change Marker Comment") { $0.comment = updatedComment }
+    }
+    private func change(actionName: String, update: (inout TimelineMarker) -> Void) {
+        do {
+            guard var updated = editor.timelineMarker(id: marker.id) else {
+                throw TimelineMarkerValidationError.invalidRange
+            }
+            update(&updated)
+            _ = try editor.changeTimelineMarkers(updates: [updated], actionName: actionName)
+            syncCommentFromModel()
+        } catch {
+            syncCommentFromModel()
+            editor.refuseWithToast(L10n.string("Couldn't change marker."))
+        }
+    }
+    private func remove() {
+        isRemoving = true
+        commentFocused = false
+        do {
+            _ = try editor.changeTimelineMarkers(
+                deleteIds: [marker.id], actionName: "Delete Marker")
+        } catch {
+            isRemoving = false
+            editor.refuseWithToast(L10n.string("Couldn't delete marker."))
+        }
+    }
+}
+
+private struct MarkerThumbnailView: View {
+    private struct RequestID: Hashable {
+        let timelineId: String
+        let frame: Int
+        let compositionGeneration: Int
+    }
+    @Environment(EditorViewModel.self) private var editor
+    @Environment(\.displayScale) private var displayScale
+    let timelineId: String
+    let frame: Int
+    let size: CGSize
+    @State private var image: CGImage?
+    @State private var isLoading = false
+
+    var body: some View {
+        ZStack {
+            AppTheme.MediaOverlay.backgroundColor
+            if let image {
+                Image(decorative: image, scale: 1).resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else if isLoading {
+                ProgressView().controlSize(.mini)
+                    .tint(AppTheme.MediaOverlay.secondaryColor)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.xs))
+        .overlay {
+            RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.hairline)
+        }
+        .task(id: RequestID(timelineId: timelineId, frame: frame,
+                            compositionGeneration: editor.timelineCompositionGeneration)) {
+            image = nil
+            isLoading = true
+            let maximumSize = CGSize(width: (size.width * displayScale).rounded(),
+                                     height: (size.height * displayScale).rounded())
+            let loaded = await editor.videoEngine?.timelineThumbnail(
+                timelineId: timelineId, frame: frame, maximumSize: maximumSize)
+            guard !Task.isCancelled else { return }
+            image = loaded
+            isLoading = false
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+enum MarkerBrowserNavigation {
+    static func sortedMarkers(
+        _ markers: [TimelineMarker],
+        matching query: String,
+        status: TimelineMarker.Status? = nil
+    ) -> [TimelineMarker] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return markers.filter {
+            (status == nil || $0.status == status)
+                && (query.isEmpty
+                    || $0.name.localizedCaseInsensitiveContains(query)
+                    || $0.comment.localizedCaseInsensitiveContains(query))
+        }
+        .sorted { ($0.startFrame, $0.id) < ($1.startFrame, $1.id) }
+    }
+}
+
+enum MarkerThumbnailMetrics {
+    static func size(canvas: CGSize, height: CGFloat) -> CGSize {
+        guard canvas.width > 0, canvas.height > 0, height > 0 else { return .zero }
+        return CGSize(width: canvas.width * height / canvas.height, height: height)
+    }
+}

--- a/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaPanelView.swift
@@ -28,6 +28,7 @@ enum MediaPanelSection: String, CaseIterable {
 struct MediaPanelView: View {
     @Environment(EditorViewModel.self) private var editor
     @State private var section: MediaPanelSection = .media
+    @State private var indexSection: IndexBrowserSection = .captions
     @State private var selectedCaptionGroupId: String?
 
     var body: some View {
@@ -50,11 +51,13 @@ struct MediaPanelView: View {
                 case .media: MediaTab()
                 case .index:
                     IndexTab(
-                        selectedCaptionGroupId: $selectedCaptionGroupId
+                        selectedCaptionGroupId: $selectedCaptionGroupId,
+                        section: $indexSection
                     )
                 case .captions:
                     CaptionTab { groupId in
                         selectedCaptionGroupId = groupId
+                        indexSection = .captions
                         selectSection(.index)
                     }
                 case .audio: AudioPanelTab()

--- a/Sources/PalmierPro/Models/TimelineMarker.swift
+++ b/Sources/PalmierPro/Models/TimelineMarker.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 struct TimelineMarker: Codable, Sendable, Equatable, Hashable, Identifiable {
+    enum Status: String, Codable, Sendable, CaseIterable {
+        case open
+        case review
+        case resolved
+    }
+
     static let maximumNameLength = 120
     static let maximumCommentLength = 4_000
     static let defaultColor = TextStyle.RGBA(r: 0, g: 0.478, b: 1, a: 1)
@@ -11,6 +17,7 @@ struct TimelineMarker: Codable, Sendable, Equatable, Hashable, Identifiable {
     var durationFrames: Int = 0
     var color: TextStyle.RGBA = defaultColor
     var comment: String = ""
+    var status: Status = .open
 
     var endFrame: Int { startFrame + durationFrames }
     var isRange: Bool { durationFrames > 0 }

--- a/Sources/PalmierPro/Models/TimelineMarker.swift
+++ b/Sources/PalmierPro/Models/TimelineMarker.swift
@@ -35,6 +35,25 @@ struct TimelineMarker: Codable, Sendable, Equatable, Hashable, Identifiable {
     }
 }
 
+extension TimelineMarker {
+    private enum CodingKeys: String, CodingKey {
+        case id, name, startFrame, durationFrames, color, comment, status
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try values.decode(String.self, forKey: .id),
+            name: try values.decode(String.self, forKey: .name),
+            startFrame: try values.decode(Int.self, forKey: .startFrame),
+            durationFrames: try values.decode(Int.self, forKey: .durationFrames),
+            color: try values.decode(TextStyle.RGBA.self, forKey: .color),
+            comment: try values.decode(String.self, forKey: .comment),
+            status: try values.decodeIfPresent(Status.self, forKey: .status) ?? .open
+        )
+    }
+}
+
 enum TimelineMarkerValidationError: Error, Equatable {
     case invalidName
     case invalidComment

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -49,6 +49,8 @@ final class VideoEngine {
     private var clipNaturalSizes: [String: CGSize] = [:]
     private var clipTransforms: [String: CGAffineTransform] = [:]
     private var compositionDuration: CMTime = .zero
+    private var timelinePreviewTimelineId: String?
+    private static let frameImageGate = AsyncSemaphore(value: 2)
 
     private var pendingInteractiveSeek: (time: CMTime, tolerance: CMTime)?
     private var interactiveThrottleTask: Task<Void, Never>?
@@ -66,6 +68,7 @@ final class VideoEngine {
         invalidateRebuild()
         cancelSourcePreviewLoad()
         compositionCache.removeAll()
+        timelinePreviewTimelineId = nil
         invalidateSeekState()
         scrubAudioEngine.teardown()
         if let timeObserver { player.removeTimeObserver(timeObserver) }
@@ -218,6 +221,7 @@ final class VideoEngine {
         sourceTrackStart = .zero
         invalidateSeekState()
         pause()
+        timelinePreviewTimelineId = nil
 
         switch tab {
         case .timeline:
@@ -413,6 +417,8 @@ final class VideoEngine {
         let item = AVPlayerItem(asset: result.composition)
         item.audioMix = appliedVisuals.audioMix
         item.videoComposition = appliedVisuals.videoComposition
+        timelinePreviewTimelineId = editor.timeline.id
+        editor.timelineCompositionGeneration &+= 1
         replacePlayerItem(item, reason: "rebuild")
 
         seek(to: editor.currentFrame, mode: .exact)
@@ -439,6 +445,8 @@ final class VideoEngine {
         )
         currentItem.audioMix = audioMix
         currentItem.videoComposition = videoComposition
+        timelinePreviewTimelineId = editor.timeline.id
+        editor.timelineCompositionGeneration &+= 1
         scrubAudioEngine.configure(asset: currentItem.asset, audioMix: audioMix, resetMeter: false)
         switch Self.visualRefreshAction(isPlaying: editor.isPlaying, playbackRate: editor.playbackRate) {
         case .meterPlayback:
@@ -452,18 +460,39 @@ final class VideoEngine {
 
     // MARK: - Scopes
 
-    /// Luma + per-channel histogram of the current composited frame (downsampled), normalized 0…1.
-    func histogramYRGB(frame: Int? = nil, count: Int = 256) async
-        -> (y: [Float], r: [Float], g: [Float], b: [Float])? {
-        guard let item = player.currentItem,
-              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
-        let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
+    func timelineThumbnail(timelineId: String, frame: Int, maximumSize: CGSize) async -> CGImage? {
+        guard timelinePreviewTimelineId == timelineId,
+              let item = player.currentItem,
+              let editor,
+              editor.activePreviewTab == .timeline,
+              editor.timeline.id == timelineId,
+              frame >= 0,
+              let time = playerTime(forPreviewFrame: frame) else { return nil }
+        return await frameImage(item: item, time: time, maximumSize: maximumSize)
+    }
+
+    private func frameImage(item: AVPlayerItem, time: CMTime, maximumSize: CGSize? = nil) async
+        -> CGImage? {
+        guard let _ = try? await Self.frameImageGate.wait() else { return nil }
+        defer { Task { await Self.frameImageGate.signal() } }
+        guard !Task.isCancelled else { return nil }
         let generator = AVAssetImageGenerator(asset: item.asset)
         generator.videoComposition = item.videoComposition
         generator.requestedTimeToleranceBefore = .zero
         generator.requestedTimeToleranceAfter = .zero
-        generator.maximumSize = CGSize(width: 320, height: 180)
-        guard let cg = try? await generator.image(at: time).image else { return nil }
+        if let maximumSize { generator.maximumSize = maximumSize }
+        guard let image = try? await generator.image(at: time).image,
+              !Task.isCancelled else { return nil }
+        return image
+    }
+
+    /// Luma + per-channel histogram of the current composited frame (downsampled), normalized 0…1.
+    func histogramYRGB(frame: Int? = nil, count: Int = 256) async
+        -> (y: [Float], r: [Float], g: [Float], b: [Float])? {
+        guard let item = player.currentItem else { return nil }
+        let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
+        guard let cg = await frameImage(item: item, time: time, maximumSize: CGSize(width: 320, height: 180))
+        else { return nil }
         return Self.histogram(from: cg, count: count)
     }
 
@@ -509,15 +538,10 @@ final class VideoEngine {
     /// Hue distribution of the current composited frame — pixel count per hue bucket, weighted by
     /// saturation so achromatic pixels don't show. Drives the silhouette behind the hue curves.
     func hueHistogram(frame: Int? = nil, count: Int = 96) async -> [Float]? {
-        guard let item = player.currentItem,
-              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
+        guard let item = player.currentItem else { return nil }
         let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
-        let generator = AVAssetImageGenerator(asset: item.asset)
-        generator.videoComposition = item.videoComposition
-        generator.requestedTimeToleranceBefore = .zero
-        generator.requestedTimeToleranceAfter = .zero
-        generator.maximumSize = CGSize(width: 320, height: 180)
-        guard let cg = try? await generator.image(at: time).image else { return nil }
+        guard let cg = await frameImage(item: item, time: time, maximumSize: CGSize(width: 320, height: 180))
+        else { return nil }
         return Self.hueHistogram(from: cg, count: count)
     }
 
@@ -550,12 +574,9 @@ final class VideoEngine {
     }
 
     func sampleKeyHue(at normalizedPoint: CGPoint, frame: Int? = nil) async -> Double? {
-        guard let item = player.currentItem,
-              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else { return nil }
+        guard let item = player.currentItem else { return nil }
         let time = frame.flatMap(playerTime(forPreviewFrame:)) ?? player.currentTime()
-        let generator = AVAssetImageGenerator(asset: item.asset)
-        generator.videoComposition = item.videoComposition
-        guard let cg = try? await generator.image(at: time).image else { return nil }
+        guard let cg = await frameImage(item: item, time: time) else { return nil }
         return Self.sampleKeyHue(from: cg, at: normalizedPoint)
     }
 

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -475,7 +475,10 @@ final class VideoEngine {
         -> CGImage? {
         guard let _ = try? await Self.frameImageGate.wait() else { return nil }
         defer { Task { await Self.frameImageGate.signal() } }
-        guard !Task.isCancelled else { return nil }
+        guard !Task.isCancelled,
+              (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else {
+            return nil
+        }
         let generator = AVAssetImageGenerator(asset: item.asset)
         generator.videoComposition = item.videoComposition
         generator.requestedTimeToleranceBefore = .zero

--- a/Sources/PalmierPro/Preview/VideoEngine.swift
+++ b/Sources/PalmierPro/Preview/VideoEngine.swift
@@ -51,6 +51,11 @@ final class VideoEngine {
     private var compositionDuration: CMTime = .zero
     private var timelinePreviewTimelineId: String?
     private static let frameImageGate = AsyncSemaphore(value: 2)
+    /// Composition snapshots are immutable after publication; each request owns its generator.
+    private struct FrameImageSource: @unchecked Sendable {
+        let asset: AVAsset
+        let videoComposition: AVVideoComposition?
+    }
 
     private var pendingInteractiveSeek: (time: CMTime, tolerance: CMTime)?
     private var interactiveThrottleTask: Task<Void, Never>?
@@ -479,8 +484,25 @@ final class VideoEngine {
               (try? await item.asset.loadTracks(withMediaType: .video).first) != nil else {
             return nil
         }
-        let generator = AVAssetImageGenerator(asset: item.asset)
-        generator.videoComposition = item.videoComposition
+        return await Self.generateFrameImage(
+            source: FrameImageSource(
+                asset: item.asset,
+                videoComposition: item.videoComposition
+            ),
+            time: time,
+            maximumSize: maximumSize
+        )
+    }
+
+    @concurrent
+    private static func generateFrameImage(
+        source: FrameImageSource,
+        time: CMTime,
+        maximumSize: CGSize?
+    ) async -> CGImage? {
+        guard !Task.isCancelled else { return nil }
+        let generator = AVAssetImageGenerator(asset: source.asset)
+        generator.videoComposition = source.videoComposition
         generator.requestedTimeToleranceBefore = .zero
         generator.requestedTimeToleranceAfter = .zero
         if let maximumSize { generator.maximumSize = maximumSize }

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -68,6 +68,7 @@
 "Add Marker (M)" = "Add Marker (M)";
 "Add Range to Chat" = "Add Range to Chat";
 "Add Text" = "Add Text";
+"Add a comment" = "Add a comment";
 "Add an Anthropic API key or credits to use this model." = "Add an Anthropic API key or credits to use this model.";
 "Add an OpenAI API key or credits to use this model." = "Add an OpenAI API key or credits to use this model.";
 "Add an email above to enable a reply" = "Add an email above to enable a reply";
@@ -98,6 +99,7 @@
 "Agentic editing" = "Agentic editing";
 "Alignment" = "Alignment";
 "All" = "All";
+"All Statuses" = "All Statuses";
 "All fonts" = "All fonts";
 "Amount" = "Amount";
 "Analyzing media so you can search it." = "Analyzing media so you can search it.";
@@ -214,6 +216,7 @@
 "Color Dodge" = "Color Dodge";
 "Color Wheels" = "Color Wheels";
 "Color for the active word." = "Color for the active word.";
+"Comments" = "Comments";
 "Community" = "Community";
 "Community Skills Unavailable" = "Community Skills Unavailable";
 "Compatibility: %@" = "Compatibility: %@";
@@ -270,6 +273,7 @@
 "Delete" = "Delete";
 "Delete %lld" = "Delete %lld";
 "Delete Keyframe" = "Delete Keyframe";
+"Delete Marker" = "Delete Marker";
 "Delete Project" = "Delete Project";
 "Delete Project?" = "Delete Project?";
 "Delete Selected Projects?" = "Delete Selected Projects?";
@@ -381,6 +385,7 @@
 "Fill prompt" = "Fill prompt";
 "Film Grain" = "Film Grain";
 "Filmmaker" = "Filmmaker";
+"Filter markers by status" = "Filter markers by status";
 "Final Cut Pro" = "Final Cut Pro";
 "First Frame" = "First Frame";
 "First-time sign-ups only" = "First-time sign-ups only";
@@ -566,6 +571,7 @@
 "Mark Speakers" = "Mark Speakers";
 "Marker %lld" = "Marker %lld";
 "Marker name" = "Marker name";
+"Markers" = "Markers";
 "Marketer" = "Marketer";
 "Master Audio Meter" = "Master Audio Meter";
 "Master — defines the group's clock and transcript." = "Master — defines the group's clock and transcript.";
@@ -633,6 +639,8 @@
 "No exports yet" = "No exports yet";
 "No generations yet" = "No generations yet";
 "No images" = "No images";
+"No markers" = "No markers";
+"No markers match this filter." = "No markers match this filter.";
 "No matches" = "No matches";
 "No matches for \"%@\"" = "No matches for \"%@\"";
 "No matches for “%@”" = "No matches for “%@”";
@@ -651,7 +659,6 @@
 "Normal" = "Normal";
 "Not selected" = "Not selected";
 "Not synced — unusable as an angle." = "Not synced — unusable as an angle.";
-"Notes" = "Notes";
 "Notifications" = "Notifications";
 "OK" = "OK";
 "Off" = "Off";
@@ -710,6 +717,7 @@
 "Preparing" = "Preparing";
 "Preparing…" = "Preparing…";
 "Presence" = "Presence";
+"Press M in the timeline to add a marker." = "Press M in the timeline to add a marker.";
 "Preview" = "Preview";
 "Privacy & Diagnostics" = "Privacy & Diagnostics";
 "Pro plan" = "Pro plan";
@@ -780,11 +788,13 @@
 "Resolution" = "Resolution";
 "Resolution must be at least 2 × 2 pixels." = "Resolution must be at least 2 × 2 pixels.";
 "Resolution must not exceed 8192 pixels on either edge." = "Resolution must not exceed 8192 pixels on either edge.";
+"Resolved" = "Resolved";
 "Restart Palmier Pro" = "Restart Palmier Pro";
 "Restart Palmier Pro to apply this change." = "Restart Palmier Pro to apply this change.";
 "Retry" = "Retry";
 "Retry Download" = "Retry Download";
 "Reveal in Finder" = "Reveal in Finder";
+"Review" = "Review";
 "Right" = "Right";
 "Ripple Delete" = "Ripple Delete";
 "Ripple Delete Gap" = "Ripple Delete Gap";
@@ -910,6 +920,8 @@
 "Start creating" = "Start creating";
 "Start creating, or explore these to get the most out of Palmier Pro." = "Start creating, or explore these to get the most out of Palmier Pro.";
 "Starts %@s into the group's clock; matched the master with %@%% confidence." = "Starts %@s into the group's clock; matched the master with %@%% confidence.";
+"Status Filter" = "Status Filter";
+"Status: %@" = "Status: %@";
 "Step %lld of %lld" = "Step %lld of %lld";
 "Step Backward" = "Step Backward";
 "Step Forward" = "Step Forward";
@@ -953,6 +965,7 @@
 "Thanks for the feedback." = "Thanks for the feedback.";
 "The clip you're adding has different settings than the current project." = "The clip you're adding has different settings than the current project.";
 "The export" = "The export";
+"The marker comment changed while you were editing. Review it and try again." = "The marker comment changed while you were editing. Review it and try again.";
 "The project will be moved to the Trash." = "The project will be moved to the Trash.";
 "The selected model refused this request. Revise the prompt and try again." = "The selected model refused this request. Revise the prompt and try again.";
 "The selected projects will be moved to the Trash." = "The selected projects will be moved to the Trash.";
@@ -982,7 +995,6 @@
 "Top" = "Top";
 "Top / Bottom" = "Top / Bottom";
 "Track Name" = "Track Name";
-"Track: %@" = "Track: %@";
 "Tracking" = "Tracking";
 "Transcribing…" = "Transcribing…";
 "Transcription failed: %@" = "Transcription failed: %@";

--- a/Sources/PalmierPro/Timeline/MarkerColorPicker.swift
+++ b/Sources/PalmierPro/Timeline/MarkerColorPicker.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MarkerColorPicker: View {
+    let selection: TextStyle.RGBA
+    let onSelect: (TextStyle.RGBA) -> Void
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.xxs) {
+            ForEach(AppTheme.TimelineMarker.presetColors, id: \.self) { preset in
+                Button { onSelect(preset) } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
+                            .stroke(
+                                selection == preset
+                                    ? AppTheme.Text.primaryColor
+                                    : .clear,
+                                lineWidth: AppTheme.BorderWidth.medium
+                            )
+                        TimelineMarkerShape()
+                            .fill(preset.swiftUIColor)
+                            .padding(AppTheme.Spacing.xxs)
+                    }
+                    .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(verbatim: preset.hexString))
+                .accessibilityAddTraits(selection == preset ? .isSelected : [])
+            }
+        }
+    }
+}

--- a/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
+++ b/Sources/PalmierPro/Timeline/MarkerEditorPopover.swift
@@ -6,7 +6,7 @@ struct MarkerEditorPopover: View {
     let onPreview: (TimelineMarker) -> Void
     let onDismiss: () -> Void
     @State private var draft: TimelineMarker
-    @FocusState private var notesFocused: Bool
+    @FocusState private var commentsFocused: Bool
     init(
         marker: TimelineMarker,
         fps: Int,
@@ -37,44 +37,23 @@ struct MarkerEditorPopover: View {
                         .gridCellColumns(3)
                 }
                 GridRow {
-                    fieldLabel(L10n.string("Notes"))
-                    TextField(String(), text: $draft.comment, axis: .vertical)
+                    fieldLabel(L10n.string("Comments"))
+                    TextField(L10n.string("Add a comment"), text: $draft.comment, axis: .vertical)
                         .textFieldStyle(.plain)
-                        .focused($notesFocused)
+                        .focused($commentsFocused)
                         .font(.system(size: AppTheme.FontSize.sm))
                         .lineLimit(3, reservesSpace: true)
-                        .frame(height: AppTheme.TimelineMarker.notesHeight)
+                        .frame(height: AppTheme.TimelineMarker.commentsHeight)
                         .padding(.horizontal, AppTheme.Spacing.sm)
                         .editorValueField(
-                            minHeight: AppTheme.TimelineMarker.notesHeight,
+                            minHeight: AppTheme.TimelineMarker.commentsHeight,
                             fill: AppTheme.Background.raisedColor
                         )
                         .gridCellColumns(3)
                 }
                 GridRow {
                     fieldLabel(L10n.string("Color"))
-                    HStack(spacing: AppTheme.Spacing.xxs) {
-                        ForEach(Array(AppTheme.TimelineMarker.presetColors.enumerated()), id: \.offset) { _, preset in
-                            Button {
-                                draft.color = preset
-                                onPreview(draft)
-                            } label: {
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: AppTheme.Radius.xs)
-                                        .stroke(
-                                            draft.color == preset ? AppTheme.Text.primaryColor : .clear,
-                                            lineWidth: AppTheme.BorderWidth.medium
-                                        )
-                                    TimelineMarkerShape()
-                                        .fill(preset.swiftUIColor)
-                                        .padding(AppTheme.Spacing.xxs)
-                                }
-                                .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel(Text(verbatim: preset.hexString))
-                        }
-                    }
+                    MarkerColorPicker(selection: draft.color) { draft.color = $0; onPreview(draft) }
                     .gridCellColumns(3)
                 }
             }
@@ -92,7 +71,7 @@ struct MarkerEditorPopover: View {
         }
         .padding(AppTheme.Spacing.md)
         .frame(width: AppTheme.TimelineMarker.editorWidth)
-        .task { notesFocused = true }
+        .task { commentsFocused = true }
     }
     private func fieldLabel(_ label: String) -> some View {
         Text(label)

--- a/Sources/PalmierPro/Timeline/TimelineContainerView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineContainerView.swift
@@ -121,6 +121,7 @@ struct TimelineContainerView: NSViewRepresentable {
             selectedClipIds: editor.selectedClipIds,
             selectedTimelineRange: editor.selectedTimelineRange,
             selectedTimelineMarkerIds: editor.selectedTimelineMarkerIds,
+            timelineMarkerPreview: editor.timelineMarkerPreview,
             pendingReplacements: editor.pendingReplacements,
             generatingAssetIds: Set(editor.mediaAssets.lazy.filter(\.isGenerating).map(\.id))
         )
@@ -170,6 +171,7 @@ struct TimelineContainerView: NSViewRepresentable {
         let selectedClipIds: Set<String>
         let selectedTimelineRange: TimelineRangeSelection?
         let selectedTimelineMarkerIds: Set<String>
+        let timelineMarkerPreview: TimelineMarker?
         let pendingReplacements: Set<String>
         let generatingAssetIds: Set<String>
     }

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -22,7 +22,6 @@ final class TimelineView: NSView, NSPopoverDelegate {
     private(set) var hoveredClipId: String?
     private let canvas = TimelineCanvasView()
     private var markerPopover: NSPopover?
-    private var markerEditorPreview: TimelineMarker?
 
     // MARK: - Init
 
@@ -315,7 +314,9 @@ final class TimelineView: NSView, NSPopoverDelegate {
             drawRippleInsertGapBand(preview: rippleInsertPreview, geometry: geo, context: ctx)
         }
         drawClips(geometry: geo, dirtyRect: dirtyRect, context: ctx, rippleInsertPreview: rippleInsertPreview)
-        var displayedMarkers = editor.displayedTimelineMarkers(preview: markerEditorPreview)
+        var displayedMarkers = editor.displayedTimelineMarkers(
+            preview: editor.timelineMarkerPreview
+        )
         if case .timelineMarker(let drag) = inputController.dragState,
            let index = displayedMarkers.firstIndex(where: { $0.id == drag.original.id }) {
             displayedMarkers[index] = drag.value
@@ -406,7 +407,7 @@ final class TimelineView: NSView, NSPopoverDelegate {
                 marker: marker,
                 fps: editor.timeline.fps,
                 onPreview: { [weak self] marker in
-                    self?.markerEditorPreview = marker
+                    self?.editor.timelineMarkerPreview = marker
                     self?.needsDisplay = true
                 },
                 onDismiss: { [weak self] in self?.dismissMarkerEditor() }
@@ -418,7 +419,7 @@ final class TimelineView: NSView, NSPopoverDelegate {
     }
 
     private func dismissMarkerEditor() {
-        markerEditorPreview = nil
+        editor.timelineMarkerPreview = nil
         markerPopover?.close()
         needsDisplay = true
     }
@@ -426,7 +427,7 @@ final class TimelineView: NSView, NSPopoverDelegate {
     func popoverDidClose(_ notification: Notification) {
         guard let closed = notification.object as? NSPopover,
               closed === markerPopover else { return }
-        markerEditorPreview = nil
+        editor.timelineMarkerPreview = nil
         markerPopover = nil
         needsDisplay = true
     }

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -186,6 +186,8 @@ enum AppTheme {
         static let warning = NSColor.systemOrange
 
         static var warningColor: Color { Color(warning) }
+
+        static var pendingColor: Color { Color(NSColor.systemYellow) }
     }
 
     enum AgentActivity {
@@ -211,7 +213,7 @@ enum AppTheme {
         static let hitSlop: CGFloat = 3
         static let editorWidth: CGFloat = 320
         static let timeFieldWidth: CGFloat = 82
-        static let notesHeight: CGFloat = 54
+        static let commentsHeight: CGFloat = 54
         static let presetColors = [
             "#4094FF", "#40CCE6", "#40BF5C", "#F2C72E", "#FF8C26", "#E64040", "#F259A6",
             "#A666F2", "#8CBFFF", "#73E6B8", "#A6D936", "#C79E6B", "#D1D1D1",
@@ -510,6 +512,11 @@ enum AppTheme {
         static let captionIndexTimecodeWidth: CGFloat = 68
         static let captionIndexDurationWidth: CGFloat = 28
         static let captionIndexGroupMenuWidth: CGFloat = 168
+        static let markerIndexTimeFieldWidth: CGFloat = 64
+        static let markerIndexDurationFieldWidth: CGFloat = 32
+        static let markerIndexCommentHeight: CGFloat = 36
+        static let markerIndexThumbnailHeight = EditorPanel.fieldMinHeight
+            + Spacing.xs + markerIndexCommentHeight
     }
 
     enum Export {

--- a/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
@@ -44,17 +44,26 @@ struct MCPMarkerTests {
             #expect(marker["name"] as? String == "Timeline note")
             #expect(marker["endFrame"] as? Int == 30)
             #expect(marker["color"] as? String == "#FF9500FF")
+            #expect(marker["status"] as? String == "open")
             _ = try json(try await client.callTool(name: "manage_markers", arguments: [
                 "action": .string("update"),
                 "markerId": .string(markerId),
                 "startFrame": .int(40),
                 "color": .string("#34C759"),
                 "comment": .string("Addressed"),
+                "status": .string("review"),
             ]))
             #expect(harness.editor.timeline.markers.first?.startFrame == 40)
             #expect(harness.editor.timeline.markers.first?.comment == "Addressed")
+            #expect(harness.editor.timeline.markers.first?.status == .review)
+            #expect((try await client.callTool(name: "manage_markers", arguments: [
+                "action": .string("update"),
+                "markerId": .string(markerId),
+                "status": .string("done"),
+            ])).isError == true)
             #expect((try await client.callTool(name: "undo")).isError != true)
             #expect(harness.editor.timeline.markers.first?.startFrame == 20)
+            #expect(harness.editor.timeline.markers.first?.status == .open)
         } catch {
             await server.stop()
             await client.disconnect()

--- a/Tests/PalmierProTests/Index/MarkerIndexTests.swift
+++ b/Tests/PalmierProTests/Index/MarkerIndexTests.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import Testing
+@testable import PalmierPro
+
+@Suite struct MarkerIndexTests {
+    @Test func sortsMarkersByTimelinePositionAndStableId() {
+        let markers = [
+            TimelineMarker(id: "later", name: "Later", startFrame: 20),
+            TimelineMarker(id: "b", name: "Second", startFrame: 10),
+            TimelineMarker(id: "a", name: "First", startFrame: 10),
+        ]
+        let result = MarkerBrowserNavigation.sortedMarkers(markers, matching: "")
+        #expect(result.map(\.id) == ["a", "b", "later"])
+    }
+
+    @Test func searchMatchesNamesAndCommentsCaseInsensitively() {
+        let markers = [
+            TimelineMarker(id: "name", name: "Opening Beat", startFrame: 0),
+            TimelineMarker(id: "note", name: "Reaction", startFrame: 10, comment: "Hold on the OPENING shot"),
+            TimelineMarker(id: "other", name: "Product", startFrame: 20),
+        ]
+        let result = MarkerBrowserNavigation.sortedMarkers(markers, matching: " opening ")
+        #expect(result.map(\.id) == ["name", "note"])
+    }
+
+    @Test func filtersMarkersByReviewStatus() {
+        let markers = [
+            TimelineMarker(id: "open", name: "Open", startFrame: 0),
+            TimelineMarker(id: "review", name: "Review", startFrame: 10, status: .review),
+            TimelineMarker(id: "resolved", name: "Resolved", startFrame: 20, status: .resolved),
+        ]
+        let result = MarkerBrowserNavigation.sortedMarkers(markers, matching: "", status: .review)
+        #expect(result.map(\.id) == ["review"])
+    }
+
+    @Test(arguments: [
+        (canvas: CGSize(width: 1920, height: 1080), expectedWidth: CGFloat(96)),
+        (canvas: CGSize(width: 1080, height: 1920), expectedWidth: CGFloat(30.375)),
+    ])
+    func thumbnailPreservesTimelineAspectRatio(canvas: CGSize, expectedWidth: CGFloat) {
+        let size = MarkerThumbnailMetrics.size(canvas: canvas, height: 54)
+        #expect(size.height == 54)
+        #expect(abs(size.width - expectedWidth) < 0.000_001)
+    }
+}

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct TimelineMarkerTests {
     @Test func markersPersistWithoutChangingContentDuration() throws {
         var timeline = Fixtures.timeline(tracks: [Fixtures.videoTrack(clips: [Fixtures.clip(start: 0, duration: 30)])])
-        timeline.markers = [TimelineMarker(name: "Review", startFrame: 40, durationFrames: 10, color: .init(r: 1, g: 0, b: 0), comment: "Tighten")]
+        timeline.markers = [TimelineMarker(name: "Review", startFrame: 40, durationFrames: 10, color: .init(r: 1, g: 0, b: 0), comment: "Tighten", status: .review)]
         let file = ProjectFile(timelines: [timeline])
         let decoded = try JSONDecoder().decode(ProjectFile.self, from: JSONEncoder().encode(file))
         #expect(decoded.timelines[0].markers == timeline.markers)
@@ -50,6 +50,21 @@ struct TimelineMarkerTests {
         #expect(editor.timelineMarkerSnapFrames(
             excludingMarkerIds: [created.id]
         ).isEmpty)
+    }
+    @Test func markerStatusChangesUndo() throws {
+        let editor = EditorViewModel()
+        let undo = UndoManager()
+        editor.undo.attach(undo)
+        editor.timeline.markers = [TimelineMarker(id: "marker", name: "Review", startFrame: 12)]
+        var marker = editor.timeline.markers[0]
+        marker.status = .review
+        _ = try editor.changeTimelineMarkers(
+            updates: [marker],
+            actionName: "Change Marker Status"
+        )
+        #expect(editor.timeline.markers[0].status == .review)
+        undo.undo()
+        #expect(editor.timeline.markers[0].status == .open)
     }
     @Test func defaultMarkerNamesUseNextNumber() {
         let editor = EditorViewModel()

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -18,6 +18,26 @@ struct TimelineMarkerTests {
         let withoutMarkers = try JSONSerialization.data(withJSONObject: object)
         #expect(try JSONDecoder().decode(Timeline.self, from: withoutMarkers).markers.isEmpty)
     }
+    @Test func markersWithoutStatusDecodeAsOpen() throws {
+        var timeline = Fixtures.timeline()
+        timeline.markers = [
+            TimelineMarker(name: "Existing marker", startFrame: 12, status: .review)
+        ]
+        var object = try #require(
+            JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(timeline)
+            ) as? [String: Any]
+        )
+        var markers = try #require(object["markers"] as? [[String: Any]])
+        markers[0].removeValue(forKey: "status")
+        object["markers"] = markers
+
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(Timeline.self, from: data)
+
+        #expect(decoded.markers.count == 1)
+        #expect(decoded.markers[0].status == .open)
+    }
     @Test func duplicateTimelineFreshensMarkerIds() throws {
         let editor = EditorViewModel()
         editor.timeline.markers = [TimelineMarker(name: "Note", startFrame: 4)]

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerTests.swift
@@ -66,6 +66,22 @@ struct TimelineMarkerTests {
         undo.undo()
         #expect(editor.timeline.markers[0].status == .open)
     }
+    @Test func committingMarkerChangeClearsItsPreview() throws {
+        let editor = EditorViewModel()
+        let marker = TimelineMarker(id: "marker", name: "Review", startFrame: 12)
+        editor.timeline.markers = [marker]
+        var preview = marker
+        preview.startFrame = 20
+        editor.timelineMarkerPreview = preview
+
+        _ = try editor.changeTimelineMarkers(
+            updates: [preview],
+            actionName: "Move Marker"
+        )
+
+        #expect(editor.timeline.markers == [preview])
+        #expect(editor.timelineMarkerPreview == nil)
+    }
     @Test func defaultMarkerNamesUseNextNumber() {
         let editor = EditorViewModel()
         editor.selectedClipIds = ["clip"]


### PR DESCRIPTION
## Summary
- add a marker browser to the timeline Index with composited thumbnails, inline comments, timing controls, color, deletion, search, and review-status filtering
- add persistent `open`, `review`, and `resolved` marker statuses shared by UI and Agent workflows
- replace the separate Index mode picker with compact Captions/Markers tabs and contextual toolbar actions

## Approach
- route all marker edits through the existing `changeTimelineMarkers` validation and undo operation
- reuse the active `VideoEngine` timeline composition for on-demand Retina thumbnails, with two concurrent frame requests and generation checks to reject stale results
- centralize temporary marker previews so timeline scrubbing and the existing marker editor render the same draft state
- keep marker color independent from review status; status uses yellow, orange, and green dots and stable machine values
- preserve panel-local Index mode in `MediaPanelView` so caption generation can navigate directly to the caption browser

## Testing
- `scripts/localization/sync.sh` — passed
- `swift build` — passed
- `swift test` — 1,601 tests across 254 suites passed
- manually reviewed Captions/Markers switching, compact toolbar layout, marker selection, composited thumbnails, inline comments, time and duration scrubbing, color selection, status filtering, and deletion
- CI checks pending

## Change statistics
- UI: +600 / -80
- domain, Agent, and preview infrastructure: +84 / -31
- localization: +14 / -2
- tests: +86 / -1
- total: +784 / -114



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted marker model, agent/MCP contracts, and async preview frame extraction from the live composition; scope is large UI surface but edits go through established marker validation/undo paths.
> 
> **Overview**
> Adds **open / review / resolved** marker statuses on `TimelineMarker` (backward-compatible decode), exposes them through **`manage_markers`** and **`get_timeline`**, and documents when agents should move markers to **review** vs **resolved**.
> 
> The media panel **Index** tab now switches between **Captions** and **Markers** via compact tabs. **MarkerBrowser** lists markers with search, status filter, composited frame thumbnails (via `VideoEngine.timelineThumbnail` and `timelineCompositionGeneration`), and inline edits (comment, time/duration, color, status, delete) routed through existing `changeTimelineMarkers` undo.
> 
> **`timelineMarkerPreview`** on `EditorViewModel` replaces timeline-local preview state so the ruler, marker popover, and index rows share draft marker positions during scrubbing; previews clear on commit, undo, and timeline switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8ba77a6e5cb0b73256bad835d1a4dc30d57d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->