### PR TITLE
[feat] Ripple timeline markers with edits

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -21,7 +21,8 @@ enum AgentInstructions {
           that for alternate versions instead of editing over the original. A nested timeline \
           appears as a clip with mediaType 'sequence'.
         - Markers are persistent timeline notes. Use manage_markers and stable markerId values; \
-          point markers have zero duration and ranges are half-open. Leave failed or ambiguous \
+          point markers have zero duration and ranges are half-open. Ripple edits may move or \
+          remove them — patch positions from the mutation delta. Leave failed or ambiguous \
           work open, set review only after applying and verifying the edit, and set resolved only \
           when the user explicitly approves or requests it.
         - IDs are short prefixes — pass them back exactly as given, never padded or completed. \
@@ -31,9 +32,10 @@ enum AgentInstructions {
         - Call get_timeline once per session (or after an out-of-band change). Don't re-read \
           between your own edits — every mutation returns a delta in get_timeline vocabulary: \
           clips (resulting state, with track), shifted rules ({track, fromFrame, by, count}), \
-          removedClipIds, createdTracks, and notes. Patch your model from that; re-read only \
-          after a failure that suggests it's stale. Caption clips arrive as captionGroup \
-          summaries — restyle whole groups from that alone; captionDetail=true (windowed) \
+          removedClipIds, markers, removedMarkerIds, createdTracks, and notes. Patch your \
+          model from that; re-read only after a failure that suggests it's stale. Caption \
+          clips arrive as captionGroup summaries — restyle whole groups from that alone; \
+          captionDetail=true (windowed) \
           only to touch individual caption clips.
         - After a batch of edits, spot-check the result: get_timeline for structure, \
           inspect_timeline when placement, layout, captions, or stacking matter.

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+MutationDelta.swift
@@ -16,6 +16,7 @@ extension ToolExecutor {
     struct TimelineSnapshot {
         let placements: [String: ClipPlacement]
         let trackIds: [String]
+        let markers: [String: TimelineMarker]
     }
 
     private static let mutationClipLimit = 30
@@ -28,7 +29,11 @@ extension ToolExecutor {
                 placements[clip.id] = ClipPlacement(trackId: track.id, index: i, start: clip.startFrame, duration: clip.durationFrames)
             }
         }
-        return TimelineSnapshot(placements: placements, trackIds: editor.timeline.tracks.map(\.id))
+        return TimelineSnapshot(
+            placements: placements,
+            trackIds: editor.timeline.tracks.map(\.id),
+            markers: Dictionary(uniqueKeysWithValues: editor.timeline.markers.map { ($0.id, $0) })
+        )
     }
 
     func mutationResult(
@@ -86,6 +91,14 @@ extension ToolExecutor {
 
         let removedIds = snapshot.placements.keys.filter { after.placements[$0] == nil }.sorted()
         if !removedIds.isEmpty { payload["removedClipIds"] = removedIds }
+
+        let changedMarkers = editor.timeline.markers.filter { snapshot.markers[$0.id] != $0 }
+        if !changedMarkers.isEmpty {
+            payload["markers"] = changedMarkers.map(Self.timelineMarkerDict)
+        }
+        let remainingMarkerIds = Set(editor.timeline.markers.map(\.id))
+        let removedMarkerIds = snapshot.markers.keys.filter { !remainingMarkerIds.contains($0) }.sorted()
+        if !removedMarkerIds.isEmpty { payload["removedMarkerIds"] = removedMarkerIds }
 
         let created = after.trackIds.enumerated()
             .filter { !snapshot.trackIds.contains($0.element) }

--- a/Sources/PalmierPro/App/MainMenu.swift
+++ b/Sources/PalmierPro/App/MainMenu.swift
@@ -110,6 +110,12 @@ enum MainMenuBuilder {
         rippleDeleteItem.keyEquivalentModifierMask = [.shift]
         menu.addItem(rippleDeleteItem)
 
+        menu.addItem(
+            withTitle: L10n.string("Ripple Timeline Markers"),
+            action: #selector(EditorActions.toggleRippleTimelineMarkers(_:)),
+            keyEquivalent: ""
+        )
+
         item.submenu = menu
         return item
     }
@@ -191,6 +197,7 @@ enum MainMenuBuilder {
     func selectForwardOnAllTracks(_ sender: Any?)
     func deleteSelectedClips(_ sender: Any?)
     func rippleDeleteSelected(_ sender: Any?)
+    func toggleRippleTimelineMarkers(_ sender: Any?)
     func importMedia(_ sender: Any?)
     func newMediaFolder(_ sender: Any?)
     func showExport(_ sender: Any?)

--- a/Sources/PalmierPro/Editor/EditorWindowController.swift
+++ b/Sources/PalmierPro/Editor/EditorWindowController.swift
@@ -301,6 +301,9 @@ extension EditorWindowController: EditorActions {
             editorViewModel.rippleDeleteSelectedClips()
         }
     }
+    @objc func toggleRippleTimelineMarkers(_ sender: Any?) {
+        editorViewModel.rippleTimelineMarkers.toggle()
+    }
     @objc func importMedia(_ sender: Any?) {
         // Handled by MediaTab directly
     }
@@ -359,6 +362,9 @@ extension EditorWindowController: EditorActions {
 
     @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
+        case #selector(toggleRippleTimelineMarkers(_:)):
+            menuItem.state = editorViewModel.rippleTimelineMarkers ? .on : .off
+            return true
         case #selector(toggleMediaPanel(_:)):
             menuItem.state = editorViewModel.mediaPanelVisible ? .on : .off
             return true

--- a/Sources/PalmierPro/Editor/RippleEngine.swift
+++ b/Sources/PalmierPro/Editor/RippleEngine.swift
@@ -67,27 +67,28 @@ enum RippleEngine {
             .map { ClipShift(clipId: $0.id, newStartFrame: $0.startFrame + pushAmount) }
     }
 
-    /// Close removed spans. One range list per shifting track; drop a point only if every track removed it.
+    /// Close removed spans. One range list per shifting track; remap only tracks that still hold the marker.
     static func rippleMarkers(_ markers: [TimelineMarker], closing trackRanges: [[FrameRange]]) -> [TimelineMarker] {
         let mergedTracks = trackRanges.map { mergeRanges($0.filter { $0.length > 0 }) }.filter { !$0.isEmpty }
         guard !mergedTracks.isEmpty else { return markers }
         return markers.compactMap { marker in
-            let mappedStarts = mergedTracks.map { mapFrame(marker.startFrame, closing: $0) }
-            if !marker.isRange {
-                let removedOnEveryTrack = mergedTracks.allSatisfy { ranges in
-                    ranges.contains { ($0.start..<$0.end).contains(marker.startFrame) }
+            let surviving = mergedTracks.compactMap { ranges -> (start: Int, end: Int)? in
+                let start = mapFrame(marker.startFrame, closing: ranges)
+                if !marker.isRange {
+                    let removed = ranges.contains { ($0.start..<$0.end).contains(marker.startFrame) }
+                    return removed ? nil : (start, start)
                 }
-                guard !removedOnEveryTrack else { return nil }
-                var next = marker
-                next.startFrame = mappedStarts.min() ?? marker.startFrame
-                return next
+                let end = mapFrame(marker.endFrame, closing: ranges)
+                return end > start ? (start, end) : nil
             }
-            let newStart = mappedStarts.min() ?? marker.startFrame
-            let newEnd = mergedTracks.map { mapFrame(marker.endFrame, closing: $0) }.min() ?? marker.endFrame
-            guard newEnd > newStart else { return nil }
+            guard let first = surviving.first else { return nil }
             var next = marker
-            next.startFrame = newStart
-            next.durationFrames = newEnd - newStart
+            next.startFrame = surviving.map(\.start).min() ?? first.start
+            if marker.isRange {
+                let newEnd = surviving.map(\.end).min() ?? first.end
+                guard newEnd > next.startFrame else { return nil }
+                next.durationFrames = newEnd - next.startFrame
+            }
             return next
         }
     }

--- a/Sources/PalmierPro/Editor/RippleEngine.swift
+++ b/Sources/PalmierPro/Editor/RippleEngine.swift
@@ -67,20 +67,27 @@ enum RippleEngine {
             .map { ClipShift(clipId: $0.id, newStartFrame: $0.startFrame + pushAmount) }
     }
 
-    /// Close removed spans: drop points inside, shrink overlapping ranges, shift the rest left.
-    static func rippleMarkers(_ markers: [TimelineMarker], closing removedRanges: [FrameRange]) -> [TimelineMarker] {
-        let merged = mergeRanges(removedRanges.filter { $0.length > 0 })
-        guard !merged.isEmpty else { return markers }
+    /// Close removed spans. One range list per shifting track; drop a point only if every track removed it.
+    static func rippleMarkers(_ markers: [TimelineMarker], closing trackRanges: [[FrameRange]]) -> [TimelineMarker] {
+        let mergedTracks = trackRanges.map { mergeRanges($0.filter { $0.length > 0 }) }.filter { !$0.isEmpty }
+        guard !mergedTracks.isEmpty else { return markers }
         return markers.compactMap { marker in
-            if !marker.isRange, merged.contains(where: { ($0.start..<$0.end).contains(marker.startFrame) }) {
-                return nil
+            let mappedStarts = mergedTracks.map { mapFrame(marker.startFrame, closing: $0) }
+            if !marker.isRange {
+                let removedOnEveryTrack = mergedTracks.allSatisfy { ranges in
+                    ranges.contains { ($0.start..<$0.end).contains(marker.startFrame) }
+                }
+                guard !removedOnEveryTrack else { return nil }
+                var next = marker
+                next.startFrame = mappedStarts.min() ?? marker.startFrame
+                return next
             }
+            let newStart = mappedStarts.min() ?? marker.startFrame
+            let newEnd = mergedTracks.map { mapFrame(marker.endFrame, closing: $0) }.min() ?? marker.endFrame
+            guard newEnd > newStart else { return nil }
             var next = marker
-            next.startFrame = mapFrame(marker.startFrame, closing: merged)
-            guard marker.isRange else { return next }
-            let newEnd = mapFrame(marker.endFrame, closing: merged)
-            guard newEnd > next.startFrame else { return nil }
-            next.durationFrames = newEnd - next.startFrame
+            next.startFrame = newStart
+            next.durationFrames = newEnd - newStart
             return next
         }
     }
@@ -95,7 +102,7 @@ enum RippleEngine {
         if pushAmount < 0 {
             return rippleMarkers(
                 markers,
-                closing: [FrameRange(start: insertFrame + pushAmount, end: insertFrame)]
+                closing: [[FrameRange(start: insertFrame + pushAmount, end: insertFrame)]]
             )
         }
         return markers.map { marker in

--- a/Sources/PalmierPro/Editor/RippleEngine.swift
+++ b/Sources/PalmierPro/Editor/RippleEngine.swift
@@ -67,7 +67,61 @@ enum RippleEngine {
             .map { ClipShift(clipId: $0.id, newStartFrame: $0.startFrame + pushAmount) }
     }
 
+    /// Close removed spans: drop points inside, shrink overlapping ranges, shift the rest left.
+    static func rippleMarkers(_ markers: [TimelineMarker], closing removedRanges: [FrameRange]) -> [TimelineMarker] {
+        let merged = mergeRanges(removedRanges.filter { $0.length > 0 })
+        guard !merged.isEmpty else { return markers }
+        return markers.compactMap { marker in
+            if !marker.isRange, merged.contains(where: { ($0.start..<$0.end).contains(marker.startFrame) }) {
+                return nil
+            }
+            var next = marker
+            next.startFrame = mapFrame(marker.startFrame, closing: merged)
+            guard marker.isRange else { return next }
+            let newEnd = mapFrame(marker.endFrame, closing: merged)
+            guard newEnd > next.startFrame else { return nil }
+            next.durationFrames = newEnd - next.startFrame
+            return next
+        }
+    }
+
+    /// Open a gap at `insertFrame`. Negative `pushAmount` closes `[insertFrame + pushAmount, insertFrame)`.
+    static func rippleMarkers(
+        _ markers: [TimelineMarker],
+        openingAt insertFrame: Int,
+        by pushAmount: Int
+    ) -> [TimelineMarker] {
+        guard pushAmount != 0 else { return markers }
+        if pushAmount < 0 {
+            return rippleMarkers(
+                markers,
+                closing: [FrameRange(start: insertFrame + pushAmount, end: insertFrame)]
+            )
+        }
+        return markers.map { marker in
+            var next = marker
+            if next.startFrame >= insertFrame {
+                next.startFrame += pushAmount
+            } else if next.isRange, next.endFrame > insertFrame {
+                next.durationFrames += pushAmount
+            }
+            return next
+        }
+    }
+
     // MARK: - Helpers
+
+    private static func mapFrame(_ frame: Int, closing ranges: [FrameRange]) -> Int {
+        var mapped = frame
+        for range in ranges {
+            if range.end <= frame {
+                mapped -= range.length
+            } else if range.start < frame {
+                mapped -= frame - range.start
+            }
+        }
+        return max(0, mapped)
+    }
 
     static func mergeRanges(_ ranges: [FrameRange]) -> [FrameRange] {
         let sorted = ranges.sorted { $0.start < $1.start }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -110,6 +110,7 @@ extension EditorViewModel {
         guard let plan = planRippleTrim(clipId: clipId, edge: edge, deltaFrames: deltaFrames, propagateToLinked: propagateToLinked) else { return }
 
         let touched = plan.targetIds.union(plan.shifts.map(\.clipId))
+        let leadEnd = findClip(id: clipId).map { timeline.tracks[$0.trackIndex].clips[$0.clipIndex].endFrame }
         withTimelineSwap(actionName: "Ripple Trim") {
             for r in plan.resizes {
                 guard let l = findClip(id: r.clipId) else { continue }
@@ -118,6 +119,9 @@ extension EditorViewModel {
                 timeline.tracks[l.trackIndex].clips[l.clipIndex].setDuration(r.duration)
             }
             applyShifts(plan.shifts)
+            if let leadEnd {
+                rippleMarkersOpening(at: leadEnd, by: plan.durationDelta)
+            }
             for ti in timeline.tracks.indices where timeline.tracks[ti].clips.contains(where: { touched.contains($0.id) }) {
                 sortClips(trackIndex: ti)
             }
@@ -208,6 +212,7 @@ extension EditorViewModel {
         withTimelineSwap(actionName: "Ripple Delete", refreshVisuals: false) {
             removeClips(ids: ids)
             for shifts in shiftsByTrack.values { applyShifts(shifts) }
+            rippleMarkersClosing(globalRemovedRanges)
         }
     }
 
@@ -220,6 +225,20 @@ extension EditorViewModel {
             applied += 1
         }
         return applied
+    }
+
+    fileprivate func rippleMarkersClosing(_ ranges: [FrameRange]) {
+        applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, closing: ranges))
+    }
+
+    fileprivate func rippleMarkersOpening(at insertFrame: Int, by pushAmount: Int) {
+        applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, openingAt: insertFrame, by: pushAmount))
+    }
+
+    private func applyRippledMarkers(_ next: [TimelineMarker]) {
+        guard rippleTimelineMarkers, next != timeline.markers else { return }
+        timeline.markers = next
+        timelineMarkerPreview = nil
     }
 
     /// Ripple-delete timeline-frame `ranges` anchored to `anchorClipId`
@@ -300,6 +319,7 @@ extension EditorViewModel {
                 shiftedClips += applyShifts(shifts)
                 sortClips(trackIndex: ti)
             }
+            rippleMarkersClosing(merged)
         }
 
         // Anchor track's post-cut layout (surviving + new fragments) so the caller needn't re-read.
@@ -361,6 +381,7 @@ extension EditorViewModel {
                     removedRanges: [gap.range]
                 ))
             }
+            rippleMarkersClosing([gap.range])
         }
         selectedGap = nil
     }
@@ -385,6 +406,7 @@ extension EditorViewModel {
                     pushAmount: totalPush
                 ))
             }
+            rippleMarkersOpening(at: atFrame, by: totalPush)
             created = createClips(from: assets, trackIndex: trackIndex, startFrame: atFrame, segments: segments)
             sortClips(trackIndex: trackIndex)
         }
@@ -504,6 +526,7 @@ extension EditorViewModel {
                     clips: timeline.tracks[ti].clips, insertFrame: atFrame, pushAmount: totalPush
                 ))
             }
