### PR TITLE
[ui] Dock the generation panel under media

### DIFF
--- a/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView+References.swift
@@ -63,13 +63,13 @@ extension GenerationView {
     }
 
     private var refGridColumns: [GridItem] {
-        [GridItem(.adaptive(minimum: AppTheme.GenerationPanel.referenceTileWidth), spacing: AppTheme.Spacing.xs)]
+        [GridItem(.adaptive(minimum: AppTheme.GenerationPanel.referenceTileWidth), spacing: AppTheme.Spacing.xxs)]
     }
 
     // MARK: - Video frame references
 
     var videoFrameStrip: some View {
-        HStack(spacing: AppTheme.Spacing.xs) {
+        HStack(spacing: AppTheme.Spacing.sm) {
             FrameSlot(label: L10n.string("First Frame"), asset: firstFrame, isTargeted: $firstFrameTargeted,
                       onDrop: { firstFrame = $0 }, onClear: { firstFrame = nil }, onError: flashDropError)
             if videoModel.supportsLastFrame {
@@ -127,7 +127,7 @@ extension GenerationView {
     // MARK: - Reference strip
 
     var referenceSections: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
             HStack(spacing: AppTheme.Spacing.xs) {
                 Text(L10n.string("References"))
                     .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
@@ -141,7 +141,7 @@ extension GenerationView {
             LazyVGrid(
                 columns: refGridColumns,
                 alignment: .leading,
-                spacing: AppTheme.Spacing.xs
+                spacing: AppTheme.Spacing.xxs
             ) {
                 ForEach(allRefCardItems, id: \.asset.id) { item in
                     RefCard(asset: item.asset, tag: item.tag) {
@@ -311,7 +311,7 @@ extension GenerationView {
     // MARK: - Image references
 
     var imageReferenceStrip: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
             Text(L10n.string("References"))
                 .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)
@@ -319,7 +319,7 @@ extension GenerationView {
             LazyVGrid(
                 columns: refGridColumns,
                 alignment: .leading,
-                spacing: AppTheme.Spacing.xs
+                spacing: AppTheme.Spacing.xxs
             ) {
                 ForEach(imageReferences) { asset in
                     RefCard(asset: asset) {

--- a/Sources/PalmierPro/Generation/UI/GenerationView.swift
+++ b/Sources/PalmierPro/Generation/UI/GenerationView.swift
@@ -180,7 +180,6 @@ struct GenerationView: View {
         .frame(maxWidth: .infinity)
         .frame(height: AppTheme.GenerationPanel.loadingHeight)
         .background { panelChrome }
-        .padding(.horizontal, AppTheme.Spacing.sm)
     }
 
     private var bodyContent: some View {
@@ -205,7 +204,7 @@ struct GenerationView: View {
             }
             .padding(.horizontal, AppTheme.Spacing.md)
 
-            VStack(spacing: AppTheme.Spacing.xs) {
+            VStack(spacing: AppTheme.Spacing.sm) {
                 referencesContent
                     .layoutPriority(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -239,12 +238,12 @@ struct GenerationView: View {
                     inputToolbar
                 }
                 .background {
-                    RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.lg, style: .continuous)
                         .fill(AppTheme.Background.prominentColor)
                 }
-                .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.lg, style: .continuous))
                 .overlay {
-                    RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.lg, style: .continuous)
                         .strokeBorder(
                             isPromptFocused
                                 ? AppTheme.Accent.primary.opacity(AppTheme.Opacity.medium)
@@ -259,10 +258,9 @@ struct GenerationView: View {
             .padding(.bottom, AppTheme.Spacing.md)
         }
         .padding(.top, AppTheme.Spacing.md)
-        .overlay(alignment: .top) { resizeHandle }
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { measuredPanelHeight = $0 }
         .background { panelChrome }
-        .padding(.horizontal, AppTheme.Spacing.sm)
+        .overlay(alignment: .top) { resizeHandle }
         .onAppear {
             let hadSeed = editor.pendingPanelSeed != nil
             consumePendingPanelSeed()
@@ -343,13 +341,13 @@ struct GenerationView: View {
     }
 
     private var panelChrome: some View {
-        RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
-            .fill(AppTheme.Background.raisedColor)
+        AppTheme.Background.surfaceColor
             .shadow(AppTheme.Shadow.overlay)
             .shadow(AppTheme.Shadow.lg)
-            .overlay {
-                RoundedRectangle(cornerRadius: AppTheme.Radius.xl, style: .continuous)
-                    .strokeBorder(AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(AppTheme.Border.primaryColor)
+                    .frame(height: AppTheme.BorderWidth.thin)
             }
             .allowsHitTesting(false)
     }
@@ -357,12 +355,12 @@ struct GenerationView: View {
     // MARK: - Resize handle
 
     private var resizeHandle: some View {
-        Capsule()
-            .fill(AppTheme.Interaction.fill(AppTheme.Opacity.soft))
-            .frame(width: 24, height: 2)
-            .frame(maxWidth: .infinity, minHeight: AppTheme.Spacing.md)
+        Color.clear
+            .frame(maxWidth: .infinity)
+            .frame(height: AppTheme.Spacing.md)
             .contentShape(Rectangle())
             .pointerStyle(.rowResize)
+            .offset(y: -AppTheme.Spacing.md / 2)
             .gesture(
                 DragGesture(minimumDistance: 0, coordinateSpace: .global)
                     .onChanged { value in

--- a/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
+++ b/Sources/PalmierPro/Generation/UI/ReferenceControls.swift
@@ -114,7 +114,7 @@ struct FrameSlot: View {
     let onError: (String) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.Spacing.xs) {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.sm) {
             Text(L10n.string(key: label))
                 .font(.system(size: AppTheme.FontSize.xs, weight: .medium))
                 .foregroundStyle(AppTheme.Text.tertiaryColor)

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -91,7 +91,7 @@ struct MediaTab: View {
                 swapBanner
             }
 
-            ZStack(alignment: .bottom) {
+            VStack(spacing: 0) {
                 MediaPanelDropArea(
                     isTargeted: $isDropTargeted,
                     onDrop: { urls in handlePanelFinderDrop(urls: urls) }
@@ -127,6 +127,8 @@ struct MediaTab: View {
                     }
                 }
                 .animation(.easeInOut(duration: AppTheme.Anim.transition), value: editor.mediaPanelToast)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .layoutPriority(1)
 
                 if editor.showGenerationPanel && !mediaAreaCollapsed {
                     GenerationView(maxPanelHeight: generationPanelMaxHeight)
@@ -469,7 +471,7 @@ struct MediaTab: View {
     }
 
     private var showsEmptyState: Bool {
-        editor.mediaAssets.isEmpty && editor.folders.isEmpty && !editor.showGenerationPanel
+        editor.mediaAssets.isEmpty && editor.folders.isEmpty
     }
 
     // MARK: - Sort & Filter

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -496,7 +496,7 @@ enum AppTheme {
     enum GenerationPanel {
         static let typeTabWidth: CGFloat = IconSize.xl + Spacing.lg
         static let minimumWidthAdjustment: CGFloat = typeTabWidth + Spacing.xxl
-        static let mediaAreaMinHeight: CGFloat = 120
+        static let mediaAreaMinHeight: CGFloat = 60
         static let loadingHeight: CGFloat = 180
         static let promptMinHeight: CGFloat = 40
         static let referenceTileWidth: CGFloat = 72

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -499,8 +499,8 @@ enum AppTheme {
         static let mediaAreaMinHeight: CGFloat = 120
         static let loadingHeight: CGFloat = 180
         static let promptMinHeight: CGFloat = 40
-        static let referenceTileWidth: CGFloat = 80
-        static let referenceTileHeight: CGFloat = 56
+        static let referenceTileWidth: CGFloat = 72
+        static let referenceTileHeight: CGFloat = 48
     }
 
     enum MediaPanel {


### PR DESCRIPTION
## Summary
- Generation now docks under the media grid instead of floating over it as a card.
- Media stays visible and scrollable while Generate is open; the empty library state still shows above the panel.
- Prompt well, reference spacing, and the hidden divider resize handle are tuned for the flush layout.

## Approach
- Replace the media-tab `ZStack` overlay with a `VStack` so generation takes its own height under the browser.
- Drop card inset, rounded chrome, and the visible grabber. Keep overlay/large shadows, a top divider, and an invisible row-resize hit target centered on that divider.
- Tighten reference tile size and grid spacing; give First/Last a little more room between label and tile.

## Design
```mermaid
flowchart TB
  subgraph before [Before]
    Z[ZStack]
    M1[Media grid]
    C[Floating generation card]
    Z --> M1
    Z --> C
  end
  subgraph after [After]
    V[VStack]
    M2[Media grid]
    P[Docked generation panel]
    V --> M2
    V --> P
  end
```

## Testing
- `swift build` in `.worktrees/generation-panel-layout` — succeeded.
- Manual UI (confirm in the worktree app):
  - Open Generate: panel docks under media; media remains visible and scrollable.
  - Empty library: empty state above, generation below.
  - Close / reopen Generate; First/Last vs References spacing.
  - Drag the top divider to resize the prompt; row-resize cursor sits on the line.
  - Toasts appear above the generation panel.

## Change statistics
- Layout / UI: 5 files, +27 / −27
- Tests: none (layout-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and theme-token changes only; no generation logic, networking, or data handling.
> 
> **Overview**
> **Docks Generate under the media area** so the grid stays visible and scrollable while the panel is open. `MediaTab` swaps the bottom-overlay `ZStack` for a `VStack`, gives the drop area flexible height, and still stacks toasts above the docked panel. The empty-library state no longer hides when Generate is open.
> 
> **Flattens generation panel chrome** in `GenerationView`: horizontal inset padding is removed, the raised rounded card becomes a full-width `surfaceColor` strip with a top divider and shadows, the prompt well uses `Radius.lg`, and the visible capsule resize grip is an invisible row-resize hit target on that divider.
> 
> **Tunes reference UI density** via `AppTheme.GenerationPanel` (smaller tiles, lower media min height) and spacing tweaks in reference strips and `FrameSlot` (tighter grids, slightly more label-to-tile gap for first/last frames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983749ab87e08d857359033a51bee50a223b15f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->