### PR TITLE
[feat] Extract audio from video into a library asset

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -24,8 +24,8 @@ extension EditorViewModel {
             name: "\(asset.name) (audio)",
             folderId: asset.folderId,
             sourceId: assetId
-        ) {
-            try await AudioTrackExtractor.extract(sourceURL: sourceURL)
+        ) { destURL in
+            _ = try await AudioTrackExtractor.extract(sourceURL: sourceURL, destURL: destURL)
         }
     }
 
@@ -46,8 +46,7 @@ extension EditorViewModel {
         let sourceFramesConsumed = clip.sourceFramesConsumed
         let durationFrames = clip.durationFrames
         let speed = clip.speed
-        await installExtractedAudio(name: name, folderId: folderId, sourceId: clipId) {
-            let stagedURL = FileIO.temporaryFileURL(pathExtension: "m4a")
+        await installExtractedAudio(name: name, folderId: folderId, sourceId: clipId) { stagedURL in
             try await Self.exportClipRange(
                 sourceURL: sourceURL,
                 destURL: stagedURL,
@@ -58,7 +57,6 @@ extension EditorViewModel {
                 speed: speed,
                 mediaType: .audio
             )
-            return stagedURL
         }
     }
 
@@ -68,22 +66,26 @@ extension EditorViewModel {
         let partners = linkedPartnerIds(of: clip.id).compactMap { clipFor(id: $0) }
         if clip.mediaType == .video {
             if let audio = partners.first(where: { $0.mediaType == .audio }) {
-                return isClipMediaOffline(audio) ? nil : audio
+                return isExtractableClip(audio) ? audio : nil
             }
             guard let asset = mediaAssetsById[clip.mediaRef], canExtractAudio(from: asset) else { return nil }
-            return isClipMediaOffline(clip) ? nil : clip
+            return isExtractableClip(clip) ? clip : nil
         }
         if clip.mediaType == .audio, partners.contains(where: { $0.mediaType == .video }) {
-            return isClipMediaOffline(clip) ? nil : clip
+            return isExtractableClip(clip) ? clip : nil
         }
         return nil
+    }
+
+    private func isExtractableClip(_ clip: Clip) -> Bool {
+        !isClipMediaOffline(clip) && !isClipMediaGenerating(clip)
     }
 
     private func installExtractedAudio(
         name: String,
         folderId: String?,
         sourceId: String,
-        produce: () async throws -> URL
+        produce: (URL) async throws -> Void
     ) async {
         guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
         let filename = Self.uniqueClipFilename(for: .audio)
@@ -94,14 +96,15 @@ extension EditorViewModel {
         placeholder.folderId = folderId
         placeholder.generationStatus = .generating
         importMediaAsset(placeholder)
-        defer { projectPackageCoordinator.endMutation() }
+        let stagedURL = FileIO.temporaryFileURL(pathExtension: "m4a")
+        defer {
+            try? FileManager.default.removeItem(at: stagedURL)
+            projectPackageCoordinator.endMutation()
+        }
 
         do {
-            let stagedURL = try await produce()
-            guard mediaAssetsById[placeholder.id] != nil else {
-                try? FileManager.default.removeItem(at: stagedURL)
-                return
-            }
+            try await produce(stagedURL)
+            guard mediaAssetsById[placeholder.id] != nil else { return }
             placeholder.url = try await commitStagedProjectMedia(
                 stagedURL,
                 filename: filename,

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+SaveAsMedia.swift
@@ -3,6 +3,120 @@ import AVFoundation
 
 extension EditorViewModel {
 
+    func canExtractAudio(from asset: MediaAsset) -> Bool {
+        asset.type == .video && asset.hasAudio && !asset.isGenerating && !isMediaOffline(asset.id)
+    }
+
+    func extractAudio(from assetIds: [String]) async {
+        for id in assetIds {
+            await extractAudio(from: id)
+        }
+    }
+
+    func extractAudio(from assetId: String) async {
+        guard let asset = mediaAssetsById[assetId] else { return }
+        guard canExtractAudio(from: asset) else { return }
+        guard let sourceURL = mediaResolver.resolveURL(for: asset.id) else {
+            Log.project.error("extractAudio: source missing for asset=\(assetId)")
+            return
+        }
+        await installExtractedAudio(
+            name: "\(asset.name) (audio)",
+            folderId: asset.folderId,
+            sourceId: assetId
+        ) {
+            try await AudioTrackExtractor.extract(sourceURL: sourceURL)
+        }
+    }
+
+    func canExtractAudio(fromClipId clipId: String) -> Bool {
+        audioClipForExtraction(clipId: clipId) != nil
+    }
+
+    func extractAudio(fromClipId clipId: String) async {
+        guard let clip = audioClipForExtraction(clipId: clipId) else { return }
+        guard let sourceURL = mediaResolver.resolveURL(for: clip.mediaRef) else {
+            Log.project.error("extractAudio: source missing for clip=\(clipId)")
+            return
+        }
+        let name = "\(mediaResolver.displayName(for: clip.mediaRef)) (audio)"
+        let folderId = mediaAssetsById[clip.mediaRef]?.folderId
+        let fps = timeline.fps
+        let trimStartFrame = clip.trimStartFrame
+        let sourceFramesConsumed = clip.sourceFramesConsumed
+        let durationFrames = clip.durationFrames
+        let speed = clip.speed
+        await installExtractedAudio(name: name, folderId: folderId, sourceId: clipId) {
+            let stagedURL = FileIO.temporaryFileURL(pathExtension: "m4a")
+            try await Self.exportClipRange(
+                sourceURL: sourceURL,
+                destURL: stagedURL,
+                fps: fps,
+                trimStartFrame: trimStartFrame,
+                sourceFramesConsumed: sourceFramesConsumed,
+                durationFrames: durationFrames,
+                speed: speed,
+                mediaType: .audio
+            )
+            return stagedURL
+        }
+    }
+
+    private func audioClipForExtraction(clipId: String) -> Clip? {
+        guard let clip = clipFor(id: clipId) else { return nil }
+        guard clip.sourceClipType != .sequence, clip.multicamGroupId == nil else { return nil }
+        let partners = linkedPartnerIds(of: clip.id).compactMap { clipFor(id: $0) }
+        if clip.mediaType == .video {
+            if let audio = partners.first(where: { $0.mediaType == .audio }) {
+                return isClipMediaOffline(audio) ? nil : audio
+            }
+            guard let asset = mediaAssetsById[clip.mediaRef], canExtractAudio(from: asset) else { return nil }
+            return isClipMediaOffline(clip) ? nil : clip
+        }
+        if clip.mediaType == .audio, partners.contains(where: { $0.mediaType == .video }) {
+            return isClipMediaOffline(clip) ? nil : clip
+        }
+        return nil
+    }
+
+    private func installExtractedAudio(
+        name: String,
+        folderId: String?,
+        sourceId: String,
+        produce: () async throws -> URL
+    ) async {
+        guard (try? projectPackageCoordinator.beginMutation()) != nil else { return }
+        let filename = Self.uniqueClipFilename(for: .audio)
+        let mediaDir = projectURL?.appendingPathComponent(Project.mediaDirectoryName)
+            ?? FileManager.default.temporaryDirectory
+        let destURL = mediaDir.appendingPathComponent(filename)
+        let placeholder = MediaAsset(url: destURL, type: .audio, name: name)
+        placeholder.folderId = folderId
+        placeholder.generationStatus = .generating
+        importMediaAsset(placeholder)
+        defer { projectPackageCoordinator.endMutation() }
+
+        do {
+            let stagedURL = try await produce()
+            guard mediaAssetsById[placeholder.id] != nil else {
+                try? FileManager.default.removeItem(at: stagedURL)
+                return
+            }
+            placeholder.url = try await commitStagedProjectMedia(
+                stagedURL,
+                filename: filename,
+                workAlreadyAdmitted: true
+            )
+            placeholder.generationStatus = .none
+            await finalizeImportedAsset(placeholder)
+            Log.project.notice("extractAudio ok source=\(sourceId) out=\(placeholder.url.lastPathComponent)")
+        } catch {
+            placeholder.generationStatus = .failed(error.localizedDescription)
+            updateManifestMetadata(for: [placeholder])
+            Log.project.error("extractAudio failed source=\(sourceId): \(error.localizedDescription)")
+        }
+    }
+
     /// Save a clip's visible source range (trim + speed baked in) as a new MediaAsset
     /// in the panel. Video and audio only
     func saveClipAsMedia(clipId: String) {

--- a/Sources/PalmierPro/Generation/Preprocessing/AudioTrackExtractor.swift
+++ b/Sources/PalmierPro/Generation/Preprocessing/AudioTrackExtractor.swift
@@ -7,6 +7,7 @@ enum AudioTrackExtractor {
         var errorDescription: String? { "Audio extraction failed: \(reason)" }
     }
 
+    @concurrent
     static func extract(
         sourceURL: URL,
         trimmedSource: TrimmedSource? = nil

--- a/Sources/PalmierPro/Generation/Preprocessing/AudioTrackExtractor.swift
+++ b/Sources/PalmierPro/Generation/Preprocessing/AudioTrackExtractor.swift
@@ -10,7 +10,8 @@ enum AudioTrackExtractor {
     @concurrent
     static func extract(
         sourceURL: URL,
-        trimmedSource: TrimmedSource? = nil
+        trimmedSource: TrimmedSource? = nil,
+        destURL: URL? = nil
     ) async throws -> URL {
         let asset = AVURLAsset(url: sourceURL)
         guard let audioTrack = try await asset.loadTracks(withMediaType: .audio).first else {
@@ -30,7 +31,7 @@ enum AudioTrackExtractor {
         }
         try compositionTrack.insertTimeRange(sourceRange, of: audioTrack, at: .zero)
 
-        let outputURL = FileManager.default.temporaryDirectory
+        let outputURL = destURL ?? FileManager.default.temporaryDirectory
             .appendingPathComponent("audio-\(UUID().uuidString).m4a")
         guard let session = AVAssetExportSession(
             asset: composition,
@@ -38,7 +39,14 @@ enum AudioTrackExtractor {
         ) else {
             throw ExtractionError(reason: "M4A export is unavailable")
         }
-        try await session.export(to: outputURL, as: .m4a)
-        return outputURL
+        do {
+            try await session.export(to: outputURL, as: .m4a)
+            return outputURL
+        } catch {
+            if destURL == nil {
+                try? FileManager.default.removeItem(at: outputURL)
+            }
+            throw error
+        }
     }
 }

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -91,6 +91,14 @@ struct AssetThumbnailView: View {
             AIEditMenu(asset: asset)
             Divider()
         }
+        if ids.contains(where: { id in
+            guard let candidate = editor.mediaAssetsById[id] else { return false }
+            return editor.canExtractAudio(from: candidate)
+        }) {
+            Button(L10n.string("Extract Audio")) {
+                Task { await editor.extractAudio(from: ids) }
+            }
+        }
         Button(L10n.string("Reveal in Finder")) { revealInFinder(ids: ids) }
         Button(L10n.string("Copy Path")) { copyPaths(ids: ids) }
         Divider()

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -371,6 +371,7 @@
 "Extend" = "Extend";
 "Extends captions across short gaps and holds the final caption." = "Extends captions across short gaps and holds the final caption.";
 "Extra Large" = "Extra Large";
+"Extract Audio" = "Extract Audio";
 "FLUX Enhance" = "FLUX Enhance";
 "Fade In" = "Fade In";
 "Fade Out" = "Fade Out";
@@ -817,6 +818,7 @@
 "Save As…" = "Save As…";
 "Save Changes" = "Save Changes";
 "Save Range as Media" = "Save Range as Media";
+"Save as Audio" = "Save as Audio";
 "Save as Media" = "Save as Media";
 "Save this project to view activity" = "Save this project to view activity";
 "Saves a copy of this project with all media bundled inside, so it opens on any machine." = "Saves a copy of this project with all media bundled inside, so it opens on any machine.";

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1526,6 +1526,12 @@ final class TimelineView: NSView, NSPopoverDelegate {
             item.representedObject = clip.id
             mediaItems.append(item)
         }
+        if clip.mediaType == .video, editor.canExtractAudio(fromClipId: clip.id) {
+            let item = NSMenuItem(title: L10n.string("Save as Audio"), action: #selector(performSaveAsAudio(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = clip.id
+            mediaItems.append(item)
+        }
         // Sync
         var syncItems: [NSMenuItem] = []
         if let pair = editor.syncSelection() {
@@ -1781,6 +1787,12 @@ final class TimelineView: NSView, NSPopoverDelegate {
         guard let item = sender as? NSMenuItem,
               let clipId = item.representedObject as? String else { return }
         editor.saveClipAsMedia(clipId: clipId)
+    }
+
+    @objc private func performSaveAsAudio(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let clipId = item.representedObject as? String else { return }
+        Task { await editor.extractAudio(fromClipId: clipId) }
     }
 
     @objc private func performSwapMedia(_ sender: Any?) {

--- a/Tests/PalmierProTests/Media/ExtractAudioTests.swift
+++ b/Tests/PalmierProTests/Media/ExtractAudioTests.swift
@@ -1,0 +1,92 @@
+import AVFoundation
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Extract Audio")
+@MainActor
+struct ExtractAudioTests {
+    @Test func skipsAssetsWithoutExtractableAudio() async {
+        let e = EditorViewModel()
+        let silentVideo = MediaAsset(url: URL(fileURLWithPath: "/tmp/silent.mp4"), type: .video, name: "Silent")
+        silentVideo.hasAudio = false
+        let audio = MediaAsset(url: URL(fileURLWithPath: "/tmp/take.m4a"), type: .audio, name: "Take")
+        audio.hasAudio = true
+        let image = MediaAsset(url: URL(fileURLWithPath: "/tmp/still.png"), type: .image, name: "Still")
+        let generating = MediaAsset(url: URL(fileURLWithPath: "/tmp/gen.mp4"), type: .video, name: "Gen")
+        generating.hasAudio = true
+        generating.generationStatus = .generating
+        for asset in [silentVideo, audio, image, generating] {
+            e.importMediaAsset(asset)
+        }
+
+        await e.extractAudio(from: [silentVideo.id, audio.id, image.id, generating.id])
+
+        #expect(e.mediaAssets.count == 4)
+        #expect(e.mediaAssets.allSatisfy { $0.type != .audio || $0.id == audio.id })
+    }
+
+    @Test func extractsStandaloneAudioAssetIntoSameFolder() async throws {
+        let sourceURL = try Self.writeSilentAudio()
+        let e = EditorViewModel()
+        let folderId = e.createFolder(name: "B-roll")
+        let source = MediaAsset(url: sourceURL, type: .video, name: "Interview")
+        source.hasAudio = true
+        source.folderId = folderId
+        e.importMediaAsset(source)
+        defer {
+            for asset in e.mediaAssets { try? FileManager.default.removeItem(at: asset.url) }
+        }
+
+        await e.extractAudio(from: [source.id])
+
+        let extracted = try #require(e.mediaAssets.first { $0.id != source.id })
+        #expect(extracted.type == .audio)
+        #expect(extracted.name == "Interview (audio)")
+        #expect(extracted.folderId == folderId)
+        #expect(extracted.generationStatus == .none)
+        #expect(extracted.duration > 0)
+        #expect(FileManager.default.fileExists(atPath: extracted.url.path))
+        #expect(extracted.url.pathExtension == "m4a")
+    }
+
+    @Test func extractsTrimmedAudioFromLinkedClipWithoutUnlinking() async throws {
+        let sourceURL = try Self.writeSilentAudio()
+        let e = EditorViewModel()
+        e.timeline.fps = 30
+        _ = e.insertTrack(at: 0, type: .video)
+        let source = MediaAsset(url: sourceURL, type: .video, name: "Interview", duration: 0.1)
+        source.hasAudio = true
+        e.importMediaAsset(source)
+        let ids = e.placeClip(asset: source, trackIndex: 0, startFrame: 0, durationFrames: 2)
+        let videoId = try #require(ids.first)
+        let audioId = try #require(ids.dropFirst().first)
+        defer {
+            for asset in e.mediaAssets { try? FileManager.default.removeItem(at: asset.url) }
+        }
+
+        #expect(e.canExtractAudio(fromClipId: videoId))
+        #expect(e.canExtractAudio(fromClipId: audioId))
+        await e.extractAudio(fromClipId: videoId)
+
+        let extracted = try #require(e.mediaAssets.first { $0.type == .audio })
+        #expect(extracted.name == "Interview (audio)")
+        #expect(extracted.generationStatus == .none)
+        #expect(FileManager.default.fileExists(atPath: extracted.url.path))
+        let video = try #require(e.clipFor(id: videoId))
+        let audio = try #require(e.clipFor(id: audioId))
+        #expect(video.linkGroupId != nil)
+        #expect(video.linkGroupId == audio.linkGroupId)
+    }
+
+    private static func writeSilentAudio() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("extract-audio-\(UUID().uuidString).caf")
+        let format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_410)!
+        buffer.frameLength = 4_410
+        try file.write(from: buffer)
+        return url
+    }
+}

--- a/Tests/PalmierProTests/Media/ExtractAudioTests.swift
+++ b/Tests/PalmierProTests/Media/ExtractAudioTests.swift
@@ -79,6 +79,26 @@ struct ExtractAudioTests {
         #expect(video.linkGroupId == audio.linkGroupId)
     }
 
+    @Test func skipsLinkedClipWhileSourceIsGenerating() async throws {
+        let e = EditorViewModel()
+        _ = e.insertTrack(at: 0, type: .video)
+        let source = MediaAsset(
+            url: URL(fileURLWithPath: "/tmp/extract-audio-generating.mp4"),
+            type: .video,
+            name: "Gen",
+            duration: 1
+        )
+        source.hasAudio = true
+        source.generationStatus = .generating
+        e.importMediaAsset(source)
+        let ids = e.placeClip(asset: source, trackIndex: 0, startFrame: 0, durationFrames: 10)
+        let videoId = try #require(ids.first)
+
+        #expect(!e.canExtractAudio(fromClipId: videoId))
+        await e.extractAudio(fromClipId: videoId)
+        #expect(e.mediaAssets.allSatisfy { $0.id == source.id })
+    }
+
     private static func writeSilentAudio() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("extract-audio-\(UUID().uuidString).caf")


### PR DESCRIPTION

<img width="632" height="381" alt="Screenshot 2026-08-18 at 10 08 33 AM" src="https://github.com/user-attachments/assets/d48929e1-35ff-40d0-a963-b5ee64e755ab" />
<img width="474" height="319" alt="Screenshot 2026-08-18 at 10 09 46 AM" src="https://github.com/user-attachments/assets/1b8fd1ef-9b98-4f47-a582-55bfa5c1602c" />


## Summary
- Add **Extract Audio** on library video assets and **Save as Audio** on timeline video clips so a video’s sound can become a standalone M4A without unlinking or saving a video file.
- Addresses repeated agent feedback that there was no direct audio-only extraction path for reuse (karaoke sources, trimmed dialogue, library assets).

## Approach
- Reuse `AudioTrackExtractor` for full-asset extraction and the existing clip-range M4A export for trimmed/speed-baked clip audio (linked partner when present).
- Install the result with the same placeholder → package commit → finalize path as Save as Media. Linked A/V pairs stay linked.
- Media panel keeps **Extract Audio**; the clip menu uses **Save as Audio** next to **Save as Media**. The command is hidden for silent, offline, generating, nested, and audio-only clips (those already have Save as Media).

## Testing
- `swift test --filter ExtractAudio` — 3 tests passed (skip ineligible assets; extract library asset into the same folder; extract trimmed linked-clip audio without unlinking).
- Localization inventory updated via `scripts/localization/sync.sh`.
- UI not verified in-app.

### UI test plan
- Video with audio in the media panel: Extract Audio creates a generating, then ready, audio asset in the same folder named `Name (audio)`.
- Image, audio, silent, or generating video: Extract Audio is hidden.
- Mixed multi-select: only videos with audio extract.
- Linked A/V clip: Save as Audio writes a trimmed M4A; the pair stays linked. Audio-side clip still uses Save as Media.
- Failed extract leaves a failed placeholder that can be deleted.

## Change statistics
- Logic: +137 (Save as Media, timeline/asset menus, extractor hop)
- Tests: +92
- Localization: +2 English keys
- Total: +229 / −0 across 6 files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project media mutation and AVFoundation export paths; failures leave failed placeholders but linked clips are intentionally preserved.
> 
> **Overview**
> Adds a direct path to turn video sound into standalone **M4A** library assets without unlinking clips or exporting video.
> 
> **Extract Audio** appears on eligible media-panel videos (has audio, not offline/generating); **Save as Audio** on timeline video clips next to **Save as Media**. Full-asset extraction uses `AudioTrackExtractor` with an optional destination URL; clip extraction reuses the existing trim/speed M4A export and prefers the linked audio partner when present. New assets are installed via the same placeholder → staged export → project commit → finalize flow as Save as Media, named `Name (audio)` in the source folder.
> 
> `AudioTrackExtractor` is marked `@concurrent` and can write to a caller-provided path with safer cleanup on failure. UI commands are gated for silent, nested, multicam, sequence, offline, and generating sources. Tests cover skip rules, folder placement, linked-clip extraction without unlinking, and generating-source skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd8f0ee7e69a6669ca4c80230977a32912d26b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->