### PR TITLE
[feat] Convert a reel into a fillable timeline template

### DIFF
--- a/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolDefinitions.swift
@@ -51,6 +51,10 @@ enum ToolName: String, CaseIterable, Sendable {
     case removeSilence = "remove_silence"
     case detectBeats = "detect_beats"
 
+    // Templates
+    case createTemplateFromReel = "create_template_from_reel"
+    case fillTemplateSlot = "fill_template_slot"
+
     // Text & captions
     case addTexts = "add_texts"
     case updateText = "update_text"
@@ -842,6 +846,28 @@ enum ToolDefinitions {
                     "endSeconds": ["type": "number", "description": "Optional. Return only beats at or before this source-media second."],
                 ],
                 required: ["mediaRef"]
+            )
+        ),
+        AgentTool(
+            name: .createTemplateFromReel,
+            description: "Analyze a video asset (a reel or similar edited piece) on-device and turn its edit into a NEW timeline: cuts are detected and become clips, and the reel's own audio is laid out as separate Music and Voice lanes. In 'placeholders' mode (default) each detected shot becomes a fillable slot carrying that shot's exact duration, detected motion energy, and a suggested playback speed — fill_template_slot (or the user) then drops footage into slots to recreate the reel's rhythm. In 'originalCuts' mode the timeline instead holds the reel split into its detected shots, still referencing the original media.\n\nThe template is appended as a new timeline and activated; the current timeline is untouched. Creating it is one undoable action. Analysis runs locally and is cached per asset revision, so re-running on the same unchanged file is fast. Only one analysis runs at a time — the call fails while one is in progress; wait and retry. Use get_media first to find the asset id.",
+            inputSchema: objectSchema(
+                properties: [
+                    "mediaRef": ["type": "string", "description": "Video asset id from get_media. Must have a video track; audio lanes are only generated when the file has audio."],
+                    "mode": ["type": "string", "enum": ["placeholders", "originalCuts"], "description": "placeholders (default) = fillable slots preserving the reel's timing. originalCuts = the reel split into its detected shots with the original media."],
+                ],
+                required: ["mediaRef"]
+            )
+        ),
+        AgentTool(
+            name: .fillTemplateSlot,
+            description: "Place a video asset into one template slot created by create_template_from_reel. The slot's timeline position and duration are preserved; its suggested speed is applied only when the source is long enough at that speed, otherwise the clip plays at 1x. Calling it on an already filled slot replaces that slot's footage. Fails if the clip is not a slot on the active timeline or the asset is not a video. One undoable action per call. Slot clip ids come from create_template_from_reel's response or get_timeline.",
+            inputSchema: objectSchema(
+                properties: [
+                    "clipId": ["type": "string", "description": "Template slot clip id on the active timeline."],
+                    "mediaRef": ["type": "string", "description": "Video asset id from get_media to place into the slot."],
+                ],
+                required: ["clipId", "mediaRef"]
             )
         ),
         AgentTool(

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor+Templates.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor+Templates.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+extension ToolExecutor {
+    private static let createTemplateFromReelAllowedKeys: Set<String> = ["mediaRef", "mode"]
+    private static let fillTemplateSlotAllowedKeys: Set<String> = ["clipId", "mediaRef"]
+
+    func createTemplateFromReel(_ editor: EditorViewModel, _ args: [String: Any]) async throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.createTemplateFromReelAllowedKeys, path: "create_template_from_reel")
+        let mediaRef = try args.requireString("mediaRef")
+        let asset = try asset(mediaRef, editor: editor)
+        guard asset.type == .video else {
+            throw ToolError("create_template_from_reel needs a video: \(mediaRef) is \(asset.type.rawValue).")
+        }
+        guard FileManager.default.fileExists(atPath: asset.url.path) else {
+            throw ToolError("Media file not on disk: \(asset.url.lastPathComponent)")
+        }
+        let mode = try Self.templateMode(args)
+
+        let receipt: TemplateGenerationReceipt
+        do {
+            receipt = try await editor.createTemplateFromReel(assetId: mediaRef, mode: mode)
+        } catch EditorViewModel.TemplateStudioError.generationInProgress {
+            throw ToolError("A reel analysis is already running. Wait for it to finish, then retry.")
+        } catch EditorViewModel.TemplateStudioError.assetNotFound {
+            throw ToolError("Asset \(mediaRef) was removed or relinked during analysis. Call get_media and retry.")
+        } catch let error as ReelAnalyzer.AnalyzeError {
+            throw ToolError("Reel analysis failed: \(error.localizedDescription)")
+        }
+
+        var out: [String: Any] = [
+            "timelineId": receipt.timelineId,
+            "mode": mode.rawValue,
+            "slotCount": receipt.slotClipIds.count,
+        ]
+        if mode == .placeholders {
+            out["slotClipIds"] = receipt.slotClipIds
+            out["note"] = "The template timeline is now active. Call get_timeline to see the slots and audio lanes, then fill_template_slot to place footage."
+        }
+        if !receipt.warnings.isEmpty {
+            out["warnings"] = receipt.warnings.map(\.rawValue)
+        }
+        guard let json = Self.jsonString(out) else { throw ToolError("Failed to encode result.") }
+        return .ok(json)
+    }
+
+    func fillTemplateSlot(_ editor: EditorViewModel, _ args: [String: Any]) throws -> ToolResult {
+        try validateUnknownKeys(args, allowed: Self.fillTemplateSlotAllowedKeys, path: "fill_template_slot")
+        let clipId = try args.requireString("clipId")
+        let mediaRef = try args.requireString("mediaRef")
+        _ = try asset(mediaRef, editor: editor)
+
+        do {
+            try editor.fillTemplateSlot(clipId: clipId, assetId: mediaRef)
+        } catch EditorViewModel.TemplateStudioError.notATemplateSlot {
+            throw ToolError("Clip \(clipId) is not a template slot on the active timeline.")
+        } catch EditorViewModel.TemplateStudioError.notAVideo {
+            throw ToolError("fill_template_slot needs a video asset: \(mediaRef) is not a video.")
+        }
+
+        guard let location = editor.findClip(id: clipId) else {
+            throw ToolError("Slot \(clipId) disappeared after the fill; call get_timeline.")
+        }
+        let clip = editor.timeline.tracks[location.trackIndex].clips[location.clipIndex]
+        let out: [String: Any] = [
+            "clipId": clipId,
+            "mediaRef": mediaRef,
+            "startFrame": clip.startFrame,
+            "durationFrames": clip.durationFrames,
+            "speed": clip.speed,
+        ]
+        guard let json = Self.jsonString(out) else { throw ToolError("Failed to encode result.") }
+        return .ok(json)
+    }
+
+    private static func templateMode(_ args: [String: Any]) throws -> TemplateMode {
+        guard let rawMode = args["mode"] as? String else { return .placeholders }
+        guard let mode = TemplateMode(rawValue: rawMode) else {
+            throw ToolError("Unknown mode '\(rawMode)'. Use 'placeholders' or 'originalCuts'.")
+        }
+        return mode
+    }
+}

