### PR TITLE
[ui] Brighten dark editor surfaces and keep chat below the tab bar

### DIFF
--- a/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
+++ b/Sources/PalmierPro/Agent/Panel/AgentPanelView.swift
@@ -59,10 +59,8 @@ struct AgentPanelView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ZStack(alignment: .top) {
-                messageList
-                floatingTabBar
-            }
+            floatingTabBar
+            messageList
             footer
         }
     }
@@ -280,7 +278,7 @@ struct AgentPanelView: View {
                         .padding(.top, AppTheme.Spacing.sm)
                 }
                 .padding(.horizontal, AppTheme.Spacing.lgXl)
-                .padding(.top, Layout.panelHeaderHeight + AppTheme.Spacing.mdLg)
+                .padding(.top, AppTheme.Spacing.mdLg)
                 .padding(.bottom, AppTheme.Spacing.smMd)
                 .frame(maxWidth: Layout.chatColumnMax)
                 .frame(maxWidth: .infinity)

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -14,19 +14,19 @@ enum AppTheme {
     enum Background {
         static let base = AppTheme.adaptive(
             light: NSColor(red: 241/255, green: 240/255, blue: 237/255, alpha: 1),
-            dark: NSColor(red: 20/255, green: 21/255, blue: 24/255, alpha: 1)
+            dark: NSColor(red: 24/255, green: 25/255, blue: 28/255, alpha: 1)
         )
         static let surface = AppTheme.adaptive(
             light: NSColor(red: 245/255, green: 244/255, blue: 241/255, alpha: 1),
-            dark: NSColor(red: 26/255, green: 27/255, blue: 31/255, alpha: 1)
+            dark: NSColor(red: 30/255, green: 31/255, blue: 35/255, alpha: 1)
         )
         static let raised = AppTheme.adaptive(
             light: NSColor(red: 249/255, green: 248/255, blue: 245/255, alpha: 1),
-            dark: NSColor(red: 34/255, green: 35/255, blue: 40/255, alpha: 1)
+            dark: NSColor(red: 38/255, green: 39/255, blue: 44/255, alpha: 1)
         )
         static let prominent = AppTheme.adaptive(
             light: NSColor(red: 252/255, green: 251/255, blue: 248/255, alpha: 1),
-            dark: NSColor(red: 44/255, green: 45/255, blue: 51/255, alpha: 1)
+            dark: NSColor(red: 48/255, green: 49/255, blue: 55/255, alpha: 1)
         )
 
         /// Alias — empty media slot is a raised plate.


### PR DESCRIPTION
## Summary
- Lift the dark-mode editor elevation ladder so Media, Preview, Inspector, Timeline, and chrome read a bit brighter.
- Stack the agent floating tab bar above the message list so chat no longer scrolls through the bar into the titlebar.

## Approach
Dark `base` / `surface` / `raised` / `prominent` each move up by 4 RGB points so hover and active plates stay a step above the new editor surface. Light mode is unchanged.

Agent chat drops the overlay `ZStack`. The tab bar is a sibling above the list, so messages clip at the bar instead of drawing through the window controls. The extra top inset that compensated for the overlay is removed.

## Testing
- `swift build` during development.
- Open a project in dark mode and confirm editor panels look slightly brighter without collapsing hover contrast.
- Open Agent, scroll a long thread: messages should stop at the floating tab bar, not the titlebar.
- Confirm window buttons and panel visibility controls still click.
- Light mode should look unchanged.

Not run: `swift test`, packaged app, Instruments.

## Change statistics
- AppTheme dark backgrounds: 4 tokens adjusted
- Agent panel layout: overlay stack removed, list inset reduced
- Net: +7 / −9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only SwiftUI changes with no auth, data, or business-logic impact.
> 
> **Overview**
> **Dark mode** lifts the editor elevation ladder: `AppTheme.Background` dark tokens for `base`, `surface`, `raised`, and `prominent` each move up by four RGB points so panels and chrome read slightly brighter while light mode stays the same.
> 
> **Agent panel** drops the overlay `ZStack` that drew the message list under the floating tab bar. The tab bar now sits above the scroll view in a `VStack`, and the list’s top inset no longer adds `Layout.panelHeaderHeight`, so long threads clip at the bar instead of scrolling through it into the titlebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d012a369a04e95c578251707b65f1598b95a872f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->