### PR TITLE
[ui] Widen Index transcript source menu

### DIFF
--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -510,7 +510,7 @@ enum AppTheme {
         static let speakerNameFieldWidth: CGFloat = 96
         static let captionIndexTimecodeWidth: CGFloat = 68
         static let captionIndexDurationWidth: CGFloat = 28
-        static let transcriptSourceMenuWidth: CGFloat = 90
+        static let transcriptSourceMenuWidth: CGFloat = 116
         static let markerIndexTimeFieldWidth: CGFloat = 64
         static let markerIndexDurationFieldWidth: CGFloat = 32
         static let markerIndexCommentHeight: CGFloat = 36


### PR DESCRIPTION
## Summary
- The Index → Transcript source picker was capped at 90pt, so **Transcript** rendered as `Tra…ript`.
- Widen `AppTheme.MediaPanel.transcriptSourceMenuWidth` to 116pt so the full label and chevron fit.

## Approach
- Keep the existing fixed-width contract on `TranscriptSourceMenu`.
- Size the constant for 11pt `Transcript` plus `EditorMenuValue` padding, spacer, and chevron.

## Testing
- Automated: none. This is a one-line layout constant.
- Manual: open Index → Transcript with captions present and confirm the source control reads **Transcript** in full. Also check a caption source such as **Caption V1**.

## Change statistics
- UI: +1 / −1 (`AppTheme.MediaPanel.transcriptSourceMenuWidth` 90 → 116)
- Tests: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout constant in the media panel; no logic, data, or API changes.
> 
> **Overview**
> Fixes truncated text in the **Index → Transcript** source picker by increasing `AppTheme.MediaPanel.transcriptSourceMenuWidth` from **90pt** to **116pt**.
> 
> The existing fixed-width layout on `TranscriptSourceMenu` is unchanged; only the theme constant is sized so labels like **Transcript** and caption track names display fully with the chevron.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2ff9a512deeb076ccf4f3e438786bc2288343e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->