--- a/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
+++ b/Sources/PalmierPro/Agent/Tools/ToolExecutor.swift
@@ -325,6 +325,8 @@ final class ToolExecutor {
         case .captureFrame:  return try await captureFrame(editor, args)
         case .getTranscript: return try await getTranscript(editor, args)
         case .detectBeats:   return try await detectBeats(editor, args)
+        case .createTemplateFromReel: return try await createTemplateFromReel(editor, args)
+        case .fillTemplateSlot: return try fillTemplateSlot(editor, args)
         case .inspectTimeline: return try await inspectTimeline(editor, args)
         case .searchMedia:   return try await searchMedia(editor, args)
         case .applyColor:    return try applyColor(editor, args)

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TemplateStudio.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel+TemplateStudio.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+struct TemplateGenerationState: Equatable, Sendable {
+    var assetId: String
+    var assetName: String
+    var progress: ReelAnalysisProgress
+}
+
+struct TemplateGenerationReceipt: Sendable {
+    var timelineId: String
+    var slotClipIds: [String]
+    var warnings: [TemplateWarning]
+}
+
+extension EditorViewModel {
+    enum TemplateStudioError: LocalizedError {
+        case assetNotFound
+        case notAVideo
+        case notATemplateSlot
+        case generationInProgress
+
+        var errorDescription: String? {
+            switch self {
+            case .assetNotFound: "The media asset could not be found."
+            case .notAVideo: "Templates can only be created from video media."
+            case .notATemplateSlot: "The clip is not a template slot."
+            case .generationInProgress: "A template is already being generated. Wait for it to finish."
+            }
+        }
+    }
+
+    /// Analyzes a reel asset and appends the generated template as a new timeline.
+    @discardableResult
+    func createTemplateFromReel(
+        assetId: String,
+        mode: TemplateMode = .placeholders
+    ) async throws -> TemplateGenerationReceipt {
+        guard templateGeneration == nil else { throw TemplateStudioError.generationInProgress }
+        guard let asset = mediaAssetsById[assetId] else { throw TemplateStudioError.assetNotFound }
+        guard asset.type == .video else { throw TemplateStudioError.notAVideo }
+
+        let sourceURL = asset.url
+        templateGeneration = TemplateGenerationState(
+            assetId: assetId,
+            assetName: asset.name,
+            progress: ReelAnalysisProgress(stage: .scenes, fraction: 0)
+        )
+        defer { templateGeneration = nil }
+
+        let analysis = try await analyzeReel(at: sourceURL, assetId: assetId)
+        try Task.checkCancellation()
+
+        guard let current = mediaAssetsById[assetId], current.url == sourceURL else {
+            throw TemplateStudioError.assetNotFound
+        }
+
+        let result = TemplateGenerator.makeTimeline(
+            from: analysis,
+            sourceMediaRef: assetId,
+            options: TemplateOptions(name: templateName(for: current.name), mode: mode)
+        )
+
+        timelines.append(result.timeline)
+        registerRemoveUndo(for: result.timeline.id, actionName: "Create Template")
+        activateTimeline(result.timeline.id)
+
+        if let warning = result.warnings.first {
+            mediaPanelToast = MediaPanelToast(message: warning.message)
+        }
+        return TemplateGenerationReceipt(
+            timelineId: result.timeline.id,
+            slotClipIds: result.slotClipIds,
+            warnings: result.warnings
+        )
+    }
+
+    func cancelTemplateGeneration() {
+        templateGenerationTask?.cancel()
+        templateGenerationTask = nil
+        templateGeneration = nil
+    }
+
+    /// Fills an unfilled template slot with a media asset, preserving the slot's timing.
+    /// The slot's suggested speed applies only when the source is long enough at that speed.
+    func fillTemplateSlot(clipId: String, assetId: String) throws {
+        guard let location = findClip(id: clipId) else { throw TemplateStudioError.notATemplateSlot }
+        let slotClip = timeline.tracks[location.trackIndex].clips[location.clipIndex]
+        guard let slot = slotClip.templateSlot else { throw TemplateStudioError.notATemplateSlot }
+        guard let asset = mediaAssetsById[assetId] else { throw TemplateStudioError.assetNotFound }
+        guard asset.type == .video else { throw TemplateStudioError.notAVideo }
+
+        prepareMediaVisuals(for: asset)
+
+        var filled = slotClip
+        filled.mediaRef = assetId
+        filled.mediaType = asset.type
+        filled.sourceClipType = asset.type
+        filled.trimStartFrame = 0
+        filled.trimEndFrame = 0
+        if let speed = slot.suggestedSpeed,
+           asset.duration * Double(timeline.fps) >= Double(slotClip.durationFrames) * speed {
+            filled.speed = speed
+        }
+        timeline.tracks[location.trackIndex].clips[location.clipIndex] = filled
+
+        registerTimelineUndo("Replace Template Slot") { editor in
+            guard let location = editor.findClip(id: clipId) else { return }
+            editor.timeline.tracks[location.trackIndex].clips[location.clipIndex] = slotClip
+            editor.notifyTimelineChanged()
+        }
+        notifyTimelineChanged()
+    }
+
+    private func analyzeReel(at sourceURL: URL, assetId: String) async throws -> ReelAnalysis {
+        do {
+            return try await ReelAnalyzer.analysis(for: sourceURL, mediaRef: assetId) { progress in
+                Task { @MainActor [weak self] in
+                    guard let self, templateGeneration?.assetId == assetId else { return }
+                    templateGeneration?.progress = progress
+                }
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as ReelAnalyzer.AnalyzeError {
+            throw error
+        } catch {
+            throw ReelAnalyzer.AnalyzeError.failed(error.localizedDescription)
+        }
+    }
+
+    private func templateName(for assetName: String) -> String {
+        let base = L10n.string("\(assetName) Template")
+        var name = base
+        var suffix = 2
+        while timelines.contains(where: { $0.name == name }) {
+            name = "\(base) \(suffix)"
+            suffix += 1
+        }
+        return name
+    }
+}

--- a/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
+++ b/Sources/PalmierPro/Editor/ViewModel/EditorViewModel.swift
@@ -308,6 +308,9 @@ final class EditorViewModel {
     var mediaPanelSearchFocusPending = false
     var isMediaPanelSearchExpanded = false
     var mediaPanelToast: MediaPanelToast?
+    /// Non-nil while a reel is being analyzed into a template; drives the media panel progress UI.
+    var templateGeneration: TemplateGenerationState?
+    @ObservationIgnored var templateGenerationTask: Task<Void, Never>?
     @ObservationIgnored var mediaImportTail: Task<MediaImportSummary, Error>?
     @ObservationIgnored var mediaImportSequence: Int = 0
     @ObservationIgnored var frameCaptureTask: Task<Void, Never>?

--- a/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/AssetThumbnailView.swift
@@ -89,6 +89,10 @@ struct AssetThumbnailView: View {
             }
             Button(L10n.string("Rename")) { beginRename() }
             AIEditMenu(asset: asset)
+            if asset.type == .video, !isMissing {
+                Button(L10n.string("Create Template from Reel")) { createTemplate() }
+                    .disabled(editor.templateGeneration != nil)
+            }
             Divider()
         }
         if ids.contains(where: { id in
@@ -114,6 +118,20 @@ struct AssetThumbnailView: View {
                 .map(\.id)
         }
         return [asset.id]
+    }
+
+    private func createTemplate() {
+        let assetId = asset.id
+        editor.templateGenerationTask = Task { [editor] in
+            defer { editor.templateGenerationTask = nil }
+            do {
+                try await editor.createTemplateFromReel(assetId: assetId)
+            } catch is CancellationError {
+                return
+            } catch {
+                editor.mediaPanelToast = MediaPanelToast(message: error.localizedDescription)
+            }
+        }
     }
 
     private func relinkFile() {

--- a/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
+++ b/Sources/PalmierPro/MediaPanel/MediaTab/MediaTab.swift
@@ -124,9 +124,15 @@ struct MediaTab: View {
                     if let toast = editor.mediaPanelToast {
                         toastBanner(toast)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
+                    } else if let generation = editor.templateGeneration {
+                        TemplateGenerationBanner(state: generation) {
+                            editor.cancelTemplateGeneration()
+                        }
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
                 }
                 .animation(.easeInOut(duration: AppTheme.Anim.transition), value: editor.mediaPanelToast)
+                .animation(.easeInOut(duration: AppTheme.Anim.transition), value: editor.templateGeneration)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .layoutPriority(1)
 

--- a/Sources/PalmierPro/Models/TemplateSlot.swift
+++ b/Sources/PalmierPro/Models/TemplateSlot.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum MotionEnergy: String, Codable, Sendable {
+    case still
+    case gentle
+    case dynamic
+    case whip
+
+    var label: String {
+        switch self {
+        case .still: L10n.key("Still")
+        case .gentle: L10n.key("Gentle")
+        case .dynamic: L10n.key("Dynamic")
+        case .whip: L10n.key("Whip")
+        }
+    }
+}
+
+struct TemplateSlot: Codable, Sendable, Equatable {
+    var index: Int
+    var motionEnergy: MotionEnergy
+    var suggestedSpeed: Double?
+}
+
+extension Clip {
+    static let templateSlotMediaRef = "template.slot"
+
+    var isUnfilledTemplateSlot: Bool {
+        templateSlot != nil && mediaRef == Self.templateSlotMediaRef
+    }
+
+    func templateSlotSummary(fps: Int) -> String {
+        guard let slot = templateSlot else { return "" }
+        let seconds = fps > 0 ? Double(durationFrames) / Double(fps) : 0
+        return "Slot \(slot.index)  ·  \(String(format: "%.1fs", seconds))  ·  \(slot.motionEnergy.label)"
+    }
+
+    func templateSlateText(fps: Int) -> String {
+        guard let slot = templateSlot else { return "" }
+        var lines = [templateSlotSummary(fps: fps)]
+        if let speed = slot.suggestedSpeed {
+            lines.append("Suggested speed \(String(format: "%.1fx", speed))")
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/PalmierPro/Models/Timeline.swift
+++ b/Sources/PalmierPro/Models/Timeline.swift
@@ -205,6 +205,8 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
     /// How this clip composites over the tracks below it. nil = normal (source-over).
     var blendMode: BlendMode?
 
+    var templateSlot: TemplateSlot?
+
     private enum CodingKeys: String, CodingKey {
         case id, mediaRef, mediaType, sourceClipType, startFrame, durationFrames
         case trimStartFrame, trimEndFrame, speed, volume
@@ -213,7 +215,7 @@ struct Clip: Codable, Sendable, Equatable, Identifiable {
         case linkGroupId, captionGroupId, multicamGroupId, textContent, textStyle, textAnimation, wordTimings
         case textFillMode
         case opacityTrack, positionTrack, scaleTrack, rotationTrack, cropTrack, volumeTrack
-        case effects, blendMode
+        case effects, blendMode, templateSlot
     }
 
     /// Frame where this clip ends on the timeline
@@ -538,7 +540,8 @@ extension Clip {
             cropTrack: try? c.decode(KeyframeTrack<Crop>.self, forKey: .cropTrack),
             volumeTrack: try? c.decode(KeyframeTrack<Double>.self, forKey: .volumeTrack),
             effects: try? c.decode([Effect].self, forKey: .effects),
-            blendMode: try? c.decode(BlendMode.self, forKey: .blendMode)
+            blendMode: try? c.decode(BlendMode.self, forKey: .blendMode),
+            templateSlot: try? c.decode(TemplateSlot.self, forKey: .templateSlot)
         )
     }
 }

--- a/Sources/PalmierPro/Preview/CompositionBuilder.swift
+++ b/Sources/PalmierPro/Preview/CompositionBuilder.swift
@@ -115,6 +115,17 @@ enum CompositionBuilder {
         )
     }
 
+    /// A text-layer twin of an unfilled template slot, so the existing text path renders its slate.
+    private static func slateClip(for clip: Clip, fps: Int) -> Clip {
+        var slate = clip
+        slate.textContent = clip.templateSlateText(fps: fps)
+        var style = TextStyle()
+        style.fontSize = 64
+        style.color = TextStyle.RGBA(r: 0.92, g: 0.92, b: 0.92, a: 1)
+        slate.textStyle = style
+        return slate
+    }
+
     /// Everything a build pass threads through insertion: inputs plus accumulators.
     private final class BuildContext {
         let composition: AVMutableComposition
@@ -289,6 +300,7 @@ enum CompositionBuilder {
         for clip in clips {
             guard clip.durationFrames > 0, clip.startFrame >= previousEndFrame else { continue }
             if clip.mediaType == .text { continue }   // text renders in instructions, nests render it in groups
+            if clip.isUnfilledTemplateSlot { continue }   // slots render as slates in instructions, never as media
             if clip.mediaType == .sequence {
                 try await expandNestVideo(carrier: clip, parentTrackIndex: parentTrackIndex, depth: depth, ctx: ctx)
                 previousEndFrame = clip.endFrame
@@ -689,6 +701,11 @@ enum CompositionBuilder {
                     if clip.mediaType == .text {
                         guard overlapsWindow, !(clip.textContent ?? "").isEmpty else { continue }
                         children.append(LayerPlan(source: .text, clip: clip, natSize: flat.childCanvas, preferredTransform: .identity))
+                    } else if clip.isUnfilledTemplateSlot {
+                        guard clip.startFrame >= prevEnd else { continue }
+                        prevEnd = clip.endFrame
+                        guard overlapsWindow else { continue }
+                        children.append(LayerPlan(source: .text, clip: slateClip(for: clip, fps: timeline.fps), natSize: flat.childCanvas, preferredTransform: .identity))
                     } else if clip.mediaType == .sequence {
                         guard clip.startFrame >= prevEnd else { continue }
                         prevEnd = clip.endFrame
@@ -731,6 +748,10 @@ enum CompositionBuilder {
                 if clip.mediaType == .text {
                     guard !(clip.textContent ?? "").isEmpty else { continue }
                     plan = LayerPlan(source: .text, clip: clip, natSize: renderSize, preferredTransform: .identity)
+                } else if clip.isUnfilledTemplateSlot {
+                    guard clip.startFrame >= prevEndFrame else { continue }
+                    prevEndFrame = clip.endFrame
+                    plan = LayerPlan(source: .text, clip: slateClip(for: clip, fps: timeline.fps), natSize: renderSize, preferredTransform: .identity)
                 } else if clip.mediaType == .sequence {
                     guard clip.startFrame >= prevEndFrame else { continue }
                     prevEndFrame = clip.endFrame

--- a/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PalmierPro/Resources/Localization/en.lproj/Localizable.strings
@@ -3,6 +3,7 @@
 "$%lld/mo" = "$%lld/mo";
 "$%lld–$%lld · Credits expire at renewal." = "$%lld–$%lld · Credits expire at renewal.";
 "%@ (Paid)" = "%@ (Paid)";
+"%@ Template" = "%@ Template";
 "%@ could not be exported." = "%@ could not be exported.";
 "%@ does not accept this media" = "%@ does not accept this media";
 "%@ does not support this media type." = "%@ does not support this media type.";
@@ -189,6 +190,7 @@
 "Choose…" = "Choose…";
 "Chroma Key" = "Chroma Key";
 "Clarity" = "Clarity";
+"Classifying audio…" = "Classifying audio…";
 "Clean Up Voice…" = "Clean Up Voice…";
 "Clear Filters" = "Clear Filters";
 "Clear Finished" = "Clear Finished";
@@ -248,10 +250,12 @@
 "Create AI Transition" = "Create AI Transition";
 "Create Matte" = "Create Matte";
 "Create Nested Timeline" = "Create Nested Timeline";
+"Create Template from Reel" = "Create Template from Reel";
 "Create Video" = "Create Video";
 "Create Video only works on images" = "Create Video only works on images";
 "Create a skill or browse the Community collection." = "Create a skill or browse the Community collection.";
 "Create matching sound for the video" = "Create matching sound for the video";
+"Creating template from \"%@\"…" = "Creating template from \"%@\"…";
 "Creating…" = "Creating…";
 "Credits" = "Credits";
 "Credits cover AI generation and chat." = "Credits cover AI generation and chat.";
@@ -306,6 +310,7 @@
 "Detect Beats" = "Detect Beats";
 "Detected %lld beats at %lld BPM." = "Detected %lld beats at %lld BPM.";
 "Detected %lld beats." = "Detected %lld beats.";
+"Detecting cuts… %lld%%" = "Detecting cuts… %lld%%";
 "Detecting speech in %lld files…" = "Detecting speech in %lld files…";
 "Detecting speech…" = "Detecting speech…";
 "Difference" = "Difference";
@@ -333,6 +338,7 @@
 "Duplicate Clips to New Track" = "Duplicate Clips to New Track";
 "Duration" = "Duration";
 "Duration (%lld-%lld seconds)" = "Duration (%lld-%lld seconds)";
+"Dynamic" = "Dynamic";
 "Edge Rounding" = "Edge Rounding";
 "Edge Softness" = "Edge Softness";
 "Edit" = "Edit";
@@ -389,6 +395,7 @@
 "Filmmaker" = "Filmmaker";
 "Filter markers by status" = "Filter markers by status";
 "Final Cut Pro" = "Final Cut Pro";
+"Finding beats…" = "Finding beats…";
 "First Frame" = "First Frame";
 "First-time sign-ups only" = "First-time sign-ups only";
 "First/Last" = "First/Last";
@@ -437,6 +444,7 @@
 "Generation complete" = "Generation complete";
 "Generation in progress" = "Generation in progress";
 "Generation panel" = "Generation panel";
+"Gentle" = "Gentle";
 "Get Anthropic API key" = "Get Anthropic API key";
 "Get OpenAI API key" = "Get OpenAI API key";
 "Get a notification when a generation finishes." = "Get a notification when a generation finishes.";
@@ -637,6 +645,7 @@
 "No audio selected." = "No audio selected.";
 "No beats detected." = "No beats detected.";
 "No conversations yet" = "No conversations yet";
+"No cuts were detected; the template has a single slot covering the whole reel." = "No cuts were detected; the template has a single slot covering the whole reel.";
 "No exports yet" = "No exports yet";
 "No generations yet" = "No generations yet";
 "No images" = "No images";
@@ -649,6 +658,7 @@
 "No media yet" = "No media yet";
 "No models match \"%@\"." = "No models match \"%@\".";
 "No music models available." = "No music models available.";
+"No music was detected in the reel's audio." = "No music was detected in the reel's audio.";
 "No projects found" = "No projects found";
 "No prompt needed" = "No prompt needed";
 "No speech detected." = "No speech detected.";
@@ -777,6 +787,8 @@
 "Rename Track" = "Rename Track";
 "Rendering" = "Rendering";
 "Rendering…" = "Rendering…";
+"Replace Slot with \"%@\"" = "Replace Slot with \"%@\"";
+"Replace Slot with Selected Media" = "Replace Slot with Selected Media";
 "Replace clip source" = "Replace clip source";
 "Replacement Audio" = "Replacement Audio";
 "Report a Problem" = "Report a Problem";
@@ -843,6 +855,7 @@
 "Select Range" = "Select Range";
 "Select compatible clips and paste settings again." = "Select compatible clips and paste settings again.";
 "Select media files or folders to import" = "Select media files or folders to import";
+"Select one video in the media panel first." = "Select one video in the media panel first.";
 "Select the timeline to add a marker." = "Select the timeline to add a marker.";
 "Selected" = "Selected";
 "Selected Clips · %lld" = "Selected Clips · %lld";
@@ -890,6 +903,7 @@
 "Sign-in couldn’t be completed. Try again." = "Sign-in couldn’t be completed. Try again.";
 "Signed in" = "Signed in";
 "Signed out" = "Signed out";
+"Silence" = "Silence";
 "Silence Detection" = "Silence Detection";
 "Size" = "Size";
 "Skill actions" = "Skill actions";
@@ -928,6 +942,7 @@
 "Step %lld of %lld" = "Step %lld of %lld";
 "Step Backward" = "Step Backward";
 "Step Forward" = "Step Forward";
+"Still" = "Still";
 "Stop" = "Stop";
 "Stop editing crop on canvas" = "Stop editing crop on canvas";
 "Stopped" = "Stopped";
@@ -970,6 +985,7 @@
 "The export" = "The export";
 "The marker comment changed while you were editing. Review it and try again." = "The marker comment changed while you were editing. Review it and try again.";
 "The project will be moved to the Trash." = "The project will be moved to the Trash.";
+"The reel has no audio track; no audio lanes were generated." = "The reel has no audio track; no audio lanes were generated.";
 "The selected model refused this request. Revise the prompt and try again." = "The selected model refused this request. Revise the prompt and try again.";
 "The selected projects will be moved to the Trash." = "The selected projects will be moved to the Trash.";
 "The timeline settings changed. Close this sheet and try again." = "The timeline settings changed. Close this sheet and try again.";
@@ -1090,6 +1106,7 @@
 "What interests you most about Palmier Pro?" = "What interests you most about Palmier Pro?";
 "What's New in v%@" = "What's New in v%@";
 "Which editors did you use before?" = "Which editors did you use before?";
+"Whip" = "Whip";
 "White Balance" = "White Balance";
 "Whites" = "Whites";
 "Whole timeline · %@" = "Whole timeline · %@";

--- a/Sources/PalmierPro/TemplateStudio/AudioSegmentClassifier.swift
+++ b/Sources/PalmierPro/TemplateStudio/AudioSegmentClassifier.swift
@@ -1,0 +1,188 @@
+import AVFoundation
+import Foundation
+import SoundAnalysis
+
+enum AudioSegmentKind: String, Codable, Sendable {
+    case music
+    case speech
+    case silence
+
+    var trackName: String {
+        switch self {
+        case .music: L10n.key("Music")
+        case .speech: L10n.key("Voice")
+        case .silence: L10n.key("Silence")
+        }
+    }
+}
+
+struct AudioSegment: Codable, Sendable, Equatable {
+    var kind: AudioSegmentKind
+    var startSeconds: Double
+    var durationSeconds: Double
+    var confidence: Double
+
+    var endSeconds: Double { startSeconds + durationSeconds }
+}
+
+/// Classifies a reel's mixed audio into music / speech / silence spans
+/// using the built-in SoundAnalysis classifier.
+enum AudioSegmentClassifier {
+    private static let minimumConfidence = 0.45
+    private static let mergeGapSeconds = 0.75
+    private static let minimumSegmentSeconds = 1.0
+
+    @concurrent
+    static func classifySegments(in sourceURL: URL) async throws -> [AudioSegment] {
+        let asset = AVURLAsset(url: sourceURL)
+        guard let audioTrack = try await asset.loadTracks(withMediaType: .audio).first else { return [] }
+        let durationSeconds = (try await audioTrack.load(.timeRange)).duration.seconds
+        guard durationSeconds.isFinite, durationSeconds > 0 else { return [] }
+        try Task.checkCancellation()
+
+        let request = try SNClassifySoundRequest(classifierIdentifier: .version1)
+        request.windowDuration = CMTime(value: 1, timescale: 1)
+        request.overlapFactor = 0.5
+
+        let windows = try await classify(url: sourceURL, request: request)
+        try Task.checkCancellation()
+        return segments(from: windows, durationSeconds: durationSeconds)
+    }
+
+    // MARK: - SoundAnalysis bridge
+
+    private struct ClassifiedWindow: Sendable {
+        var startSeconds: Double
+        var durationSeconds: Double
+        var kind: AudioSegmentKind
+        var confidence: Double
+    }
+
+    private static func classify(url: URL, request: SNClassifySoundRequest) async throws -> [ClassifiedWindow] {
+        let analyzer = try SNAudioFileAnalyzer(url: url)
+        let box = AnalyzerBox(analyzer)
+        let observer = WindowObserver()
+        try analyzer.add(request, withObserver: observer)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                observer.adopt(continuation)
+                box.analyzer.analyze { didSucceed in
+                    guard !didSucceed else { return }
+                    observer.finish(.failure(CancellationError()))
+                }
+            }
+        } onCancel: {
+            box.analyzer.cancelAnalysis()
+        }
+    }
+
+    private final class AnalyzerBox: @unchecked Sendable {
+        let analyzer: SNAudioFileAnalyzer
+
+        init(_ analyzer: SNAudioFileAnalyzer) {
+            self.analyzer = analyzer
+        }
+    }
+
+    private final class WindowObserver: NSObject, SNResultsObserving, @unchecked Sendable {
+        private let lock = NSLock()
+        private var windows: [ClassifiedWindow] = []
+        private var continuation: CheckedContinuation<[ClassifiedWindow], Error>?
+        private var finished = false
+
+        func adopt(_ continuation: CheckedContinuation<[ClassifiedWindow], Error>) {
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+        }
+
+        func request(_ request: SNRequest, didProduce result: SNResult) {
+            guard let result = result as? SNClassificationResult else { return }
+            let music = result.classification(forIdentifier: "music")?.confidence ?? 0
+            let speech = result.classification(forIdentifier: "speech")?.confidence ?? 0
+
+            let kind: AudioSegmentKind
+            let confidence: Double
+            if speech >= minimumConfidence, speech >= music {
+                kind = .speech
+                confidence = speech
+            } else if music >= minimumConfidence {
+                kind = .music
+                confidence = music
+            } else {
+                kind = .silence
+                confidence = 1 - max(music, speech)
+            }
+
+            lock.lock()
+            windows.append(ClassifiedWindow(
+                startSeconds: result.timeRange.start.seconds,
+                durationSeconds: result.timeRange.duration.seconds,
+                kind: kind,
+                confidence: confidence
+            ))
+            lock.unlock()
+        }
+
+        func request(_ request: SNRequest, didFailWithError error: Error) {
+            finish(.failure(error))
+        }
+
+        func requestDidComplete(_ request: SNRequest) {
+            lock.lock()
+            let collected = windows
+            lock.unlock()
+            finish(.success(collected))
+        }
+
+        func finish(_ result: Result<[ClassifiedWindow], Error>) {
+            lock.lock()
+            guard !finished, let continuation else {
+                lock.unlock()
+                return
+            }
+            finished = true
+            self.continuation = nil
+            lock.unlock()
+            continuation.resume(with: result)
+        }
+    }
+
+    // MARK: - Segment merging
+
+    private static func segments(from windows: [ClassifiedWindow], durationSeconds: Double) -> [AudioSegment] {
+        guard !windows.isEmpty else {
+            return [AudioSegment(kind: .silence, startSeconds: 0, durationSeconds: durationSeconds, confidence: 1)]
+        }
+
+        var merged: [AudioSegment] = []
+        for window in windows.sorted(by: { $0.startSeconds < $1.startSeconds }) {
+            let start = min(window.startSeconds, durationSeconds)
+            let end = min(window.startSeconds + window.durationSeconds, durationSeconds)
+            guard end > start else { continue }
+            if var last = merged.last, last.kind == window.kind, start - last.endSeconds <= mergeGapSeconds {
+                last.confidence = (last.confidence + window.confidence) / 2
+                last.durationSeconds = end - last.startSeconds
+                merged[merged.count - 1] = last
+            } else {
+                merged.append(AudioSegment(
+                    kind: window.kind,
+                    startSeconds: start,
+                    durationSeconds: end - start,
+                    confidence: window.confidence
+                ))
+            }
+        }
+
+        var debounced: [AudioSegment] = []
+        for segment in merged {
+            if segment.durationSeconds < minimumSegmentSeconds, var last = debounced.last {
+                last.durationSeconds = segment.endSeconds - last.startSeconds
+                debounced[debounced.count - 1] = last
+            } else {
+                debounced.append(segment)
+            }
+        }
+        return debounced.isEmpty ? merged : debounced
+    }
+}

--- a/Sources/PalmierPro/TemplateStudio/ReelAnalyzer.swift
+++ b/Sources/PalmierPro/TemplateStudio/ReelAnalyzer.swift
@@ -1,0 +1,139 @@
+import AVFoundation
+import Foundation
+
+struct ReelAnalysis: Codable, Sendable, Equatable {
+    var shots: [DetectedShot]
+    var audioSegments: [AudioSegment]
+    /// Beat times in source-media seconds; empty when no music was detected.
+    var beats: [Double]
+    var durationSeconds: Double
+    var sourceWidth: Int
+    var sourceHeight: Int
+    var sourceFPS: Double
+    var hasAudio: Bool
+
+    var musicSegments: [AudioSegment] { audioSegments.filter { $0.kind == .music } }
+    var speechSegments: [AudioSegment] { audioSegments.filter { $0.kind == .speech } }
+}
+
+struct ReelAnalysisProgress: Sendable, Equatable {
+    enum Stage: Sendable, Equatable {
+        case scenes
+        case audio
+        case beats
+    }
+
+    var stage: Stage
+    /// 0–1 within the current stage.
+    var fraction: Double
+}
+
+/// Runs scene, audio, and beat analysis for a reel and caches the result per asset revision.
+enum ReelAnalyzer {
+    enum AnalyzeError: LocalizedError {
+        case notAVideo
+        case emptyMedia
+        case failed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notAVideo: "The media has no video track."
+            case .emptyMedia: "The media has zero or indefinite duration."
+            case .failed(let reason): reason
+            }
+        }
+    }
+
+    private static let cache = DiskCache(named: "ReelAnalysis")
+
+    @concurrent
+    static func analysis(
+        for sourceURL: URL,
+        mediaRef: String,
+        force: Bool = false,
+        progress: (@Sendable (ReelAnalysisProgress) -> Void)? = nil
+    ) async throws -> ReelAnalysis {
+        if !force, let cached = cachedAnalysis(for: sourceURL, mediaRef: mediaRef) {
+            return cached
+        }
+        try Task.checkCancellation()
+
+        let asset = AVURLAsset(url: sourceURL)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw AnalyzeError.notAVideo
+        }
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let transform = try await videoTrack.load(.preferredTransform)
+        let displaySize = naturalSize.applying(transform)
+        let nominalFPS = Double(try await videoTrack.load(.nominalFrameRate))
+        let durationSeconds = (try await videoTrack.load(.timeRange)).duration.seconds
+        guard durationSeconds.isFinite, durationSeconds > 0 else { throw AnalyzeError.emptyMedia }
+        let hasAudio = !((try? await asset.loadTracks(withMediaType: .audio)) ?? []).isEmpty
+
+        progress?(ReelAnalysisProgress(stage: .scenes, fraction: 0))
+        let shots = try await SceneCutDetector.detectShots(in: sourceURL) { fraction in
+            progress?(ReelAnalysisProgress(stage: .scenes, fraction: fraction))
+        }
+        try Task.checkCancellation()
+
+        var audioSegments: [AudioSegment] = []
+        if hasAudio {
+            progress?(ReelAnalysisProgress(stage: .audio, fraction: 0))
+            audioSegments = try await AudioSegmentClassifier.classifySegments(in: sourceURL)
+            progress?(ReelAnalysisProgress(stage: .audio, fraction: 1))
+        }
+        try Task.checkCancellation()
+
+        var beats: [Double] = []
+        if audioSegments.contains(where: { $0.kind == .music }) {
+            progress?(ReelAnalysisProgress(stage: .beats, fraction: 0))
+            // Beats enrich the template; a reel whose beat pass fails is still a valid template.
+            beats = (try? await BeatDetector.analysis(for: sourceURL, mediaRef: mediaRef))?.beats ?? []
+            progress?(ReelAnalysisProgress(stage: .beats, fraction: 1))
+        }
+        try Task.checkCancellation()
+
+        let analysis = ReelAnalysis(
+            shots: shots,
+            audioSegments: audioSegments,
+            beats: beats,
+            durationSeconds: durationSeconds,
+            sourceWidth: Int(abs(displaySize.width)),
+            sourceHeight: Int(abs(displaySize.height)),
+            sourceFPS: nominalFPS > 0 ? nominalFPS : 30,
+            hasAudio: hasAudio
+        )
+        persist(analysis, for: sourceURL, mediaRef: mediaRef)
+        return analysis
+    }
+
+    // MARK: - Cache
+
+    private static func cachedAnalysis(for sourceURL: URL, mediaRef: String) -> ReelAnalysis? {
+        guard let data = try? Data(contentsOf: analysisURL(for: sourceURL, mediaRef: mediaRef)) else { return nil }
+        return try? JSONDecoder().decode(ReelAnalysis.self, from: data)
+    }
+
+    private static func persist(_ analysis: ReelAnalysis, for sourceURL: URL, mediaRef: String) {
+        let outputURL = analysisURL(for: sourceURL, mediaRef: mediaRef)
+        removeStaleCaches(for: mediaRef, keeping: outputURL)
+        guard let data = try? JSONEncoder().encode(analysis) else { return }
+        try? data.write(to: outputURL)
+    }
+
+    private static func analysisURL(for sourceURL: URL, mediaRef: String) -> URL {
+        cache.directory.appendingPathComponent("\(mediaRef)_\(DiskCache.sizeMtimeTag(for: sourceURL))_reel.json")
+    }
+
+    private static func removeStaleCaches(for mediaRef: String, keeping keep: URL) {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: cache.directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for entry in entries
+        where entry.lastPathComponent.hasPrefix("\(mediaRef)_") && entry.lastPathComponent != keep.lastPathComponent {
+            try? fileManager.removeItem(at: entry)
+        }
+    }
+}

--- a/Sources/PalmierPro/TemplateStudio/SceneCutDetector.swift
+++ b/Sources/PalmierPro/TemplateStudio/SceneCutDetector.swift
@@ -1,0 +1,216 @@
+import AVFoundation
+import CoreVideo
+import Foundation
+
+struct DetectedShot: Codable, Sendable, Equatable {
+    var startSeconds: Double
+    var durationSeconds: Double
+    /// Mean inter-frame difference inside the shot, normalized 0–1.
+    var motionScore: Double
+
+    var endSeconds: Double { startSeconds + durationSeconds }
+    var motionEnergy: MotionEnergy { MotionEnergyEstimator.bucket(forScore: motionScore) }
+}
+
+enum MotionEnergyEstimator {
+    static func bucket(forScore score: Double) -> MotionEnergy {
+        switch score {
+        case ..<0.02: .still
+        case ..<0.06: .gentle
+        case ..<0.14: .dynamic
+        default: .whip
+        }
+    }
+
+    static func suggestedSpeed(for shot: DetectedShot) -> Double? {
+        switch shot.motionEnergy {
+        case .whip where shot.durationSeconds < 1.0: 2.0
+        case .still where shot.durationSeconds > 4.0: 0.5
+        default: nil
+        }
+    }
+}
+
+/// Detects shot boundaries by decoding downscaled frames and scoring luma-histogram
+/// plus mean-pixel differences against an adaptive threshold.
+enum SceneCutDetector {
+    enum DetectError: Error {
+        case noVideoTrack
+        case readFailed(String)
+    }
+
+    private static let analysisWidth = 120
+    private static let sampleFPS = 8.0
+    private static let minimumShotSeconds = 0.35
+    private static let histogramBins = 32
+    private static let cancellationStride = 24
+
+    @concurrent
+    static func detectShots(
+        in sourceURL: URL,
+        progress: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> [DetectedShot] {
+        let asset = AVURLAsset(url: sourceURL)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+            throw DetectError.noVideoTrack
+        }
+        let timeRange = try await track.load(.timeRange)
+        let naturalSize = try await track.load(.naturalSize)
+        let durationSeconds = timeRange.duration.seconds
+        guard durationSeconds.isFinite, durationSeconds > 0 else {
+            throw DetectError.readFailed("Source has zero or indefinite duration.")
+        }
+
+        let samples = try frameSamples(
+            asset: asset,
+            track: track,
+            timeRange: timeRange,
+            naturalSize: naturalSize,
+            durationSeconds: durationSeconds,
+            progress: progress
+        )
+        return shots(from: samples, durationSeconds: durationSeconds)
+    }
+
+    // MARK: - Decoding
+
+    private struct FrameFeatures {
+        var histogram: [Double]
+        var meanLuma: Double
+    }
+
+    private struct FrameSample {
+        var seconds: Double
+        var score: Double
+    }
+
+    private static func frameSamples(
+        asset: AVURLAsset,
+        track: AVAssetTrack,
+        timeRange: CMTimeRange,
+        naturalSize: CGSize,
+        durationSeconds: Double,
+        progress: (@Sendable (Double) -> Void)?
+    ) throws -> [FrameSample] {
+        let aspect = naturalSize.width > 0 ? Double(naturalSize.height) / Double(naturalSize.width) : 1
+        let analysisHeight = max(2, Int((Double(analysisWidth) * aspect).rounded()))
+
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: analysisWidth,
+            kCVPixelBufferHeightKey as String: analysisHeight,
+        ])
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else { throw DetectError.readFailed("Cannot configure video reader.") }
+        reader.add(output)
+        guard reader.startReading() else {
+            throw DetectError.readFailed(reader.error?.localizedDescription ?? "Reader failed to start.")
+        }
+        defer { reader.cancelReading() }
+
+        let sampleInterval = 1.0 / sampleFPS
+        var samples: [FrameSample] = []
+        var previous: FrameFeatures?
+        var lastSampledSeconds = -Double.infinity
+        var framesSinceCancellationCheck = 0
+
+        while let buffer = output.copyNextSampleBuffer() {
+            framesSinceCancellationCheck += 1
+            if framesSinceCancellationCheck >= cancellationStride {
+                framesSinceCancellationCheck = 0
+                try Task.checkCancellation()
+            }
+            let seconds = CMSampleBufferGetPresentationTimeStamp(buffer).seconds - timeRange.start.seconds
+            guard seconds - lastSampledSeconds >= sampleInterval,
+                  let pixelBuffer = CMSampleBufferGetImageBuffer(buffer) else { continue }
+            lastSampledSeconds = seconds
+
+            let features = frameFeatures(from: pixelBuffer)
+            if let previous {
+                samples.append(FrameSample(seconds: seconds, score: difference(previous, features)))
+            }
+            previous = features
+            progress?(min(1, seconds / durationSeconds))
+        }
+        if reader.status == .failed {
+            throw DetectError.readFailed(reader.error?.localizedDescription ?? "Video decode failed.")
+        }
+        try Task.checkCancellation()
+        return samples
+    }
+
+    private static func frameFeatures(from pixelBuffer: CVPixelBuffer) -> FrameFeatures {
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+        var histogram = [Double](repeating: 0, count: histogramBins)
+        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+            return FrameFeatures(histogram: histogram, meanLuma: 0)
+        }
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        let bytes = base.assumingMemoryBound(to: UInt8.self)
+
+        var lumaSum = 0.0
+        var count = 0
+        for y in 0..<height {
+            let row = bytes + y * bytesPerRow
+            for x in 0..<width {
+                let pixel = row + x * 4
+                // BGRA integer luma approximation: (b + 2g + r) / 4.
+                let luma = (Int(pixel[0]) + (Int(pixel[1]) << 1) + Int(pixel[2])) >> 2
+                histogram[min(histogramBins - 1, luma * histogramBins / 256)] += 1
+                lumaSum += Double(luma)
+                count += 1
+            }
+        }
+        guard count > 0 else { return FrameFeatures(histogram: histogram, meanLuma: 0) }
+        let total = Double(count)
+        for bin in histogram.indices { histogram[bin] /= total }
+        return FrameFeatures(histogram: histogram, meanLuma: lumaSum / total / 255.0)
+    }
+
+    private static func difference(_ a: FrameFeatures, _ b: FrameFeatures) -> Double {
+        var histogramDistance = 0.0
+        for bin in a.histogram.indices {
+            histogramDistance += abs(a.histogram[bin] - b.histogram[bin])
+        }
+        return (histogramDistance / 2.0) * 0.75 + abs(a.meanLuma - b.meanLuma) * 0.25
+    }
+
+    // MARK: - Boundary extraction
+
+    private static func shots(from samples: [FrameSample], durationSeconds: Double) -> [DetectedShot] {
+        guard !samples.isEmpty else {
+            return [DetectedShot(startSeconds: 0, durationSeconds: durationSeconds, motionScore: 0)]
+        }
+
+        let scores = samples.map(\.score)
+        let mean = scores.reduce(0, +) / Double(scores.count)
+        let variance = scores.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Double(scores.count)
+        let threshold = max(0.18, mean + 3.5 * variance.squareRoot())
+
+        var cutSeconds: [Double] = []
+        for sample in samples where sample.score >= threshold {
+            guard sample.seconds >= minimumShotSeconds,
+                  durationSeconds - sample.seconds >= minimumShotSeconds,
+                  sample.seconds - (cutSeconds.last ?? -.infinity) >= minimumShotSeconds else { continue }
+            cutSeconds.append(sample.seconds)
+        }
+
+        let boundaries = ([0.0] + cutSeconds + [durationSeconds]).sorted()
+        var shots: [DetectedShot] = []
+        for index in 0..<(boundaries.count - 1) {
+            let start = boundaries[index]
+            let end = boundaries[index + 1]
+            guard end > start else { continue }
+            let inShot = samples.filter { $0.seconds >= start && $0.seconds < end && $0.score < threshold }
+            let motion = inShot.isEmpty ? 0 : inShot.map(\.score).reduce(0, +) / Double(inShot.count)
+            shots.append(DetectedShot(startSeconds: start, durationSeconds: end - start, motionScore: motion))
+        }
+        guard shots.isEmpty else { return shots }
+        return [DetectedShot(startSeconds: 0, durationSeconds: durationSeconds, motionScore: mean)]
+    }
+}

--- a/Sources/PalmierPro/TemplateStudio/TemplateGenerationBanner.swift
+++ b/Sources/PalmierPro/TemplateStudio/TemplateGenerationBanner.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Media-panel banner showing reel-to-template analysis progress with a cancel affordance.
+struct TemplateGenerationBanner: View {
+    let state: TemplateGenerationState
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            ProgressView()
+                .controlSize(.small)
+            VStack(alignment: .leading, spacing: AppTheme.Spacing.xxs) {
+                Text(L10n.string("Creating template from \"\(state.assetName)\"…"))
+                    .font(.system(size: AppTheme.FontSize.sm, weight: .medium))
+                    .foregroundStyle(AppTheme.Text.primaryColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(stageLabel)
+                    .font(.system(size: AppTheme.FontSize.xs))
+                    .foregroundStyle(AppTheme.Text.secondaryColor)
+            }
+            Button(L10n.string("Cancel"), action: onCancel)
+                .buttonStyle(.plain)
+                .font(.system(size: AppTheme.FontSize.xs, weight: .semibold))
+                .foregroundStyle(AppTheme.Text.secondaryColor)
+        }
+        .padding(.horizontal, AppTheme.Spacing.mdLg)
+        .padding(.vertical, AppTheme.Spacing.smMd)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                .fill(AppTheme.Background.prominentColor)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppTheme.Radius.md)
+                        .strokeBorder(AppTheme.Border.primaryColor, lineWidth: AppTheme.BorderWidth.hairline)
+                )
+        )
+        .shadow(AppTheme.Shadow.lg)
+        .padding(.horizontal, AppTheme.Spacing.lgXl)
+        .padding(.bottom, AppTheme.Spacing.lgXl)
+    }
+
+    private var stageLabel: String {
+        let percent = Int((state.progress.fraction * 100).rounded())
+        switch state.progress.stage {
+        case .scenes: return L10n.string("Detecting cuts… \(percent)%")
+        case .audio: return L10n.string("Classifying audio…")
+        case .beats: return L10n.string("Finding beats…")
+        }
+    }
+}

--- a/Sources/PalmierPro/TemplateStudio/TemplateGenerator.swift
+++ b/Sources/PalmierPro/TemplateStudio/TemplateGenerator.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+enum TemplateMode: String, Codable, Sendable {
+    /// Fillable placeholder slots the user drops their own media onto.
+    case placeholders
+    /// The reel split into its detected shots, still referencing the original media.
+    case originalCuts
+}
+
+enum TemplateWarning: String, Sendable {
+    case noCutsDetected
+    case noMusicDetected
+    case noAudioTrack
+
+    @MainActor
+    var message: String {
+        switch self {
+        case .noCutsDetected:
+            L10n.string("No cuts were detected; the template has a single slot covering the whole reel.")
+        case .noMusicDetected:
+            L10n.string("No music was detected in the reel's audio.")
+        case .noAudioTrack:
+            L10n.string("The reel has no audio track; no audio lanes were generated.")
+        }
+    }
+}
+
+struct TemplateOptions: Sendable {
+    var name: String
+    var mode: TemplateMode = .placeholders
+    var includeAudioLanes = true
+}
+
+struct TemplateGenerationResult: Sendable {
+    var timeline: Timeline
+    /// Clip IDs of the generated slots, in shot order.
+    var slotClipIds: [String]
+    var warnings: [TemplateWarning]
+}
+
+/// Turns a `ReelAnalysis` into an ordinary `Timeline`. All frame math happens
+/// here once, in the generated timeline's fps domain.
+enum TemplateGenerator {
+    static func makeTimeline(
+        from analysis: ReelAnalysis,
+        sourceMediaRef: String,
+        options: TemplateOptions
+    ) -> TemplateGenerationResult {
+        let fps = max(1, min(240, Int(analysis.sourceFPS.rounded())))
+        let sourceFrames = frame(forSeconds: analysis.durationSeconds, fps: fps)
+        var warnings: [TemplateWarning] = []
+
+        let slots = slotClips(
+            shots: analysis.shots,
+            sourceMediaRef: sourceMediaRef,
+            sourceFrames: sourceFrames,
+            fps: fps,
+            mode: options.mode
+        )
+        if slots.count <= 1 { warnings.append(.noCutsDetected) }
+
+        var tracks = [Track(type: .video, clips: slots)]
+        if options.includeAudioLanes {
+            if analysis.hasAudio {
+                tracks.append(contentsOf: audioLanes(
+                    analysis: analysis,
+                    sourceMediaRef: sourceMediaRef,
+                    sourceFrames: sourceFrames,
+                    fps: fps
+                ))
+                if analysis.musicSegments.isEmpty { warnings.append(.noMusicDetected) }
+            } else {
+                warnings.append(.noAudioTrack)
+            }
+        }
+
+        let timeline = Timeline(
+            name: options.name,
+            fps: fps,
+            width: analysis.sourceWidth,
+            height: analysis.sourceHeight,
+            settingsConfigured: true,
+            tracks: tracks
+        )
+        return TemplateGenerationResult(
+            timeline: timeline,
+            slotClipIds: slots.map(\.id),
+            warnings: warnings
+        )
+    }
+
+    // MARK: - Video slots
+
+    private static func slotClips(
+        shots: [DetectedShot],
+        sourceMediaRef: String,
+        sourceFrames: Int,
+        fps: Int,
+        mode: TemplateMode
+    ) -> [Clip] {
+        // Boundaries come from absolute shot times so rounding never accumulates drift.
+        let boundaries = shots.map { frame(forSeconds: $0.startSeconds, fps: fps) } + [sourceFrames]
+
+        var clips: [Clip] = []
+        for (index, shot) in shots.enumerated() {
+            let startFrame = boundaries[index]
+            let durationFrames = boundaries[index + 1] - startFrame
+            guard durationFrames > 0 else { continue }
+
+            var clip: Clip
+            switch mode {
+            case .placeholders:
+                clip = Clip(
+                    mediaRef: Clip.templateSlotMediaRef,
+                    startFrame: startFrame,
+                    durationFrames: durationFrames
+                )
+            case .originalCuts:
+                clip = Clip(
+                    mediaRef: sourceMediaRef,
+                    startFrame: startFrame,
+                    durationFrames: durationFrames,
+                    trimStartFrame: startFrame,
+                    trimEndFrame: max(0, sourceFrames - startFrame - durationFrames)
+                )
+            }
+            clip.templateSlot = TemplateSlot(
+                index: clips.count + 1,
+                motionEnergy: shot.motionEnergy,
+                suggestedSpeed: MotionEnergyEstimator.suggestedSpeed(for: shot)
+            )
+            clips.append(clip)
+        }
+        return clips
+    }
+
+    // MARK: - Audio lanes
+
+    private static func audioLanes(
+        analysis: ReelAnalysis,
+        sourceMediaRef: String,
+        sourceFrames: Int,
+        fps: Int
+    ) -> [Track] {
+        let lanes: [(kind: AudioSegmentKind, segments: [AudioSegment])] = [
+            (.music, analysis.musicSegments),
+            (.speech, analysis.speechSegments),
+        ]
+        return lanes.compactMap { lane in
+            let clips = audioClips(
+                for: lane.segments,
+                sourceMediaRef: sourceMediaRef,
+                sourceFrames: sourceFrames,
+                fps: fps
+            )
+            guard !clips.isEmpty else { return nil }
+            return Track(type: .audio, name: lane.kind.trackName, clips: clips)
+        }
+    }
+
+    private static func audioClips(
+        for segments: [AudioSegment],
+        sourceMediaRef: String,
+        sourceFrames: Int,
+        fps: Int
+    ) -> [Clip] {
+        segments.compactMap { segment in
+            let startFrame = frame(forSeconds: segment.startSeconds, fps: fps)
+            let durationFrames = min(frame(forSeconds: segment.endSeconds, fps: fps), sourceFrames) - startFrame
+            guard durationFrames > 0 else { return nil }
+            return Clip(
+                mediaRef: sourceMediaRef,
+                mediaType: .audio,
+                startFrame: startFrame,
+                durationFrames: durationFrames,
+                trimStartFrame: startFrame,
+                trimEndFrame: max(0, sourceFrames - startFrame - durationFrames)
+            )
+        }
+    }
+
+    private static func frame(forSeconds seconds: Double, fps: Int) -> Int {
+        guard seconds.isFinite else { return 0 }
+        return max(0, Int((seconds * Double(fps)).rounded()))
+    }
+}

--- a/Sources/PalmierPro/Timeline/ClipRenderer.swift
+++ b/Sources/PalmierPro/Timeline/ClipRenderer.swift
@@ -192,6 +192,10 @@ enum ClipRenderer {
             context.strokePath()
         }
 
+        if clip.isUnfilledTemplateSlot {
+            drawTemplateSlot(clip: clip, in: rect, cornerRadius: cornerRadius, fps: fps, context: context)
+        }
+
         let showDetailChrome = rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth
         let showLabel = showsLabel(isSelected: isSelected, in: rect)
 
@@ -220,6 +224,47 @@ enum ClipRenderer {
         if opacity < 1.0 {
             context.restoreGState()
         }
+    }
+
+    // MARK: - Template slots
+
+    private static func drawTemplateSlot(
+        clip: Clip,
+        in rect: NSRect,
+        cornerRadius: CGFloat,
+        fps: Int,
+        context: CGContext
+    ) {
+        let outline = rect.insetBy(dx: AppTheme.Spacing.xxs, dy: AppTheme.Spacing.xxs)
+        guard outline.width > 0, outline.height > 0 else { return }
+
+        context.saveGState()
+        context.setStrokeColor(
+            clip.sourceClipType.themeForegroundColor.withAlphaComponent(AppTheme.Opacity.strong).cgColor
+        )
+        context.setLineWidth(AppTheme.BorderWidth.thin)
+        context.setLineDash(phase: 0, lengths: [4, 3])
+        context.addPath(CGPath(
+            roundedRect: outline,
+            cornerWidth: cornerRadius,
+            cornerHeight: cornerRadius,
+            transform: nil
+        ))
+        context.strokePath()
+        context.restoreGState()
+
+        guard rect.width >= AppTheme.ComponentSize.timelineClipDetailMinWidth else { return }
+        let summary = NSAttributedString(string: clip.templateSlotSummary(fps: fps), attributes: [
+            .font: NSFont.systemFont(ofSize: AppTheme.FontSize.xs, weight: .semibold),
+            .foregroundColor: clip.sourceClipType.themeForegroundColor,
+        ])
+        let size = summary.size()
+        let body = clipBodyRect(in: rect)
+        guard size.width <= body.width, size.height <= body.height else { return }
+        context.saveGState()
+        context.clip(to: body)
+        summary.draw(at: NSPoint(x: body.midX - size.width / 2, y: body.midY - size.height / 2))
+        context.restoreGState()
     }
 
     // MARK: - Keyframe markers

--- a/Sources/PalmierPro/Timeline/TimelineView+TemplateSlotMenu.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView+TemplateSlotMenu.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+extension TimelineView {
+    /// Menu items for filling a template slot from the media panel selection.
+    func templateSlotMenuItems(for clip: Clip) -> [NSMenuItem] {
+        guard clip.templateSlot != nil else { return [] }
+
+        let selectedVideos = editor.mediaAssets.filter {
+            editor.selectedMediaAssetIds.contains($0.id) && $0.type == .video
+        }
+        guard selectedVideos.count == 1, let asset = selectedVideos.first else {
+            let item = NSMenuItem(
+                title: L10n.string("Replace Slot with Selected Media"),
+                action: nil,
+                keyEquivalent: ""
+            )
+            item.isEnabled = false
+            item.toolTip = L10n.string("Select one video in the media panel first.")
+            return [item]
+        }
+
+        let item = NSMenuItem(
+            title: L10n.string("Replace Slot with \"\(asset.name)\""),
+            action: #selector(performFillTemplateSlot(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        item.representedObject = TemplateSlotFillRequest(clipId: clip.id, assetId: asset.id)
+        return [item]
+    }
+
+    @objc func performFillTemplateSlot(_ sender: NSMenuItem) {
+        guard let request = sender.representedObject as? TemplateSlotFillRequest else { return }
+        do {
+            try editor.fillTemplateSlot(clipId: request.clipId, assetId: request.assetId)
+        } catch {
+            editor.mediaPanelToast = MediaPanelToast(message: error.localizedDescription, kind: .warning)
+        }
+    }
+}
+
+final class TemplateSlotFillRequest: NSObject {
+    let clipId: String
+    let assetId: String
+
+    init(clipId: String, assetId: String) {
+        self.clipId = clipId
+        self.assetId = assetId
+    }
+}

--- a/Sources/PalmierPro/Timeline/TimelineView.swift
+++ b/Sources/PalmierPro/Timeline/TimelineView.swift
@@ -1576,7 +1576,9 @@ final class TimelineView: NSView, NSPopoverDelegate {
             multicamItems.append(ungroupItem)
         }
 
-        for group in [timelineItems, aiItems, nestItems, mediaItems, syncItems, multicamItems] where !group.isEmpty {
+        let templateSlotItems = templateSlotMenuItems(for: clip)
+
+        for group in [templateSlotItems, timelineItems, aiItems, nestItems, mediaItems, syncItems, multicamItems] where !group.isEmpty {
             if !menu.items.isEmpty { menu.addItem(.separator()) }
             group.forEach { menu.addItem($0) }
         }

--- a/Tests/PalmierProTests/TemplateStudio/TemplateGeneratorTests.swift
+++ b/Tests/PalmierProTests/TemplateStudio/TemplateGeneratorTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import PalmierPro
+
+@Suite("Template generator")
+@MainActor
+struct TemplateGeneratorTests {
+    private static func analysis(
+        shots: [DetectedShot],
+        audioSegments: [AudioSegment] = [],
+        durationSeconds: Double,
+        hasAudio: Bool = false
+    ) -> ReelAnalysis {
+        ReelAnalysis(
+            shots: shots,
+            audioSegments: audioSegments,
+            beats: [],
+            durationSeconds: durationSeconds,
+            sourceWidth: 1080,
+            sourceHeight: 1920,
+            sourceFPS: 30,
+            hasAudio: hasAudio
+        )
+    }
+
+    @Test func shotsBecomeGaplessSlotsCoveringTheReel() {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [
+                    DetectedShot(startSeconds: 0, durationSeconds: 1.1, motionScore: 0.01),
+                    DetectedShot(startSeconds: 1.1, durationSeconds: 0.9, motionScore: 0.08),
+                    DetectedShot(startSeconds: 2.0, durationSeconds: 1.0, motionScore: 0.3),
+                ],
+                durationSeconds: 3.0
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template")
+        )
+
+        let slots = result.timeline.tracks[0].clips
+        #expect(slots.map(\.startFrame) == [0, 33, 60])
+        #expect(slots.map(\.durationFrames) == [33, 27, 30])
+        #expect(slots.map { $0.templateSlot?.index } == [1, 2, 3])
+        #expect(slots.map { $0.templateSlot?.motionEnergy } == [.still, .dynamic, .whip])
+        #expect(slots.allSatisfy { $0.mediaRef == Clip.templateSlotMediaRef })
+        #expect(slots.allSatisfy { $0.isUnfilledTemplateSlot })
+        #expect(result.slotClipIds == slots.map(\.id))
+        #expect(result.timeline.totalFrames == 90)
+    }
+
+    @Test func originalCutsTrimTheSourceInsteadOfPlaceholders() {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [
+                    DetectedShot(startSeconds: 0, durationSeconds: 1.0, motionScore: 0.03),
+                    DetectedShot(startSeconds: 1.0, durationSeconds: 1.0, motionScore: 0.03),
+                ],
+                durationSeconds: 2.0
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template", mode: .originalCuts)
+        )
+
+        let slots = result.timeline.tracks[0].clips
+        #expect(slots.allSatisfy { $0.mediaRef == "reel" })
+        #expect(slots.allSatisfy { !$0.isUnfilledTemplateSlot })
+        #expect(slots.map(\.trimStartFrame) == [0, 30])
+        #expect(slots.map(\.trimEndFrame) == [30, 0])
+    }
+
+    @Test func musicAndSpeechSegmentsBecomeSeparateNamedLanes() {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [DetectedShot(startSeconds: 0, durationSeconds: 4.0, motionScore: 0.03)],
+                audioSegments: [
+                    AudioSegment(kind: .music, startSeconds: 0, durationSeconds: 4.0, confidence: 0.9),
+                    AudioSegment(kind: .speech, startSeconds: 1.0, durationSeconds: 2.0, confidence: 0.8),
+                ],
+                durationSeconds: 4.0,
+                hasAudio: true
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template")
+        )
+
+        #expect(result.timeline.tracks.map(\.type) == [.video, .audio, .audio])
+        #expect(result.timeline.tracks[1].name == AudioSegmentKind.music.trackName)
+        #expect(result.timeline.tracks[2].name == AudioSegmentKind.speech.trackName)
+        #expect(result.timeline.tracks[2].clips.map(\.startFrame) == [30])
+        #expect(result.timeline.tracks[2].clips.map(\.durationFrames) == [60])
+        #expect(result.timeline.tracks[1].clips.allSatisfy { $0.mediaType == .audio })
+    }
+
+    @Test func singleShotReelWarnsAndStillProducesOneSlot() {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [DetectedShot(startSeconds: 0, durationSeconds: 5.0, motionScore: 0.03)],
+                durationSeconds: 5.0
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template")
+        )
+
+        #expect(result.slotClipIds.count == 1)
+        #expect(result.warnings == [.noCutsDetected, .noAudioTrack])
+        #expect(result.timeline.tracks.count == 1)
+    }
+
+    @Test func zeroLengthShotsAreDroppedWithoutGapsInSlotNumbering() {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [
+                    DetectedShot(startSeconds: 0, durationSeconds: 1.0, motionScore: 0.03),
+                    DetectedShot(startSeconds: 1.0, durationSeconds: 0.001, motionScore: 0.03),
+                    DetectedShot(startSeconds: 1.0, durationSeconds: 1.0, motionScore: 0.03),
+                ],
+                durationSeconds: 2.0
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template")
+        )
+
+        let slots = result.timeline.tracks[0].clips
+        #expect(slots.map { $0.templateSlot?.index } == [1, 2])
+        #expect(slots.map(\.startFrame) == [0, 30])
+    }
+
+    @Test(arguments: [
+        (MotionEnergy.whip, 0.5, 2.0 as Double?),
+        (MotionEnergy.whip, 2.0, nil),
+        (MotionEnergy.still, 5.0, 0.5),
+        (MotionEnergy.still, 2.0, nil),
+        (MotionEnergy.gentle, 5.0, nil),
+    ])
+    func suggestedSpeedFollowsMotionEnergyAndLength(
+        energy: MotionEnergy,
+        durationSeconds: Double,
+        expected: Double?
+    ) {
+        let score: Double = switch energy {
+        case .still: 0.01
+        case .gentle: 0.04
+        case .dynamic: 0.1
+        case .whip: 0.3
+        }
+        let shot = DetectedShot(startSeconds: 0, durationSeconds: durationSeconds, motionScore: score)
+        #expect(shot.motionEnergy == energy)
+        #expect(MotionEnergyEstimator.suggestedSpeed(for: shot) == expected)
+    }
+
+    @Test func slotsSurviveProjectRoundTrip() throws {
+        let result = TemplateGenerator.makeTimeline(
+            from: Self.analysis(
+                shots: [DetectedShot(startSeconds: 0, durationSeconds: 0.5, motionScore: 0.3)],
+                durationSeconds: 0.5
+            ),
+            sourceMediaRef: "reel",
+            options: TemplateOptions(name: "Reel Template")
+        )
+        let file = ProjectFile(timelines: [result.timeline])
+        let decoded = try JSONDecoder().decode(ProjectFile.self, from: JSONEncoder().encode(file))
+        #expect(decoded.timelines[0].tracks[0].clips[0].templateSlot
+            == result.timeline.tracks[0].clips[0].templateSlot)
+    }
+}


