### PR TITLE
[fix] Restore Home clicks after dismissing Update overlay

### DIFF
--- a/Sources/PalmierPro/Home/HomeView.swift
+++ b/Sources/PalmierPro/Home/HomeView.swift
@@ -24,15 +24,22 @@ struct HomeView: View {
         .task { await VisualModelLoader.shared.prepare() }
         .onAppear { changelog.checkForWhatsNew() }
         .overlay {
-            if !onboarding.isComplete {
-                OnboardingOverlay(onboarding: onboarding)
-            } else if let entry = changelog.pending {
-                UpdateOverlay(entry: entry, changelogURL: changelog.changelogURL) {
-                    withAnimation { changelog.dismiss() }
+            ZStack {
+                if !onboarding.isComplete {
+                    OnboardingOverlay(onboarding: onboarding)
+                } else if let entry = changelog.pending {
+                    UpdateOverlay(entry: entry, changelogURL: changelog.changelogURL) {
+                        changelog.dismiss()
+                    }
                 }
             }
+            .allowsHitTesting(isModalOverlayPresented)
         }
-        .animation(.easeInOut(duration: AppTheme.Anim.transition), value: onboarding.isComplete)
+        .animation(.easeInOut(duration: AppTheme.Anim.transition), value: isModalOverlayPresented)
+    }
+
+    private var isModalOverlayPresented: Bool {
+        !onboarding.isComplete || changelog.pending != nil
     }
 
     private var content: some View {

--- a/Sources/PalmierPro/Home/UpdateOverlay.swift
+++ b/Sources/PalmierPro/Home/UpdateOverlay.swift
@@ -7,15 +7,12 @@ struct UpdateOverlay: View {
     let onDismiss: () -> Void
 
     var body: some View {
-        GeometryReader { proxy in
-            ZStack {
-                AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
-                    .ignoresSafeArea()
-                card
-                    .frame(width: AppTheme.ComponentSize.updateOverlayWidth)
-                    .frame(maxHeight: max(0, proxy.size.height - AppTheme.Spacing.xxl * 2))
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ZStack {
+            AppTheme.MediaOverlay.backgroundColor.opacity(AppTheme.Opacity.strong)
+                .ignoresSafeArea()
+            card
+                .frame(width: AppTheme.ComponentSize.updateOverlayWidth)
+                .padding(.vertical, AppTheme.Spacing.xxl)
         }
         .transition(.opacity)
     }


### PR DESCRIPTION
## Summary
- Dismissing the What's New overlay left Home buttons unresponsive until the app was relaunched.
- The fade kept a full-window overlay in the hit-test tree at opacity 0, so New Project, Open Project, Settings, and project cards never received clicks.
- Home now disables overlay hit-testing as soon as the sheet is gone, and What's New no longer uses a `GeometryReader` that can linger after dismiss.

## Approach
- Wrap the Home modal overlay in a persistent `ZStack` and gate `.allowsHitTesting` on whether onboarding or What's New is actually presented. Hits pass through during and after the fade.
- Drive the existing opacity transition from that same presented flag instead of `withAnimation` on dismiss.
- Size the What's New card with vertical padding instead of `GeometryReader`, matching Onboarding's dimmer-plus-card stack.

## Testing
- `swift build --target PalmierPro` — passed
- Manual: `defaults write io.palmier.pro lastSeenVersion '"0.0.0"'`, launch Home, dismiss What's New, then click New Project, Open Project, Settings, and a project card without quitting. Also verified Return-to-dismiss and a scrolling changelog.
- Unit tests were not added; this is a SwiftUI hit-testing defect and is not practical to cover in unit tests.

## Change statistics
- Logic: +19 / −15 across `HomeView.swift` and `UpdateOverlay.swift`
- Tests: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SwiftUI interaction fix on Home overlays with no auth, data, or API changes.
> 
> **Overview**
> Fixes Home staying unclickable after closing the **What's New** sheet because a full-window overlay could remain in the hit-test tree at zero opacity during the fade-out.
> 
> **Home** wraps onboarding and What's New in a stable `ZStack` and ties `.allowsHitTesting` to `isModalOverlayPresented` (onboarding incomplete or changelog pending), so pointer events reach sidebar and project UI as soon as the modal is logically dismissed—including while the opacity transition runs. The overlay animation now tracks that same flag instead of only onboarding completion, and dismiss no longer wraps `changelog.dismiss()` in `withAnimation`.
> 
> **UpdateOverlay** drops `GeometryReader` in favor of vertical padding on the card, avoiding layout/hit-testing quirks that could leave an invisible blocker after dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389569334083a8acd54571fc91e78149529f62ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->