### PR TITLE
[telemetry] Make Sentry hangs and sessions searchable

### DIFF
--- a/Sources/PalmierPro/Account/AccountService.swift
+++ b/Sources/PalmierPro/Account/AccountService.swift
@@ -207,11 +207,15 @@ final class AccountService {
         guard let convex else { return }
 
         let user = Clerk.shared.user
-        Telemetry.setUser(id: user?.id)
-        Analytics.identifyUser(id: user?.id)
         let name = [user?.firstName, user?.lastName]
             .compactMap { $0 }
             .joined(separator: " ")
+        Telemetry.setUser(
+            id: user?.id,
+            email: user?.primaryEmailAddress?.emailAddress,
+            username: name.isEmpty ? nil : name
+        )
+        Analytics.identifyUser(id: user?.id)
         let args: [String: ConvexEncodable?] = [
             "email": user?.primaryEmailAddress?.emailAddress,
             "name": name.isEmpty ? nil : name,

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -77,13 +77,15 @@ enum Telemetry {
         String(id.prefix(8))
     }
 
-    static func setUser(id: String?) {
+    static func setUser(id: String?, email: String? = nil, username: String? = nil) {
         #if PRODUCTION_TELEMETRY
         guard didStart else { return }
         SentrySDK.configureScope { scope in
             guard let id else { scope.setUser(nil); return }
             let user = User()
             user.userId = id
+            user.email = email
+            user.username = username
             scope.setUser(user)
         }
         #endif

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -46,9 +46,19 @@ enum Telemetry {
             #endif
             options.tracesSampleRate = 0.1
             options.appHangTimeoutInterval = 5.0
+            options.enableLogs = true
             options.attachStacktrace = true
             options.enableCaptureFailedRequests = false
             options.enableUncaughtNSExceptionReporting = true
+            options.beforeSend = { event in
+                let type = event.exceptions?.first?.type ?? ""
+                if type.localizedCaseInsensitiveContains("App Hang") {
+                    let frames = event.exceptions?.first?.stacktrace?.frames ?? []
+                    let symbol = frames.last(where: { $0.inApp?.boolValue == true })?.function ?? "unknown"
+                    event.fingerprint = ["app-hang", symbol]
+                }
+                return event
+            }
             if let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
                let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String {
                 options.releaseName = "palmier-pro@\(version)+\(build)"
@@ -112,27 +122,45 @@ enum Telemetry {
         setExtra(value: nil, key: "active_operation")
     }
 
+    static func logInfo(_ message: String, category: String, data: Payload? = nil) {
+        sendLog(message, level: .info, category: category, data: data)
+    }
+
     static func logWarning(_ message: String, category: String, data: Payload? = nil) {
         breadcrumb(message, category: category, level: .warning, data: data)
+        sendLog(message, level: .warning, category: category, data: data)
     }
 
     static func logError(_ message: String, category: String, data: Payload? = nil) {
-        captureLogMessage(message, level: .error, category: category, data: data)
+        breadcrumb(message, category: category, level: .error, data: data)
+        sendLog(message, level: .error, category: category, data: data)
     }
 
     static func logFault(_ message: String, category: String, data: Payload? = nil) {
-        captureLogMessage(message, level: .fatal, category: category, data: data)
+        breadcrumb(message, category: category, level: .fatal, data: data)
+        sendLog(message, level: .fatal, category: category, data: data)
     }
 
-    private static func captureLogMessage(_ message: String, level: Level, category: String, data: Payload?) {
+    private static func sendLog(_ message: String, level: Level, category: String, data: Payload?) {
         #if PRODUCTION_TELEMETRY
         guard didStart else { return }
-        SentrySDK.capture(message: message) { scope in
-            scope.setLevel(level.sentryLevel)
-            scope.setTag(value: category, key: "log_category")
-            if let data {
-                scope.setExtra(value: data, key: "log")
+        var attributes: [String: Any] = ["category": category]
+        if let data {
+            for (key, value) in data {
+                switch value {
+                case let string as String: attributes[key] = string
+                case let bool as Bool: attributes[key] = bool
+                case let int as Int: attributes[key] = int
+                case let double as Double: attributes[key] = double
+                default: break
+                }
             }
+        }
+        switch level {
+        case .info: SentrySDK.logger.info(message, attributes: attributes)
+        case .warning: SentrySDK.logger.warn(message, attributes: attributes)
+        case .error: SentrySDK.logger.error(message, attributes: attributes)
+        case .fatal: SentrySDK.logger.fatal(message, attributes: attributes)
         }
         #endif
     }

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -147,13 +147,7 @@ enum Telemetry {
         var attributes: [String: Any] = ["category": category]
         if let data {
             for (key, value) in data {
-                switch value {
-                case let string as String: attributes[key] = string
-                case let bool as Bool: attributes[key] = bool
-                case let int as Int: attributes[key] = int
-                case let double as Double: attributes[key] = double
-                default: break
-                }
+                attributes[key] = value
             }
         }
         switch level {

--- a/Sources/PalmierPro/Telemetry/Telemetry.swift
+++ b/Sources/PalmierPro/Telemetry/Telemetry.swift
@@ -45,7 +45,7 @@ enum Telemetry {
             options.environment = "production"
             #endif
             options.tracesSampleRate = 0.1
-            options.appHangTimeoutInterval = 8.0
+            options.appHangTimeoutInterval = 5.0
             options.attachStacktrace = true
             options.enableCaptureFailedRequests = false
             options.enableUncaughtNSExceptionReporting = true

--- a/Sources/PalmierPro/Utilities/Log.swift
+++ b/Sources/PalmierPro/Utilities/Log.swift
@@ -66,6 +66,7 @@ struct CategoryLog {
     func notice(_ m: String, telemetry: String? = nil, data: Telemetry.Payload? = nil) {
         mirror("NOTICE", m)
         logger.notice("\(m, privacy: .public)")
+        Telemetry.logInfo(m, category: category, data: data)
         if let telemetry {
             Telemetry.breadcrumb(telemetry, category: category, data: data)
         }


### PR DESCRIPTION
## Summary
- Set Sentry `user.email` / `username` on sign-in so support can find a user without a Convex lookup.
- Lower the app-hang timeout from 8s to 5s, and fingerprint hangs by the stuck in-app frame so they stop collapsing into `PALMIER-PRO-Q`.
- Send `Log.notice` / `warning` / `error` / `fault` to Sentry Logs instead of opening issues from `Log.error`, so a quiet session is still searchable.

## Approach
- Email is set only after Clerk sign-in; opt-out still skips `SentrySDK.start` for that launch. `sendDefaultPii` stays off (no IP).
- Hang events already carry the stack on the exception. `beforeSend` sets `fingerprint = ["app-hang", <last in-app function>]`. Existing `PALMIER-PRO-Q` is unchanged; new events split after this ships.
- `enableLogs = true`. Logs are independent of crashes. `Log.info` / `debug` stay local. Breadcrumbs still attach only to a later issue.

## Testing
- `swift build --traits ProductionTelemetry` succeeded.
- Local `./scripts/dev.sh --telemetry`: Logs appeared in Sentry as `environment:development` for `harrison@palmier.io` (project read, MCP start, search sweep). `Log.error` did not open a development issue.
- Hang fingerprinting was not live-verified (no induced ≥5s hang in that run).

## Change statistics
- Code: +47 / −12 across `Telemetry.swift`, `Log.swift`, `AccountService.swift`
- Tests: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production telemetry (PII-adjacent email on Sentry user, hang detection sensitivity, and how errors surface in Sentry); behavior is scoped to post-sign-in and existing telemetry opt-out.
> 
> **Overview**
> Improves **Sentry** support workflows by attaching **Clerk email and display name** to the Sentry user on sign-in (after building the name used for Convex provisioning), so sessions can be found without a Convex lookup.
> 
> **Telemetry** changes tighten **app-hang** detection (timeout **8s → 5s**), enable **Sentry Logs**, and **fingerprint** App Hang events by the last in-app stack frame so they group by stuck symbol instead of one bucket. **Warning/error/fault** logging now goes through **Sentry logger** (with breadcrumbs) instead of **`capture(message)`**, reducing spurious issues while keeping quiet sessions searchable; **`Log.notice`** also forwards to **`Telemetry.logInfo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7bae37ad1305c040616d710ac85844a35f22ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->