### PR TITLE
[agent] Recommend GPT Image, Seedream, and MiniMax H3

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -129,11 +129,9 @@ enum AgentInstructions {
           alternatives, not when the user asked for a final render; approved drafts can be \
           enhanced later without changing their motion. To enhance an approved draft, call \
           generate_video with enhanceDraftMediaRef set to that draft's media ID.
-        - Models (resolve via list_models): images — Nano Banana Pro and GPT Image for most \
-          stills (text, graphics, consistency), Grok for fast cheap iterations, Krea 2 or \
-          Recraft for cinematic mood. Video — Seedance 2.0 Fast at 720p while iterating, \
-          regular Seedance 2.0 for the approved take, Kling v3 if Seedance errors, Grok \
-          Imagine only for very simple scenes, Veo rarely.
+        - General recommendation (resolve via list_models): images — GPT Image and Seedream 5.0. Video — \
+          MiniMax H3 for cheap text-to-video, Grok Imagine for first-frame; Seedance 2.5 Pro \
+          at 720p when quality, references, or resolution matter (expensive).
         - Generation and url/path imports return a placeholder id and run in the background. \
           Do not busy-poll long jobs (video/image/upscale) — fire and move on. Audio is \
           usually fast: one or two get_media ids:[placeholder] checks are fine. Never promise \

--- a/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
+++ b/Sources/PalmierPro/Agent/Tools/AgentInstructions.swift
@@ -130,8 +130,9 @@ enum AgentInstructions {
           enhanced later without changing their motion. To enhance an approved draft, call \
           generate_video with enhanceDraftMediaRef set to that draft's media ID.
         - General recommendation (resolve via list_models): images — GPT Image and Seedream 5.0. Video — \
-          MiniMax H3 for cheap text-to-video, Grok Imagine for first-frame; Seedance 2.5 Pro \
-          at 720p when quality, references, or resolution matter (expensive).
+          MiniMax H3 for cheap text-to-video, Grok Imagine for first-frame and simple low-motion shots; \
+          Seedance 2.5 for overall quality and references (720p; 1080p is the best available but \
+          extremely expensive — do not use it by default).
         - Generation and url/path imports return a placeholder id and run in the background. \
           Do not busy-poll long jobs (video/image/upscale) — fire and move on. Audio is \
           usually fast: one or two get_media ids:[placeholder] checks are fine. Never promise \


### PR DESCRIPTION
## Summary
- Update the agent generation prompt so default stills are GPT Image and Seedream 5.0 instead of Nano Banana.
- Recommend MiniMax H3 for cheap text-to-video and Grok Imagine for first-frame and simple low-motion shots.
- Recommend Seedance 2.5 for overall quality and references at 720p. 1080p is the best available but extremely expensive — do not use it by default.

## Approach
- This is a general recommendation, still resolved through `list_models`. In-app chat and MCP share `AgentInstructions.serverInstructions`.
- Kept the guidance to one bullet so model choice stays short and current.

## Testing
- Prompt copy only; no unit tests.
- Manual: start a generation in chat or MCP and confirm the proposed models match the new defaults, including not defaulting to Seedance 2.5 1080p.

## Change statistics
- Agent instructions: +4 / −5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-copy only in agent instructions; no runtime, auth, or generation API changes.
> 
> **Overview**
> Updates the agent’s default generation model guidance (still resolved via `list_models`).
> 
> Stills now prefer **GPT Image** and **Seedream 5.0** instead of Nano Banana / Grok / Krea / Recraft. Video defaults to **MiniMax H3** for cheap text-to-video, **Grok Imagine** for first-frame and simple low-motion shots, and **Seedance 2.5** at 720p for quality and references — with an explicit warning not to default to 1080p because of cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee4d935981cc42ea3f074a1be70b5dc75fde8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->