+            rippleMarkersOpening(at: atFrame, by: totalPush)
 
             var cursor = atFrame
             for spec in specs {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Ripple.swift
@@ -120,7 +120,7 @@ extension EditorViewModel {
             }
             applyShifts(plan.shifts)
             if let leadEnd {
-                rippleMarkersOpening(at: leadEnd, by: plan.durationDelta)
+                applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, openingAt: leadEnd, by: plan.durationDelta))
             }
             for ti in timeline.tracks.indices where timeline.tracks[ti].clips.contains(where: { touched.contains($0.id) }) {
                 sortClips(trackIndex: ti)
@@ -192,11 +192,15 @@ extension EditorViewModel {
         }
 
         var shiftsByTrack: [Int: [ClipShift]] = [:]
+        var markerRanges: [[FrameRange]] = []
         for ti in timeline.tracks.indices {
             let track = timeline.tracks[ti]
             let hasOwnRemovals = track.clips.contains { ids.contains($0.id) }
             if hasOwnRemovals {
                 shiftsByTrack[ti] = RippleEngine.computeRippleShifts(clips: track.clips, removedIds: ids)
+                markerRanges.append(track.clips.filter { ids.contains($0.id) }.map {
+                    FrameRange(start: $0.startFrame, end: $0.endFrame)
+                })
             } else if track.syncLocked {
                 shiftsByTrack[ti] = RippleEngine.computeRippleShiftsForRanges(
                     clips: track.clips,
@@ -206,13 +210,14 @@ extension EditorViewModel {
                     refuseRipple(reason: reason)
                     return
                 }
+                markerRanges.append(globalRemovedRanges)
             }
         }
 
         withTimelineSwap(actionName: "Ripple Delete", refreshVisuals: false) {
             removeClips(ids: ids)
             for shifts in shiftsByTrack.values { applyShifts(shifts) }
-            rippleMarkersClosing(globalRemovedRanges)
+            applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, closing: markerRanges))
         }
     }
 
