### PR TITLE
[ui] Show generation model and cost in inspector

### DIFF
--- a/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
+++ b/Sources/PalmierPro/Generation/Catalog/ModelCatalog.swift
@@ -24,6 +24,16 @@ enum ModelRegistry {
         case .none: id
         }
     }
+
+    @MainActor static func providerIconKey(for id: String) -> String? {
+        switch byId[id] {
+        case .video(let m): m.entry.providerIconKey
+        case .image(let m): m.entry.providerIconKey
+        case .audio(let m): m.entry.providerIconKey
+        case .upscale(let m): m.entry.providerIconKey
+        case .none: nil
+        }
+    }
 }
 
 @Observable

--- a/Sources/PalmierPro/Generation/GenerationService.swift
+++ b/Sources/PalmierPro/Generation/GenerationService.swift
@@ -319,6 +319,8 @@ final class GenerationService {
         enhancedInput.resolution = "1080p"
         enhancedInput.backendJobId = nil
         enhancedInput.resultURLs = nil
+        enhancedInput.costCredits = nil
+        enhancedInput.refundedCredits = nil
         enhancedInput.createdAt = Date()
         let placeholder = createPlaceholder(
             type: .video,
@@ -622,6 +624,7 @@ final class GenerationService {
             if updateBackendJobMetadata(
                 placeholders,
                 backendJobId: backendJobId,
+                costCredits: job.costCredits,
                 editor: editor
             ) {
                 editor.onProjectCheckpointRequired?()
@@ -640,6 +643,9 @@ final class GenerationService {
             for placeholder in placeholders {
                 updateGenerationMetadata(placeholder, editor: editor, status: .failed(message)) { input in
                     input.backendJobId = backendJobId
+                    if let costCredits = job.costCredits {
+                        input.costCredits = costCredits
+                    }
                     input.refundedCredits = job.refundedCredits
                 }
             }
@@ -650,6 +656,7 @@ final class GenerationService {
             if updateBackendJobMetadata(
                 placeholders,
                 backendJobId: backendJobId,
+                costCredits: job.costCredits,
                 editor: editor
             ) {
                 editor.onProjectCheckpointRequired?()
@@ -662,17 +669,22 @@ final class GenerationService {
     private func updateBackendJobMetadata(
         _ placeholders: [MediaAsset],
         backendJobId: String,
+        costCredits: Int?,
         editor: EditorViewModel
     ) -> Bool {
         var changed = false
         for placeholder in placeholders {
-            guard placeholder.generationStatus != .downloading,
-                    placeholder.generationStatus != .generating ||
-                    placeholder.generationInput?.backendJobId != backendJobId else {
-                continue
-            }
+            guard placeholder.generationStatus != .downloading else { continue }
+            let input = placeholder.generationInput
+            let metadataUnchanged = placeholder.generationStatus == .generating
+                && input?.backendJobId == backendJobId
+                && (costCredits == nil || input?.costCredits == costCredits)
+            guard !metadataUnchanged else { continue }
             updateGenerationMetadata(placeholder, editor: editor, status: .generating) { input in
                 input.backendJobId = backendJobId
+                if let costCredits {
+                    input.costCredits = costCredits
+                }
             }
             changed = true
         }

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -1005,13 +1005,7 @@ struct InspectorView: View {
                             .frame(height: AppTheme.BorderWidth.hairline)
                     }
                     if !metadata.isEmpty {
-                        Text(verbatim: metadata)
-                            .font(.system(size: AppTheme.FontSize.xs))
-                            .foregroundStyle(AppTheme.Text.tertiaryColor)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .textSelection(.enabled)
-                            .help(Text(verbatim: metadata))
+                        generationMetadataRow(gen, metadata: metadata)
                     }
                 }
                 .padding(.horizontal, AppTheme.Spacing.smMd)
@@ -1043,6 +1037,40 @@ struct InspectorView: View {
                 .foregroundStyle(AppTheme.Text.secondaryColor)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func generationMetadataRow(_ gen: GenerationInput, metadata: String) -> some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            if let iconKey = ModelRegistry.providerIconKey(for: gen.model) {
+                ProviderLogo(iconKey: iconKey, size: AppTheme.IconSize.xs)
+            } else {
+                Image(systemName: "sparkles")
+                    .font(.system(size: AppTheme.FontSize.xxs))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+                    .frame(width: AppTheme.IconSize.xs, height: AppTheme.IconSize.xs)
+                    .accessibilityHidden(true)
+            }
+            Text(verbatim: metadata)
+                .font(.system(size: AppTheme.FontSize.xs))
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .textSelection(.enabled)
+                .help(Text(verbatim: metadata))
+            Spacer(minLength: AppTheme.Spacing.xs)
+            if let cost = gen.costCredits {
+                HStack(spacing: AppTheme.Spacing.xxs) {
+                    Image(systemName: "dollarsign.circle.fill")
+                    Text(verbatim: cost.formatted())
+                }
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .monospacedDigit()
+                .foregroundStyle(AppTheme.Text.tertiaryColor)
+                .fixedSize()
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(CostEstimator.localizedUsedCredits(cost))
+            }
         }
     }
 

--- a/Sources/PalmierPro/Models/MediaManifest.swift
+++ b/Sources/PalmierPro/Models/MediaManifest.swift
@@ -80,6 +80,7 @@ struct GenerationInput: Codable, Sendable, Equatable {
     var backendJobId: String?
     var outputIndex: Int?
     var resultURLs: [String]?
+    var costCredits: Int?
     var refundedCredits: Int?
 }
 

--- a/Tests/PalmierProTests/Generation/BackendGenerationJobTests.swift
+++ b/Tests/PalmierProTests/Generation/BackendGenerationJobTests.swift
@@ -10,7 +10,9 @@ struct BackendGenerationJobTests {
         let withoutRefund = try JSONDecoder().decode(BackendGenerationJob.self, from: Data("""
         {"_id":"j2","status":"succeeded","resultUrls":["https://example.com/out.mp4"],"costCredits":10,"completedAt":1}
         """.utf8))
+        #expect(withRefund.costCredits == 27)
         #expect(withRefund.refundedCredits == 27)
+        #expect(withoutRefund.costCredits == 10)
         #expect(withoutRefund.refundedCredits == nil)
     }
 }

--- a/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
+++ b/Tests/PalmierProTests/Media/ManifestMetadataTests.swift
@@ -51,6 +51,7 @@ import Testing
             prompt: "Fail", model: "flux-3", duration: 5,
             aspectRatio: "16:9", resolution: "720p"
         )
+        input.costCredits = 12
         input.refundedCredits = 12
         let generated = MediaAsset(
             url: URL(fileURLWithPath: "/tmp/failed.mp4"),
@@ -64,6 +65,7 @@ import Testing
             entry: try JSONDecoder().decode(MediaManifestEntry.self, from: data),
             resolvedURL: generated.url
         )
+        #expect(asset.generationInput?.costCredits == 12)
         #expect(asset.generationInput?.refundedCredits == 12)
         #expect(asset.wasGenerationRefunded)
         asset.generationInput?.refundedCredits = 0


### PR DESCRIPTION
## Summary
- Show the selected model's provider logo in the Generation Input inspector metadata.
- Show the actual backend credit charge as a compact icon and number.
- Persist billing metadata so generated assets retain their cost after reopening a project.

## Approach
- Resolve provider icon keys from the model catalog using the stored model ID, with the existing generic logo fallback for unavailable providers.
- Copy `costCredits` from backend job updates into `GenerationInput` and persist it through the media manifest.
- Preserve known charges when a later backend update omits cost data, and clear inherited billing metadata when enhancing a draft.
- Leave cost hidden for historical assets that do not contain actual billing metadata rather than displaying an estimate.

## Testing
- `swift test` — passed, 1,622 tests in 256 suites.
- `swift build` — passed.
- Manual UI verification not completed:
  - [ ] Generate an asset and confirm Generation Input shows its provider logo and numeric cost after completion.
  - [ ] Reopen the project and confirm the cost remains visible.
  - [ ] Enhance a draft and confirm the original draft cost is not shown on the new job while it starts.

## Change statistics
- Application code: +63 / -12
- Tests: +4 / -0
- Total: +67 / -12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing metadata persistence and job-update skip logic, so incorrect cost copy or skip conditions could show stale charges or extra checkpoints. Not auth or payment processing.
> 
> **Overview**
> The Generation Input inspector now shows the model’s **provider logo** and the **actual credit charge** from the backend, instead of metadata text alone.
> 
> `costCredits` is copied from job updates into `GenerationInput` and persisted in the media manifest so cost survives project reopen. Later updates that omit cost keep the known value; draft enhance clears inherited billing so the new job does not show the draft’s charge. Historical assets without stored cost stay blank rather than showing an estimate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddb96d3c0bed06fc8a1f1d0363b7fe7e2509a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->