### PR DESCRIPTION
Turn any imported reel into a reusable edit. Palmier Pro analyzes the video on-device, detects its cuts, classifies its soundtrack, and emits a new timeline whose clips carry the reel's exact shot timing. The filmmaker then drops their own footage into each slot to inherit the reel's rhythm without rebuilding the edit by hand.

Reachable from the media panel (right-click a video -> Create Template from Reel), from the timeline (right-click a slot -> Replace Slot with "...") and from the agent via create_template_from_reel and fill_template_slot.

Approach
--------
Analysis is split into three focused units under TemplateStudio, so each stage is independently testable and none of them knows about the editor:

- SceneCutDetector decodes the source at 120px wide and 8 fps through an AVAssetReader, scores each sampled pair on luma-histogram L1 distance plus mean-luma jump, and cuts where the score clears an adaptive mean + 3.5 sigma threshold. Shots below 0.35s merge into their predecessor. The mean in-shot score becomes a motion-energy bucket (still/gentle/dynamic/whip) and a speed hint: short whip shots suggest 2x, long static shots 0.5x.
- AudioSegmentClassifier runs the built-in SoundAnalysis version1 classifier over 1s windows at 0.5 overlap, then merges adjacent same-kind windows and absorbs sub-second blips into music / voice / silence spans.
- ReelAnalyzer sequences both, enriches music with BeatDetector, and caches the result per asset id plus size/mtime tag under the existing DiskCache, so re-running on an unchanged file is instant. It is a plain enum of @concurrent statics rather than an actor: createTemplateFromReel already admits one analysis at a time, so cancellation propagates through structured concurrency and one caller can never cancel another's work.