@@ -225,14 +230,6 @@ extension EditorViewModel {
             applied += 1
         }
         return applied
-    }
-
-    fileprivate func rippleMarkersClosing(_ ranges: [FrameRange]) {
-        applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, closing: ranges))
-    }
-
-    fileprivate func rippleMarkersOpening(at insertFrame: Int, by pushAmount: Int) {
-        applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, openingAt: insertFrame, by: pushAmount))
     }
 
     private func applyRippledMarkers(_ next: [TimelineMarker]) {
@@ -319,7 +316,7 @@ extension EditorViewModel {
                 shiftedClips += applyShifts(shifts)
                 sortClips(trackIndex: ti)
             }
-            rippleMarkersClosing(merged)
+            applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, closing: [merged]))
         }
 
         // Anchor track's post-cut layout (surviving + new fragments) so the caller needn't re-read.
@@ -381,7 +378,7 @@ extension EditorViewModel {
                     removedRanges: [gap.range]
                 ))
             }
-            rippleMarkersClosing([gap.range])
+            applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, closing: [[gap.range]]))
         }
         selectedGap = nil
     }
@@ -406,7 +403,7 @@ extension EditorViewModel {
                     pushAmount: totalPush
                 ))
             }
-            rippleMarkersOpening(at: atFrame, by: totalPush)
+            applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, openingAt: atFrame, by: totalPush))
             created = createClips(from: assets, trackIndex: trackIndex, startFrame: atFrame, segments: segments)
             sortClips(trackIndex: trackIndex)
         }
