### PR TITLE
[ui] Show editor icons for timeline exports

### DIFF
--- a/Sources/PalmierPro/Export/EditorIconLoader.swift
+++ b/Sources/PalmierPro/Export/EditorIconLoader.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum ExportEditorApplication: String, Identifiable, Sendable {
+    case premierePro = "Premiere Pro"
+    case davinciResolve = "DaVinci Resolve"
+    case finalCutPro = "Final Cut Pro"
+
+    var id: Self { self }
+    var displayName: String { rawValue }
+}
+
+enum EditorIconLoader {
+    private struct ApplicationBundleInfo: Decodable {
+        let bundleIdentifier: String
+        let iconFile: String?
+
+        enum CodingKeys: String, CodingKey {
+            case bundleIdentifier = "CFBundleIdentifier"
+            case iconFile = "CFBundleIconFile"
+        }
+    }
+
+    @concurrent
+    static func loadIconData(
+        searchDirectories: [URL]? = nil
+    ) async -> [ExportEditorApplication: Data] {
+        let fileManager = FileManager.default
+        let roots = searchDirectories ?? [
+            FileManager.SearchPathDomainMask.localDomainMask,
+            .userDomainMask,
+        ].compactMap {
+            fileManager.urls(for: .applicationDirectory, in: $0).first
+        }
+        let rootEntries = roots.flatMap { contents(of: $0, fileManager: fileManager) }
+        let nestedEntries = rootEntries
+            .filter {
+                guard $0.pathExtension.lowercased() != "app",
+                      let values = try? $0.resourceValues(
+                          forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+                      ) else { return false }
+                return values.isDirectory == true && values.isSymbolicLink != true
+            }
+            .flatMap { contents(of: $0, fileManager: fileManager) }
+
+        var icons: [ExportEditorApplication: Data] = [:]
+        for applicationURL in (rootEntries + nestedEntries)
+            where applicationURL.pathExtension.lowercased() == "app" {
+            let contentsURL = applicationURL.appendingPathComponent("Contents", isDirectory: true)
+            guard let infoData = try? Data(
+                contentsOf: contentsURL.appendingPathComponent("Info.plist")
+            ),
+            let info = try? PropertyListDecoder().decode(ApplicationBundleInfo.self, from: infoData),
+            let editor = editor(forBundleIdentifier: info.bundleIdentifier),
+            icons[editor] == nil,
+            let iconFile = info.iconFile, !iconFile.isEmpty else { continue }
+
+            let iconURL = contentsURL.appendingPathComponent("Resources/\(iconFile)")
+            let candidates = iconURL.pathExtension.isEmpty
+                ? [iconURL, iconURL.appendingPathExtension("icns")]
+                : [iconURL]
+            if let data = candidates.lazy.compactMap({ try? Data(contentsOf: $0) }).first {
+                icons[editor] = data
+            }
+        }
+        return icons
+    }
+
+    static func editor(forBundleIdentifier bundleIdentifier: String) -> ExportEditorApplication? {
+        if bundleIdentifier.hasPrefix("com.adobe.PremierePro") { return .premierePro }
+        if bundleIdentifier == "com.blackmagic-design.DaVinciResolve" { return .davinciResolve }
+        if bundleIdentifier.hasPrefix("com.apple.FinalCut") { return .finalCutPro }
+        return nil
+    }
+
+    private static func contents(of url: URL, fileManager: FileManager) -> [URL] {
+        (try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+}

--- a/Sources/PalmierPro/Export/ExportView.swift
+++ b/Sources/PalmierPro/Export/ExportView.swift
@@ -51,10 +51,10 @@ enum TimelineExportFormat: String, CaseIterable, Identifiable {
         }
     }
 
-    var compatibilityLabel: String {
+    var compatibleEditors: [ExportEditorApplication] {
         switch self {
-        case .xmeml: "Premiere Pro and DaVinci Resolve"
-        case .fcpxml: "DaVinci Resolve and Final Cut Pro"
+        case .xmeml: [.davinciResolve, .premierePro]
+        case .fcpxml: [.davinciResolve, .finalCutPro]
         }
     }
 }
@@ -71,6 +71,7 @@ struct ExportView: View {
     @State private var submissionError: String?
     @State private var palmierSummary: (collect: Int, missing: Int, bytes: Int64) = (0, 0, 0)
     @State private var selectedTimelineId: String?
+    @State private var installedEditorIcons: [ExportEditorApplication: NSImage] = [:]
 
     private var exportTimeline: Timeline {
         selectedTimelineId.flatMap { editor.timeline(for: $0) } ?? editor.timeline
@@ -106,6 +107,11 @@ struct ExportView: View {
             }.value
             guard !Task.isCancelled else { return }
             palmierSummary = summary
+        }
+        .task {
+            let iconData = await EditorIconLoader.loadIconData()
+            guard !Task.isCancelled else { return }
+            installedEditorIcons = iconData.compactMapValues(NSImage.init(data:))
         }
     }
 
@@ -582,10 +588,7 @@ struct ExportView: View {
                         .foregroundStyle(AppTheme.Text.tertiaryColor)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    Text(L10n.string("Compatibility: \(format.compatibilityLabel)"))
-                        .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
-                        .foregroundStyle(AppTheme.Text.secondaryColor)
-                        .fixedSize(horizontal: false, vertical: true)
+                    timelineCompatibility(format)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -605,6 +608,44 @@ struct ExportView: View {
             RoundedRectangle(cornerRadius: AppTheme.Radius.sm, style: .continuous)
                 .strokeBorder(selected ? AppTheme.Border.primaryColor : AppTheme.Border.subtleColor, lineWidth: AppTheme.BorderWidth.thin)
         }
+    }
+
+    private func timelineCompatibility(_ format: TimelineExportFormat) -> some View {
+        let label = L10n.string("Compatibility: \("")")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return HStack(spacing: AppTheme.Spacing.xs) {
+            Text(label)
+                .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+
+            ForEach(format.compatibleEditors) { application in
+                HStack(spacing: AppTheme.Spacing.xxs) {
+                    exportEditorIcon(application)
+                    Text(verbatim: application.displayName)
+                        .font(.system(size: AppTheme.FontSize.xs, weight: AppTheme.FontWeight.medium))
+                        .foregroundStyle(AppTheme.Text.secondaryColor)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func exportEditorIcon(_ application: ExportEditorApplication) -> some View {
+        Group {
+            if let image = installedEditorIcons[application] {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                Image(systemName: "app")
+                    .font(.system(size: AppTheme.FontSize.sm))
+                    .foregroundStyle(AppTheme.Text.tertiaryColor)
+            }
+        }
+        .frame(width: AppTheme.IconSize.sm, height: AppTheme.IconSize.sm)
+        .clipShape(RoundedRectangle(cornerRadius: AppTheme.Radius.xs, style: .continuous))
+        .accessibilityHidden(true)
     }
 
     private var estimatedFileSize: String {

--- a/Tests/PalmierProTests/Export/EditorIconLoaderTests.swift
+++ b/Tests/PalmierProTests/Export/EditorIconLoaderTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("EditorIconLoader")
+struct EditorIconLoaderTests {
+    @Test(
+        arguments: [
+            ("com.adobe.PremierePro.26", ExportEditorApplication.premierePro as ExportEditorApplication?),
+            ("com.blackmagic-design.DaVinciResolve", .davinciResolve),
+            ("com.apple.FinalCut", .finalCutPro),
+            ("com.apple.FinalCutApp", .finalCutPro),
+            ("com.example.VideoEditor", nil),
+        ]
+    )
+    func identifiesSupportedEditor(
+        bundleIdentifier: String,
+        expected: ExportEditorApplication?
+    ) {
+        #expect(EditorIconLoader.editor(forBundleIdentifier: bundleIdentifier) == expected)
+    }
+
+    @Test func loadsIconFromNestedApplicationBundle() async throws {
+        let iconData = Data("icon".utf8)
+        let icons = try await Task.detached(priority: .utility) {
+            let fileManager = FileManager.default
+            let root = fileManager.temporaryDirectory
+                .appendingPathComponent("export-editor-icons-\(UUID())", isDirectory: true)
+            defer { try? fileManager.removeItem(at: root) }
+
+            let applicationURL = root
+                .appendingPathComponent("Video Editors", isDirectory: true)
+                .appendingPathComponent("Final Cut Pro.app", isDirectory: true)
+            let contentsURL = applicationURL.appendingPathComponent("Contents", isDirectory: true)
+            let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+            try fileManager.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+            try PropertyListSerialization.data(
+                fromPropertyList: [
+                    "CFBundleIdentifier": "com.apple.FinalCutApp",
+                    "CFBundleIconFile": "AppIcon.png",
+                ],
+                format: .xml,
+                options: 0
+            )
+            .write(to: contentsURL.appendingPathComponent("Info.plist"))
+            try iconData.write(to: resourcesURL.appendingPathComponent("AppIcon.png"))
+
+            return await EditorIconLoader.loadIconData(searchDirectories: [root])
+        }.value
+
+        #expect(icons[.finalCutPro] == iconData)
+    }
+}


### PR DESCRIPTION
## Summary
- Show recognizable editor icons and names for each timeline export format.
- Use installed application artwork without bundling or redistributing third-party icons.
- Keep compatibility understandable when an editor is absent through a generic app fallback.

## Approach
- Discover Premiere Pro, DaVinci Resolve, and Final Cut Pro bundles asynchronously outside the main actor.
- Match stable bundle identifier families, including Final Cut Pro Creator Studio, and read each installed app's icon data.
- Render Resolve then Premiere for XMEML, and Resolve then Final Cut Pro for FCPXML.

## Testing
- `swift test --filter EditorIconLoaderTests` — passed, 2 tests in 1 suite.
- `swift build` — passed.
- Manual UI verification: open Export → Timeline and confirm installed icons, fallback icons, names, selection, and both format rows. Not completed by the Agent.

## Change statistics
- Code and UI: +130 / -7 lines.
- Tests: +54 / -0 lines.
- Total: +184 / -7 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that reads local app Info.plist/icon files; no auth, export pipeline, or data-handling changes.
> 
> **Overview**
> Timeline export format cards now show **named editor compatibility** with icons loaded from installed Premiere Pro, DaVinci Resolve, and Final Cut Pro apps, instead of a plain text compatibility string.
> 
> `EditorIconLoader` scans Applications (including one nested folder level) off the main actor, matches known bundle ID families, and reads each app’s icon file. Missing apps fall back to a generic SF Symbol. XMEML lists Resolve then Premiere; FCPXML lists Resolve then Final Cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9c802618be90d3d361aabc7f18eeac86aea5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->