TemplateGenerator is pure: ReelAnalysis in, Timeline out. All frame math happens once, in the generated timeline's fps domain, and shot boundaries are derived from absolute source times so rounding cannot accumulate drift across a long reel. Placeholder mode emits clips against a template.slot sentinel mediaRef; originalCuts mode emits trimmed references to the source. Detected music and speech become separate named audio lanes. Slot numbering counts emitted clips, so a dropped zero-length shot leaves no gap in the sequence.

An unfilled slot is an ordinary Clip carrying a TemplateSlot marker, so it persists, ripples, trims, and undoes like any other clip. Two render paths special-case it: ClipRenderer draws a dashed outline with a centered slot/duration/energy summary, and CompositionBuilder skips it during media insertion and instead synthesizes a text-layer twin so the existing text instruction path renders the slate in preview and export. Filling a slot preserves its timeline position and duration, and applies the suggested speed only when the chosen source is long enough to cover the slot at that speed.

Creating a template appends a new timeline and activates it; the current timeline is untouched and the whole creation is one undoable action, as is each slot fill. Warnings are a TemplateWarning enum so the machine-facing tool receipt carries stable raw values while the media-panel toast shows localized copy.

Testing
-------
- swift build: clean, no new warnings.
- swift test --filter TemplateGeneratorTests --filter TimelineMarkerTests --filter ClipMathTests: 48 tests in 5 suites passed. New coverage asserts gapless slot boundaries and frame rounding, originalCuts trim math, named music/voice lanes, single-shot and zero-length-shot handling, the motion-energy to suggested-speed matrix, and slot survival across a project round trip.
- scripts/localization/sync.sh: passed, en.lproj regenerated with 17 new keys; no non-English catalog touched.
- Not run: full swift test (blocked by a keychain prompt in this environment) and UI verification. Manual plan: import a reel, right-click -> Create Template from Reel, confirm the progress banner and Cancel, confirm the new activated timeline shows dashed slots plus named audio lanes, scrub preview for slates, select one video in the media panel and fill a slot from the timeline context menu, then undo the fill and the creation.

Change statistics
-----------------
- Analysis and generation: 4 new files, ~690 lines.
- Model and rendering integration: 1 new file, ~150 lines across 4 files.
- UI and agent surfaces: 3 new files, ~200 lines across 5 files.
- Tests: 1 new file, ~165 lines.