@@ -526,7 +523,7 @@ extension EditorViewModel {
                     clips: timeline.tracks[ti].clips, insertFrame: atFrame, pushAmount: totalPush
                 ))
             }
-            rippleMarkersOpening(at: atFrame, by: totalPush)
+            applyRippledMarkers(RippleEngine.rippleMarkers(timeline.markers, openingAt: atFrame, by: totalPush))
 
             var cursor = atFrame
             for spec in specs {

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -261,6 +261,12 @@ final class EditorViewModel {
         }
     }
 
+    var rippleTimelineMarkers: Bool = {
+        UserDefaults.standard.object(forKey: "rippleTimelineMarkers") as? Bool ?? true
+    }() {
+        didSet { UserDefaults.standard.set(rippleTimelineMarkers, forKey: "rippleTimelineMarkers") }
+    }
+
     var silenceRemovalSettings = SilenceRemovalSettings.default {
         didSet {
             mediaVisualCache.timelineView?.needsDisplay = true

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -799,6 +799,7 @@
 "Ripple Delete" = "Ripple Delete";
 "Ripple Delete Gap" = "Ripple Delete Gap";
 "Ripple Insert" = "Ripple Insert";
+"Ripple Timeline Markers" = "Ripple Timeline Markers";
 "Ripple Trim" = "Ripple Trim";
 "Ripple-deletes every silent section; downstream clips close the gaps." = "Ripple-deletes every silent section; downstream clips close the gaps.";
 "Rotation" = "Rotation";

--- a/Sources/PalmierPro/Toolbar/ToolbarView.swift
+++ b/Sources/PalmierPro/Toolbar/ToolbarView.swift
@@ -96,17 +96,39 @@ struct ToolbarView: View {
     }
 
     private var markerButton: some View {
-        Button { _ = editor.addTimelineMarkerAtSelection() } label: {
-            TimelineMarkerShape()
-                .fill(AppTheme.Text.secondaryColor)
-                .frame(
-                    width: AppTheme.TimelineMarker.flagWidth,
-                    height: AppTheme.TimelineMarker.flagHeight
+        HStack(spacing: AppTheme.Spacing.xxs) {
+            Button { _ = editor.addTimelineMarkerAtSelection() } label: {
+                TimelineMarkerShape()
+                    .fill(AppTheme.Text.secondaryColor)
+                    .frame(
+                        width: AppTheme.TimelineMarker.flagWidth,
+                        height: AppTheme.TimelineMarker.flagHeight
+                    )
+                    .frame(width: AppTheme.IconSize.md, height: AppTheme.IconSize.mdLg)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(L10n.string("Add Marker (M)"))
+
+            Menu {
+                Toggle(
+                    L10n.string("Ripple Timeline Markers"),
+                    isOn: Bindable(editor).rippleTimelineMarkers
                 )
-                .frame(width: AppTheme.IconSize.mdLg, height: AppTheme.IconSize.mdLg)
-                .hoverHighlight()
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: AppTheme.FontSize.micro, weight: AppTheme.FontWeight.semibold))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+                    .frame(width: AppTheme.Spacing.md, height: AppTheme.IconSize.mdLg)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.button)
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .accessibilityLabel(L10n.string("Ripple Timeline Markers"))
         }
-        .buttonStyle(.plain)
+        .padding(.trailing, AppTheme.Spacing.xxs)
+        .hoverHighlight()
         .hoverTooltip(L10n.string("Add Marker (M)"))
     }
 

--- a/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
+++ b/Tests/PalmierProTests/Agent/MCPMarkerTests.swift
@@ -72,6 +72,47 @@ struct MCPMarkerTests {
         await server.stop()
         await client.disconnect()
     }
+
+    @Test func rippleDeleteShiftsMarkersThroughMCP() async throws {
+        let harness = ToolHarness(timeline: Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [Fixtures.clip(id: "clip", start: 0, duration: 100)])
+        ]))
+        harness.editor.rippleTimelineMarkers = true
+        harness.editor.timeline.markers = [
+            TimelineMarker(id: "inside", name: "Inside", startFrame: 45),
+            TimelineMarker(id: "after", name: "After", startFrame: 80),
+        ]
+        let server = Server(
+            name: "marker-ripple-test",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await MCPService.registerTools(on: server, executor: harness.executor)
+        let transports = await InMemoryTransport.createConnectedPair()
+        let client = Client(name: "marker-ripple-test", version: "1.0.0")
+        try await server.start(transport: transports.server)
+        do {
+            _ = try await client.connect(transport: transports.client)
+            let ripple = try json(try await client.callTool(name: "ripple_delete_ranges", arguments: [
+                "trackIndex": .int(0),
+                "ranges": .array([.array([.int(40), .int(50)])]),
+            ]))
+            #expect(ripple["removedMarkerIds"] as? [String] == ["inside"])
+            let markers = try #require(ripple["markers"] as? [[String: Any]])
+            #expect(markers[0]["markerId"] as? String == "after")
+            #expect(markers[0]["startFrame"] as? Int == 70)
+            let timeline = try json(try await client.callTool(name: "get_timeline", arguments: [:]))
+            let readBack = try #require((timeline["markers"] as? [[String: Any]])?.first)
+            #expect(readBack["startFrame"] as? Int == 70)
+        } catch {
+            await server.stop()
+            await client.disconnect()
+            throw error
+        }
+        await server.stop()
+        await client.disconnect()
+    }
+
     private func json(_ result: (content: [Tool.Content], isError: Bool?)) throws -> [String: Any] {
         guard case .text(let text, _, _) = result.content.first else {
             throw CocoaError(.coderReadCorrupt)

--- a/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
@@ -116,6 +116,56 @@ struct RippleEngineTests {
         )
         #expect(shifts == [ClipShift(clipId: "b", newStartFrame: 225)])
     }
+
+    // MARK: - rippleMarkers
+
+    @Test func closingDropsPointInsideRemovedRange() {
+        let markers = [
+            TimelineMarker(id: "before", name: "Before", startFrame: 10),
+            TimelineMarker(id: "inside", name: "Inside", startFrame: 45),
+            TimelineMarker(id: "join", name: "Join", startFrame: 50),
+            TimelineMarker(id: "after", name: "After", startFrame: 80),
+        ]
+        let next = RippleEngine.rippleMarkers(markers, closing: [FrameRange(start: 40, end: 50)])
+        #expect(next.map(\.id) == ["before", "join", "after"])
+        #expect(next.map(\.startFrame) == [10, 40, 70])
+    }
+
+    @Test func closingShrinksOverlappingRangeAndDeletesConsumedRange() {
+        let overlap = TimelineMarker(id: "overlap", name: "Overlap", startFrame: 10, durationFrames: 40)
+        let consumed = TimelineMarker(id: "consumed", name: "Consumed", startFrame: 40, durationFrames: 10)
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 60, durationFrames: 20)
+        let next = RippleEngine.rippleMarkers(
+            [overlap, consumed, after],
+            closing: [FrameRange(start: 40, end: 50)]
+        )
+        #expect(next.map(\.id) == ["overlap", "after"])
+        #expect(next[0].startFrame == 10)
+        #expect(next[0].durationFrames == 30)
+        #expect(next[1].startFrame == 50)
+        #expect(next[1].durationFrames == 20)
+    }
+
+    @Test func openingShiftsAtOrAfterAndExtendsContainingRange() {
+        let before = TimelineMarker(id: "before", name: "Before", startFrame: 10)
+        let containing = TimelineMarker(id: "range", name: "Range", startFrame: 20, durationFrames: 40)
+        let atInsert = TimelineMarker(id: "at", name: "At", startFrame: 50)
+        let next = RippleEngine.rippleMarkers(
+            [before, containing, atInsert],
+            openingAt: 50,
+            by: 20
+        )
+        #expect(next.map(\.startFrame) == [10, 20, 70])
+        #expect(next[1].durationFrames == 60)
+    }
+
+    @Test func negativeOpeningClosesTheTrimmedTail() {
+        let onTail = TimelineMarker(id: "tail", name: "Tail", startFrame: 90)
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 120)
+        let next = RippleEngine.rippleMarkers([onTail, after], openingAt: 100, by: -20)
+        #expect(next.map(\.id) == ["after"])
+        #expect(next[0].startFrame == 100)
+    }
 }
 
 // MARK: - Adversarial

