### PR TITLE
[ui] Left-align inspector keys with section headers

### DIFF
--- a/Sources/PalmierPro/Inspector/Components/InspectorRow.swift
+++ b/Sources/PalmierPro/Inspector/Components/InspectorRow.swift
@@ -11,7 +11,7 @@ struct InspectorRow<Trailing: View>: View {
     init(
         label: String,
         labelHelp: String? = nil,
-        labelAlignment: Alignment = .trailing,
+        labelAlignment: Alignment = .leading,
         onReset: (() -> Void)? = nil,
         @ViewBuilder trailing: @escaping () -> Trailing
     ) {

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -159,13 +159,7 @@ struct InspectorView: View {
             ScrollView {
                 EditorPanelGroup(
                     L10n.string("Canvas"),
-                    contentSpacing: AppTheme.Spacing.sm,
-                    contentInsets: EdgeInsets(
-                        top: AppTheme.Spacing.smMd,
-                        leading: AppTheme.Spacing.smMd + AppTheme.IconSize.xs + AppTheme.Spacing.sm,
-                        bottom: AppTheme.Spacing.smMd,
-                        trailing: AppTheme.Spacing.smMd
-                    )
+                    contentSpacing: AppTheme.Spacing.sm
                 ) {
                     menuMetadataRow(label: L10n.string("Resolution"), value: "\(editor.timeline.width) × \(editor.timeline.height)") { qualityMenuItems }
                     menuMetadataRow(label: L10n.string("Frame Rate"), value: "\(editor.timeline.fps) fps") { fpsMenuItems }

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/AudioPanelTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/AudioPanelTab.swift
@@ -1,14 +1,5 @@
 import SwiftUI
 
-enum AudioPanelSectionLayout {
-    static let contentInsets = EdgeInsets(
-        top: AppTheme.Spacing.smMd,
-        leading: AppTheme.Spacing.mdLg,
-        bottom: AppTheme.Spacing.smMd,
-        trailing: AppTheme.Spacing.mdLg
-    )
-}
-
 struct AudioPanelTab: View {
     @Environment(EditorViewModel.self) private var editor
     @State private var musicExpanded = true

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/MusicTab.swift
@@ -134,8 +134,7 @@ struct MusicSection: View {
     private var musicSection: some View {
         EditorPanelGroup(
             L10n.string("Music"),
-            isExpanded: $isExpanded,
-            contentInsets: AudioPanelSectionLayout.contentInsets
+            isExpanded: $isExpanded
         ) {
             sourceControls
             modelControl

--- a/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
+++ b/Sources/PalmierPro/MediaPanel/AudioPanelTab/SpeechTab.swift
@@ -16,8 +16,7 @@ struct SpeechAnalysisSections: View {
     private var speakersSection: some View {
         EditorPanelGroup(
             L10n.string("Speaker Detection"),
-            isExpanded: $speakerExpanded,
-            contentInsets: AudioPanelSectionLayout.contentInsets
+            isExpanded: $speakerExpanded
         ) {
             InspectorRow(
                 label: L10n.string("Mark Speakers"),
@@ -109,8 +108,7 @@ struct SpeechAnalysisSections: View {
     private var silenceSection: some View {
         EditorPanelGroup(
             L10n.string("Silence Detection"),
-            isExpanded: $silenceExpanded,
-            contentInsets: AudioPanelSectionLayout.contentInsets
+            isExpanded: $silenceExpanded
         ) {
             InspectorRow(
                 label: L10n.string("Mark Silence"),

--- a/Sources/PalmierPro/UI/AppTheme.swift
+++ b/Sources/PalmierPro/UI/AppTheme.swift
@@ -472,6 +472,12 @@ enum AppTheme {
         static let compactNumericFieldWidth: CGFloat = 36
         static let fontMenuWidth: CGFloat = 160
         static let textEditorMinHeight: CGFloat = 96
+        static let contentInsets = EdgeInsets(
+            top: Spacing.smMd,
+            leading: Spacing.smMd + IconSize.xs + Spacing.sm,
+            bottom: Spacing.smMd,
+            trailing: Spacing.smMd
+        )
     }
 
     enum Window {

--- a/Sources/PalmierPro/UI/EditorPanel/EditorPanelGroup.swift
+++ b/Sources/PalmierPro/UI/EditorPanel/EditorPanelGroup.swift
@@ -14,12 +14,7 @@ struct EditorPanelGroup<Content: View, HeaderAccessory: View>: View {
         _ title: String,
         isExpanded: Binding<Bool>? = nil,
         contentSpacing: CGFloat = AppTheme.Spacing.smMd,
-        contentInsets: EdgeInsets = EdgeInsets(
-            top: AppTheme.Spacing.smMd,
-            leading: AppTheme.Spacing.smMd,
-            bottom: AppTheme.Spacing.smMd,
-            trailing: AppTheme.Spacing.smMd
-        ),
+        contentInsets: EdgeInsets = AppTheme.EditorPanel.contentInsets,
         onReset: (() -> Void)? = nil,
         @ViewBuilder headerAccessory: @escaping () -> HeaderAccessory,
         @ViewBuilder content: @escaping () -> Content
@@ -118,12 +113,7 @@ extension EditorPanelGroup where HeaderAccessory == EmptyView {
         _ title: String,
         isExpanded: Binding<Bool>? = nil,
         contentSpacing: CGFloat = AppTheme.Spacing.smMd,
-        contentInsets: EdgeInsets = EdgeInsets(
-            top: AppTheme.Spacing.smMd,
-            leading: AppTheme.Spacing.smMd,
-            bottom: AppTheme.Spacing.smMd,
-            trailing: AppTheme.Spacing.smMd
-        ),
+        contentInsets: EdgeInsets = AppTheme.EditorPanel.contentInsets,
         onReset: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) {


### PR DESCRIPTION
## Summary
- Inspector and editor-panel row keys are left-aligned instead of right-aligned in the label column, so short labels like Position and Speed no longer sit toward the center.
- Group content now uses a shared leading inset that matches the section title after the disclosure chevron.
- Media Audio (Music, Silence Detection, Speaker Detection) drops its custom 12pt inset and uses the same alignment as Inspector and Canvas.

## Approach
`InspectorRow` defaults to leading label alignment. `AppTheme.EditorPanel.contentInsets` is the single source of truth for group padding: leading is `smMd + IconSize.xs + Spacing.sm` so content lines up with the header title. Canvas and the audio tab no longer pass one-off insets.

## Testing
- `swift build` / `swift test` not run (layout-only SwiftUI change).
- Manual UI: open a clip inspector and confirm Transform, Image Adjustment, and Playback keys share a left edge with their headers.
- Manual UI: Media → Audio — Music, Silence Detection, and Speaker Detection keys align with their section titles.
- Manual UI: empty-timeline Canvas metadata rows still align with the Canvas header.

## Change statistics
- Code: +13 / −35 across 7 files (`InspectorRow`, `EditorPanelGroup`, `AppTheme`, Inspector Canvas insets, audio tab layout).
- Tests: none.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI layout and spacing only; no logic, data, or API changes.
> 
> **Overview**
> Inspector and editor panel **row labels** now default to **leading** alignment in `InspectorRow`, so short keys (e.g. Position, Speed) sit on the left edge of the label column instead of hugging the center.
> 
> **Group content padding** is centralized in `AppTheme.EditorPanel.contentInsets`, with a **leading inset** sized to line up with section titles after the disclosure chevron. `EditorPanelGroup` uses that as its default; the Canvas metadata block and Media → Audio sections (Music, Silence Detection, Speaker Detection) drop one-off `contentInsets` and the removed `AudioPanelSectionLayout` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b7e20877a481fd6615d71faae02aa9a0a2c4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->