### PR TITLE
[fix] Retime linked audio together with its video clip

### DIFF
--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+ClipMutations.swift
@@ -222,32 +222,50 @@ extension EditorViewModel {
         return true
     }
 
-    func applyClipSpeed(clipId: String, newSpeed: Double) {
-        guard !refusesMulticamRetime(clipIds: [clipId], quiet: true) else { return }
-        guard let loc = findClip(id: clipId) else { return }
-        guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].supportsRetiming else { return }
+    /// Retiming a clip must retime its linked partners. Otherwise the untouched side keeps its old
+    /// length and speed, drifting out of sync and overlapping whatever follows it on its own track.
+    /// Ordered by track then start frame so each track's ripple runs deterministically.
+    func retimeTargets(_ ids: [String], propagateToLinked: Bool) -> [String] {
+        let candidates = propagateToLinked ? expandToLinkGroup(Set(ids)) : Set(ids)
+        return candidates
+            .compactMap { id -> (id: String, track: Int, start: Int)? in
+                guard let loc = findClip(id: id) else { return nil }
+                let clip = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+                guard clip.supportsRetiming else { return nil }
+                return (id, loc.trackIndex, clip.startFrame)
+            }
+            .sorted { ($0.track, $0.start) < ($1.track, $1.start) }
+            .map(\.id)
+    }
+
+    func applyClipSpeed(ids: [String], newSpeed: Double, propagateToLinked: Bool = true) {
+        let targets = retimeTargets(ids, propagateToLinked: propagateToLinked)
+        guard !targets.isEmpty, !refusesMulticamRetime(clipIds: targets, quiet: true) else { return }
         if preDragTimeline == nil {
             preDragTimeline = timeline
         }
-        if dragBefore[clipId] == nil {
-            dragBefore[clipId] = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+        for id in targets {
+            guard let loc = findClip(id: id) else { continue }
+            if dragBefore[id] == nil {
+                dragBefore[id] = timeline.tracks[loc.trackIndex].clips[loc.clipIndex]
+            }
+            setClipSpeed(at: loc, newSpeed: newSpeed)
         }
-        setClipSpeed(at: loc, newSpeed: newSpeed)
     }
 
-    func commitClipSpeed(ids: [String], newSpeed: Double, ripple: Bool = true) {
-        guard !refusesMulticamRetime(clipIds: ids) else { return }
+    func commitClipSpeed(ids: [String], newSpeed: Double, ripple: Bool = true, propagateToLinked: Bool = true) {
+        let targets = retimeTargets(ids, propagateToLinked: propagateToLinked)
+        guard !refusesMulticamRetime(clipIds: targets) else { return }
         let before: Timeline = preDragTimeline ?? timeline
-        for id in ids {
+        for id in targets {
             guard let loc = findClip(id: id) else { continue }
-            guard timeline.tracks[loc.trackIndex].clips[loc.clipIndex].supportsRetiming else { continue }
             if timeline.tracks[loc.trackIndex].clips[loc.clipIndex].speed != newSpeed {
                 setClipSpeed(at: loc, newSpeed: newSpeed, ripple: ripple)
             }
         }
         let after = timeline
         preDragTimeline = nil
-        for id in ids { dragBefore.removeValue(forKey: id) }
+        for id in targets { dragBefore.removeValue(forKey: id) }
         guard before != after else { return }
         registerTimelineSwap(undoState: before, redoState: after, actionName: "Change Speed")
     }

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+Sync.swift
@@ -317,7 +317,10 @@ extension EditorViewModel {
         if !moves.isEmpty || !retimes.isEmpty {
             try Task.checkCancellation()
             let apply: @MainActor () -> Void = { [self] in
-                for retime in retimes { commitClipSpeed(ids: retime.ids, newSpeed: retime.speed, ripple: false) }
+                // Sync already resolved its own retime unit and deliberately excludes the reference clip.
+                for retime in retimes {
+                    commitClipSpeed(ids: retime.ids, newSpeed: retime.speed, ripple: false, propagateToLinked: false)
+                }
                 if !moves.isEmpty { moveClips(moves) }
             }
             if let mutation {

--- a/Sources/PalmierPro/Inspector/InspectorView.swift
+++ b/Sources/PalmierPro/Inspector/InspectorView.swift
@@ -452,7 +452,7 @@ struct InspectorView: View {
                         dragSensitivity: 0.01,
                         fieldWidth: AppTheme.EditorPanel.numericFieldWidth,
                         onChanged: { newVal in
-                            for c in clips { editor.applyClipSpeed(clipId: c.id, newSpeed: newVal) }
+                            editor.applyClipSpeed(ids: clips.map(\.id), newSpeed: newVal)
                         }
                     ) { newVal in
                         editor.commitClipSpeed(ids: clips.map(\.id), newSpeed: newVal)

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -462,9 +462,7 @@ enum CompositionBuilder {
             compTrack.insertEmptyTimeRange(CMTimeRange(start: cursor, duration: gap))
         }
 
-        let sourceFrames = clip.speed == 1.0
-            ? clip.durationFrames
-            : max(1, Int(Double(clip.durationFrames) * clip.speed))
+        let sourceFrames = max(1, clip.sourceFramesConsumed)
         let durationSeconds = Double(sourceFrames) / Double(timescale)
         var sourceDuration = CMTime(seconds: durationSeconds, preferredTimescale: sourceTimescale)
         // Baked sources can be a hair shorter than the original; clamp instead of throwing.
@@ -559,6 +557,15 @@ enum CompositionBuilder {
         }
     }
 
+    /// AVPlayerItem stretches retimed audio with the time-domain algorithm while AVAssetExportSession
+    /// and AVAssetReaderAudioMixOutput default to spectral. Pinning it here is the one point both
+    /// preview and every export path read, so a retimed clip sounds identical in each.
+    private static func makeInputParameters(track: AVMutableCompositionTrack) -> AVMutableAudioMixInputParameters {
+        let params = AVMutableAudioMixInputParameters(track: track)
+        params.audioTimePitchAlgorithm = .spectral
+        return params
+    }
+
     /// Rebuild only visual properties (transforms, opacity, volume)
     static func buildVisuals(
         timeline: Timeline,
@@ -577,7 +584,7 @@ enum CompositionBuilder {
             case .blackBackground:
                 return nil
             case .nested(let clips, let carrier, let parentTrackIndex):
-                let params = AVMutableAudioMixInputParameters(track: mapping.compositionTrack)
+                let params = makeInputParameters(track: mapping.compositionTrack)
                 guard timeline.tracks.indices.contains(parentTrackIndex) else { return params }
                 let parentTrack = timeline.tracks[parentTrackIndex]
                 if parentTrack.muted {
@@ -593,7 +600,7 @@ enum CompositionBuilder {
             case .timeline(let trackIndex, let clipIds):
                 guard timeline.tracks.indices.contains(trackIndex) else { return nil }
                 let track = timeline.tracks[trackIndex]
-                let params = AVMutableAudioMixInputParameters(track: mapping.compositionTrack)
+                let params = makeInputParameters(track: mapping.compositionTrack)
                 if track.muted {
                     params.setVolume(0, at: .zero)
                     return params

--- a/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
+++ b/Tests/PalmierProTests/Export/CompositionBuilderTests.swift
@@ -403,7 +403,7 @@ struct CompositionBuildAudioTrackTests {
         #expect(mappings[2].target.start == CMTime(value: 48, timescale: ts))
     }
 
-    @Test func fractionalSpeedAudioUsesTruncatedSourceFramesForCompositionInsertion() async throws {
+    @Test func fractionalSpeedAudioConsumesRoundedSourceFrames() async throws {
         let audioURL = try makeSilentWav(durationSeconds: 4)
         defer { try? FileManager.default.removeItem(at: audioURL) }
         let sourceAsset = AVURLAsset(url: audioURL)
@@ -432,10 +432,32 @@ struct CompositionBuildAudioTrackTests {
 
         let audioMapping = try #require(result.trackMappings.first { !$0.isVideo })
         let mediaSegment = try #require(audioMapping.compositionTrack.segments.first { !$0.isEmpty })
-        let expectedSourceSeconds = Double(13) / Double(timeline.fps)
+        // insertClip must consume the same source span the model reports; truncating to 13 here made
+        // the scaleTimeRange a 13f -> 13f no-op and the clip played at 1x despite speed != 1.
+        let expectedSourceSeconds = Double(clip.sourceFramesConsumed) / Double(timeline.fps)
         #expect(abs(mediaSegment.timeMapping.source.duration.seconds - expectedSourceSeconds) <= 1.0 / Double(sourceTimescale))
         #expect(mediaSegment.timeMapping.source.duration.timescale == sourceTimescale)
         #expect(mediaSegment.timeMapping.target.duration == CMTime(value: 13, timescale: 24))
+    }
+
+
+    @Test func audioMixPinsPitchAlgorithmSoPreviewAndExportMatch() async throws {
+        // AVPlayerItem defaults to time domain and AVAssetExportSession to spectral; an unset
+        // algorithm makes a retimed clip sound different in preview than in the exported file.
+        let audioURL = try makeSilentWav(durationSeconds: 4)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let clip = Fixtures.clip(id: "a1", mediaRef: "audio", mediaType: .audio, start: 0, duration: 24, speed: 1.4)
+        let timeline = Fixtures.timeline(fps: 24, tracks: [Fixtures.audioTrack(clips: [clip])])
+
+        let result = try await CompositionBuilder.build(
+            timeline: timeline,
+            resolveURL: { _ in audioURL },
+            renderSize: CGSize(width: 320, height: 180)
+        )
+
+        let params = try #require(result.audioMix.inputParameters.first)
+        #expect(params.audioTimePitchAlgorithm == .spectral)
     }
 
     private func clipIds(_ mapping: TrackMapping) -> Set<String>? {

--- a/Tests/PalmierProTests/Media/LottieVideoGeneratorTests.swift
+++ b/Tests/PalmierProTests/Media/LottieVideoGeneratorTests.swift
@@ -90,13 +90,11 @@ struct LottieVideoGeneratorTests {
         let codec = try #require(formats.first.map { CMFormatDescriptionGetMediaSubType($0) })
         #expect(codec == kCMVideoCodecType_AppleProRes4444)
 
-        let gen = AVAssetImageGenerator(asset: asset)
-        gen.requestedTimeToleranceBefore = .zero
-        gen.requestedTimeToleranceAfter = .zero
-        nonisolated(unsafe) let unsafeGen = gen
-
         func sample(_ seconds: Double) async throws -> (top: NSColor, bottom: NSColor) {
-            let frame = try await unsafeGen.image(at: CMTime(seconds: seconds, preferredTimescale: 600)).image
+            let gen = AVAssetImageGenerator(asset: asset)
+            gen.requestedTimeToleranceBefore = .zero
+            gen.requestedTimeToleranceAfter = .zero
+            let frame = try await gen.image(at: CMTime(seconds: seconds, preferredTimescale: 600)).image
             let rep = NSBitmapImageRep(cgImage: frame)
             return (
                 try #require(rep.colorAt(x: frame.width / 4, y: frame.height / 4)),

--- a/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
+++ b/Tests/PalmierProTests/Timeline/ClipMutationsTests.swift
@@ -17,7 +17,7 @@ struct ApplyClipSpeedTests {
     @Test func applyClipSpeedDoublesScalesDurationDownByHalf() {
         let clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
         let e = editor([Fixtures.videoTrack(clips: [clip])])
-        e.applyClipSpeed(clipId: "c1", newSpeed: 2.0)
+        e.applyClipSpeed(ids: ["c1"], newSpeed: 2.0)
         let updated = e.timeline.tracks[0].clips[0]
         #expect(updated.speed == 2.0)
         // sourceFrames=60*1=60; newDuration = 60/2 = 30.
@@ -27,7 +27,7 @@ struct ApplyClipSpeedTests {
     @Test func applyClipSpeedHalfDoublesDuration() {
         let clip = Fixtures.clip(id: "c1", start: 0, duration: 60)
         let e = editor([Fixtures.videoTrack(clips: [clip])])
-        e.applyClipSpeed(clipId: "c1", newSpeed: 0.5)
+        e.applyClipSpeed(ids: ["c1"], newSpeed: 0.5)
         #expect(e.timeline.tracks[0].clips[0].durationFrames == 120)
     }
 
@@ -37,7 +37,7 @@ struct ApplyClipSpeedTests {
         let c1 = Fixtures.clip(id: "c1", start: 0, duration: 60)
         let c2 = Fixtures.clip(id: "c2", start: 60, duration: 30)
         let e = editor([Fixtures.videoTrack(clips: [c1, c2])])
-        e.applyClipSpeed(clipId: "c1", newSpeed: 2.0)
+        e.applyClipSpeed(ids: ["c1"], newSpeed: 2.0)
         let updated = e.timeline.tracks[0].clips.sorted { $0.startFrame < $1.startFrame }
         #expect(updated[0].durationFrames == 30)
         #expect(updated[1].startFrame == 30)
@@ -48,7 +48,7 @@ struct ApplyClipSpeedTests {
         let c1 = Fixtures.clip(id: "c1", start: 0, duration: 60)
         let c2 = Fixtures.clip(id: "c2", start: 100, duration: 30)
         let e = editor([Fixtures.videoTrack(clips: [c1, c2])])
-        e.applyClipSpeed(clipId: "c1", newSpeed: 2.0)
+        e.applyClipSpeed(ids: ["c1"], newSpeed: 2.0)
         let updated = e.timeline.tracks[0].clips.first { $0.id == "c2" }!
         #expect(updated.startFrame == 100)
     }
@@ -84,12 +84,94 @@ struct ApplyClipSpeedTests {
         clip.scaleTrack = KeyframeTrack(keyframes: [Keyframe(frame: 59, value: AnimPair(a: 2.0, b: 2.0))])
         let e = editor([Fixtures.videoTrack(clips: [clip])])
 
-        e.applyClipSpeed(clipId: "c1", newSpeed: 2.0)
+        e.applyClipSpeed(ids: ["c1"], newSpeed: 2.0)
         let updated = e.timeline.tracks[0].clips[0]
 
         #expect(updated.durationFrames == 30)
         #expect(updated.opacityTrack?.keyframes.map(\.frame) == [0, 15, 29])
         #expect(updated.scaleTrack?.keyframes.map(\.frame) == [29])
+    }
+
+    @Test func retimeCarriesToLinkedAudioPartner() {
+        // Regression: speeding a video clip whose audio lives on a linked audio track left the audio
+        // at 1x and full length, so it ran past the picture and overlapped the following clip.
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 60)
+        video.linkGroupId = "g1"
+        var audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60)
+        audio.linkGroupId = "g1"
+        let nextVideo = Fixtures.clip(id: "v2", start: 60, duration: 30)
+        let nextAudio = Fixtures.clip(id: "a2", mediaType: .audio, start: 60, duration: 30)
+        let e = editor([
+            Fixtures.videoTrack(clips: [video, nextVideo]),
+            Fixtures.audioTrack(clips: [audio, nextAudio]),
+        ])
+
+        e.commitClipSpeed(ids: ["v1"], newSpeed: 1.5)
+
+        let v = e.timeline.tracks[0].clips.first { $0.id == "v1" }!
+        let a = e.timeline.tracks[1].clips.first { $0.id == "a1" }!
+        #expect(v.speed == 1.5)
+        #expect(a.speed == 1.5)
+        #expect(a.durationFrames == v.durationFrames)
+        #expect(a.endFrame == v.endFrame)
+        // Both tracks ripple, so picture and sound stay aligned at the next cut.
+        #expect(e.timeline.tracks[0].clips.first { $0.id == "v2" }!.startFrame == 40)
+        #expect(e.timeline.tracks[1].clips.first { $0.id == "a2" }!.startFrame == 40)
+    }
+
+    @Test func liveRetimeDragCarriesToLinkedAudioPartner() {
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 60)
+        video.linkGroupId = "g1"
+        var audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60)
+        audio.linkGroupId = "g1"
+        let e = editor([
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        e.applyClipSpeed(ids: ["v1"], newSpeed: 2.0)
+
+        #expect(e.timeline.tracks[1].clips[0].speed == 2.0)
+        #expect(e.timeline.tracks[1].clips[0].durationFrames == 30)
+    }
+
+    @Test func retimeWithLinkPropagationOffLeavesPartnerUntouched() {
+        // Sync resolves its own retime unit and must not have partners folded back in.
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 60)
+        video.linkGroupId = "g1"
+        var audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60)
+        audio.linkGroupId = "g1"
+        let e = editor([
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+
+        e.commitClipSpeed(ids: ["v1"], newSpeed: 2.0, propagateToLinked: false)
+
+        #expect(e.timeline.tracks[0].clips[0].speed == 2.0)
+        #expect(e.timeline.tracks[1].clips[0].speed == 1.0)
+        #expect(e.timeline.tracks[1].clips[0].durationFrames == 60)
+    }
+
+    @Test func retimeUndoRestoresBothSidesOfTheLinkGroup() {
+        var video = Fixtures.clip(id: "v1", start: 0, duration: 60)
+        video.linkGroupId = "g1"
+        var audio = Fixtures.clip(id: "a1", mediaType: .audio, start: 0, duration: 60)
+        audio.linkGroupId = "g1"
+        let e = editor([
+            Fixtures.videoTrack(clips: [video]),
+            Fixtures.audioTrack(clips: [audio]),
+        ])
+        let undo = UndoManager()
+        e.undo.attach(undo)
+
+        e.commitClipSpeed(ids: ["v1"], newSpeed: 2.0)
+        undo.undo()
+
+        #expect(e.timeline.tracks[0].clips[0].speed == 1.0)
+        #expect(e.timeline.tracks[0].clips[0].durationFrames == 60)
+        #expect(e.timeline.tracks[1].clips[0].speed == 1.0)
+        #expect(e.timeline.tracks[1].clips[0].durationFrames == 60)
     }
 }
 


### PR DESCRIPTION
Speeding up a clip only retimed the picture. The linked audio stayed at 1x and full
length, so it ran past the video and overlapped the next clip.

Speed was the only retime that didn't expand to the link group split, slip and trim
all do. Now it does too.