--- a/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
@@ -173,6 +173,32 @@ struct RippleEngineTests {
         #expect(next.map(\.startFrame) == [170, 250])
     }
 
+    @Test func closingIgnoresCollapsedMapsFromTracksThatRemovedThePoint() {
+        let onPicture = TimelineMarker(id: "onPicture", name: "On picture", startFrame: 220)
+        let next = RippleEngine.rippleMarkers(
+            [onPicture],
+            closing: [
+                [FrameRange(start: 0, end: 50)],
+                [FrameRange(start: 100, end: 250)],
+            ]
+        )
+        #expect(next.map(\.startFrame) == [170])
+    }
+
+    @Test func closingKeepsRangeThatAnotherTrackConsumed() {
+        let span = TimelineMarker(id: "span", name: "Span", startFrame: 300, durationFrames: 50)
+        let next = RippleEngine.rippleMarkers(
+            [span],
+            closing: [
+                [FrameRange(start: 0, end: 50)],
+                [FrameRange(start: 200, end: 400)],
+            ]
+        )
+        #expect(next.map(\.id) == ["span"])
+        #expect(next[0].startFrame == 250)
+        #expect(next[0].durationFrames == 50)
+    }
+
     @Test func negativeOpeningClosesTheTrimmedTail() {
         let onTail = TimelineMarker(id: "tail", name: "Tail", startFrame: 90)
         let after = TimelineMarker(id: "after", name: "After", startFrame: 120)

--- a/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
+++ b/Tests/PalmierProTests/Timeline/RippleEngineTests.swift
@@ -126,7 +126,7 @@ struct RippleEngineTests {
             TimelineMarker(id: "join", name: "Join", startFrame: 50),
             TimelineMarker(id: "after", name: "After", startFrame: 80),
         ]
-        let next = RippleEngine.rippleMarkers(markers, closing: [FrameRange(start: 40, end: 50)])
+        let next = RippleEngine.rippleMarkers(markers, closing: [[FrameRange(start: 40, end: 50)]])
         #expect(next.map(\.id) == ["before", "join", "after"])
         #expect(next.map(\.startFrame) == [10, 40, 70])
     }
@@ -137,7 +137,7 @@ struct RippleEngineTests {
         let after = TimelineMarker(id: "after", name: "After", startFrame: 60, durationFrames: 20)
         let next = RippleEngine.rippleMarkers(
             [overlap, consumed, after],
-            closing: [FrameRange(start: 40, end: 50)]
+            closing: [[FrameRange(start: 40, end: 50)]]
         )
         #expect(next.map(\.id) == ["overlap", "after"])
         #expect(next[0].startFrame == 10)
@@ -157,6 +157,20 @@ struct RippleEngineTests {
         )
         #expect(next.map(\.startFrame) == [10, 20, 70])
         #expect(next[1].durationFrames == 60)
+    }
+
+    @Test func closingKeepsPointsThatStillExistOnAnotherTrack() {
+        let onPicture = TimelineMarker(id: "onPicture", name: "On picture", startFrame: 220)
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 300)
+        let next = RippleEngine.rippleMarkers(
+            [onPicture, after],
+            closing: [
+                [FrameRange(start: 0, end: 50)],
+                [FrameRange(start: 200, end: 250)],
+            ]
+        )
+        #expect(next.map(\.id) == ["onPicture", "after"])
+        #expect(next.map(\.startFrame) == [170, 250])
     }
 
     @Test func negativeOpeningClosesTheTrimmedTail() {

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
@@ -39,6 +39,29 @@ struct TimelineMarkerRippleTests {
         #expect(e.timeline.markers.map(\.startFrame) == [45, 80])
     }
 
+    @Test func multiTrackRippleDeleteDoesNotOverShiftMarkers() {
+        let e = EditorViewModel()
+        e.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "v1", start: 0, duration: 50),
+                Fixtures.clip(id: "v2", start: 200, duration: 100),
+            ]),
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "a1", mediaType: .audio, start: 200, duration: 50),
+                Fixtures.clip(id: "a2", mediaType: .audio, start: 300, duration: 50),
+            ]),
+        ])
+        e.rippleTimelineMarkers = true
+        e.timeline.markers = [
+            TimelineMarker(id: "onPicture", name: "On picture", startFrame: 220),
+            TimelineMarker(id: "after", name: "After", startFrame: 300),
+        ]
+        e.selectedClipIds = ["v1", "a1"]
+        e.rippleDeleteSelectedClips()
+        #expect(e.timeline.markers.map(\.id) == ["onPicture", "after"])
+        #expect(e.timeline.markers.map(\.startFrame) == [170, 250])
+    }
+
     @Test func markerRippleUndoesWithTheEdit() {
         let after = TimelineMarker(id: "after", name: "After", startFrame: 80)
         let e = editor(markers: [after], ripple: true)

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
@@ -62,6 +62,27 @@ struct TimelineMarkerRippleTests {
         #expect(e.timeline.markers.map(\.startFrame) == [170, 250])
     }
 
+    @Test func multiTrackRippleDeleteDoesNotFollowACollapsedHole() {
+        let e = EditorViewModel()
+        e.timeline = Fixtures.timeline(tracks: [
+            Fixtures.videoTrack(clips: [
+                Fixtures.clip(id: "v1", start: 0, duration: 50),
+                Fixtures.clip(id: "v2", start: 200, duration: 100),
+            ]),
+            Fixtures.audioTrack(clips: [
+                Fixtures.clip(id: "a1", mediaType: .audio, start: 100, duration: 150),
+                Fixtures.clip(id: "a2", mediaType: .audio, start: 300, duration: 50),
+            ]),
+        ])
+        e.rippleTimelineMarkers = true
+        e.timeline.markers = [
+            TimelineMarker(id: "onPicture", name: "On picture", startFrame: 220),
+        ]
+        e.selectedClipIds = ["v1", "a1"]
+        e.rippleDeleteSelectedClips()
+        #expect(e.timeline.markers.map(\.startFrame) == [170])
+    }
+
     @Test func markerRippleUndoesWithTheEdit() {
         let after = TimelineMarker(id: "after", name: "After", startFrame: 80)
         let e = editor(markers: [after], ripple: true)

--- a/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
+++ b/Tests/PalmierProTests/Timeline/TimelineMarkerRippleTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@MainActor
+private func editor(markers: [TimelineMarker], ripple: Bool) -> EditorViewModel {
+    let e = EditorViewModel()
+    e.timeline = Fixtures.timeline(tracks: [
+        Fixtures.videoTrack(clips: [
+            Fixtures.clip(id: "c1", start: 0, duration: 100, trimEnd: 50),
+            Fixtures.clip(id: "c2", start: 100, duration: 50),
+        ])
+    ])
+    e.timeline.markers = markers
+    e.rippleTimelineMarkers = ripple
+    return e
+}
+
+@Suite("EditorViewModel — ripple timeline markers")
+@MainActor
+struct TimelineMarkerRippleTests {
+    @Test func rippleDeleteShiftsAndRemovesMarkersWhenEnabled() {
+        let before = TimelineMarker(id: "before", name: "Before", startFrame: 10)
+        let inside = TimelineMarker(id: "inside", name: "Inside", startFrame: 45)
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 80)
+        let e = editor(markers: [before, inside, after], ripple: true)
+        let outcome = e.rippleDeleteRanges(anchorClipId: "c1", ranges: [FrameRange(start: 40, end: 50)])
+        guard case .ok = outcome else { Issue.record("expected .ok"); return }
+        #expect(e.timeline.markers.map(\.id) == ["before", "after"])
+        #expect(e.timeline.markers.map(\.startFrame) == [10, 70])
+    }
+
+    @Test func rippleDeleteLeavesMarkersWhenDisabled() {
+        let inside = TimelineMarker(id: "inside", name: "Inside", startFrame: 45)
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 80)
+        let e = editor(markers: [inside, after], ripple: false)
+        let outcome = e.rippleDeleteRanges(anchorClipId: "c1", ranges: [FrameRange(start: 40, end: 50)])
+        guard case .ok = outcome else { Issue.record("expected .ok"); return }
+        #expect(e.timeline.markers.map(\.startFrame) == [45, 80])
+    }
+
+    @Test func markerRippleUndoesWithTheEdit() {
+        let after = TimelineMarker(id: "after", name: "After", startFrame: 80)
+        let e = editor(markers: [after], ripple: true)
+        let undo = UndoManager()
+        e.undo.attach(undo)
+        let outcome = e.rippleDeleteRanges(anchorClipId: "c1", ranges: [FrameRange(start: 40, end: 50)])
+        guard case .ok = outcome else { Issue.record("expected .ok"); return }
+        #expect(e.timeline.markers[0].startFrame == 70)
+        undo.undo()
+        #expect(e.timeline.markers[0].startFrame == 80)
+        undo.redo()
+        #expect(e.timeline.markers[0].startFrame == 70)
+    }
+}


### PR DESCRIPTION
## Summary
- Timeline markers now follow ripple delete, insert, and trim so review notes stay on the cut instead of absolute frames.
- A preference (on by default) turns that off for program-time pins; it lives on the marker toolbar control and in the Edit menu.
- Ripple mutation deltas report `markers` and `removedMarkerIds` so the Agent can patch without re-reading the timeline.

## Approach
Markers stay timeline-owned. When the preference is on, `RippleEngine` remaps them in the same undo group as the clip shifts: points inside a deleted span are dropped, overlapping ranges shrink, later markers shift, and an insert inside a range extends it. The preference is a `UserDefaults`-backed `EditorViewModel` flag, matching other editor toggles.

Rejected a Settings pane — this is an editing behavior, not a general preference. Rejected clip-attached markers for this PR; one marker type, one optional ripple rule.

## Testing
- `swift test --filter 'RippleEngineTests|TimelineMarkerRippleTests|MCPMarkerTests|RippleDeleteRangesTests|RippleTrimTests'` — passed
- `swift build` — passed
- Not run: full `swift test`, packaged app

**UI**
- [ ] Add markers before, on, and after a clip; ripple-delete with the option on — later markers move, the one on the deleted span disappears; undo restores them
- [ ] Turn the option off from the toolbar chevron; repeat — markers stay put
- [ ] Confirm Edit → Ripple Timeline Markers stays in sync with the toolbar
- [ ] Flag click still adds a marker; hover lights the flag and chevron as one control
- [ ] Ripple-insert inside a range marker — the range lengthens

## Change statistics
- Logic: ~165 insertions across ripple engine, editor apply path, preference, toolbar/menu, and Agent delta
- Tests: +146 (engine, editor preference/undo, MCP readback)
- Localization: +1 English string

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ripple editing and timeline marker state across delete/insert/trim paths; mistakes could misplace or drop review markers, though behavior is gated by a preference and covered by new tests.
> 
> **Overview**
> **Ripple timeline markers** (default **on**) keep review notes aligned with the cut: on ripple delete, insert, and trim, markers shift, shrink, extend, or drop when they fall in removed spans—applied in the same undo group as clip shifts via new `RippleEngine.rippleMarkers` logic and `applyRippledMarkers` when `rippleTimelineMarkers` is enabled.
> 
> Users can turn the behavior off with **Ripple Timeline Markers** on the marker toolbar chevron menu and under **Edit**; the setting persists in `UserDefaults`.
> 
> **Agent** mutation deltas now include `markers` and `removedMarkerIds`, and instructions tell the agent to patch marker positions from those fields after ripple edits.
> 
> Tests cover the engine, editor (including multi-track and undo), and MCP `ripple_delete_ranges` readback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d500233ba126a0e2b129fd06652680fa4e0746d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->